### PR TITLE
image: add new image type "minimal-raw" for fedora

### DIFF
--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -319,6 +319,24 @@ var (
 		payloadPipelines: []string{"os", "container"},
 		exports:          []string{"container"},
 	}
+
+	minimalrawImgType = imageType{
+		name:     "minimal-raw",
+		filename: "raw.img",
+		mimeType: "application/disk",
+		packageSets: map[string]packageSetFunc{
+			osPkgsKey: minimalrpmPackageSet,
+		},
+		rpmOstree:           false,
+		kernelOptions:       defaultKernelOptions,
+		bootable:            true,
+		defaultSize:         2 * common.GibiByte,
+		image:               liveImage,
+		buildPipelines:      []string{"build"},
+		payloadPipelines:    []string{"os", "image"},
+		exports:             []string{"image"},
+		basePartitionTables: defaultBasePartitionTables,
+	}
 )
 
 type distribution struct {
@@ -965,6 +983,24 @@ func newDistro(version int) distro.Distro {
 			UEFIVendor: "fedora",
 		},
 		iotRawImgType,
+	)
+	x86_64.addImageTypes(
+		&platform.X86{
+			UEFIVendor: "fedora",
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_RAW,
+			},
+		},
+		minimalrawImgType,
+	)
+	aarch64.addImageTypes(
+		&platform.Aarch64{
+			UEFIVendor: "fedora",
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_RAW,
+			},
+		},
+		minimalrawImgType,
 	)
 
 	s390x.addImageTypes(nil)

--- a/internal/distro/fedora/distro_test.go
+++ b/internal/distro/fedora/distro_test.go
@@ -165,6 +165,14 @@ func TestFilenameFromType(t *testing.T) {
 			args: args{"foobar"},
 			want: wantResult{wantErr: true},
 		},
+		{
+			name: "minimal-raw",
+			args: args{"minimal-raw"},
+			want: wantResult{
+				filename: "raw.img",
+				mimeType: "application/disk",
+			},
+		},
 	}
 	for _, dist := range fedoraFamilyDistros {
 		t.Run(dist.name, func(t *testing.T) {
@@ -263,6 +271,7 @@ func TestImageType_Name(t *testing.T) {
 				"iot-raw-image",
 				"oci",
 				"image-installer",
+				"minimal-raw",
 			},
 		},
 		{
@@ -277,6 +286,7 @@ func TestImageType_Name(t *testing.T) {
 				"iot-installer",
 				"iot-raw-image",
 				"image-installer",
+				"minimal-raw",
 			},
 		},
 	}
@@ -438,6 +448,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"oci",
 				"container",
 				"image-installer",
+				"minimal-raw",
 			},
 		},
 		{
@@ -453,6 +464,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"oci",
 				"container",
 				"image-installer",
+				"minimal-raw",
 			},
 		},
 	}

--- a/internal/distro/fedora/package_sets.go
+++ b/internal/distro/fedora/package_sets.go
@@ -571,3 +571,11 @@ func bareMetalPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	}
 }
+
+func minimalrpmPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"@core",
+		},
+	}
+}

--- a/internal/store/json.go
+++ b/internal/store/json.go
@@ -371,6 +371,7 @@ var imageTypeCompatMapping = map[string]string{
 	"tar":              "Tar",
 	"gce":              "GCP",
 	"gce-rhui":         "GCE RHUI",
+	"minimal-raw":      "minimal-raw",
 }
 
 func imageTypeToCompatString(imgType distro.ImageType) string {

--- a/test/data/manifests/fedora_36-aarch64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-minimal_raw-boot.json
@@ -1,0 +1,11248 @@
+{
+  "compose-request": {
+    "distro": "fedora-36",
+    "arch": "aarch64",
+    "image-type": "minimal-raw",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-modular-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-modular-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      }
+    ],
+    "filename": "raw.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora36",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a08d286b9015d162f3e8248e8ced742d9065e54fcc33a01689714a1d0b64651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a141789dc071c315b35f694a589c21db351c78edcaa4634dfadbed07878acf8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b26994af6e0aafe1706f898ed1be912044c648b6c2633a5b6ece597a524f0cd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb7a19f92b0b42f970235c99f6cd1b0b7fb6c466ae63cf87805eb60711964745",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:884646f991f0933338144306ae6b9d67236f62e443707543c4ce901564a69bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:852a03da5786a6a5606376c9541141b9ddefedceb36e2694e5cd9c9b7a5e059d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:126f3ee41c2bb96347d3ab0229bb006a989f7e48ccdfd44d3862afdee6eac107",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38ebb700f11be9e1ac2f8753e6037648b53c937411b1858a08dc29ceecb813db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41c95fd87ce2a0b728954ed6848ebf80e4519837f745f6dbeac729f2abe3b651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e178cf8f39471a8829e584f3c1e9d94fdb621709dc1bc7dc2e230bf21b665bdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d3f567968ae37eb62da4a462efb65e9ac701e1e5c653f031b56c41011b2cad0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d36faded5e082ec50b4cdde0597f1c05455a16418649fd5b519cd5ee70c385b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:096c032db3c0c78df89b0e051f1f807b77b4a4661fd59437e0e489cc9fbfe1c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c3f31303fcd1c402f9c8dfe908e76a3c1bb818a2bb72bb918b6fb8e5c13a615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a93ddba157c3ed782eb2837d8776015b502e8340438fa0fc542325dfc0ad8f0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3274448af5863e4d033cae37e1283c647618ee95ea9e5b5dae485db15b915239",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6adf1b0421c75dfb110ddd7246bc9809b20826da096a3fed2524aafa3dd688e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e718c0fbbe1aa1811ac61df7a8d1d7b284ed969fae26da057a46155788e00fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af613725d58b9cb001a9ed68bdb69cca8c85c0057f46f572685414cf2f40388b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20c9d6f3e8674e639c0d370620654cf9556c570cdf06cdb4ab33fda6d57aff34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:814cab6e8a8ce7ed2a001be07bd1803dd0272297773f6f484eea4fcc0abef9c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f1e84b2dc7e805a465cb79a81322cdb6c0ba2bdd825a303072167f6545654b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ac5303ac6a3e0bece7270d9b36a5c3f7d522374607cbafc74bf04c72fc5f3d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b2aa00b613a153dc0963a25e1b6212b7aafcebf238e61f67febd4c57a626a53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f7612c662435439a6e09ac050816590d1c98bacbce2d70c18696afe15272e205",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32bdee52ac0cb28a8b55acaf3fc80e407d79758099da5487838cd41c871b5812",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a548ba4d90ce68be3ac7083c86d89465dcbc85339f03399b102eac973252ad1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63a7183b381bcdc27a0f40f49330acdf1d8df39f38ac5a41fcfd6e300d4ceb44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8571e0aaae58fae1f5c077f018d8c8e7205f6d759c07a0c174e1272c7698e44e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b62055e75833f9668150628dc7e8f9ac18c52d8876dcdf1a7882b871b26300b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f9f65c27c5d61050717ff42938f5b1e588b73b0d96aa5f85599e0585fd12dbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f247b28f422aa4ecbcff2d556429db9a59de36deb0c66394a801bd86bc4b2a28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd3ded5f10c06ebc2ca7fc9e4ab89dabc1d6cdb3d64b8b717de495e95a6d0c68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1937625b5b6344ccef8ed465a2a4b4d73e1265cf327f20f0dfd5ebae51a4858",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c468c65cb0f9660357380096464e136fbe851492b75e229a2caebf1b47960b9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12654036e2d1dd40bff4e9c81a48a6ea85e52484b548382177f3f4ccf905e6a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1eafb080b3662d4a6defb25434390821aa04bd33588ae763f676a9719cc6ead",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:905194dbd14a47d86152644643a9fa69992465f39cca7de578676fcc9ce4f7c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0395ad209dc004e63178aabe17031446693f54d961695a520f67ba432c6ee82e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cac3a8242ae62dbfa931be632123487920b635a37858f6e54e3c0b89d3ecfd34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:57bc09a4192d79a1c48d9f770daded8ac8d94dd177974608aaae88868e5efb07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2960bca7d94a6533182b3d72331d3369c774bc5ee9cb842b6a2acec83c53bb6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a06ad3aac9087efe26dd1a00ca34922287292debc1a0a61f8b7a74cd1849e0ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9251a60ce56aed426a00f82160dbb3f93493f2c393632b78c52b79db43d8cf5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f34685b66f0b0847aaac6903e0b92d2ff778e0d8f5e95c7852ee38bb87100a78",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:292256d4c9001078c7ee49f703fe7630b1622f514510a5c8ab33acd5235770a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0855f5b2b07917099be76c6813474b45cfa73d7ee5c3afad4e20d3f9ccc970d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bb7051047e7a1e8bc3b4960cea2dde77ec452c18383d16f2258216f489100525",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d690dfccef93e95be27982044eef6a4d0251c77e94c7304bd99de45c20c238f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8eeb1a2e783a61a814b20b12cddb3ffec8b27c02c6fbdcbf3cdef583fa59fa04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c0ed9385ccb82bec74755e2ba3977a1edecfc449998b88e03e1096f8f5084d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2498f161d9d4d847efdc08c44edf420a8eab5605572a98ddded1ddce78ffdb57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f90ba4f8bdcbb2a340d4ee9727d16e6808fcb850fe697d217a5a2ce496b0968a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9caa3d6d1d101b8fccbea3f13004308300b326dc675989bac3b3a7d178201812",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed120f43b16b9ea8473b4ff6be591de9f4c9f3724c7f232b76f70764b35018df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:706ca338a869ed017d3e0c4c5d8d8541deca2579a9a4afa0e87a73dd024cf558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1335f3bc82fd0981738f4b1c6eea10f55af5e2a481977c87d32e11a7f21889b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d17ce6aa8886afdc6acbf54208c18b49155e9169e0804eeb4958105d484c930c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28c22176fa563a26d898595c71215b5ad687748024138721500976ecdad6d10f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2be980efad7c111d859023ff1562c2b3663179fda9713e76946a12df33e3992",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f4d63c769183bbb950de6ce0e257c68f56d377baab6bfd89fb4351260717b81",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f94e4072a677d5315650798b6ad0251023e9dfe91e5eb933a5c0a44df1d54b6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bce33c50c5cc10387ed614ee8e1b91e304ce439f2ece1c590065a026655c8ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18e6c9215635ae3603ca0176b0b59cb81b844a7f91b37ebf3a6251a2a5a4a280",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbdaaba781d15ef4acf291749a770ee2a6a83a60d0f7680997300a07951fb1aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c504b5dc406c2c1414fd5f2d15e0e02f1085e31f32a9f8b4df2315ffb19015e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:effff0e3bf2d0dcfc701c8ed1cdfc517297de99222193d5c656e17a22c685fe0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d62545616da3a47fd25b32f03fcfa2f35473d111b972f10b33393419b96773e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cf4d3f64e9460dd6206027f5760b3ad5b1284f0a33cddba9c34c7e03a87f794",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51a67a8e86ce54b668fd70163798e3f1083ab04605f43b00028a37fe214c3817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58cf82736ed0d866f86f4fa396eae4c6267b0ba7851d9e456d1d721e4c7dd423",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55d253ad1a90b0dd8079b93b13167627f49d6e11c2d4ef4054af931403d1b1c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:afe8edcd9ce0b0d86ef388100d88c9d2a78672d08c3be56ed28eec3766e85ea4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e33fd672f043426d3ab578d2b72fe2a969e54acd7c7df32487e58c1861d5ed3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b6a7cf86b9a8741590da8a1a72a20cea153babf004db8f543e51ebedce6df0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5edc290d9f5ab21421fd23f0454472ca1086fdad55bc0c1ce992684788a47b17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a97dc4e08be47862c1804038ff1035d767979f80e9d37dcecfdff4984fb82426",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54d879df37f53234af6ef191b7427e2c5c4402b4c0c0e808a40a16820c5a5bef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9ae38a5147ae91c75ad22a30efc7cefaec4ab3dda140d19b410173461a4752b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce799cfef53276047634cf1418c6463c2bd06ffce8d3b41272cd9f3e16d2d242",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07d6ac3bde8fd80b026d90087b17816aa544f60aedcf67c57cabb83bfba68112",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36844ba28f2810c5cf2c9bf29cf669923633ce092eb3da22e19a914c6b4c4423",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70672771b5d1207a7994f362e2ffa281f086f8f186f4a1cf7cd880860e2398ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7741248fcc49a78a93652544bc8040b553cb5247b033591391a0b4e548ea0eed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8c4a706f63a757c207a3b2f7fd0d5798e8c4e1c0d1dc7460966ab0e930e1b76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28988067197e9ad286df064d9c28fb64d0813fb45915d50b6e10916cbd2d54f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee8470ec697de1eeac209ef3b08c5a68d9dc45039d0eef7f778462e0ff6ae97b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fde5b07254aea246a374a735acc04ef3f772a736e3188cfb06b462817a17ad36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43c817e2e39c45fc3056cfedfd3af60b3f221c6abd6912d56e4492c9376dfe21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbd583bf2317307de7e6610c39d65e3013b33570151d141fc3997f2efb73e22c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e299af5e2cf5530f50f128f24d24f98a74212edb511257266a524e9fb7d09703",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:995b579ad1e52d4ef1725862f1d40d8f51959d13c8fa1dac32837cde752d206d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f88d6063fe15fd262ed1a3531b74cfc5a76224fc3291099d3a6214717d2f2af8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bba50d4ba38c5cc615d67e39d0a197eb55ee14f9dedddf831a7888a5da138af3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f46a54f9379b4959f7e7a9d0d97436a36ebfb198bab76b91f44b00881385afa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86a25e18a0d5e1c314e35653ae975f01dc951108467b021a2d24da0a7a896dbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf034a64a7f5b0c4abb5da8ff274def143c12a0ec5a043b28048c2c854c56e17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6bc2bfb1fe071a65bc4ad3fed6a107457c2e4875aecdc8d42fd866aaa417fc0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb0a844d22ec62c476a689afad1f62e152de69f56d35d4958098426c9c53cbde",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39e2a80b7b68271aca9317ff0d96183a26d5077e3aeef8ca28269c28dda72a0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e070ecfd7a0068d61423ea75d1608a5a9013a01a319d2bddeec8a965cea5a0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3032035b371e27c6347c1fa7f01a802cb451c699095d68cbcec22c70471b2b0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6141c8c3bbed6c6fcd4a69041ae165b7bf1d58d88f533be47d9f8a5109b64be9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb397c60cbb5cffa69fbf48a0570fa60c9f1d14a7c3df5e5016145e94c49c07e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac3fc3af7df5af00455180726fff651412eff2423614b57cc00e9e798e5f5da0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3468c03d68ee562d80f7a2bd830e54abbc95f7c915028c78ec4a8cc2930f790e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dad7181357cf9ad9f6b43663aa67d16993355b140a900db1ce7b274808893b06",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c297d39659648688bfa140649057942fbde26942f9388f8a2f2a6f3b89feab1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a91d250ca05b736fc50e8c2b029f2ee0f160dfc639287cc0b419ee7dd17d898e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbf042700542b50ce9c93e1457c1d4d49cde8cf609562ebc46ef38be3a8e3be0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:065befa0aa9e24df7b5c5c29943ff559b0508600a668ede3f75aa86dfb306ae1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db82a25bca1d37ce148e2b7fd4edbf5ef673573a650a46ede399f92d6c5d1384",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d580be005d64283434e750f9ef760554ce814dfaa527699541a655f5d7de4d8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d3293398c397ada3d74243def9e2aaa72b2944383924213aef7fd8ccfcfcbf5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5fc05299dd26a52da3011a466b1454da89727ab7dd7815595bd162b83adc28b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d317220153bb88b12eb170b840dc08b2b2d82e95811be4cd4437c29b0b80a58a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:543d7ee043aa48bbe5e59e7c3be68a1e388165b2d739975b05875c50b5787e17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac55ff27ae14022eafd2045548223d137159d9d593675cbb99a41143f7ce9e99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42bc60e4eb49930b10fd5c8567d82aacd7bece633b47f25773ff75d9591f7740",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb3668ab3897dc10e8ae032491b2597cb07b066232bc8cb0c50d9c4f506c379d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4f1a2968526b12ffba46005e3136b7e561e9fc9a415270884d74824e4d4c248",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:103b7bfd272a52e9b3d2c455c0dab98103635ca44c225c3460cbdc32682e9510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83c0479bbcf44639596f844f0ca89bee8b8df547cf63ad6d95e1e42cac505ddd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54916f1a8a37e1e569d984a965e420d0d90a172176128b4d841976ec324bf41e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7a9c68d4537d5085f2da7bea020c15c1bc99d80a210d07ccf0aa1bc1f8535fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3150aca3cbb4c9e18866293fb7c78ebf88c781fb0ce0e82ecbb56216153eb142",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2168561de6b48e138ac894fa7bdccd054603516c5e1acae01c1f06de96376580",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19414d35ff0112965137f13f5b65f76ccceae4f11b76430e2be5e5fbaa7d1410",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2c8cf981ac3b4ce62fed5fc692965ef1db5935df990bc024781785e354dcc16",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf7fd9b6579cafbaf0a8eb7f2b920b811a9eb140100e1c3757ed8e3d8981fcf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d86220c34713ac28d674be349ccc9eb53aa790c2b39025596532ffb92eafcbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1513639e8a21c9e23c998dad07484abb911441a7a614790a0cfd42789446c8ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8defe410aa1c967c90c87bfcffb39cda4ef7e22dec00cfd9b4d7fe4cdffbd1ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26d9bfa8bcccabc4565c64027146f39a11f4750e937179a9e023ec272aa3a480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2fa391f0c8dab9b77728f5506a1cce5f644a6399c57e230f24da11edb645764",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6619af57c800fb5ec8cdd5ec8ea070897f012c968235f748e313d4de71abd342",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:364f7226e498df8c3100d07a2795413268fdc1bc0ef038e3b58265d1f45bb0d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9076efd678b1ce0c33b970507a60d055f94fe9f764dd696ded14271d79f2732e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c2f825a9c528760b292febdcaf6c2a90e4085a5654e5e47fff04aceb9ed25a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4af1f337b8fba9e963211d361544438cadfed85b6bad7da4d924989bfef80e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20c18c9dd69a8a760b193d007ceb51696d645c870674e423f2028e27d8b162ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdfb32e0a20b992aa5264195c22882bcca86c46be2d82d1f9681dc1acae4fd47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20c7cb6eed94c035c9b1e3a24f839a4dbbd6ef33bc66795f2d4a860b7734c9d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4af8d1faa176bd1fe8271b2bc4dbff6bea7331e3ec696155c87011c367a48467",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08752167a3f35572f3aee4281ccb0925a91e88a04448e13c41a7fd66fbe8f0ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a2faf2c81074e12b902585c1dc9df7a5c4dfe9abd651c9849a5cdf52462d2b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa387421816ee1b9b1313282810c8a05da4175e3817f13a71486e9608a3617e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:168429c25bcc7d36dde47ef25e5aaf1ca50b7f6f9350a058c45f4e67d5cdce40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc45c301e200fee07cafcd3a3e10f4c139fa4a9ca1f181813933fa92569c4e68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2c31e98b36dcad624e0b01560f97aaeabd212979b19904fc273630f71ba9f0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:724954cb4c5dc17ebd72ac3d9b58ff5d4df10d235ec5f4d7b48f852614c0167a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c28a0626decb9d370ee2a0119c041dceba4293715df8773991a8c8ed5abd96c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7073d75482635b4d8f9cd4955447edf54c0bedab4656c71fd76ca5f97479020",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23b6dad4a3d114360b897128785498229edcff1b1a9f18016cdabdc1b4b8a719",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c80b2a2f0b2e3daf7f3feaa708bea6487a17f729ee80be687ebab9ea8fa85fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33e0afc0fd03e559ee53e6179868783da343158d8257e6401b3def99a59ac67b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a5a6f87ef42ce9bce5bb1cb4308eed0b85ea020d870bfdcd2baac3e471fe7ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:912c53614e3488d3ba7226a4615f43c59fd6f63c18baa1fd38d2d5093abdc6f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:558d90151758e0894a377aadd6f4d651f139e7491f211c4d7548f644a55675ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8beac96d9b0e29c84ec86a891585c48f2db50248f2e4e361936e56d0eb5c6d33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab0f174db1bf134f5288510c8c7c0fa64d3d28ac85ed45fb58d6e0d4ae8af564",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2646322ae496c10f0ad319945a943e726010e2e1e6e7dcf904b7ffcacff9662f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:913ac376a600ae00bcc55346bbbbd1b52e2b77713ff9fe01ae564a72fa337531",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2fdac173bf9bc76ee4dc10cdca0b7e27666b722edf72dd0275410d2b8aa4eac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4df251d7f0566e132997e1813732b7f315a4d64e706b0377e4b97637a1ced615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ce75259eee99d0f7c5a7a3a41169b22059c9996bd7c0de7509ff63f363ef5f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8efcccc5141a5360ab8af037ad9be02d2b617a43db19117133e672806245e34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06667da4cd013c4a8c06dc2af38f243ce14d947c0af801b0ee5a49b41ee34944",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30dab70d00871471edc0c2e9fff73780297291e4740243bc3af3f7c99d32c599",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:632e6035364601a88d882591ab095bdd32cbacdb66a5bf9e12ad1900b6494b6e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f5e069f7741d6a5278149c5d9953aab4c421c8dd617bf2eaee900c4f2238ca7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ee60160a557cdd0a9180895d929366b2fbc1ce570f4d5e255f2b6be56d75353",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.18.9-200.fc36.aarch64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "raw.img",
+              "size": "3957325824"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 409600,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 411648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1435648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 2048,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 411648,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 1435648,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 411648,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 2048,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 1435648,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.aarch64.rpm"
+          },
+          "sha256:0395ad209dc004e63178aabe17031446693f54d961695a520f67ba432c6ee82e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgcab1-1.4-6.fc36.aarch64.rpm"
+          },
+          "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.aarch64.rpm"
+          },
+          "sha256:065befa0aa9e24df7b5c5c29943ff559b0508600a668ede3f75aa86dfb306ae1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:06667da4cd013c4a8c06dc2af38f243ce14d947c0af801b0ee5a49b41ee34944": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-client-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.aarch64.rpm"
+          },
+          "sha256:07d6ac3bde8fd80b026d90087b17816aa544f60aedcf67c57cabb83bfba68112": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.aarch64.rpm"
+          },
+          "sha256:0855f5b2b07917099be76c6813474b45cfa73d7ee5c3afad4e20d3f9ccc970d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.aarch64.rpm"
+          },
+          "sha256:08752167a3f35572f3aee4281ccb0925a91e88a04448e13c41a7fd66fbe8f0ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxmlb-0.3.9-1.fc36.aarch64.rpm"
+          },
+          "sha256:096c032db3c0c78df89b0e051f1f807b77b4a4661fd59437e0e489cc9fbfe1c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/flashrom-1.2-8.fc36.aarch64.rpm"
+          },
+          "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efi-filesystem-5-5.fc36.noarch.rpm"
+          },
+          "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm"
+          },
+          "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/geolite2-city-20191217-6.fc36.noarch.rpm"
+          },
+          "sha256:0f4d63c769183bbb950de6ce0e257c68f56d377baab6bfd89fb4351260717b81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libuser-0.63-10.fc36.aarch64.rpm"
+          },
+          "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm"
+          },
+          "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:103b7bfd272a52e9b3d2c455c0dab98103635ca44c225c3460cbdc32682e9510": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-fs-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:12654036e2d1dd40bff4e9c81a48a6ea85e52484b548382177f3f4ccf905e6a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.aarch64.rpm"
+          },
+          "sha256:126f3ee41c2bb96347d3ab0229bb006a989f7e48ccdfd44d3862afdee6eac107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/deltarpm-3.6.2-11.fc36.aarch64.rpm"
+          },
+          "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-oomd-defaults-250.7-1.fc36.noarch.rpm"
+          },
+          "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-modular-36-1.noarch.rpm"
+          },
+          "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.aarch64.rpm"
+          },
+          "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.aarch64.rpm"
+          },
+          "sha256:1513639e8a21c9e23c998dad07484abb911441a7a614790a0cfd42789446c8ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libldb-2.5.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:168429c25bcc7d36dde47ef25e5aaf1ca50b7f6f9350a058c45f4e67d5cdce40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.aarch64.rpm"
+          },
+          "sha256:18e6c9215635ae3603ca0176b0b59cb81b844a7f91b37ebf3a6251a2a5a4a280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/man-db-2.10.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:19414d35ff0112965137f13f5b65f76ccceae4f11b76430e2be5e5fbaa7d1410": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbytesize-2.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.aarch64.rpm"
+          },
+          "sha256:1f5e069f7741d6a5278149c5d9953aab4c421c8dd617bf2eaee900c4f2238ca7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/unbound-libs-1.16.0-4.fc36.aarch64.rpm"
+          },
+          "sha256:20c18c9dd69a8a760b193d007ceb51696d645c870674e423f2028e27d8b162ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_sudo-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:20c7cb6eed94c035c9b1e3a24f839a4dbbd6ef33bc66795f2d4a860b7734c9d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtdb-1.4.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:20c9d6f3e8674e639c0d370620654cf9556c570cdf06cdb4ab33fda6d57aff34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iproute-5.15.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:2168561de6b48e138ac894fa7bdccd054603516c5e1acae01c1f06de96376580": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-utils-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.aarch64.rpm"
+          },
+          "sha256:23b6dad4a3d114360b897128785498229edcff1b1a9f18016cdabdc1b4b8a719": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-util-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.aarch64.rpm"
+          },
+          "sha256:2498f161d9d4d847efdc08c44edf420a8eab5605572a98ddded1ddce78ffdb57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:2646322ae496c10f0ad319945a943e726010e2e1e6e7dcf904b7ffcacff9662f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:26d9bfa8bcccabc4565c64027146f39a11f4750e937179a9e023ec272aa3a480": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:28988067197e9ad286df064d9c28fb64d0813fb45915d50b6e10916cbd2d54f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-gpg-1.15.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:28c22176fa563a26d898595c71215b5ad687748024138721500976ecdad6d10f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libudisks2-2.9.4-4.fc36.aarch64.rpm"
+          },
+          "sha256:292256d4c9001078c7ee49f703fe7630b1622f514510a5c8ab33acd5235770a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmaxminddb-1.6.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:2960bca7d94a6533182b3d72331d3369c774bc5ee9cb842b6a2acec83c53bb6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:2a08d286b9015d162f3e8248e8ced742d9065e54fcc33a01689714a1d0b64651": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-3.0.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm"
+          },
+          "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:2e070ecfd7a0068d61423ea75d1608a5a9013a01a319d2bddeec8a965cea5a0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/ModemManager-glib-1.18.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm"
+          },
+          "sha256:2ee60160a557cdd0a9180895d929366b2fbc1ce570f4d5e255f2b6be56d75353": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/v/vim-minimal-8.2.5172-1.fc36.aarch64.rpm"
+          },
+          "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.aarch64.rpm"
+          },
+          "sha256:3032035b371e27c6347c1fa7f01a802cb451c699095d68cbcec22c70471b2b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/NetworkManager-1.38.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:30dab70d00871471edc0c2e9fff73780297291e4740243bc3af3f7c99d32c599": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-common-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:3150aca3cbb4c9e18866293fb7c78ebf88c781fb0ce0e82ecbb56216153eb142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-swap-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:3274448af5863e4d033cae37e1283c647618ee95ea9e5b5dae485db15b915239": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/groff-base-1.22.4-9.fc36.aarch64.rpm"
+          },
+          "sha256:32bdee52ac0cb28a8b55acaf3fc80e407d79758099da5487838cd41c871b5812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:33e0afc0fd03e559ee53e6179868783da343158d8257e6401b3def99a59ac67b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-libs-2022.5.17-1.fc36.aarch64.rpm"
+          },
+          "sha256:3468c03d68ee562d80f7a2bd830e54abbc95f7c915028c78ec4a8cc2930f790e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-efi-1.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:364f7226e498df8c3100d07a2795413268fdc1bc0ef038e3b58265d1f45bb0d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.aarch64.rpm"
+          },
+          "sha256:36844ba28f2810c5cf2c9bf29cf669923633ce092eb3da22e19a914c6b4c4423": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm"
+          },
+          "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:38ebb700f11be9e1ac2f8753e6037648b53c937411b1858a08dc29ceecb813db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dmidecode-3.3-3.fc36.aarch64.rpm"
+          },
+          "sha256:39e2a80b7b68271aca9317ff0d96183a26d5077e3aeef8ca28269c28dda72a0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zram-generator-1.1.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:3a2faf2c81074e12b902585c1dc9df7a5c4dfe9abd651c9849a5cdf52462d2b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mokutil-0.6.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.aarch64.rpm"
+          },
+          "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-5.41-4.fc36.aarch64.rpm"
+          },
+          "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.aarch64.rpm"
+          },
+          "sha256:3d3293398c397ada3d74243def9e2aaa72b2944383924213aef7fd8ccfcfcbf5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.aarch64.rpm"
+          },
+          "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/initscripts-service-10.16-2.fc36.noarch.rpm"
+          },
+          "sha256:3d86220c34713ac28d674be349ccc9eb53aa790c2b39025596532ffb92eafcbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/popt-1.18-7.fc36.aarch64.rpm"
+          },
+          "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/v/vim-data-8.2.5172-1.fc36.noarch.rpm"
+          },
+          "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sed-4.8-10.fc36.aarch64.rpm"
+          },
+          "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.aarch64.rpm"
+          },
+          "sha256:41c95fd87ce2a0b728954ed6848ebf80e4519837f745f6dbeac729f2abe3b651": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.aarch64.rpm"
+          },
+          "sha256:42bc60e4eb49930b10fd5c8567d82aacd7bece633b47f25773ff75d9591f7740": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-modules-5.18.9-200.fc36.aarch64.rpm"
+          },
+          "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm"
+          },
+          "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/firewalld-filesystem-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:43c817e2e39c45fc3056cfedfd3af60b3f221c6abd6912d56e4492c9376dfe21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-rpm-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.aarch64.rpm"
+          },
+          "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm"
+          },
+          "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zram-generator-defaults-1.1.2-1.fc36.noarch.rpm"
+          },
+          "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:4af8d1faa176bd1fe8271b2bc4dbff6bea7331e3ec696155c87011c367a48467": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtevent-0.12.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:4ce75259eee99d0f7c5a7a3a41169b22059c9996bd7c0de7509ff63f363ef5f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-unbound-1.16.0-4.fc36.aarch64.rpm"
+          },
+          "sha256:4d36faded5e082ec50b4cdde0597f1c05455a16418649fd5b519cd5ee70c385b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.aarch64.rpm"
+          },
+          "sha256:4df251d7f0566e132997e1813732b7f315a4d64e706b0377e4b97637a1ced615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libdnf-0.67.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.aarch64.rpm"
+          },
+          "sha256:4f46a54f9379b4959f7e7a9d0d97436a36ebfb198bab76b91f44b00881385afa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sudo-python-plugin-1.9.8-5.p2.fc36.aarch64.rpm"
+          },
+          "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.aarch64.rpm"
+          },
+          "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.aarch64.rpm"
+          },
+          "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/geolite2-country-20191217-6.fc36.noarch.rpm"
+          },
+          "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:51a67a8e86ce54b668fd70163798e3f1083ab04605f43b00028a37fe214c3817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-8.8p1-1.fc36.1.aarch64.rpm"
+          },
+          "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.aarch64.rpm"
+          },
+          "sha256:543d7ee043aa48bbe5e59e7c3be68a1e388165b2d739975b05875c50b5787e17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-5.18.9-200.fc36.aarch64.rpm"
+          },
+          "sha256:54916f1a8a37e1e569d984a965e420d0d90a172176128b4d841976ec324bf41e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-mdraid-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:54d879df37f53234af6ef191b7427e2c5c4402b4c0c0e808a40a16820c5a5bef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-core-libs-22.02.122-1.fc36.aarch64.rpm"
+          },
+          "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:558d90151758e0894a377aadd6f4d651f139e7491f211c4d7548f644a55675ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/oniguruma-6.9.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:55d253ad1a90b0dd8079b93b13167627f49d6e11c2d4ef4054af931403d1b1c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-server-8.8p1-1.fc36.1.aarch64.rpm"
+          },
+          "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.aarch64.rpm"
+          },
+          "sha256:57bc09a4192d79a1c48d9f770daded8ac8d94dd177974608aaae88868e5efb07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgusb-0.3.10-2.fc36.aarch64.rpm"
+          },
+          "sha256:58cf82736ed0d866f86f4fa396eae4c6267b0ba7851d9e456d1d721e4c7dd423": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-clients-8.8p1-1.fc36.1.aarch64.rpm"
+          },
+          "sha256:5a5a6f87ef42ce9bce5bb1cb4308eed0b85ea020d870bfdcd2baac3e471fe7ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-system-compression-1.0-9.fc36.aarch64.rpm"
+          },
+          "sha256:5b2aa00b613a153dc0963a25e1b6212b7aafcebf238e61f67febd4c57a626a53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-nft-1.8.7-15.fc36.aarch64.rpm"
+          },
+          "sha256:5b6a7cf86b9a8741590da8a1a72a20cea153babf004db8f543e51ebedce6df0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.aarch64.rpm"
+          },
+          "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm"
+          },
+          "sha256:5c3f31303fcd1c402f9c8dfe908e76a3c1bb818a2bb72bb918b6fb8e5c13a615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gobject-introspection-1.72.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:5cf4d3f64e9460dd6206027f5760b3ad5b1284f0a33cddba9c34c7e03a87f794": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/npth-1.6-8.fc36.aarch64.rpm"
+          },
+          "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:5e718c0fbbe1aa1811ac61df7a8d1d7b284ed969fae26da057a46155788e00fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm"
+          },
+          "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/firewalld-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:5edc290d9f5ab21421fd23f0454472ca1086fdad55bc0c1ce992684788a47b17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:5fc05299dd26a52da3011a466b1454da89727ab7dd7815595bd162b83adc28b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-efi-aa64-2.06-42.fc36.aarch64.rpm"
+          },
+          "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libreport-filesystem-2.17.1-1.fc36.noarch.rpm"
+          },
+          "sha256:6141c8c3bbed6c6fcd4a69041ae165b7bf1d58d88f533be47d9f8a5109b64be9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/NetworkManager-libnm-1.38.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:632e6035364601a88d882591ab095bdd32cbacdb66a5bf9e12ad1900b6494b6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-kcm-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:63a7183b381bcdc27a0f40f49330acdf1d8df39f38ac5a41fcfd6e300d4ceb44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.aarch64.rpm"
+          },
+          "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.aarch64.rpm"
+          },
+          "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.aarch64.rpm"
+          },
+          "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.aarch64.rpm"
+          },
+          "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm"
+          },
+          "sha256:6619af57c800fb5ec8cdd5ec8ea070897f012c968235f748e313d4de71abd342": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-29-7.fc36.aarch64.rpm"
+          },
+          "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.aarch64.rpm"
+          },
+          "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm"
+          },
+          "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.aarch64.rpm"
+          },
+          "sha256:6adf1b0421c75dfb110ddd7246bc9809b20826da096a3fed2524aafa3dd688e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/h/hostname-3.23-6.fc36.aarch64.rpm"
+          },
+          "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm"
+          },
+          "sha256:6bc2bfb1fe071a65bc4ad3fed6a107457c2e4875aecdc8d42fd866aaa417fc0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/v/volume_key-libs-0.3.12-15.fc36.aarch64.rpm"
+          },
+          "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm"
+          },
+          "sha256:6c28a0626decb9d370ee2a0119c041dceba4293715df8773991a8c8ed5abd96c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-softokn-freebl-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-dnf-plugins-core-4.2.1-1.fc36.noarch.rpm"
+          },
+          "sha256:6c80b2a2f0b2e3daf7f3feaa708bea6487a17f729ee80be687ebab9ea8fa85fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-2022.5.17-1.fc36.aarch64.rpm"
+          },
+          "sha256:6f1e84b2dc7e805a465cb79a81322cdb6c0ba2bdd825a303072167f6545654b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipset-libs-7.15-2.fc36.aarch64.rpm"
+          },
+          "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm"
+          },
+          "sha256:6f9f65c27c5d61050717ff42938f5b1e588b73b0d96aa5f85599e0585fd12dbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libatasmart-0.19-22.fc36.aarch64.rpm"
+          },
+          "sha256:70672771b5d1207a7994f362e2ffa281f086f8f186f4a1cf7cd880860e2398ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm"
+          },
+          "sha256:706ca338a869ed017d3e0c4c5d8d8541deca2579a9a4afa0e87a73dd024cf558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libqrtr-glib-1.0.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.aarch64.rpm"
+          },
+          "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.aarch64.rpm"
+          },
+          "sha256:724954cb4c5dc17ebd72ac3d9b58ff5d4df10d235ec5f4d7b48f852614c0167a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-softokn-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-plugins-core-4.2.1-1.fc36.noarch.rpm"
+          },
+          "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm"
+          },
+          "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.aarch64.rpm"
+          },
+          "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.aarch64.rpm"
+          },
+          "sha256:7741248fcc49a78a93652544bc8040b553cb5247b033591391a0b4e548ea0eed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/psmisc-23.4-3.fc36.aarch64.rpm"
+          },
+          "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-six-1.16.0-5.fc36.noarch.rpm"
+          },
+          "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.aarch64.rpm"
+          },
+          "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.aarch64.rpm"
+          },
+          "sha256:7ac5303ac6a3e0bece7270d9b36a5c3f7d522374607cbafc74bf04c72fc5f3d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.aarch64.rpm"
+          },
+          "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:814cab6e8a8ce7ed2a001be07bd1803dd0272297773f6f484eea4fcc0abef9c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipset-7.15-2.fc36.aarch64.rpm"
+          },
+          "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.aarch64.rpm"
+          },
+          "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-data-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:83c0479bbcf44639596f844f0ca89bee8b8df547cf63ad6d95e1e42cac505ddd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-loop-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:852a03da5786a6a5606376c9541141b9ddefedceb36e2694e5cd9c9b7a5e059d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-libs-1.14.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:8571e0aaae58fae1f5c077f018d8c8e7205f6d759c07a0c174e1272c7698e44e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/less-590-3.fc36.aarch64.rpm"
+          },
+          "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm"
+          },
+          "sha256:86a25e18a0d5e1c314e35653ae975f01dc951108467b021a2d24da0a7a896dbd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/u/udisks2-2.9.4-4.fc36.aarch64.rpm"
+          },
+          "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-056-1.fc36.aarch64.rpm"
+          },
+          "sha256:884646f991f0933338144306ae6b9d67236f62e443707543c4ce901564a69bb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-dicts-2.9.6-28.fc36.aarch64.rpm"
+          },
+          "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:8a548ba4d90ce68be3ac7083c86d89465dcbc85339f03399b102eac973252ad1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jq-1.6-13.fc36.aarch64.rpm"
+          },
+          "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.aarch64.rpm"
+          },
+          "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm"
+          },
+          "sha256:8beac96d9b0e29c84ec86a891585c48f2db50248f2e4e361936e56d0eb5c6d33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-compat-2.6.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:8c0ed9385ccb82bec74755e2ba3977a1edecfc449998b88e03e1096f8f5084d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.aarch64.rpm"
+          },
+          "sha256:8c2f825a9c528760b292febdcaf6c2a90e4085a5654e5e47fff04aceb9ed25a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_idmap-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-dnf-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:8d3f567968ae37eb62da4a462efb65e9ac701e1e5c653f031b56c41011b2cad0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efibootmgr-16-12.fc36.aarch64.rpm"
+          },
+          "sha256:8defe410aa1c967c90c87bfcffb39cda4ef7e22dec00cfd9b4d7fe4cdffbd1ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmbim-1.26.4-1.fc36.aarch64.rpm"
+          },
+          "sha256:8eeb1a2e783a61a814b20b12cddb3ffec8b27c02c6fbdcbf3cdef583fa59fa04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.aarch64.rpm"
+          },
+          "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:905194dbd14a47d86152644643a9fa69992465f39cca7de578676fcc9ce4f7c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libftdi-1.5-3.fc36.aarch64.rpm"
+          },
+          "sha256:9076efd678b1ce0c33b970507a60d055f94fe9f764dd696ded14271d79f2732e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_certmap-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:912c53614e3488d3ba7226a4615f43c59fd6f63c18baa1fd38d2d5093abdc6f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfsprogs-2022.5.17-1.fc36.aarch64.rpm"
+          },
+          "sha256:913ac376a600ae00bcc55346bbbbd1b52e2b77713ff9fe01ae564a72fa337531": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-gobject-base-3.42.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:9251a60ce56aed426a00f82160dbb3f93493f2c393632b78c52b79db43d8cf5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libjcat-0.1.10-1.fc36.aarch64.rpm"
+          },
+          "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.aarch64.rpm"
+          },
+          "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm"
+          },
+          "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.aarch64.rpm"
+          },
+          "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm"
+          },
+          "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.aarch64.rpm"
+          },
+          "sha256:995b579ad1e52d4ef1725862f1d40d8f51959d13c8fa1dac32837cde752d206d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-sign-libs-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.aarch64.rpm"
+          },
+          "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.aarch64.rpm"
+          },
+          "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:9bce33c50c5cc10387ed614ee8e1b91e304ce439f2ece1c590065a026655c8ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lmdb-libs-0.9.29-3.fc36.aarch64.rpm"
+          },
+          "sha256:9caa3d6d1d101b8fccbea3f13004308300b326dc675989bac3b3a7d178201812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/linux-firmware-20220610-135.fc36.noarch.rpm"
+          },
+          "sha256:a06ad3aac9087efe26dd1a00ca34922287292debc1a0a61f8b7a74cd1849e0ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libini_config-1.3.1-50.fc36.aarch64.rpm"
+          },
+          "sha256:a141789dc071c315b35f694a589c21db351c78edcaa4634dfadbed07878acf8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bluez-5.64-1.fc36.aarch64.rpm"
+          },
+          "sha256:a1eafb080b3662d4a6defb25434390821aa04bd33588ae763f676a9719cc6ead": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm"
+          },
+          "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grep-3.7-2.fc36.aarch64.rpm"
+          },
+          "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/y/yum-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.aarch64.rpm"
+          },
+          "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm"
+          },
+          "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:a8c4a706f63a757c207a3b2f7fd0d5798e8c4e1c0d1dc7460966ab0e930e1b76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-dbus-1.2.18-3.fc36.aarch64.rpm"
+          },
+          "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:a91d250ca05b736fc50e8c2b029f2ee0f160dfc639287cc0b419ee7dd17d898e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:a93ddba157c3ed782eb2837d8776015b502e8340438fa0fc542325dfc0ad8f0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:a97dc4e08be47862c1804038ff1035d767979f80e9d37dcecfdff4984fb82426": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-22.02.122-1.fc36.aarch64.rpm"
+          },
+          "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:aa387421816ee1b9b1313282810c8a05da4175e3817f13a71486e9608a3617e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-firewall-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:ab0f174db1bf134f5288510c8c7c0fa64d3d28ac85ed45fb58d6e0d4ae8af564": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:ac3fc3af7df5af00455180726fff651412eff2423614b57cc00e9e798e5f5da0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-1.8.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:ac55ff27ae14022eafd2045548223d137159d9d593675cbb99a41143f7ce9e99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-core-5.18.9-200.fc36.aarch64.rpm"
+          },
+          "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dhcp-common-4.4.3-2.fc36.noarch.rpm"
+          },
+          "sha256:af613725d58b9cb001a9ed68bdb69cca8c85c0057f46f572685414cf2f40388b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipcalc-1.0.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm"
+          },
+          "sha256:afe8edcd9ce0b0d86ef388100d88c9d2a78672d08c3be56ed28eec3766e85ea4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/parted-3.4-12.fc36.aarch64.rpm"
+          },
+          "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.aarch64.rpm"
+          },
+          "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:b26994af6e0aafe1706f898ed1be912044c648b6c2633a5b6ece597a524f0cd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:b62055e75833f9668150628dc7e8f9ac18c52d8876dcdf1a7882b871b26300b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm"
+          },
+          "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/linux-firmware-whence-20220610-135.fc36.noarch.rpm"
+          },
+          "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.aarch64.rpm"
+          },
+          "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.aarch64.rpm"
+          },
+          "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.aarch64.rpm"
+          },
+          "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.aarch64.rpm"
+          },
+          "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.aarch64.rpm"
+          },
+          "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/readline-8.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:bb7051047e7a1e8bc3b4960cea2dde77ec452c18383d16f2258216f489100525": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:bba50d4ba38c5cc615d67e39d0a197eb55ee14f9dedddf831a7888a5da138af3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sudo-1.9.8-5.p2.fc36.aarch64.rpm"
+          },
+          "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:bf034a64a7f5b0c4abb5da8ff274def143c12a0ec5a043b28048c2c854c56e17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/u/userspace-rcu-0.13.0-4.fc36.aarch64.rpm"
+          },
+          "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.aarch64.rpm"
+          },
+          "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:c1335f3bc82fd0981738f4b1c6eea10f55af5e2a481977c87d32e11a7f21889b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libref_array-0.1.5-50.fc36.aarch64.rpm"
+          },
+          "sha256:c297d39659648688bfa140649057942fbde26942f9388f8a2f2a6f3b89feab1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-modem-manager-1.8.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm"
+          },
+          "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:c2fa391f0c8dab9b77728f5506a1cce5f644a6399c57e230f24da11edb645764": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libqmi-1.30.6-1.fc36.aarch64.rpm"
+          },
+          "sha256:c468c65cb0f9660357380096464e136fbe851492b75e229a2caebf1b47960b9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdhash-0.5.0-50.fc36.aarch64.rpm"
+          },
+          "sha256:c504b5dc406c2c1414fd5f2d15e0e02f1085e31f32a9f8b4df2315ffb19015e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nano-6.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.aarch64.rpm"
+          },
+          "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-gobject-base-noarch-3.42.1-1.fc36.noarch.rpm"
+          },
+          "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.aarch64.rpm"
+          },
+          "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm"
+          },
+          "sha256:cac3a8242ae62dbfa931be632123487920b635a37858f6e54e3c0b89d3ecfd34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgudev-237-2.fc36.aarch64.rpm"
+          },
+          "sha256:cb397c60cbb5cffa69fbf48a0570fa60c9f1d14a7c3df5e5016145e94c49c07e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dhcp-client-4.4.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:cb7a19f92b0b42f970235c99f6cd1b0b7fb6c466ae63cf87805eb60711964745": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/c-ares-1.17.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm"
+          },
+          "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.aarch64.rpm"
+          },
+          "sha256:ce799cfef53276047634cf1418c6463c2bd06ffce8d3b41272cd9f3e16d2d242": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.aarch64.rpm"
+          },
+          "sha256:cf7fd9b6579cafbaf0a8eb7f2b920b811a9eb140100e1c3757ed8e3d8981fcf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libdnf-0.67.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:d17ce6aa8886afdc6acbf54208c18b49155e9169e0804eeb4958105d484c930c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.aarch64.rpm"
+          },
+          "sha256:d2fdac173bf9bc76ee4dc10cdca0b7e27666b722edf72dd0275410d2b8aa4eac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-hawkey-0.67.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:d317220153bb88b12eb170b840dc08b2b2d82e95811be4cd4437c29b0b80a58a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/i/inih-55-1.fc36.aarch64.rpm"
+          },
+          "sha256:d4af1f337b8fba9e963211d361544438cadfed85b6bad7da4d924989bfef80e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_nss_idmap-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:d4f1a2968526b12ffba46005e3136b7e561e9fc9a415270884d74824e4d4c248": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-crypto-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:d580be005d64283434e750f9ef760554ce814dfaa527699541a655f5d7de4d8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.aarch64.rpm"
+          },
+          "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.aarch64.rpm"
+          },
+          "sha256:d62545616da3a47fd25b32f03fcfa2f35473d111b972f10b33393419b96773e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:d690dfccef93e95be27982044eef6a4d0251c77e94c7304bd99de45c20c238f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libndp-1.8-3.fc36.aarch64.rpm"
+          },
+          "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:d7073d75482635b4d8f9cd4955447edf54c0bedab4656c71fd76ca5f97479020": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-sysinit-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.aarch64.rpm"
+          },
+          "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.aarch64.rpm"
+          },
+          "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.aarch64.rpm"
+          },
+          "sha256:dad7181357cf9ad9f6b43663aa67d16993355b140a900db1ce7b274808893b06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-flashrom-1.8.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:db82a25bca1d37ce148e2b7fd4edbf5ef673573a650a46ede399f92d6c5d1384": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.aarch64.rpm"
+          },
+          "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm"
+          },
+          "sha256:dd3ded5f10c06ebc2ca7fc9e4ab89dabc1d6cdb3d64b8b717de495e95a6d0c68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcollection-0.7.0-50.fc36.aarch64.rpm"
+          },
+          "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.aarch64.rpm"
+          },
+          "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:e178cf8f39471a8829e584f3c1e9d94fdb621709dc1bc7dc2e230bf21b665bdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-rescue-056-1.fc36.aarch64.rpm"
+          },
+          "sha256:e1937625b5b6344ccef8ed465a2a4b4d73e1265cf327f20f0dfd5ebae51a4858": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm"
+          },
+          "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm"
+          },
+          "sha256:e299af5e2cf5530f50f128f24d24f98a74212edb511257266a524e9fb7d09703": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:e2c31e98b36dcad624e0b01560f97aaeabd212979b19904fc273630f71ba9f0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:e2c8cf981ac3b4ce62fed5fc692965ef1db5935df990bc024781785e354dcc16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-python3-0.8.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:e33fd672f043426d3ab578d2b72fe2a969e54acd7c7df32487e58c1861d5ed3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/passwd-0.80-12.fc36.aarch64.rpm"
+          },
+          "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm"
+          },
+          "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.aarch64.rpm"
+          },
+          "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-dateutil-2.8.1-8.fc36.noarch.rpm"
+          },
+          "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm"
+          },
+          "sha256:e7a9c68d4537d5085f2da7bea020c15c1bc99d80a210d07ccf0aa1bc1f8535fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-part-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.aarch64.rpm"
+          },
+          "sha256:eb0a844d22ec62c476a689afad1f62e152de69f56d35d4958098426c9c53cbde": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xfsprogs-5.14.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:ed120f43b16b9ea8473b4ff6be591de9f4c9f3724c7f232b76f70764b35018df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpipeline-1.5.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:ee8470ec697de1eeac209ef3b08c5a68d9dc45039d0eef7f778462e0ff6ae97b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm"
+          },
+          "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:effff0e3bf2d0dcfc701c8ed1cdfc517297de99222193d5c656e17a22c685fe0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-6.2-9.20210508.fc36.aarch64.rpm"
+          },
+          "sha256:f247b28f422aa4ecbcff2d556429db9a59de36deb0c66394a801bd86bc4b2a28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbasicobjects-0.1.1-50.fc36.aarch64.rpm"
+          },
+          "sha256:f2be980efad7c111d859023ff1562c2b3663179fda9713e76946a12df33e3992": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.aarch64.rpm"
+          },
+          "sha256:f34685b66f0b0847aaac6903e0b92d2ff778e0d8f5e95c7852ee38bb87100a78": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.aarch64.rpm"
+          },
+          "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.aarch64.rpm"
+          },
+          "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.aarch64.rpm"
+          },
+          "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-distro-1.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:f7612c662435439a6e09ac050816590d1c98bacbce2d70c18696afe15272e205": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iputils-20211215-2.fc36.aarch64.rpm"
+          },
+          "sha256:f88d6063fe15fd262ed1a3531b74cfc5a76224fc3291099d3a6214717d2f2af8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shared-mime-info-2.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:f8efcccc5141a5360ab8af037ad9be02d2b617a43db19117133e672806245e34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/shim-aa64-15.6-1.aarch64.rpm"
+          },
+          "sha256:f90ba4f8bdcbb2a340d4ee9727d16e6808fcb850fe697d217a5a2ce496b0968a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpath_utils-0.2.1-50.fc36.aarch64.rpm"
+          },
+          "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:f94e4072a677d5315650798b6ad0251023e9dfe91e5eb933a5c0a44df1d54b6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm"
+          },
+          "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.aarch64.rpm"
+          },
+          "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:f9ae38a5147ae91c75ad22a30efc7cefaec4ab3dda140d19b410173461a4752b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-scripts-22.02.122-1.fc36.aarch64.rpm"
+          },
+          "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:fb3668ab3897dc10e8ae032491b2597cb07b066232bc8cb0c50d9c4f506c379d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:fbd583bf2317307de7e6610c39d65e3013b33570151d141fc3997f2efb73e22c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-build-libs-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:fbdaaba781d15ef4acf291749a770ee2a6a83a60d0f7680997300a07951fb1aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mdadm-4.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:fbf042700542b50ce9c93e1457c1d4d49cde8cf609562ebc46ef38be3a8e3be0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gdisk-1.0.9-2.fc36.aarch64.rpm"
+          },
+          "sha256:fc45c301e200fee07cafcd3a3e10f4c139fa4a9ca1f181813933fa92569c4e68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nspr-4.34.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:fde5b07254aea246a374a735acc04ef3f772a736e3188cfb06b462817a17ad36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-nftables-1.0.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:fdfb32e0a20b992aa5264195c22882bcca86c46be2d82d1f9681dc1acae4fd47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtalloc-2.3.4-1.fc36.aarch64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.aarch64.rpm",
+        "checksum": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.aarch64.rpm",
+        "checksum": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.aarch64.rpm",
+        "checksum": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.aarch64.rpm",
+        "checksum": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm",
+        "checksum": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.aarch64.rpm",
+        "checksum": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grep-3.7-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.aarch64.rpm",
+        "checksum": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.aarch64.rpm",
+        "checksum": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.aarch64.rpm",
+        "checksum": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.aarch64.rpm",
+        "checksum": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.aarch64.rpm",
+        "checksum": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.aarch64.rpm",
+        "checksum": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.aarch64.rpm",
+        "checksum": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.aarch64.rpm",
+        "checksum": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.aarch64.rpm",
+        "checksum": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.aarch64.rpm",
+        "checksum": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.aarch64.rpm",
+        "checksum": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.aarch64.rpm",
+        "checksum": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.aarch64.rpm",
+        "checksum": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.aarch64.rpm",
+        "checksum": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.aarch64.rpm",
+        "checksum": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.aarch64.rpm",
+        "checksum": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.aarch64.rpm",
+        "checksum": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/popt-1.18-7.fc36.aarch64.rpm",
+        "checksum": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.aarch64.rpm",
+        "checksum": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/readline-8.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sed-4.8-10.fc36.aarch64.rpm",
+        "checksum": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.aarch64.rpm",
+        "checksum": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.aarch64.rpm",
+        "checksum": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.aarch64.rpm",
+        "checksum": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.aarch64.rpm",
+        "checksum": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.aarch64.rpm",
+        "checksum": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-3.0.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2a08d286b9015d162f3e8248e8ced742d9065e54fcc33a01689714a1d0b64651",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bluez-5.64-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a141789dc071c315b35f694a589c21db351c78edcaa4634dfadbed07878acf8d",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b26994af6e0aafe1706f898ed1be912044c648b6c2633a5b6ece597a524f0cd2",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.aarch64.rpm",
+        "checksum": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/c-ares-1.17.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:cb7a19f92b0b42f970235c99f6cd1b0b7fb6c466ae63cf87805eb60711964745",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.aarch64.rpm",
+        "checksum": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-dicts-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:884646f991f0933338144306ae6b9d67236f62e443707543c4ce901564a69bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.aarch64.rpm",
+        "checksum": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-libs-1.14.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:852a03da5786a6a5606376c9541141b9ddefedceb36e2694e5cd9c9b7a5e059d",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/deltarpm-3.6.2-11.fc36.aarch64.rpm",
+        "checksum": "sha256:126f3ee41c2bb96347d3ab0229bb006a989f7e48ccdfd44d3862afdee6eac107",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm",
+        "checksum": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dmidecode-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:38ebb700f11be9e1ac2f8753e6037648b53c937411b1858a08dc29ceecb813db",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:41c95fd87ce2a0b728954ed6848ebf80e4519837f745f6dbeac729f2abe3b651",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-rescue-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e178cf8f39471a8829e584f3c1e9d94fdb621709dc1bc7dc2e230bf21b665bdf",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "5.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efi-filesystem-5-5.fc36.noarch.rpm",
+        "checksum": "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efibootmgr-16-12.fc36.aarch64.rpm",
+        "checksum": "sha256:8d3f567968ae37eb62da4a462efb65e9ac701e1e5c653f031b56c41011b2cad0",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4d36faded5e082ec50b4cdde0597f1c05455a16418649fd5b519cd5ee70c385b",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-modular-36-1.noarch.rpm",
+        "checksum": "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/firewalld-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/firewalld-filesystem-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/flashrom-1.2-8.fc36.aarch64.rpm",
+        "checksum": "sha256:096c032db3c0c78df89b0e051f1f807b77b4a4661fd59437e0e489cc9fbfe1c7",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.aarch64.rpm",
+        "checksum": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/geolite2-city-20191217-6.fc36.noarch.rpm",
+        "checksum": "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/geolite2-country-20191217-6.fc36.noarch.rpm",
+        "checksum": "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.72.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gobject-introspection-1.72.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5c3f31303fcd1c402f9c8dfe908e76a3c1bb818a2bb72bb918b6fb8e5c13a615",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:a93ddba157c3ed782eb2837d8776015b502e8340438fa0fc542325dfc0ad8f0d",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grep-3.7-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/groff-base-1.22.4-9.fc36.aarch64.rpm",
+        "checksum": "sha256:3274448af5863e4d033cae37e1283c647618ee95ea9e5b5dae485db15b915239",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.aarch64.rpm",
+        "checksum": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.aarch64.rpm",
+        "checksum": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/h/hostname-3.23-6.fc36.aarch64.rpm",
+        "checksum": "sha256:6adf1b0421c75dfb110ddd7246bc9809b20826da096a3fed2524aafa3dd688e6",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm",
+        "checksum": "sha256:5e718c0fbbe1aa1811ac61df7a8d1d7b284ed969fae26da057a46155788e00fd",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.16",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/initscripts-service-10.16-2.fc36.noarch.rpm",
+        "checksum": "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipcalc-1.0.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:af613725d58b9cb001a9ed68bdb69cca8c85c0057f46f572685414cf2f40388b",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.15.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iproute-5.15.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:20c9d6f3e8674e639c0d370620654cf9556c570cdf06cdb4ab33fda6d57aff34",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipset-7.15-2.fc36.aarch64.rpm",
+        "checksum": "sha256:814cab6e8a8ce7ed2a001be07bd1803dd0272297773f6f484eea4fcc0abef9c0",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipset-libs-7.15-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6f1e84b2dc7e805a465cb79a81322cdb6c0ba2bdd825a303072167f6545654b2",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.aarch64.rpm",
+        "checksum": "sha256:7ac5303ac6a3e0bece7270d9b36a5c3f7d522374607cbafc74bf04c72fc5f3d3",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-nft-1.8.7-15.fc36.aarch64.rpm",
+        "checksum": "sha256:5b2aa00b613a153dc0963a25e1b6212b7aafcebf238e61f67febd4c57a626a53",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iputils-20211215-2.fc36.aarch64.rpm",
+        "checksum": "sha256:f7612c662435439a6e09ac050816590d1c98bacbce2d70c18696afe15272e205",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:32bdee52ac0cb28a8b55acaf3fc80e407d79758099da5487838cd41c871b5812",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "13.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jq-1.6-13.fc36.aarch64.rpm",
+        "checksum": "sha256:8a548ba4d90ce68be3ac7083c86d89465dcbc85339f03399b102eac973252ad1",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.aarch64.rpm",
+        "checksum": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.aarch64.rpm",
+        "checksum": "sha256:63a7183b381bcdc27a0f40f49330acdf1d8df39f38ac5a41fcfd6e300d4ceb44",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.aarch64.rpm",
+        "checksum": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/less-590-3.fc36.aarch64.rpm",
+        "checksum": "sha256:8571e0aaae58fae1f5c077f018d8c8e7205f6d759c07a0c174e1272c7698e44e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm",
+        "checksum": "sha256:b62055e75833f9668150628dc7e8f9ac18c52d8876dcdf1a7882b871b26300b5",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "22.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libatasmart-0.19-22.fc36.aarch64.rpm",
+        "checksum": "sha256:6f9f65c27c5d61050717ff42938f5b1e588b73b0d96aa5f85599e0585fd12dbb",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbasicobjects-0.1.1-50.fc36.aarch64.rpm",
+        "checksum": "sha256:f247b28f422aa4ecbcff2d556429db9a59de36deb0c66394a801bd86bc4b2a28",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.aarch64.rpm",
+        "checksum": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.aarch64.rpm",
+        "checksum": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcollection-0.7.0-50.fc36.aarch64.rpm",
+        "checksum": "sha256:dd3ded5f10c06ebc2ca7fc9e4ab89dabc1d6cdb3d64b8b717de495e95a6d0c68",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm",
+        "checksum": "sha256:e1937625b5b6344ccef8ed465a2a4b4d73e1265cf327f20f0dfd5ebae51a4858",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.aarch64.rpm",
+        "checksum": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdhash-0.5.0-50.fc36.aarch64.rpm",
+        "checksum": "sha256:c468c65cb0f9660357380096464e136fbe851492b75e229a2caebf1b47960b9f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "41.20210910cvs.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.aarch64.rpm",
+        "checksum": "sha256:12654036e2d1dd40bff4e9c81a48a6ea85e52484b548382177f3f4ccf905e6a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.aarch64.rpm",
+        "checksum": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm",
+        "checksum": "sha256:a1eafb080b3662d4a6defb25434390821aa04bd33588ae763f676a9719cc6ead",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libftdi-1.5-3.fc36.aarch64.rpm",
+        "checksum": "sha256:905194dbd14a47d86152644643a9fa69992465f39cca7de578676fcc9ce4f7c2",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgcab1-1.4-6.fc36.aarch64.rpm",
+        "checksum": "sha256:0395ad209dc004e63178aabe17031446693f54d961695a520f67ba432c6ee82e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgudev-237-2.fc36.aarch64.rpm",
+        "checksum": "sha256:cac3a8242ae62dbfa931be632123487920b635a37858f6e54e3c0b89d3ecfd34",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgusb-0.3.10-2.fc36.aarch64.rpm",
+        "checksum": "sha256:57bc09a4192d79a1c48d9f770daded8ac8d94dd177974608aaae88868e5efb07",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "39.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2960bca7d94a6533182b3d72331d3369c774bc5ee9cb842b6a2acec83c53bb6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.aarch64.rpm",
+        "checksum": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libini_config-1.3.1-50.fc36.aarch64.rpm",
+        "checksum": "sha256:a06ad3aac9087efe26dd1a00ca34922287292debc1a0a61f8b7a74cd1849e0ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.10",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libjcat-0.1.10-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9251a60ce56aed426a00f82160dbb3f93493f2c393632b78c52b79db43d8cf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:f34685b66f0b0847aaac6903e0b92d2ff778e0d8f5e95c7852ee38bb87100a78",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmaxminddb-1.6.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:292256d4c9001078c7ee49f703fe7630b1622f514510a5c8ab33acd5235770a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.aarch64.rpm",
+        "checksum": "sha256:0855f5b2b07917099be76c6813474b45cfa73d7ee5c3afad4e20d3f9ccc970d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:bb7051047e7a1e8bc3b4960cea2dde77ec452c18383d16f2258216f489100525",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libndp-1.8-3.fc36.aarch64.rpm",
+        "checksum": "sha256:d690dfccef93e95be27982044eef6a4d0251c77e94c7304bd99de45c20c238f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.aarch64.rpm",
+        "checksum": "sha256:8eeb1a2e783a61a814b20b12cddb3ffec8b27c02c6fbdcbf3cdef583fa59fa04",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "21.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.aarch64.rpm",
+        "checksum": "sha256:8c0ed9385ccb82bec74755e2ba3977a1edecfc449998b88e03e1096f8f5084d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2498f161d9d4d847efdc08c44edf420a8eab5605572a98ddded1ddce78ffdb57",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpath_utils-0.2.1-50.fc36.aarch64.rpm",
+        "checksum": "sha256:f90ba4f8bdcbb2a340d4ee9727d16e6808fcb850fe697d217a5a2ce496b0968a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:9caa3d6d1d101b8fccbea3f13004308300b326dc675989bac3b3a7d178201812",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpipeline-1.5.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:ed120f43b16b9ea8473b4ff6be591de9f4c9f3724c7f232b76f70764b35018df",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.aarch64.rpm",
+        "checksum": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.aarch64.rpm",
+        "checksum": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libqrtr-glib-1.0.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:706ca338a869ed017d3e0c4c5d8d8541deca2579a9a4afa0e87a73dd024cf558",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libref_array-0.1.5-50.fc36.aarch64.rpm",
+        "checksum": "sha256:c1335f3bc82fd0981738f4b1c6eea10f55af5e2a481977c87d32e11a7f21889b",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libreport-filesystem-2.17.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d17ce6aa8886afdc6acbf54208c18b49155e9169e0804eeb4958105d484c930c",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.aarch64.rpm",
+        "checksum": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libudisks2-2.9.4-4.fc36.aarch64.rpm",
+        "checksum": "sha256:28c22176fa563a26d898595c71215b5ad687748024138721500976ecdad6d10f",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.aarch64.rpm",
+        "checksum": "sha256:f2be980efad7c111d859023ff1562c2b3663179fda9713e76946a12df33e3992",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libuser-0.63-10.fc36.aarch64.rpm",
+        "checksum": "sha256:0f4d63c769183bbb950de6ce0e257c68f56d377baab6bfd89fb4351260717b81",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.aarch64.rpm",
+        "checksum": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm",
+        "checksum": "sha256:f94e4072a677d5315650798b6ad0251023e9dfe91e5eb933a5c0a44df1d54b6d",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lmdb-libs-0.9.29-3.fc36.aarch64.rpm",
+        "checksum": "sha256:9bce33c50c5cc10387ed614ee8e1b91e304ce439f2ece1c590065a026655c8ca",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.10.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/man-db-2.10.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:18e6c9215635ae3603ca0176b0b59cb81b844a7f91b37ebf3a6251a2a5a4a280",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mdadm-4.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fbdaaba781d15ef4acf291749a770ee2a6a83a60d0f7680997300a07951fb1aa",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.aarch64.rpm",
+        "checksum": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nano-6.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c504b5dc406c2c1414fd5f2d15e0e02f1085e31f32a9f8b4df2315ffb19015e8",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-6.2-9.20210508.fc36.aarch64.rpm",
+        "checksum": "sha256:effff0e3bf2d0dcfc701c8ed1cdfc517297de99222193d5c656e17a22c685fe0",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.aarch64.rpm",
+        "checksum": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:d62545616da3a47fd25b32f03fcfa2f35473d111b972f10b33393419b96773e6",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/npth-1.6-8.fc36.aarch64.rpm",
+        "checksum": "sha256:5cf4d3f64e9460dd6206027f5760b3ad5b1284f0a33cddba9c34c7e03a87f794",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-8.8p1-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:51a67a8e86ce54b668fd70163798e3f1083ab04605f43b00028a37fe214c3817",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-clients-8.8p1-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:58cf82736ed0d866f86f4fa396eae4c6267b0ba7851d9e456d1d721e4c7dd423",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-server-8.8p1-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:55d253ad1a90b0dd8079b93b13167627f49d6e11c2d4ef4054af931403d1b1c4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.aarch64.rpm",
+        "checksum": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.aarch64.rpm",
+        "checksum": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/parted-3.4-12.fc36.aarch64.rpm",
+        "checksum": "sha256:afe8edcd9ce0b0d86ef388100d88c9d2a78672d08c3be56ed28eec3766e85ea4",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/passwd-0.80-12.fc36.aarch64.rpm",
+        "checksum": "sha256:e33fd672f043426d3ab578d2b72fe2a969e54acd7c7df32487e58c1861d5ed3f",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5b6a7cf86b9a8741590da8a1a72a20cea153babf004db8f543e51ebedce6df0c",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5edc290d9f5ab21421fd23f0454472ca1086fdad55bc0c1ce992684788a47b17",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-22.02.122-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a97dc4e08be47862c1804038ff1035d767979f80e9d37dcecfdff4984fb82426",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-core-libs-22.02.122-1.fc36.aarch64.rpm",
+        "checksum": "sha256:54d879df37f53234af6ef191b7427e2c5c4402b4c0c0e808a40a16820c5a5bef",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-scripts-22.02.122-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f9ae38a5147ae91c75ad22a30efc7cefaec4ab3dda140d19b410173461a4752b",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.aarch64.rpm",
+        "checksum": "sha256:ce799cfef53276047634cf1418c6463c2bd06ffce8d3b41272cd9f3e16d2d242",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.aarch64.rpm",
+        "checksum": "sha256:07d6ac3bde8fd80b026d90087b17816aa544f60aedcf67c57cabb83bfba68112",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "21.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm",
+        "checksum": "sha256:36844ba28f2810c5cf2c9bf29cf669923633ce092eb3da22e19a914c6b4c4423",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/popt-1.18-7.fc36.aarch64.rpm",
+        "checksum": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.aarch64.rpm",
+        "checksum": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:70672771b5d1207a7994f362e2ffa281f086f8f186f4a1cf7cd880860e2398ff",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/psmisc-23.4-3.fc36.aarch64.rpm",
+        "checksum": "sha256:7741248fcc49a78a93652544bc8040b553cb5247b033591391a0b4e548ea0eed",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "8.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-dateutil-2.8.1-8.fc36.noarch.rpm",
+        "checksum": "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-dbus-1.2.18-3.fc36.aarch64.rpm",
+        "checksum": "sha256:a8c4a706f63a757c207a3b2f7fd0d5798e8c4e1c0d1dc7460966ab0e930e1b76",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-distro-1.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-firewall-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-gpg-1.15.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:28988067197e9ad286df064d9c28fb64d0813fb45915d50b6e10916cbd2d54f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm",
+        "checksum": "sha256:ee8470ec697de1eeac209ef3b08c5a68d9dc45039d0eef7f778462e0ff6ae97b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-nftables-1.0.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:fde5b07254aea246a374a735acc04ef3f772a736e3188cfb06b462817a17ad36",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-rpm-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:43c817e2e39c45fc3056cfedfd3af60b3f221c6abd6912d56e4492c9376dfe21",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "5.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-six-1.16.0-5.fc36.noarch.rpm",
+        "checksum": "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/readline-8.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "31.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm",
+        "checksum": "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-build-libs-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:fbd583bf2317307de7e6610c39d65e3013b33570151d141fc3997f2efb73e22c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:e299af5e2cf5530f50f128f24d24f98a74212edb511257266a524e9fb7d09703",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-sign-libs-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:995b579ad1e52d4ef1725862f1d40d8f51959d13c8fa1dac32837cde752d206d",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sed-4.8-10.fc36.aarch64.rpm",
+        "checksum": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shared-mime-info-2.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:f88d6063fe15fd262ed1a3531b74cfc5a76224fc3291099d3a6214717d2f2af8",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "5.p2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sudo-1.9.8-5.p2.fc36.aarch64.rpm",
+        "checksum": "sha256:bba50d4ba38c5cc615d67e39d0a197eb55ee14f9dedddf831a7888a5da138af3",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "5.p2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sudo-python-plugin-1.9.8-5.p2.fc36.aarch64.rpm",
+        "checksum": "sha256:4f46a54f9379b4959f7e7a9d0d97436a36ebfb198bab76b91f44b00881385afa",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/u/udisks2-2.9.4-4.fc36.aarch64.rpm",
+        "checksum": "sha256:86a25e18a0d5e1c314e35653ae975f01dc951108467b021a2d24da0a7a896dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/u/userspace-rcu-0.13.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:bf034a64a7f5b0c4abb5da8ff274def143c12a0ec5a043b28048c2c854c56e17",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/v/volume_key-libs-0.3.12-15.fc36.aarch64.rpm",
+        "checksum": "sha256:6bc2bfb1fe071a65bc4ad3fed6a107457c2e4875aecdc8d42fd866aaa417fc0d",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.14.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xfsprogs-5.14.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:eb0a844d22ec62c476a689afad1f62e152de69f56d35d4958098426c9c53cbde",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.aarch64.rpm",
+        "checksum": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zram-generator-1.1.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:39e2a80b7b68271aca9317ff0d96183a26d5077e3aeef8ca28269c28dda72a0a",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zram-generator-defaults-1.1.2-1.fc36.noarch.rpm",
+        "checksum": "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04",
+        "check_gpg": true
+      },
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/ModemManager-glib-1.18.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2e070ecfd7a0068d61423ea75d1608a5a9013a01a319d2bddeec8a965cea5a0d",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.38.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/NetworkManager-1.38.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:3032035b371e27c6347c1fa7f01a802cb451c699095d68cbcec22c70471b2b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.38.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/NetworkManager-libnm-1.38.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6141c8c3bbed6c6fcd4a69041ae165b7bf1d58d88f533be47d9f8a5109b64be9",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dhcp-client-4.4.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:cb397c60cbb5cffa69fbf48a0570fa60c9f1d14a7c3df5e5016145e94c49c07e",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dhcp-common-4.4.3-2.fc36.noarch.rpm",
+        "checksum": "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-data-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-plugins-core-4.2.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-1.8.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:ac3fc3af7df5af00455180726fff651412eff2423614b57cc00e9e798e5f5da0",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-efi-1.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3468c03d68ee562d80f7a2bd830e54abbc95f7c915028c78ec4a8cc2930f790e",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-flashrom-1.8.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dad7181357cf9ad9f6b43663aa67d16993355b140a900db1ce7b274808893b06",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-modem-manager-1.8.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c297d39659648688bfa140649057942fbde26942f9388f8a2f2a6f3b89feab1d",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a91d250ca05b736fc50e8c2b029f2ee0f160dfc639287cc0b419ee7dd17d898e",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gdisk-1.0.9-2.fc36.aarch64.rpm",
+        "checksum": "sha256:fbf042700542b50ce9c93e1457c1d4d49cde8cf609562ebc46ef38be3a8e3be0",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.72.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:065befa0aa9e24df7b5c5c29943ff559b0508600a668ede3f75aa86dfb306ae1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.aarch64.rpm",
+        "checksum": "sha256:db82a25bca1d37ce148e2b7fd4edbf5ef673573a650a46ede399f92d6c5d1384",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d580be005d64283434e750f9ef760554ce814dfaa527699541a655f5d7de4d8c",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.6",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3d3293398c397ada3d74243def9e2aaa72b2944383924213aef7fd8ccfcfcbf5",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-efi-aa64-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:5fc05299dd26a52da3011a466b1454da89727ab7dd7815595bd162b83adc28b7",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "55",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/i/inih-55-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d317220153bb88b12eb170b840dc08b2b2d82e95811be4cd4437c29b0b80a58a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-5.18.9-200.fc36.aarch64.rpm",
+        "checksum": "sha256:543d7ee043aa48bbe5e59e7c3be68a1e388165b2d739975b05875c50b5787e17",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-core-5.18.9-200.fc36.aarch64.rpm",
+        "checksum": "sha256:ac55ff27ae14022eafd2045548223d137159d9d593675cbb99a41143f7ce9e99",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-modules-5.18.9-200.fc36.aarch64.rpm",
+        "checksum": "sha256:42bc60e4eb49930b10fd5c8567d82aacd7bece633b47f25773ff75d9591f7740",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.aarch64.rpm",
+        "checksum": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.aarch64.rpm",
+        "checksum": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fb3668ab3897dc10e8ae032491b2597cb07b066232bc8cb0c50d9c4f506c379d",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-crypto-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d4f1a2968526b12ffba46005e3136b7e561e9fc9a415270884d74824e4d4c248",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-fs-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:103b7bfd272a52e9b3d2c455c0dab98103635ca44c225c3460cbdc32682e9510",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-loop-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:83c0479bbcf44639596f844f0ca89bee8b8df547cf63ad6d95e1e42cac505ddd",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-mdraid-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:54916f1a8a37e1e569d984a965e420d0d90a172176128b4d841976ec324bf41e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-part-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e7a9c68d4537d5085f2da7bea020c15c1bc99d80a210d07ccf0aa1bc1f8535fd",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-swap-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3150aca3cbb4c9e18866293fb7c78ebf88c781fb0ce0e82ecbb56216153eb142",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-utils-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2168561de6b48e138ac894fa7bdccd054603516c5e1acae01c1f06de96376580",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbytesize-2.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:19414d35ff0112965137f13f5b65f76ccceae4f11b76430e2be5e5fbaa7d1410",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-python3-0.8.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e2c8cf981ac3b4ce62fed5fc692965ef1db5935df990bc024781785e354dcc16",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libdnf-0.67.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:cf7fd9b6579cafbaf0a8eb7f2b920b811a9eb140100e1c3757ed8e3d8981fcf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "69.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:3d86220c34713ac28d674be349ccc9eb53aa790c2b39025596532ffb92eafcbc",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libldb-2.5.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:1513639e8a21c9e23c998dad07484abb911441a7a614790a0cfd42789446c8ff",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmbim-1.26.4-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8defe410aa1c967c90c87bfcffb39cda4ef7e22dec00cfd9b4d7fe4cdffbd1ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.6.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:26d9bfa8bcccabc4565c64027146f39a11f4750e937179a9e023ec272aa3a480",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libqmi-1.30.6-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c2fa391f0c8dab9b77728f5506a1cce5f644a6399c57e230f24da11edb645764",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6619af57c800fb5ec8cdd5ec8ea070897f012c968235f748e313d4de71abd342",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.aarch64.rpm",
+        "checksum": "sha256:364f7226e498df8c3100d07a2795413268fdc1bc0ef038e3b58265d1f45bb0d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_certmap-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:9076efd678b1ce0c33b970507a60d055f94fe9f764dd696ded14271d79f2732e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_idmap-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8c2f825a9c528760b292febdcaf6c2a90e4085a5654e5e47fff04aceb9ed25a0",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_nss_idmap-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:d4af1f337b8fba9e963211d361544438cadfed85b6bad7da4d924989bfef80e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_sudo-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:20c18c9dd69a8a760b193d007ceb51696d645c870674e423f2028e27d8b162ee",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtalloc-2.3.4-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fdfb32e0a20b992aa5264195c22882bcca86c46be2d82d1f9681dc1acae4fd47",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtdb-1.4.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:20c7cb6eed94c035c9b1e3a24f839a4dbbd6ef33bc66795f2d4a860b7734c9d3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.12.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtevent-0.12.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:4af8d1faa176bd1fe8271b2bc4dbff6bea7331e3ec696155c87011c367a48467",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.9",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxmlb-0.3.9-1.fc36.aarch64.rpm",
+        "checksum": "sha256:08752167a3f35572f3aee4281ccb0925a91e88a04448e13c41a7fd66fbe8f0ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20220610",
+        "release": "135.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/linux-firmware-20220610-135.fc36.noarch.rpm",
+        "checksum": "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20220610",
+        "release": "135.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/linux-firmware-whence-20220610-135.fc36.noarch.rpm",
+        "checksum": "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mokutil-0.6.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3a2faf2c81074e12b902585c1dc9df7a5c4dfe9abd651c9849a5cdf52462d2b5",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs91",
+        "epoch": 0,
+        "version": "91.11.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:aa387421816ee1b9b1313282810c8a05da4175e3817f13a71486e9608a3617e5",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:168429c25bcc7d36dde47ef25e5aaf1ca50b7f6f9350a058c45f4e67d5cdce40",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.34.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nspr-4.34.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fc45c301e200fee07cafcd3a3e10f4c139fa4a9ca1f181813933fa92569c4e68",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e2c31e98b36dcad624e0b01560f97aaeabd212979b19904fc273630f71ba9f0a",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-softokn-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:724954cb4c5dc17ebd72ac3d9b58ff5d4df10d235ec5f4d7b48f852614c0167a",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-softokn-freebl-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6c28a0626decb9d370ee2a0119c041dceba4293715df8773991a8c8ed5abd96c",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-sysinit-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d7073d75482635b4d8f9cd4955447edf54c0bedab4656c71fd76ca5f97479020",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-util-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:23b6dad4a3d114360b897128785498229edcff1b1a9f18016cdabdc1b4b8a719",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-2022.5.17-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6c80b2a2f0b2e3daf7f3feaa708bea6487a17f729ee80be687ebab9ea8fa85fa",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-libs-2022.5.17-1.fc36.aarch64.rpm",
+        "checksum": "sha256:33e0afc0fd03e559ee53e6179868783da343158d8257e6401b3def99a59ac67b",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-system-compression-1.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:5a5a6f87ef42ce9bce5bb1cb4308eed0b85ea020d870bfdcd2baac3e471fe7ee",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfsprogs-2022.5.17-1.fc36.aarch64.rpm",
+        "checksum": "sha256:912c53614e3488d3ba7226a4615f43c59fd6f63c18baa1fd38d2d5093abdc6f2",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/oniguruma-6.9.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:558d90151758e0894a377aadd6f4d651f139e7491f211c4d7548f644a55675ab",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap-compat",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-compat-2.6.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8beac96d9b0e29c84ec86a891585c48f2db50248f2e4e361936e56d0eb5c6d33",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.aarch64.rpm",
+        "checksum": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:ab0f174db1bf134f5288510c8c7c0fa64d3d28ac85ed45fb58d6e0d4ae8af564",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2646322ae496c10f0ad319945a943e726010e2e1e6e7dcf904b7ffcacff9662f",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-dnf-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-dnf-plugins-core-4.2.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-gobject-base-3.42.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:913ac376a600ae00bcc55346bbbbd1b52e2b77713ff9fe01ae564a72fa337531",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-gobject-base-noarch-3.42.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-hawkey-0.67.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:d2fdac173bf9bc76ee4dc10cdca0b7e27666b722edf72dd0275410d2b8aa4eac",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libdnf-0.67.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4df251d7f0566e132997e1813732b7f315a4d64e706b0377e4b97637a1ced615",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-unbound-1.16.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:4ce75259eee99d0f7c5a7a3a41169b22059c9996bd7c0de7509ff63f363ef5f2",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/shim-aa64-15.6-1.aarch64.rpm",
+        "checksum": "sha256:f8efcccc5141a5360ab8af037ad9be02d2b617a43db19117133e672806245e34",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-client-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:06667da4cd013c4a8c06dc2af38f243ce14d947c0af801b0ee5a49b41ee34944",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-common-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:30dab70d00871471edc0c2e9fff73780297291e4740243bc3af3f7c99d32c599",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-kcm-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:632e6035364601a88d882591ab095bdd32cbacdb66a5bf9e12ad1900b6494b6e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-oomd-defaults-250.7-1.fc36.noarch.rpm",
+        "checksum": "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/unbound-libs-1.16.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:1f5e069f7741d6a5278149c5d9953aab4c421c8dd617bf2eaee900c4f2238ca7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.5172",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/v/vim-data-8.2.5172-1.fc36.noarch.rpm",
+        "checksum": "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.5172",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/v/vim-minimal-8.2.5172-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2ee60160a557cdd0a9180895d929366b2fbc1ce570f4d5e255f2b6be56d75353",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/y/yum-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_36-x86_64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-minimal_raw-boot.json
@@ -1,0 +1,11357 @@
+{
+  "compose-request": {
+    "distro": "fedora-36",
+    "arch": "x86_64",
+    "image-type": "minimal-raw",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-modular-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-modular-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      }
+    ],
+    "filename": "raw.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora36",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bafbc5e2d6b05c4911cb000b4f80f7475cac9afcd14172b26a8b0038c8491f1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4db9bb285f364b472000badad7fc7e29999f8edf0b62b6d1ef5d379435fd165f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28b98634695e2f0a9f5f616b84ecb21d2726f1b360ca16ba8f48aceda4a8e0fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9e689f42a53bf760c2d56e0254f4c69213f13b57b1a0cd12ee2ef0529c6f70b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f7516bcfc6dae3781d581225f488e410531184b85bb221ce409bb7583fc20439",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaeb5140174492d0bd26806a079ae00c26e78da1d67aecbbdd274e1e74f4ca93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89ce9d545da60404ed91ec236b2d3040c3fcbc9c61658c0a07baf0adcb512360",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ee89bb45ed9fea2cd576a967978acd3c93095f22414fd81e2042522ec04d79e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55b9b9595efb83f4f6638c47125817cabb3b486ecbc786d4ce2b014e8a81cca9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c775dfbd34c0f950be4aa77dd67f7d9b30c880f64b29b453896d83812a69722f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6e85834503eae1bf62340e8d24b208faabbf632151425675dc4075a27e112f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaf42f29c0f991a0059fcaa41c79b1ebff0c243c5b8f398bfba2aab2b5c89cf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c4dfb2d2b98022bdcfa0bcde99345c340ba2ec1cbb19ddc33a02dd8f70a12e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb95ae512e34a19ec7d2b4f36e244c7fbb2622e2046a79aa7f9cf514d817a9ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4cf97f8df32e57949d6cd29c95da335bc3f1b8bbe8d5f73dfb327e64fd500e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa180f3216a84395f92ca6e4044b5f8067c351cd516d91c25a16335cabe4a43e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6828edb88734beb0ed0a3f92257c2d8528fba1fac90bfd44747d8491e83eaf57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20026a80599cc22463cefafe5607d90d249dd414306e5f3bb5616cb45836403a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90373252c19e5af71af8c0db1775727a9fc66e801bfa94390e8e482d38c209bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1adc225761ab40fe003e4136e8d327e8afa0fe5da74d1aeecebc706b2ece4f8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ca472a7624eaeae3dcb111e9d9ba3eac791f1a44567c77c680f1a4b06f03e22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a24ce1c4e69fe649d79a58f2636e4891c365bf36c3c9a35c49114fe72df5426",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6218b686e396a0eec312f93e7d1418e00b7a32ae95926fb7d7835f44e72f8526",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43c0e8bfebcaa60781ebe874e6790fdeea4ea0fde572ce47d8cffce1f2f2c89a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3bea089c91795fb1754cbcd7f54f84caa5adff4a36422c6b74d150f3f30d4734",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aef4b7bd425f1118403818bf469878b1ba2881d21385074bec813d1ba3f3fb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdfa9da9d905dc4c5dd71a0b22a829bcdd05e9274ebd0538e57e18036fe63ad1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4538200e6752e1cc8844a50115193d736ee06d4fb6096c51bd925d1a2bd9bd8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b30ca62dd91fcddba2a393ef7e023ceb9f9ee2ac4d59b9a61d56ab929832da0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f4f8b80a39f4cde1a15072097cba266333cc1a840f494c7f33affbcc0f66f49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7169456c74b621072ff489f95505802556ec1598c9d69185c95904344e19f86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1c0911df45e7a2ed245ee9481ed9aef3c2264cf866e7237498f1d24140054c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2f4ad1b7ed2110117dae0e82ab0478be595cc8c0491b18128165bc825e389a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5599f35f62d74cde1a7cec626faf41c1aca4b4b872b1a017adc898a543179359",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f2fa774b2b443df4aadea87a4e8efe331d67f232884d2be49921370d431b413",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dffa57881ede2980c3384f2d8890b60169581414031b25253f9bf032ae7ed48e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcf12edb225a10edfbf0e4af820fc6495997218b357c25ec638f6fa458fdc383",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f55cdb2f49ab0910aacfb5745b65291399a00fda3f012c624c464aee70457bbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d4db64668bfb08b1fe6be0276ef811e4c92239f27c0d45932b3287ae9639b38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d28889b38e09168928ff3a9e3acdbdcb4c8beb53f79d987b5471341e4e7ae310",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e83a644bea22129ba6a3ea31a7432418037b3e9440002dddf1c2cbbf0ce5847",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b4a9e98cb73582362e6e70390c1c643b26f50c289ea0acbc74b5bb75d85e23b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d02acd08b3208cd1af93820b7e8961538e4819c1903ec7452af12f4aad2ef91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c3da481a459d940f0e9d99f7e41b336e0709ef226bf7651cdce30b3ea0562df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60144990fba08c95b1f9fb68055d85b608870c09426af187b6048912b6337708",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:991f6fd822110685e42f499f3059cc5abab2beeff405fc24c74f9e89c41088b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9070b6896e9ea6dbfcfcbdcdf2d2e427603522e95187854dd10faf38f5a7b98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:995d03ccc92a1c35fc0e25a7f7ba3f4bde6bac5068220a0e2722f377dfaf26a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00cda4f023ab0f5d5b64f29cc36325e2b1395bf5c23547c515140051d50df1cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dae9a479c013680294508bf366c3501d84b1e7f564ee9f1d31af320ac150b95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc3339d24b5e60cb8967a671cd9dd357955f46c3825ccf1e4a3b542dcc4ae19a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08786a771c7d95deefd7e8dea790e7e14fbf337c2fff980778005a9fb7a0050c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a397257a1b5fc428cc663bf266b3feccbe94198d5ebe93bc168022d64dbf4fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3dec50f65f6e49c3ce1c000af1006984c0ac7a5ce6b9ab28715de70abcd3c668",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:899f4f96d68160c167c1b59f8b3e0dd4e4586864c312e4377fc1a5cc58a054ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecd2362482d03354b6e79229bcd59533629c072982ef31b41762a888b7718b50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0c3b904030213a5c81258bbffe122d5f80b3d8115ef1d3062b18e7a1c20fe4c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62d444882048ea292185a97922b013e7b276fa257fae4cc8ee3ca92973f76ac3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a028d16393155c75d89016ddc1d5fa3b9c05ad3c6393aa6366a4ea330431532d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88c97e93ff20a638e697b0d02dd0c58ca413d0c135e85c8f9596c2d02ef29430",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c2e78543b7f7d2e9b4e9aa6e32170b386ec56da3266d56c7aaa229a17becf88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d514b1df4f58c8c23e7a386dc8edcf616339a0b2ee84aad2203c034c2cb439d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dd0909aa6d4efe3f024b1f52bfbcf7b4ec6e9ab981d9c18efce53ab4ea2fbce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23cc660bf40b82d9c1739412d9cdcaebb70da60ae2d05cf2a9fbea088f22cdd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87d94a884629f4538f36f1e54190dfd230dc7ad3eb44b8da31ee22d79794f14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c88d2e0f7ff66362269a62f5ca96ec627c18336a975d4aef2ade8ccb51ff32ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae93958303747451864dcd8092e402fee9b2cb56ab3442d847ef12852c61f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47bc2405ee5e88c02004bc467006df9a8dfaaf15e8d561891639d6825b41adc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7ec9cbcec2b2fb49e5959b51b8ca1fde6da526cbca9e89eb73e3eb04cddc157",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70f255fc22530dc6213d015700dd237d0173784e616cbc2ffc284e5a2f7b10c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6fb42c4b7617f96e5ef0c7050315d7a7e0a4100cec0cfee39722a8301ebec8e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a97a365db61e244f5b5b400f8e91b63b3beea0db30ab9e6a9c4664b0f273fc17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31879e909524e7e7971dc6d3858786a65ed4fba8f58e2f9d11029a2772ffb5cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfc877337ecf753c9b20f7d8ce2c4670936972dec92b5ce95e0d7b672b28b148",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d899a6ced2354d6e86191a85e08df4d581ff3bce47544300d07d6d40f258f32b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:57ecedb3b77bce1226a4bd179b6c6749bc56a6c888c6996504f45bd862eeec15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b59f54f0b25de26d10cbde4a3823a7420410a664eaeb3c5cedb6f0801d5da245",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c77199fb123dc6f9a0ce3f7f10e0f0519f2cbf5d5439e76d13df1837cd349934",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c7c429d157a9e803c56ac9b28bf74ae8908fc0d33515c9729ed51509a696026",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cb911922237fbb08da19a35b650aa3f9a3ea6dd48f74885b34337716373eb83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df15662946f61c06fafb3f9256ccd7170accefa3ddb348926add49f1b9995c44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d8ef454ffc43ea87c135c0d3df3ec23fa80a9042b8fb220db299cc9963c5e26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d995b70b266834c71640b61a57f4a83c011035cebea52813d9faca21e9bda52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d748ab15ed2bf7f64489dd6c0819ce7f5419af488322703553b2318c542c78fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cce2c735fd092558a5d050708e93200768f523bc36a4071a6c2857c6bad23f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30bb23da61ac270b3a011384f2e87a41d7a31e1808b21e6ca7caa60491c9c630",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c1eb0ffd38925eef11269d600d506a31581b3d7d741cae6557d021eeef5e6df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2eb7ace975fa86defcb8e5962e0636b02f62dc8fc1e733d1bc041b12bf28fd63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac440f60f60e271dfdcfdb16ec82cba720bb2f903a2f7cf2330bd4e18aa4154b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:daa3aa3f516d08d8a5053aabc521f8b3af4fcef3a1304a051ceca93ae18bfa3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00cb1f66de0fc574ae601b76b96c3326834a6682ff119445e5940bca2249302c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:777e4333ca9437d55b2bae930fadfe5db487ed6acd8a66ab42a7d0cd8680cf33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b401b7b05c6142cba74685a40d003d902de2a6cccd1c60134c618189073bbe87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43eb75ad2afc0b4a538cbdc6a0ae4a4be8c84d00a03aa450787b0702abd2e5c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26b776eaf819fc466d562e595860f86cf183066494d0577f146f6a2c9dc4c6d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a049afa68579427322ee38b9085251115a6c022786530d804d6a2081a84ceca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74c9d86eb0743f18d4fb25ac82e616b7103f5ca79c37aa8aa69be477b4d2a2f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dda1ae9c2d6920761996734c846883fe26d4a2222364fec6fde58fab9a9dc3dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad06336b4a496a063e390e0f6a15b08bfe2626465a3247a45f8c98c503a4b5a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a00fc7941175e0934b46efa63721dd9f45b23905b2afc1643f0113d13db63ed3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc1a60ef9acfc90ab773b2800eb515e3f9acd647827de3d60ee2390baf4d1f83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aa699025a0a751a62b20f9da7fbfc44c1de6517963f4c1195b9a4a640425310",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c7854309a224fbdb2715f943f8cd23f4c68038c3ae4c2399e2db092c8c78267",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd5c235acf908e4b0191f6f4b89589c123e218b21b991e79ecde140867b54282",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b360093e3a04856310a3c967b4c59a597ec6ff33826affab4052ca212676699",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52ac12150f661e1857b5abd1bdb57a2d6615cc26e35ba2990ee1e582907b3418",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12b80a2d8cfafd1112c6355e3886270610e816b453202595157a2828fa7aa452",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc2230cb7e68870285ecf11d82e8607e74d42f01a57889b3c3e1b1d9e386404c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:544a6838523a5a871c593097d5a48d37b7acf3c415a5f1a23e87854a730d45ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43ab5eacc5b675862f8821fa8328c33624eb945662536b737e2b4f064c4ddfe5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:404eb6145247a020308ae78c6d42c6a81c0cec7f0258a5f83578ce1b6a93433f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0395a5b8959a1cb66d616c758944e985c0f5864ea4e4527fea8e1224e2b0fd5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2da32b1fcc10b56b30f7939618450fd863c7469508250508060ebd36b61ec5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:035efd371a5a69a7ea1c833af1bdcf74e7f70b6ba36f961f37bddcc9732e0bee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d86ab10e70b5bcdfa8f437196fe10a8a5256cb16b941162e329c5d2eabffd70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:075b89e5b1b132eacb4e6057d00764c9ee342b95d926d819c0e711d2c3ee8ac3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e6402679ebbb705a4cb74a238d34fdfd62c395a8b3d28fc0faafc27e6f4a73f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c4a0eafc33b320af3e6c370d1e9d3506f92b02607ef2ec773c602ba504da00a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61544f1ac4a32d1903e24f406fa1286bf54d21151e460bec4b2bc046840a42cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bafc8af7a461cbed16417ffce4d30735895e5316d3ec4af7232951acad6fdcf4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e29caa9cbe813b19d8b22301af1ccc0dba47a401b7acf66eb658f3eeb5aa8ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1947cb52a8cbba29dfd79456fab69ee967572ca35855340e45b1b5a2b68e594",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adfa2718dc5d4bae822b5905f1628bdc0fa830bb06c561caa331716293a2d340",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12798887ed97a1746bb9551d61dee38717982f2587aff35dd4085adf9e95a4bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbc8762daadb5927a05241924646bd1a5149a52170d80558e78312f192a67624",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78f1f12225b42a3edcfabd694df561064ce39d02abd6d71bb85fe7beee747101",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20b5d48f802024c668285d4014c0a92eeed3031738474123cb5700ea5dfefa6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db1423134b954c1c00786cce7a2242d9fe98f26964f51b707ddf00f8fffd7e8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf0a6ad360f4ebc1b3e1f6d9e583751b100195f57106cad48cde4fe4a6eb7195",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9c2d1401d9c58a48eb7ee7ac873d97612662d65a4a5ead7473ec6b311145b87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:996f22624b2f771360c80b1724dcd63ea1132b72db52bf0887446f7fa1c6c7cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbac26c434fa5eb6ef77751738f9ef4b0e02d11e657812b388b6a047ab6fc7a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0a26bee81681c31c0ff8e3dfd5031b8861bdbdd5ebf25fc59763878ceef2d7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55085d771e68ac6ed4be095c5cce52bf39f49d0c65bdfdc92d6a0fe2493c99a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58e27f4659cef20e393eb063f6eae99ee32f1b421a55fb147d919bc36e42dba6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:866dc0c718466213e578633155aaa9d69fb860f1ac44b44611025a957780a8fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76842198d98983f83241be2ae73b24efd580ee0af7d0a5a301dd02a7c417c801",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:981e35ad67bb3aebeedfba78b4880e581d6a6db2b7ec4023484c94998fc66a5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb149c8897d2e78727e2dac441bcc05e064e045edb73705af0a0c57a5d17fe4e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae15191393ec4f56460271f47e1cc2ac7bc847ccb03eaf0035175d1c28c219a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c073eeb631912aa260da3cb99353cddff4e7f02ffebd775a329ef260ab42ff29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6cd3dfba9bd5c1d8527ee3ae8bae3bf7a1a375932f7fa4a1ee5c317eb70b0f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49b784fc4e9fe1bd00063c509f31cfc1e08749bb203804654f4a01214455853e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:011377565612bdc103fed99f4e041100a0a836fc31fd517baa998cba6549ada4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:234d03de5e310e9afc481eb35fb9b01072c6a946ec8c22c6429d33ec59a00eed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e791d318effa04ff1c463f60d0632acb5ff6f2ad6f04a836bbfdd07e500d91a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:929f61d675345450d11bc44ab2466cc621f9ece823b031c784ca79e657e179a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7130cc35fa8510939a0e7e72770261982f8a5b062253e85251288d0acf5f6e21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66ec27d6c6b52dcd456accf412d14db29ca5cf976194b721407a9f5feedc1dc8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94021f69bdd5e8be4b186081e6b5748a27b37e8d7762ca6b8973bc0f1ab8b16c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2b02e6ee909472aeb994d0040e1255ffd6c45150c32d9b084609d928caada61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e2785ea0e99173e686416f33d9cc80a74c21a836a25af89d5b50415c6142701",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8cc2172a8c6cae8fd0e3c56a266a20425194ed024b730d2f2d04ee3ab9bfb5b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d74d44ff991a85bc5aed1bf170446cb324bc8ba9f476a16443b856f689325e89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13aeb3b9889afb0dfe607b8e5a694f7debd69b5e92525e3bb8be606ef46a1c0e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ee2bd16b0321e89607019cc53a5972625f11e331f0a4e9af57e990bb6d6485a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b1739660922063971de03928e8cd7154d96b703099e669e8a9b5523c1522310",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2240717e975e4f42f07025fe33240470aef04dd9da9eeda02e7dc5e806bea24b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4bf6b2c21cfae19a0f3f4b0279823d1d7958c40b9bb483b825d30a1d9279ecb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e03035313c0396abf2c9acb21bbb5b303cc73726473ab115d1ba58aa1e3c7fb0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:429e1f761cf68fc139e64dd6bc3cbedfec8a10f244db9c87d2368cbefae73d20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa6dc185c17dd7421299c069850cb22fcc68ed34a9a5ff720ff03269b3d874cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db4eb4ae787ee174d1d2957c80b0413ccf31e0bb539d70ba7e0c606f102bb2de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7090f335d0d210b20ec4b8ac8adb1b801c51eea363d52d3b48f821512e38500",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:901a4d6e3875a08f48665f5ddb9d169d75639f85d93e1a877a155c026eaceada",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77d143afad8d60b1ed9a206e8a1e2c1211218e709eb2c830c8f07744b06aef1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05a455a9892b4c4c77255f1d396c738e2e46291e8c4ac381f2a343b8d98e1873",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9ad1c81ed20265422b5fcc8865f055a4172bc3325b9cb212ad073266057aab5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b276451caa30f1ce4739822473100781b3810423528a170c4ddd8405d1689f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc9e1d57af84ad965d533c76162c1d31808b96705a085e679e061f1385acb70e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef1f95d053d7c6dc6a2fc14039358f2db3db91b42ce79194a98c28a0c34376bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0580325e7f48f65cee2a914fb36712f068eb6202a607f962ee36b6e3cd9605c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e37d6a627ace13dd51f94114e5c669fa8a5a6f695bb9dc446eed1b9a9bd6919f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bfc17431245ff01b7431893884275d6357138d014d4634c073b20bb5007d798",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:853e915ae73a3b0a08f3cb36a8289552e488f99a4245c4bc431ff8ac531138bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.18.9-200.fc36.x86_64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "raw.img",
+              "size": "3958374400"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 2048,
+                  "start": 2048,
+                  "type": "21686148-6449-6E6F-744E-656564454649",
+                  "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+                },
+                {
+                  "size": 409600,
+                  "start": 4096,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 413696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1437696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 4096,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 413696,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 1437696,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 413696,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 4096,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 1437696,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:00cb1f66de0fc574ae601b76b96c3326834a6682ff119445e5940bca2249302c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-nftables-1.0.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:00cda4f023ab0f5d5b64f29cc36325e2b1395bf5c23547c515140051d50df1cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:011377565612bdc103fed99f4e041100a0a836fc31fd517baa998cba6549ada4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_sudo-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:035efd371a5a69a7ea1c833af1bdcf74e7f70b6ba36f961f37bddcc9732e0bee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:0395a5b8959a1cb66d616c758944e985c0f5864ea4e4527fea8e1224e2b0fd5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:05a455a9892b4c4c77255f1d396c738e2e46291e8c4ac381f2a343b8d98e1873": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-hawkey-0.67.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.x86_64.rpm"
+          },
+          "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:075b89e5b1b132eacb4e6057d00764c9ee342b95d926d819c0e711d2c3ee8ac3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.x86_64.rpm"
+          },
+          "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:08786a771c7d95deefd7e8dea790e7e14fbf337c2fff980778005a9fb7a0050c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.x86_64.rpm"
+          },
+          "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.x86_64.rpm"
+          },
+          "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.x86_64.rpm"
+          },
+          "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efi-filesystem-5-5.fc36.noarch.rpm"
+          },
+          "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm"
+          },
+          "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/geolite2-city-20191217-6.fc36.noarch.rpm"
+          },
+          "sha256:0e6402679ebbb705a4cb74a238d34fdfd62c395a8b3d28fc0faafc27e6f4a73f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.x86_64.rpm"
+          },
+          "sha256:0e791d318effa04ff1c463f60d0632acb5ff6f2ad6f04a836bbfdd07e500d91a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtdb-1.4.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:0f2fa774b2b443df4aadea87a4e8efe331d67f232884d2be49921370d431b413": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdhash-0.5.0-50.fc36.x86_64.rpm"
+          },
+          "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm"
+          },
+          "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:12798887ed97a1746bb9551d61dee38717982f2587aff35dd4085adf9e95a4bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-crypto-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-oomd-defaults-250.7-1.fc36.noarch.rpm"
+          },
+          "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-modular-36-1.noarch.rpm"
+          },
+          "sha256:12b80a2d8cfafd1112c6355e3886270610e816b453202595157a2828fa7aa452": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dhcp-client-4.4.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:13aeb3b9889afb0dfe607b8e5a694f7debd69b5e92525e3bb8be606ef46a1c0e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-softokn-freebl-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.x86_64.rpm"
+          },
+          "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.x86_64.rpm"
+          },
+          "sha256:1adc225761ab40fe003e4136e8d327e8afa0fe5da74d1aeecebc706b2ece4f8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iproute-5.15.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.x86_64.rpm"
+          },
+          "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:1c7854309a224fbdb2715f943f8cd23f4c68038c3ae4c2399e2db092c8c78267": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zram-generator-1.1.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:1ca472a7624eaeae3dcb111e9d9ba3eac791f1a44567c77c680f1a4b06f03e22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipset-7.15-2.fc36.x86_64.rpm"
+          },
+          "sha256:1cce2c735fd092558a5d050708e93200768f523bc36a4071a6c2857c6bad23f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm"
+          },
+          "sha256:1d02acd08b3208cd1af93820b7e8961538e4819c1903ec7452af12f4aad2ef91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libini_config-1.3.1-50.fc36.x86_64.rpm"
+          },
+          "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:1dd0909aa6d4efe3f024b1f52bfbcf7b4ec6e9ab981d9c18efce53ab4ea2fbce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libuser-0.63-10.fc36.x86_64.rpm"
+          },
+          "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:1f4f8b80a39f4cde1a15072097cba266333cc1a840f494c7f33affbcc0f66f49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm"
+          },
+          "sha256:20026a80599cc22463cefafe5607d90d249dd414306e5f3bb5616cb45836403a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm"
+          },
+          "sha256:20b5d48f802024c668285d4014c0a92eeed3031738474123cb5700ea5dfefa6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-mdraid-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:2240717e975e4f42f07025fe33240470aef04dd9da9eeda02e7dc5e806bea24b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-2022.5.17-1.fc36.x86_64.rpm"
+          },
+          "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.x86_64.rpm"
+          },
+          "sha256:234d03de5e310e9afc481eb35fb9b01072c6a946ec8c22c6429d33ec59a00eed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtalloc-2.3.4-1.fc36.x86_64.rpm"
+          },
+          "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.x86_64.rpm"
+          },
+          "sha256:23cc660bf40b82d9c1739412d9cdcaebb70da60ae2d05cf2a9fbea088f22cdd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm"
+          },
+          "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.x86_64.rpm"
+          },
+          "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm"
+          },
+          "sha256:26b776eaf819fc466d562e595860f86cf183066494d0577f146f6a2c9dc4c6d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-sign-libs-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:28b98634695e2f0a9f5f616b84ecb21d2726f1b360ca16ba8f48aceda4a8e0fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm"
+          },
+          "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.x86_64.rpm"
+          },
+          "sha256:2d4db64668bfb08b1fe6be0276ef811e4c92239f27c0d45932b3287ae9639b38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgcab1-1.4-6.fc36.x86_64.rpm"
+          },
+          "sha256:2dae9a479c013680294508bf366c3501d84b1e7f564ee9f1d31af320ac150b95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libndp-1.8-3.fc36.x86_64.rpm"
+          },
+          "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm"
+          },
+          "sha256:2eb7ace975fa86defcb8e5962e0636b02f62dc8fc1e733d1bc041b12bf28fd63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-dbus-1.2.18-3.fc36.x86_64.rpm"
+          },
+          "sha256:2ee89bb45ed9fea2cd576a967978acd3c93095f22414fd81e2042522ec04d79e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dmidecode-3.3-3.fc36.x86_64.rpm"
+          },
+          "sha256:30bb23da61ac270b3a011384f2e87a41d7a31e1808b21e6ca7caa60491c9c630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:31879e909524e7e7971dc6d3858786a65ed4fba8f58e2f9d11029a2772ffb5cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-clients-8.8p1-1.fc36.1.x86_64.rpm"
+          },
+          "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.x86_64.rpm"
+          },
+          "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.x86_64.rpm"
+          },
+          "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.x86_64.rpm"
+          },
+          "sha256:3bea089c91795fb1754cbcd7f54f84caa5adff4a36422c6b74d150f3f30d4734": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iputils-20211215-2.fc36.x86_64.rpm"
+          },
+          "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.x86_64.rpm"
+          },
+          "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/initscripts-service-10.16-2.fc36.noarch.rpm"
+          },
+          "sha256:3d86ab10e70b5bcdfa8f437196fe10a8a5256cb16b941162e329c5d2eabffd70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.x86_64.rpm"
+          },
+          "sha256:3d8ef454ffc43ea87c135c0d3df3ec23fa80a9042b8fb220db299cc9963c5e26": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-scripts-22.02.122-1.fc36.x86_64.rpm"
+          },
+          "sha256:3dec50f65f6e49c3ce1c000af1006984c0ac7a5ce6b9ab28715de70abcd3c668": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpath_utils-0.2.1-50.fc36.x86_64.rpm"
+          },
+          "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/v/vim-data-8.2.5172-1.fc36.noarch.rpm"
+          },
+          "sha256:404eb6145247a020308ae78c6d42c6a81c0cec7f0258a5f83578ce1b6a93433f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-modem-manager-1.8.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.x86_64.rpm"
+          },
+          "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.x86_64.rpm"
+          },
+          "sha256:429e1f761cf68fc139e64dd6bc3cbedfec8a10f244db9c87d2368cbefae73d20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfsprogs-2022.5.17-1.fc36.x86_64.rpm"
+          },
+          "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm"
+          },
+          "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/firewalld-filesystem-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:43ab5eacc5b675862f8821fa8328c33624eb945662536b737e2b4f064c4ddfe5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-flashrom-1.8.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:43c0e8bfebcaa60781ebe874e6790fdeea4ea0fde572ce47d8cffce1f2f2c89a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-nft-1.8.7-15.fc36.x86_64.rpm"
+          },
+          "sha256:43eb75ad2afc0b4a538cbdc6a0ae4a4be8c84d00a03aa450787b0702abd2e5c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:4538200e6752e1cc8844a50115193d736ee06d4fb6096c51bd925d1a2bd9bd8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.x86_64.rpm"
+          },
+          "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.x86_64.rpm"
+          },
+          "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm"
+          },
+          "sha256:47bc2405ee5e88c02004bc467006df9a8dfaaf15e8d561891639d6825b41adc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nano-6.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-5.41-4.fc36.x86_64.rpm"
+          },
+          "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.x86_64.rpm"
+          },
+          "sha256:49b784fc4e9fe1bd00063c509f31cfc1e08749bb203804654f4a01214455853e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_nss_idmap-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.x86_64.rpm"
+          },
+          "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.x86_64.rpm"
+          },
+          "sha256:4aa699025a0a751a62b20f9da7fbfc44c1de6517963f4c1195b9a4a640425310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xfsprogs-5.14.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zram-generator-defaults-1.1.2-1.fc36.noarch.rpm"
+          },
+          "sha256:4aef4b7bd425f1118403818bf469878b1ba2881d21385074bec813d1ba3f3fb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:4b1739660922063971de03928e8cd7154d96b703099e669e8a9b5523c1522310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-util-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:4db9bb285f364b472000badad7fc7e29999f8edf0b62b6d1ef5d379435fd165f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bluez-5.64-1.fc36.x86_64.rpm"
+          },
+          "sha256:4ee2bd16b0321e89607019cc53a5972625f11e331f0a4e9af57e990bb6d6485a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-sysinit-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/geolite2-country-20191217-6.fc36.noarch.rpm"
+          },
+          "sha256:52ac12150f661e1857b5abd1bdb57a2d6615cc26e35ba2990ee1e582907b3418": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/NetworkManager-libnm-1.38.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.x86_64.rpm"
+          },
+          "sha256:544a6838523a5a871c593097d5a48d37b7acf3c415a5f1a23e87854a730d45ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-efi-1.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:55085d771e68ac6ed4be095c5cce52bf39f49d0c65bdfdc92d6a0fe2493c99a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:5599f35f62d74cde1a7cec626faf41c1aca4b4b872b1a017adc898a543179359": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm"
+          },
+          "sha256:55b9b9595efb83f4f6638c47125817cabb3b486ecbc786d4ce2b014e8a81cca9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.x86_64.rpm"
+          },
+          "sha256:57ecedb3b77bce1226a4bd179b6c6749bc56a6c888c6996504f45bd862eeec15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/passwd-0.80-12.fc36.x86_64.rpm"
+          },
+          "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.x86_64.rpm"
+          },
+          "sha256:58e27f4659cef20e393eb063f6eae99ee32f1b421a55fb147d919bc36e42dba6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libldb-2.5.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.x86_64.rpm"
+          },
+          "sha256:5b276451caa30f1ce4739822473100781b3810423528a170c4ddd8405d1689f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-unbound-1.16.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.x86_64.rpm"
+          },
+          "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm"
+          },
+          "sha256:5c1eb0ffd38925eef11269d600d506a31581b3d7d741cae6557d021eeef5e6df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/psmisc-23.4-3.fc36.x86_64.rpm"
+          },
+          "sha256:5c4a0eafc33b320af3e6c370d1e9d3506f92b02607ef2ec773c602ba504da00a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-efi-x64-2.06-42.fc36.x86_64.rpm"
+          },
+          "sha256:5cb911922237fbb08da19a35b650aa3f9a3ea6dd48f74885b34337716373eb83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-22.02.122-1.fc36.x86_64.rpm"
+          },
+          "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.x86_64.rpm"
+          },
+          "sha256:5e2785ea0e99173e686416f33d9cc80a74c21a836a25af89d5b50415c6142701": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nspr-4.34.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/firewalld-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-056-1.fc36.x86_64.rpm"
+          },
+          "sha256:60144990fba08c95b1f9fb68055d85b608870c09426af187b6048912b6337708": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libjcat-0.1.10-1.fc36.x86_64.rpm"
+          },
+          "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libreport-filesystem-2.17.1-1.fc36.noarch.rpm"
+          },
+          "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.x86_64.rpm"
+          },
+          "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:61544f1ac4a32d1903e24f406fa1286bf54d21151e460bec4b2bc046840a42cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/i/inih-55-1.fc36.x86_64.rpm"
+          },
+          "sha256:6218b686e396a0eec312f93e7d1418e00b7a32ae95926fb7d7835f44e72f8526": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.x86_64.rpm"
+          },
+          "sha256:62d444882048ea292185a97922b013e7b276fa257fae4cc8ee3ca92973f76ac3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libref_array-0.1.5-50.fc36.x86_64.rpm"
+          },
+          "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm"
+          },
+          "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.x86_64.rpm"
+          },
+          "sha256:66ec27d6c6b52dcd456accf412d14db29ca5cf976194b721407a9f5feedc1dc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mokutil-0.6.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm"
+          },
+          "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:6828edb88734beb0ed0a3f92257c2d8528fba1fac90bfd44747d8491e83eaf57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/h/hostname-3.23-6.fc36.x86_64.rpm"
+          },
+          "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.x86_64.rpm"
+          },
+          "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.x86_64.rpm"
+          },
+          "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.x86_64.rpm"
+          },
+          "sha256:6a049afa68579427322ee38b9085251115a6c022786530d804d6a2081a84ceca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shared-mime-info-2.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.x86_64.rpm"
+          },
+          "sha256:6a24ce1c4e69fe649d79a58f2636e4891c365bf36c3c9a35c49114fe72df5426": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipset-libs-7.15-2.fc36.x86_64.rpm"
+          },
+          "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.x86_64.rpm"
+          },
+          "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm"
+          },
+          "sha256:6b360093e3a04856310a3c967b4c59a597ec6ff33826affab4052ca212676699": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/NetworkManager-1.38.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm"
+          },
+          "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-dnf-plugins-core-4.2.1-1.fc36.noarch.rpm"
+          },
+          "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:6c7c429d157a9e803c56ac9b28bf74ae8908fc0d33515c9729ed51509a696026": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:6e83a644bea22129ba6a3ea31a7432418037b3e9440002dddf1c2cbbf0ce5847": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgusb-0.3.10-2.fc36.x86_64.rpm"
+          },
+          "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm"
+          },
+          "sha256:6fb42c4b7617f96e5ef0c7050315d7a7e0a4100cec0cfee39722a8301ebec8e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/npth-1.6-8.fc36.x86_64.rpm"
+          },
+          "sha256:70f255fc22530dc6213d015700dd237d0173784e616cbc2ffc284e5a2f7b10c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:7130cc35fa8510939a0e7e72770261982f8a5b062253e85251288d0acf5f6e21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxmlb-0.3.9-1.fc36.x86_64.rpm"
+          },
+          "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-plugins-core-4.2.1-1.fc36.noarch.rpm"
+          },
+          "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm"
+          },
+          "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/popt-1.18-7.fc36.x86_64.rpm"
+          },
+          "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:74c9d86eb0743f18d4fb25ac82e616b7103f5ca79c37aa8aa69be477b4d2a2f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sudo-1.9.8-5.p2.fc36.x86_64.rpm"
+          },
+          "sha256:76842198d98983f83241be2ae73b24efd580ee0af7d0a5a301dd02a7c417c801": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:777e4333ca9437d55b2bae930fadfe5db487ed6acd8a66ab42a7d0cd8680cf33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-rpm-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-six-1.16.0-5.fc36.noarch.rpm"
+          },
+          "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:77d143afad8d60b1ed9a206e8a1e2c1211218e709eb2c830c8f07744b06aef1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-gobject-base-3.42.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.x86_64.rpm"
+          },
+          "sha256:78f1f12225b42a3edcfabd694df561064ce39d02abd6d71bb85fe7beee747101": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-loop-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:7c4dfb2d2b98022bdcfa0bcde99345c340ba2ec1cbb19ddc33a02dd8f70a12e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/flashrom-1.2-8.fc36.x86_64.rpm"
+          },
+          "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:7d995b70b266834c71640b61a57f4a83c011035cebea52813d9faca21e9bda52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.x86_64.rpm"
+          },
+          "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-data-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:853e915ae73a3b0a08f3cb36a8289552e488f99a4245c4bc431ff8ac531138bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/v/vim-minimal-8.2.5172-1.fc36.x86_64.rpm"
+          },
+          "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm"
+          },
+          "sha256:866dc0c718466213e578633155aaa9d69fb860f1ac44b44611025a957780a8fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmbim-1.26.4-1.fc36.x86_64.rpm"
+          },
+          "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:88c97e93ff20a638e697b0d02dd0c58ca413d0c135e85c8f9596c2d02ef29430": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsmbios-2.4.3-5.fc36.x86_64.rpm"
+          },
+          "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:899f4f96d68160c167c1b59f8b3e0dd4e4586864c312e4377fc1a5cc58a054ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:89ce9d545da60404ed91ec236b2d3040c3fcbc9c61658c0a07baf0adcb512360": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/deltarpm-3.6.2-11.fc36.x86_64.rpm"
+          },
+          "sha256:8a397257a1b5fc428cc663bf266b3feccbe94198d5ebe93bc168022d64dbf4fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:8b4a9e98cb73582362e6e70390c1c643b26f50c289ea0acbc74b5bb75d85e23b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-dnf-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.x86_64.rpm"
+          },
+          "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:901a4d6e3875a08f48665f5ddb9d169d75639f85d93e1a877a155c026eaceada": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:90373252c19e5af71af8c0db1775727a9fc66e801bfa94390e8e482d38c209bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipcalc-1.0.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.x86_64.rpm"
+          },
+          "sha256:929f61d675345450d11bc44ab2466cc621f9ece823b031c784ca79e657e179a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtevent-0.12.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:94021f69bdd5e8be4b186081e6b5748a27b37e8d7762ca6b8973bc0f1ab8b16c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.x86_64.rpm"
+          },
+          "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.x86_64.rpm"
+          },
+          "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm"
+          },
+          "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm"
+          },
+          "sha256:981e35ad67bb3aebeedfba78b4880e581d6a6db2b7ec4023484c94998fc66a5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libqmi-1.30.6-1.fc36.x86_64.rpm"
+          },
+          "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-29-7.fc36.x86_64.rpm"
+          },
+          "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:991f6fd822110685e42f499f3059cc5abab2beeff405fc24c74f9e89c41088b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:995d03ccc92a1c35fc0e25a7f7ba3f4bde6bac5068220a0e2722f377dfaf26a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.x86_64.rpm"
+          },
+          "sha256:996f22624b2f771360c80b1724dcd63ea1132b72db52bf0887446f7fa1c6c7cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbytesize-2.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:9bfc17431245ff01b7431893884275d6357138d014d4634c073b20bb5007d798": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/unbound-libs-1.16.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:9c2e78543b7f7d2e9b4e9aa6e32170b386ec56da3266d56c7aaa229a17becf88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libudisks2-2.9.4-4.fc36.x86_64.rpm"
+          },
+          "sha256:9c3da481a459d940f0e9d99f7e41b336e0709ef226bf7651cdce30b3ea0562df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libjaylink-0.2.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.x86_64.rpm"
+          },
+          "sha256:9e29caa9cbe813b19d8b22301af1ccc0dba47a401b7acf66eb658f3eeb5aa8ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-core-5.18.9-200.fc36.x86_64.rpm"
+          },
+          "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/linux-firmware-20220610-135.fc36.noarch.rpm"
+          },
+          "sha256:a00fc7941175e0934b46efa63721dd9f45b23905b2afc1643f0113d13db63ed3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/u/userspace-rcu-0.13.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:a028d16393155c75d89016ddc1d5fa3b9c05ad3c6393aa6366a4ea330431532d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.x86_64.rpm"
+          },
+          "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.x86_64.rpm"
+          },
+          "sha256:a0c3b904030213a5c81258bbffe122d5f80b3d8115ef1d3062b18e7a1c20fe4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libqrtr-glib-1.0.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:a2b02e6ee909472aeb994d0040e1255ffd6c45150c32d9b084609d928caada61": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.x86_64.rpm"
+          },
+          "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/y/yum-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm"
+          },
+          "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm"
+          },
+          "sha256:a97a365db61e244f5b5b400f8e91b63b3beea0db30ab9e6a9c4664b0f273fc17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-8.8p1-1.fc36.1.x86_64.rpm"
+          },
+          "sha256:a9e689f42a53bf760c2d56e0254f4c69213f13b57b1a0cd12ee2ef0529c6f70b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/c-ares-1.17.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-firewall-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:aa6dc185c17dd7421299c069850cb22fcc68ed34a9a5ff720ff03269b3d874cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/oniguruma-6.9.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:ac440f60f60e271dfdcfdb16ec82cba720bb2f903a2f7cf2330bd4e18aa4154b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-gpg-1.15.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:ad06336b4a496a063e390e0f6a15b08bfe2626465a3247a45f8c98c503a4b5a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/u/udisks2-2.9.4-4.fc36.x86_64.rpm"
+          },
+          "sha256:adfa2718dc5d4bae822b5905f1628bdc0fa830bb06c561caa331716293a2d340": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dhcp-common-4.4.3-2.fc36.noarch.rpm"
+          },
+          "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm"
+          },
+          "sha256:b0580325e7f48f65cee2a914fb36712f068eb6202a607f962ee36b6e3cd9605c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-common-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:b0a26bee81681c31c0ff8e3dfd5031b8861bdbdd5ebf25fc59763878ceef2d7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libdnf-0.67.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.x86_64.rpm"
+          },
+          "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:b30ca62dd91fcddba2a393ef7e023ceb9f9ee2ac4d59b9a61d56ab929832da0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/less-590-3.fc36.x86_64.rpm"
+          },
+          "sha256:b401b7b05c6142cba74685a40d003d902de2a6cccd1c60134c618189073bbe87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-build-libs-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:b59f54f0b25de26d10cbde4a3823a7420410a664eaeb3c5cedb6f0801d5da245": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pciutils-libs-3.7.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.x86_64.rpm"
+          },
+          "sha256:b7169456c74b621072ff489f95505802556ec1598c9d69185c95904344e19f86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libatasmart-0.19-22.fc36.x86_64.rpm"
+          },
+          "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/linux-firmware-whence-20220610-135.fc36.noarch.rpm"
+          },
+          "sha256:b9070b6896e9ea6dbfcfcbdcdf2d2e427603522e95187854dd10faf38f5a7b98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmaxminddb-1.6.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:b9ad1c81ed20265422b5fcc8865f055a4172bc3325b9cb212ad073266057aab5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libdnf-0.67.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:bafbc5e2d6b05c4911cb000b4f80f7475cac9afcd14172b26a8b0038c8491f1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-3.0.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:bafc8af7a461cbed16417ffce4d30735895e5316d3ec4af7232951acad6fdcf4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-5.18.9-200.fc36.x86_64.rpm"
+          },
+          "sha256:bbac26c434fa5eb6ef77751738f9ef4b0e02d11e657812b388b6a047ab6fc7a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-python3-0.8.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:bc1a60ef9acfc90ab773b2800eb515e3f9acd647827de3d60ee2390baf4d1f83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/v/volume_key-libs-0.3.12-15.fc36.x86_64.rpm"
+          },
+          "sha256:bc2230cb7e68870285ecf11d82e8607e74d42f01a57889b3c3e1b1d9e386404c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-1.8.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:bc3339d24b5e60cb8967a671cd9dd357955f46c3825ccf1e4a3b542dcc4ae19a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.x86_64.rpm"
+          },
+          "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm"
+          },
+          "sha256:bd5c235acf908e4b0191f6f4b89589c123e218b21b991e79ecde140867b54282": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/ModemManager-glib-1.18.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.x86_64.rpm"
+          },
+          "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.x86_64.rpm"
+          },
+          "sha256:bfc877337ecf753c9b20f7d8ce2c4670936972dec92b5ce95e0d7b672b28b148": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-server-8.8p1-1.fc36.1.x86_64.rpm"
+          },
+          "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:c073eeb631912aa260da3cb99353cddff4e7f02ffebd775a329ef260ab42ff29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_certmap-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.x86_64.rpm"
+          },
+          "sha256:c1c0911df45e7a2ed245ee9481ed9aef3c2264cf866e7237498f1d24140054c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbasicobjects-0.1.1-50.fc36.x86_64.rpm"
+          },
+          "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm"
+          },
+          "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grep-3.7-2.fc36.x86_64.rpm"
+          },
+          "sha256:c4bf6b2c21cfae19a0f3f4b0279823d1d7958c40b9bb483b825d30a1d9279ecb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-libs-2022.5.17-1.fc36.x86_64.rpm"
+          },
+          "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-gobject-base-noarch-3.42.1-1.fc36.noarch.rpm"
+          },
+          "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.x86_64.rpm"
+          },
+          "sha256:c77199fb123dc6f9a0ce3f7f10e0f0519f2cbf5d5439e76d13df1837cd349934": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:c775dfbd34c0f950be4aa77dd67f7d9b30c880f64b29b453896d83812a69722f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-rescue-056-1.fc36.x86_64.rpm"
+          },
+          "sha256:c7ec9cbcec2b2fb49e5959b51b8ca1fde6da526cbca9e89eb73e3eb04cddc157": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-6.2-9.20210508.fc36.x86_64.rpm"
+          },
+          "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm"
+          },
+          "sha256:c88d2e0f7ff66362269a62f5ca96ec627c18336a975d4aef2ade8ccb51ff32ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/man-db-2.10.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.x86_64.rpm"
+          },
+          "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm"
+          },
+          "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.x86_64.rpm"
+          },
+          "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.x86_64.rpm"
+          },
+          "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:cf0a6ad360f4ebc1b3e1f6d9e583751b100195f57106cad48cde4fe4a6eb7195": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-swap-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.x86_64.rpm"
+          },
+          "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:d28889b38e09168928ff3a9e3acdbdcb4c8beb53f79d987b5471341e4e7ae310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgudev-237-2.fc36.x86_64.rpm"
+          },
+          "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm"
+          },
+          "sha256:d4cf97f8df32e57949d6cd29c95da335bc3f1b8bbe8d5f73dfb327e64fd500e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:d514b1df4f58c8c23e7a386dc8edcf616339a0b2ee84aad2203c034c2cb439d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.x86_64.rpm"
+          },
+          "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:d6e85834503eae1bf62340e8d24b208faabbf632151425675dc4075a27e112f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efibootmgr-16-12.fc36.x86_64.rpm"
+          },
+          "sha256:d748ab15ed2bf7f64489dd6c0819ce7f5419af488322703553b2318c542c78fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.x86_64.rpm"
+          },
+          "sha256:d74d44ff991a85bc5aed1bf170446cb324bc8ba9f476a16443b856f689325e89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-softokn-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:d87d94a884629f4538f36f1e54190dfd230dc7ad3eb44b8da31ee22d79794f14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lmdb-libs-0.9.29-3.fc36.x86_64.rpm"
+          },
+          "sha256:d899a6ced2354d6e86191a85e08df4d581ff3bce47544300d07d6d40f258f32b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/parted-3.4-12.fc36.x86_64.rpm"
+          },
+          "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sed-4.8-10.fc36.x86_64.rpm"
+          },
+          "sha256:daa3aa3f516d08d8a5053aabc521f8b3af4fcef3a1304a051ceca93ae18bfa3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm"
+          },
+          "sha256:dae15191393ec4f56460271f47e1cc2ac7bc847ccb03eaf0035175d1c28c219a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.x86_64.rpm"
+          },
+          "sha256:dae93958303747451864dcd8092e402fee9b2cb56ab3442d847ef12852c61f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mdadm-4.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-compat-4.4.28-1.fc36.x86_64.rpm"
+          },
+          "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.x86_64.rpm"
+          },
+          "sha256:db1423134b954c1c00786cce7a2242d9fe98f26964f51b707ddf00f8fffd7e8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-part-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:db4eb4ae787ee174d1d2957c80b0413ccf31e0bb539d70ba7e0c606f102bb2de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-compat-2.6.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:dbc8762daadb5927a05241924646bd1a5149a52170d80558e78312f192a67624": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-fs-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/readline-8.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:dda1ae9c2d6920761996734c846883fe26d4a2222364fec6fde58fab9a9dc3dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sudo-python-plugin-1.9.8-5.p2.fc36.x86_64.rpm"
+          },
+          "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:df15662946f61c06fafb3f9256ccd7170accefa3ddb348926add49f1b9995c44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-core-libs-22.02.122-1.fc36.x86_64.rpm"
+          },
+          "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm"
+          },
+          "sha256:dffa57881ede2980c3384f2d8890b60169581414031b25253f9bf032ae7ed48e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.x86_64.rpm"
+          },
+          "sha256:e03035313c0396abf2c9acb21bbb5b303cc73726473ab115d1ba58aa1e3c7fb0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-system-compression-1.0-9.fc36.x86_64.rpm"
+          },
+          "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:e1947cb52a8cbba29dfd79456fab69ee967572ca35855340e45b1b5a2b68e594": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-modules-5.18.9-200.fc36.x86_64.rpm"
+          },
+          "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm"
+          },
+          "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:e37d6a627ace13dd51f94114e5c669fa8a5a6f695bb9dc446eed1b9a9bd6919f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-kcm-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-dateutil-2.8.1-8.fc36.noarch.rpm"
+          },
+          "sha256:e6cd3dfba9bd5c1d8527ee3ae8bae3bf7a1a375932f7fa4a1ee5c317eb70b0f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_idmap-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm"
+          },
+          "sha256:e7090f335d0d210b20ec4b8ac8adb1b801c51eea363d52d3b48f821512e38500": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.x86_64.rpm"
+          },
+          "sha256:e9c2d1401d9c58a48eb7ee7ac873d97612662d65a4a5ead7473ec6b311145b87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-utils-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:eaeb5140174492d0bd26806a079ae00c26e78da1d67aecbbdd274e1e74f4ca93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-libs-1.14.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:eaf42f29c0f991a0059fcaa41c79b1ebff0c243c5b8f398bfba2aab2b5c89cf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.x86_64.rpm"
+          },
+          "sha256:eb149c8897d2e78727e2dac441bcc05e064e045edb73705af0a0c57a5d17fe4e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:eb95ae512e34a19ec7d2b4f36e244c7fbb2622e2046a79aa7f9cf514d817a9ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gobject-introspection-1.72.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:ecd2362482d03354b6e79229bcd59533629c072982ef31b41762a888b7718b50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpipeline-1.5.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.x86_64.rpm"
+          },
+          "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:ef1f95d053d7c6dc6a2fc14039358f2db3db91b42ce79194a98c28a0c34376bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-client-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.x86_64.rpm"
+          },
+          "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.x86_64.rpm"
+          },
+          "sha256:f2da32b1fcc10b56b30f7939618450fd863c7469508250508060ebd36b61ec5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gdisk-1.0.9-2.fc36.x86_64.rpm"
+          },
+          "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.x86_64.rpm"
+          },
+          "sha256:f2f4ad1b7ed2110117dae0e82ab0478be595cc8c0491b18128165bc825e389a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcollection-0.7.0-50.fc36.x86_64.rpm"
+          },
+          "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm"
+          },
+          "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:f55cdb2f49ab0910aacfb5745b65291399a00fda3f012c624c464aee70457bbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libftdi-1.5-3.fc36.x86_64.rpm"
+          },
+          "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-distro-1.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:f7516bcfc6dae3781d581225f488e410531184b85bb221ce409bb7583fc20439": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-dicts-2.9.6-28.fc36.x86_64.rpm"
+          },
+          "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:f8cc2172a8c6cae8fd0e3c56a266a20425194ed024b730d2f2d04ee3ab9bfb5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:fa180f3216a84395f92ca6e4044b5f8067c351cd516d91c25a16335cabe4a43e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/groff-base-1.22.4-9.fc36.x86_64.rpm"
+          },
+          "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.x86_64.rpm"
+          },
+          "sha256:fc9e1d57af84ad965d533c76162c1d31808b96705a085e679e061f1385acb70e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/shim-x64-15.6-1.x86_64.rpm"
+          },
+          "sha256:fcf12edb225a10edfbf0e4af820fc6495997218b357c25ec638f6fa458fdc383": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm"
+          },
+          "sha256:fdfa9da9d905dc4c5dd71a0b22a829bcdd05e9274ebd0538e57e18036fe63ad1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jq-1.6-13.fc36.x86_64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.x86_64.rpm",
+        "checksum": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm",
+        "checksum": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.x86_64.rpm",
+        "checksum": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.x86_64.rpm",
+        "checksum": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
+        "checksum": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.x86_64.rpm",
+        "checksum": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.x86_64.rpm",
+        "checksum": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grep-3.7-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.x86_64.rpm",
+        "checksum": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.x86_64.rpm",
+        "checksum": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.x86_64.rpm",
+        "checksum": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.x86_64.rpm",
+        "checksum": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.x86_64.rpm",
+        "checksum": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.x86_64.rpm",
+        "checksum": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.x86_64.rpm",
+        "checksum": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.x86_64.rpm",
+        "checksum": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.x86_64.rpm",
+        "checksum": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.x86_64.rpm",
+        "checksum": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.x86_64.rpm",
+        "checksum": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.x86_64.rpm",
+        "checksum": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm",
+        "checksum": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-compat-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.x86_64.rpm",
+        "checksum": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.x86_64.rpm",
+        "checksum": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.x86_64.rpm",
+        "checksum": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/popt-1.18-7.fc36.x86_64.rpm",
+        "checksum": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/readline-8.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sed-4.8-10.fc36.x86_64.rpm",
+        "checksum": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.x86_64.rpm",
+        "checksum": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.x86_64.rpm",
+        "checksum": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.x86_64.rpm",
+        "checksum": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.x86_64.rpm",
+        "checksum": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.x86_64.rpm",
+        "checksum": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-3.0.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bafbc5e2d6b05c4911cb000b4f80f7475cac9afcd14172b26a8b0038c8491f1e",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bluez-5.64-1.fc36.x86_64.rpm",
+        "checksum": "sha256:4db9bb285f364b472000badad7fc7e29999f8edf0b62b6d1ef5d379435fd165f",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:28b98634695e2f0a9f5f616b84ecb21d2726f1b360ca16ba8f48aceda4a8e0fa",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm",
+        "checksum": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/c-ares-1.17.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:a9e689f42a53bf760c2d56e0254f4c69213f13b57b1a0cd12ee2ef0529c6f70b",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.x86_64.rpm",
+        "checksum": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-dicts-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:f7516bcfc6dae3781d581225f488e410531184b85bb221ce409bb7583fc20439",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.x86_64.rpm",
+        "checksum": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-libs-1.14.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:eaeb5140174492d0bd26806a079ae00c26e78da1d67aecbbdd274e1e74f4ca93",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/deltarpm-3.6.2-11.fc36.x86_64.rpm",
+        "checksum": "sha256:89ce9d545da60404ed91ec236b2d3040c3fcbc9c61658c0a07baf0adcb512360",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
+        "checksum": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dmidecode-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:2ee89bb45ed9fea2cd576a967978acd3c93095f22414fd81e2042522ec04d79e",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:55b9b9595efb83f4f6638c47125817cabb3b486ecbc786d4ce2b014e8a81cca9",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-rescue-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c775dfbd34c0f950be4aa77dd67f7d9b30c880f64b29b453896d83812a69722f",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "5.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efi-filesystem-5-5.fc36.noarch.rpm",
+        "checksum": "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efibootmgr-16-12.fc36.x86_64.rpm",
+        "checksum": "sha256:d6e85834503eae1bf62340e8d24b208faabbf632151425675dc4075a27e112f1",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.x86_64.rpm",
+        "checksum": "sha256:eaf42f29c0f991a0059fcaa41c79b1ebff0c243c5b8f398bfba2aab2b5c89cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-modular-36-1.noarch.rpm",
+        "checksum": "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/firewalld-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/firewalld-filesystem-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/flashrom-1.2-8.fc36.x86_64.rpm",
+        "checksum": "sha256:7c4dfb2d2b98022bdcfa0bcde99345c340ba2ec1cbb19ddc33a02dd8f70a12e3",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.x86_64.rpm",
+        "checksum": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.x86_64.rpm",
+        "checksum": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/geolite2-city-20191217-6.fc36.noarch.rpm",
+        "checksum": "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/geolite2-country-20191217-6.fc36.noarch.rpm",
+        "checksum": "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.72.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gobject-introspection-1.72.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:eb95ae512e34a19ec7d2b4f36e244c7fbb2622e2046a79aa7f9cf514d817a9ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:d4cf97f8df32e57949d6cd29c95da335bc3f1b8bbe8d5f73dfb327e64fd500e7",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grep-3.7-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/groff-base-1.22.4-9.fc36.x86_64.rpm",
+        "checksum": "sha256:fa180f3216a84395f92ca6e4044b5f8067c351cd516d91c25a16335cabe4a43e",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.x86_64.rpm",
+        "checksum": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.x86_64.rpm",
+        "checksum": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/h/hostname-3.23-6.fc36.x86_64.rpm",
+        "checksum": "sha256:6828edb88734beb0ed0a3f92257c2d8528fba1fac90bfd44747d8491e83eaf57",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
+        "checksum": "sha256:20026a80599cc22463cefafe5607d90d249dd414306e5f3bb5616cb45836403a",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.16",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/initscripts-service-10.16-2.fc36.noarch.rpm",
+        "checksum": "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipcalc-1.0.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:90373252c19e5af71af8c0db1775727a9fc66e801bfa94390e8e482d38c209bc",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.15.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iproute-5.15.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:1adc225761ab40fe003e4136e8d327e8afa0fe5da74d1aeecebc706b2ece4f8b",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipset-7.15-2.fc36.x86_64.rpm",
+        "checksum": "sha256:1ca472a7624eaeae3dcb111e9d9ba3eac791f1a44567c77c680f1a4b06f03e22",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipset-libs-7.15-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6a24ce1c4e69fe649d79a58f2636e4891c365bf36c3c9a35c49114fe72df5426",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.x86_64.rpm",
+        "checksum": "sha256:6218b686e396a0eec312f93e7d1418e00b7a32ae95926fb7d7835f44e72f8526",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-nft-1.8.7-15.fc36.x86_64.rpm",
+        "checksum": "sha256:43c0e8bfebcaa60781ebe874e6790fdeea4ea0fde572ce47d8cffce1f2f2c89a",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iputils-20211215-2.fc36.x86_64.rpm",
+        "checksum": "sha256:3bea089c91795fb1754cbcd7f54f84caa5adff4a36422c6b74d150f3f30d4734",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:4aef4b7bd425f1118403818bf469878b1ba2881d21385074bec813d1ba3f3fb9",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "13.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jq-1.6-13.fc36.x86_64.rpm",
+        "checksum": "sha256:fdfa9da9d905dc4c5dd71a0b22a829bcdd05e9274ebd0538e57e18036fe63ad1",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4538200e6752e1cc8844a50115193d736ee06d4fb6096c51bd925d1a2bd9bd8d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.x86_64.rpm",
+        "checksum": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/less-590-3.fc36.x86_64.rpm",
+        "checksum": "sha256:b30ca62dd91fcddba2a393ef7e023ceb9f9ee2ac4d59b9a61d56ab929832da0b",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm",
+        "checksum": "sha256:1f4f8b80a39f4cde1a15072097cba266333cc1a840f494c7f33affbcc0f66f49",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "22.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libatasmart-0.19-22.fc36.x86_64.rpm",
+        "checksum": "sha256:b7169456c74b621072ff489f95505802556ec1598c9d69185c95904344e19f86",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbasicobjects-0.1.1-50.fc36.x86_64.rpm",
+        "checksum": "sha256:c1c0911df45e7a2ed245ee9481ed9aef3c2264cf866e7237498f1d24140054c8",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.x86_64.rpm",
+        "checksum": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.x86_64.rpm",
+        "checksum": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcollection-0.7.0-50.fc36.x86_64.rpm",
+        "checksum": "sha256:f2f4ad1b7ed2110117dae0e82ab0478be595cc8c0491b18128165bc825e389a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
+        "checksum": "sha256:5599f35f62d74cde1a7cec626faf41c1aca4b4b872b1a017adc898a543179359",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.x86_64.rpm",
+        "checksum": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdhash-0.5.0-50.fc36.x86_64.rpm",
+        "checksum": "sha256:0f2fa774b2b443df4aadea87a4e8efe331d67f232884d2be49921370d431b413",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "41.20210910cvs.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.x86_64.rpm",
+        "checksum": "sha256:dffa57881ede2980c3384f2d8890b60169581414031b25253f9bf032ae7ed48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.x86_64.rpm",
+        "checksum": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.x86_64.rpm",
+        "checksum": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
+        "checksum": "sha256:fcf12edb225a10edfbf0e4af820fc6495997218b357c25ec638f6fa458fdc383",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libftdi-1.5-3.fc36.x86_64.rpm",
+        "checksum": "sha256:f55cdb2f49ab0910aacfb5745b65291399a00fda3f012c624c464aee70457bbf",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgcab1-1.4-6.fc36.x86_64.rpm",
+        "checksum": "sha256:2d4db64668bfb08b1fe6be0276ef811e4c92239f27c0d45932b3287ae9639b38",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgudev-237-2.fc36.x86_64.rpm",
+        "checksum": "sha256:d28889b38e09168928ff3a9e3acdbdcb4c8beb53f79d987b5471341e4e7ae310",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgusb-0.3.10-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6e83a644bea22129ba6a3ea31a7432418037b3e9440002dddf1c2cbbf0ce5847",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "39.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:8b4a9e98cb73582362e6e70390c1c643b26f50c289ea0acbc74b5bb75d85e23b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.x86_64.rpm",
+        "checksum": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libini_config-1.3.1-50.fc36.x86_64.rpm",
+        "checksum": "sha256:1d02acd08b3208cd1af93820b7e8961538e4819c1903ec7452af12f4aad2ef91",
+        "check_gpg": true
+      },
+      {
+        "name": "libjaylink",
+        "epoch": 0,
+        "version": "0.2.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libjaylink-0.2.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9c3da481a459d940f0e9d99f7e41b336e0709ef226bf7651cdce30b3ea0562df",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.10",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libjcat-0.1.10-1.fc36.x86_64.rpm",
+        "checksum": "sha256:60144990fba08c95b1f9fb68055d85b608870c09426af187b6048912b6337708",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:991f6fd822110685e42f499f3059cc5abab2beeff405fc24c74f9e89c41088b5",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmaxminddb-1.6.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:b9070b6896e9ea6dbfcfcbdcdf2d2e427603522e95187854dd10faf38f5a7b98",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.x86_64.rpm",
+        "checksum": "sha256:995d03ccc92a1c35fc0e25a7f7ba3f4bde6bac5068220a0e2722f377dfaf26a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:00cda4f023ab0f5d5b64f29cc36325e2b1395bf5c23547c515140051d50df1cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libndp-1.8-3.fc36.x86_64.rpm",
+        "checksum": "sha256:2dae9a479c013680294508bf366c3501d84b1e7f564ee9f1d31af320ac150b95",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bc3339d24b5e60cb8967a671cd9dd357955f46c3825ccf1e4a3b542dcc4ae19a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "21.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.x86_64.rpm",
+        "checksum": "sha256:08786a771c7d95deefd7e8dea790e7e14fbf337c2fff980778005a9fb7a0050c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8a397257a1b5fc428cc663bf266b3feccbe94198d5ebe93bc168022d64dbf4fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpath_utils-0.2.1-50.fc36.x86_64.rpm",
+        "checksum": "sha256:3dec50f65f6e49c3ce1c000af1006984c0ac7a5ce6b9ab28715de70abcd3c668",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:899f4f96d68160c167c1b59f8b3e0dd4e4586864c312e4377fc1a5cc58a054ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpipeline-1.5.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:ecd2362482d03354b6e79229bcd59533629c072982ef31b41762a888b7718b50",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.x86_64.rpm",
+        "checksum": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.x86_64.rpm",
+        "checksum": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libqrtr-glib-1.0.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:a0c3b904030213a5c81258bbffe122d5f80b3d8115ef1d3062b18e7a1c20fe4c",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libref_array-0.1.5-50.fc36.x86_64.rpm",
+        "checksum": "sha256:62d444882048ea292185a97922b013e7b276fa257fae4cc8ee3ca92973f76ac3",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libreport-filesystem-2.17.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a028d16393155c75d89016ddc1d5fa3b9c05ad3c6393aa6366a4ea330431532d",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.x86_64.rpm",
+        "checksum": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmbios",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsmbios-2.4.3-5.fc36.x86_64.rpm",
+        "checksum": "sha256:88c97e93ff20a638e697b0d02dd0c58ca413d0c135e85c8f9596c2d02ef29430",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm",
+        "checksum": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libudisks2-2.9.4-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9c2e78543b7f7d2e9b4e9aa6e32170b386ec56da3266d56c7aaa229a17becf88",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.x86_64.rpm",
+        "checksum": "sha256:d514b1df4f58c8c23e7a386dc8edcf616339a0b2ee84aad2203c034c2cb439d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libuser-0.63-10.fc36.x86_64.rpm",
+        "checksum": "sha256:1dd0909aa6d4efe3f024b1f52bfbcf7b4ec6e9ab981d9c18efce53ab4ea2fbce",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-compat-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm",
+        "checksum": "sha256:23cc660bf40b82d9c1739412d9cdcaebb70da60ae2d05cf2a9fbea088f22cdd3",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lmdb-libs-0.9.29-3.fc36.x86_64.rpm",
+        "checksum": "sha256:d87d94a884629f4538f36f1e54190dfd230dc7ad3eb44b8da31ee22d79794f14",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.10.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/man-db-2.10.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:c88d2e0f7ff66362269a62f5ca96ec627c18336a975d4aef2ade8ccb51ff32ae",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mdadm-4.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:dae93958303747451864dcd8092e402fee9b2cb56ab3442d847ef12852c61f52",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.x86_64.rpm",
+        "checksum": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nano-6.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:47bc2405ee5e88c02004bc467006df9a8dfaaf15e8d561891639d6825b41adc9",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-6.2-9.20210508.fc36.x86_64.rpm",
+        "checksum": "sha256:c7ec9cbcec2b2fb49e5959b51b8ca1fde6da526cbca9e89eb73e3eb04cddc157",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.x86_64.rpm",
+        "checksum": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:70f255fc22530dc6213d015700dd237d0173784e616cbc2ffc284e5a2f7b10c9",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/npth-1.6-8.fc36.x86_64.rpm",
+        "checksum": "sha256:6fb42c4b7617f96e5ef0c7050315d7a7e0a4100cec0cfee39722a8301ebec8e3",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-8.8p1-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:a97a365db61e244f5b5b400f8e91b63b3beea0db30ab9e6a9c4664b0f273fc17",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-clients-8.8p1-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:31879e909524e7e7971dc6d3858786a65ed4fba8f58e2f9d11029a2772ffb5cc",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-server-8.8p1-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:bfc877337ecf753c9b20f7d8ce2c4670936972dec92b5ce95e0d7b672b28b148",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.x86_64.rpm",
+        "checksum": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/parted-3.4-12.fc36.x86_64.rpm",
+        "checksum": "sha256:d899a6ced2354d6e86191a85e08df4d581ff3bce47544300d07d6d40f258f32b",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/passwd-0.80-12.fc36.x86_64.rpm",
+        "checksum": "sha256:57ecedb3b77bce1226a4bd179b6c6749bc56a6c888c6996504f45bd862eeec15",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pciutils-libs-3.7.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:b59f54f0b25de26d10cbde4a3823a7420410a664eaeb3c5cedb6f0801d5da245",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c77199fb123dc6f9a0ce3f7f10e0f0519f2cbf5d5439e76d13df1837cd349934",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6c7c429d157a9e803c56ac9b28bf74ae8908fc0d33515c9729ed51509a696026",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-22.02.122-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5cb911922237fbb08da19a35b650aa3f9a3ea6dd48f74885b34337716373eb83",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-core-libs-22.02.122-1.fc36.x86_64.rpm",
+        "checksum": "sha256:df15662946f61c06fafb3f9256ccd7170accefa3ddb348926add49f1b9995c44",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-scripts-22.02.122-1.fc36.x86_64.rpm",
+        "checksum": "sha256:3d8ef454ffc43ea87c135c0d3df3ec23fa80a9042b8fb220db299cc9963c5e26",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.x86_64.rpm",
+        "checksum": "sha256:7d995b70b266834c71640b61a57f4a83c011035cebea52813d9faca21e9bda52",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.x86_64.rpm",
+        "checksum": "sha256:d748ab15ed2bf7f64489dd6c0819ce7f5419af488322703553b2318c542c78fe",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "21.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm",
+        "checksum": "sha256:1cce2c735fd092558a5d050708e93200768f523bc36a4071a6c2857c6bad23f8",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/popt-1.18-7.fc36.x86_64.rpm",
+        "checksum": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:30bb23da61ac270b3a011384f2e87a41d7a31e1808b21e6ca7caa60491c9c630",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/psmisc-23.4-3.fc36.x86_64.rpm",
+        "checksum": "sha256:5c1eb0ffd38925eef11269d600d506a31581b3d7d741cae6557d021eeef5e6df",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "8.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-dateutil-2.8.1-8.fc36.noarch.rpm",
+        "checksum": "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-dbus-1.2.18-3.fc36.x86_64.rpm",
+        "checksum": "sha256:2eb7ace975fa86defcb8e5962e0636b02f62dc8fc1e733d1bc041b12bf28fd63",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-distro-1.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-firewall-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-gpg-1.15.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:ac440f60f60e271dfdcfdb16ec82cba720bb2f903a2f7cf2330bd4e18aa4154b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
+        "checksum": "sha256:daa3aa3f516d08d8a5053aabc521f8b3af4fcef3a1304a051ceca93ae18bfa3f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-nftables-1.0.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:00cb1f66de0fc574ae601b76b96c3326834a6682ff119445e5940bca2249302c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-rpm-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:777e4333ca9437d55b2bae930fadfe5db487ed6acd8a66ab42a7d0cd8680cf33",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "5.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-six-1.16.0-5.fc36.noarch.rpm",
+        "checksum": "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/readline-8.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "31.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm",
+        "checksum": "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-build-libs-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:b401b7b05c6142cba74685a40d003d902de2a6cccd1c60134c618189073bbe87",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:43eb75ad2afc0b4a538cbdc6a0ae4a4be8c84d00a03aa450787b0702abd2e5c2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-sign-libs-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:26b776eaf819fc466d562e595860f86cf183066494d0577f146f6a2c9dc4c6d5",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sed-4.8-10.fc36.x86_64.rpm",
+        "checksum": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shared-mime-info-2.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:6a049afa68579427322ee38b9085251115a6c022786530d804d6a2081a84ceca",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "5.p2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sudo-1.9.8-5.p2.fc36.x86_64.rpm",
+        "checksum": "sha256:74c9d86eb0743f18d4fb25ac82e616b7103f5ca79c37aa8aa69be477b4d2a2f0",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "5.p2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sudo-python-plugin-1.9.8-5.p2.fc36.x86_64.rpm",
+        "checksum": "sha256:dda1ae9c2d6920761996734c846883fe26d4a2222364fec6fde58fab9a9dc3dd",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/u/udisks2-2.9.4-4.fc36.x86_64.rpm",
+        "checksum": "sha256:ad06336b4a496a063e390e0f6a15b08bfe2626465a3247a45f8c98c503a4b5a6",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/u/userspace-rcu-0.13.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:a00fc7941175e0934b46efa63721dd9f45b23905b2afc1643f0113d13db63ed3",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/v/volume_key-libs-0.3.12-15.fc36.x86_64.rpm",
+        "checksum": "sha256:bc1a60ef9acfc90ab773b2800eb515e3f9acd647827de3d60ee2390baf4d1f83",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.14.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xfsprogs-5.14.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4aa699025a0a751a62b20f9da7fbfc44c1de6517963f4c1195b9a4a640425310",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.x86_64.rpm",
+        "checksum": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zram-generator-1.1.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:1c7854309a224fbdb2715f943f8cd23f4c68038c3ae4c2399e2db092c8c78267",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zram-generator-defaults-1.1.2-1.fc36.noarch.rpm",
+        "checksum": "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04",
+        "check_gpg": true
+      },
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/ModemManager-glib-1.18.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bd5c235acf908e4b0191f6f4b89589c123e218b21b991e79ecde140867b54282",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.38.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/NetworkManager-1.38.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6b360093e3a04856310a3c967b4c59a597ec6ff33826affab4052ca212676699",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.38.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/NetworkManager-libnm-1.38.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:52ac12150f661e1857b5abd1bdb57a2d6615cc26e35ba2990ee1e582907b3418",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dhcp-client-4.4.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:12b80a2d8cfafd1112c6355e3886270610e816b453202595157a2828fa7aa452",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dhcp-common-4.4.3-2.fc36.noarch.rpm",
+        "checksum": "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-data-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-plugins-core-4.2.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-1.8.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bc2230cb7e68870285ecf11d82e8607e74d42f01a57889b3c3e1b1d9e386404c",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-efi-1.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:544a6838523a5a871c593097d5a48d37b7acf3c415a5f1a23e87854a730d45ab",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-flashrom-1.8.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:43ab5eacc5b675862f8821fa8328c33624eb945662536b737e2b4f064c4ddfe5",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-modem-manager-1.8.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:404eb6145247a020308ae78c6d42c6a81c0cec7f0258a5f83578ce1b6a93433f",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:0395a5b8959a1cb66d616c758944e985c0f5864ea4e4527fea8e1224e2b0fd5f",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gdisk-1.0.9-2.fc36.x86_64.rpm",
+        "checksum": "sha256:f2da32b1fcc10b56b30f7939618450fd863c7469508250508060ebd36b61ec5e",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.72.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:035efd371a5a69a7ea1c833af1bdcf74e7f70b6ba36f961f37bddcc9732e0bee",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.x86_64.rpm",
+        "checksum": "sha256:3d86ab10e70b5bcdfa8f437196fe10a8a5256cb16b941162e329c5d2eabffd70",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.x86_64.rpm",
+        "checksum": "sha256:075b89e5b1b132eacb4e6057d00764c9ee342b95d926d819c0e711d2c3ee8ac3",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.6",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0e6402679ebbb705a4cb74a238d34fdfd62c395a8b3d28fc0faafc27e6f4a73f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-efi-x64-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:5c4a0eafc33b320af3e6c370d1e9d3506f92b02607ef2ec773c602ba504da00a",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "55",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/i/inih-55-1.fc36.x86_64.rpm",
+        "checksum": "sha256:61544f1ac4a32d1903e24f406fa1286bf54d21151e460bec4b2bc046840a42cf",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-5.18.9-200.fc36.x86_64.rpm",
+        "checksum": "sha256:bafc8af7a461cbed16417ffce4d30735895e5316d3ec4af7232951acad6fdcf4",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-core-5.18.9-200.fc36.x86_64.rpm",
+        "checksum": "sha256:9e29caa9cbe813b19d8b22301af1ccc0dba47a401b7acf66eb658f3eeb5aa8ba",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-modules-5.18.9-200.fc36.x86_64.rpm",
+        "checksum": "sha256:e1947cb52a8cbba29dfd79456fab69ee967572ca35855340e45b1b5a2b68e594",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.x86_64.rpm",
+        "checksum": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.x86_64.rpm",
+        "checksum": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:adfa2718dc5d4bae822b5905f1628bdc0fa830bb06c561caa331716293a2d340",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-crypto-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:12798887ed97a1746bb9551d61dee38717982f2587aff35dd4085adf9e95a4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-fs-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:dbc8762daadb5927a05241924646bd1a5149a52170d80558e78312f192a67624",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-loop-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:78f1f12225b42a3edcfabd694df561064ce39d02abd6d71bb85fe7beee747101",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-mdraid-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:20b5d48f802024c668285d4014c0a92eeed3031738474123cb5700ea5dfefa6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-part-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:db1423134b954c1c00786cce7a2242d9fe98f26964f51b707ddf00f8fffd7e8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-swap-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:cf0a6ad360f4ebc1b3e1f6d9e583751b100195f57106cad48cde4fe4a6eb7195",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-utils-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e9c2d1401d9c58a48eb7ee7ac873d97612662d65a4a5ead7473ec6b311145b87",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbytesize-2.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:996f22624b2f771360c80b1724dcd63ea1132b72db52bf0887446f7fa1c6c7cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-python3-0.8.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bbac26c434fa5eb6ef77751738f9ef4b0e02d11e657812b388b6a047ab6fc7a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libdnf-0.67.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:b0a26bee81681c31c0ff8e3dfd5031b8861bdbdd5ebf25fc59763878ceef2d7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "69.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:55085d771e68ac6ed4be095c5cce52bf39f49d0c65bdfdc92d6a0fe2493c99a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libldb-2.5.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:58e27f4659cef20e393eb063f6eae99ee32f1b421a55fb147d919bc36e42dba6",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmbim-1.26.4-1.fc36.x86_64.rpm",
+        "checksum": "sha256:866dc0c718466213e578633155aaa9d69fb860f1ac44b44611025a957780a8fa",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.6.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:76842198d98983f83241be2ae73b24efd580ee0af7d0a5a301dd02a7c417c801",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libqmi-1.30.6-1.fc36.x86_64.rpm",
+        "checksum": "sha256:981e35ad67bb3aebeedfba78b4880e581d6a6db2b7ec4023484c94998fc66a5d",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:eb149c8897d2e78727e2dac441bcc05e064e045edb73705af0a0c57a5d17fe4e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.x86_64.rpm",
+        "checksum": "sha256:dae15191393ec4f56460271f47e1cc2ac7bc847ccb03eaf0035175d1c28c219a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_certmap-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c073eeb631912aa260da3cb99353cddff4e7f02ffebd775a329ef260ab42ff29",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_idmap-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e6cd3dfba9bd5c1d8527ee3ae8bae3bf7a1a375932f7fa4a1ee5c317eb70b0f9",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_nss_idmap-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:49b784fc4e9fe1bd00063c509f31cfc1e08749bb203804654f4a01214455853e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_sudo-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:011377565612bdc103fed99f4e041100a0a836fc31fd517baa998cba6549ada4",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtalloc-2.3.4-1.fc36.x86_64.rpm",
+        "checksum": "sha256:234d03de5e310e9afc481eb35fb9b01072c6a946ec8c22c6429d33ec59a00eed",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtdb-1.4.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:0e791d318effa04ff1c463f60d0632acb5ff6f2ad6f04a836bbfdd07e500d91a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.12.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtevent-0.12.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:929f61d675345450d11bc44ab2466cc621f9ece823b031c784ca79e657e179a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.9",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxmlb-0.3.9-1.fc36.x86_64.rpm",
+        "checksum": "sha256:7130cc35fa8510939a0e7e72770261982f8a5b062253e85251288d0acf5f6e21",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20220610",
+        "release": "135.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/linux-firmware-20220610-135.fc36.noarch.rpm",
+        "checksum": "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20220610",
+        "release": "135.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/linux-firmware-whence-20220610-135.fc36.noarch.rpm",
+        "checksum": "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.x86_64.rpm",
+        "checksum": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mokutil-0.6.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:66ec27d6c6b52dcd456accf412d14db29ca5cf976194b721407a9f5feedc1dc8",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs91",
+        "epoch": 0,
+        "version": "91.11.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:94021f69bdd5e8be4b186081e6b5748a27b37e8d7762ca6b8973bc0f1ab8b16c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a2b02e6ee909472aeb994d0040e1255ffd6c45150c32d9b084609d928caada61",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.34.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nspr-4.34.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5e2785ea0e99173e686416f33d9cc80a74c21a836a25af89d5b50415c6142701",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f8cc2172a8c6cae8fd0e3c56a266a20425194ed024b730d2f2d04ee3ab9bfb5b",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-softokn-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:d74d44ff991a85bc5aed1bf170446cb324bc8ba9f476a16443b856f689325e89",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-softokn-freebl-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:13aeb3b9889afb0dfe607b8e5a694f7debd69b5e92525e3bb8be606ef46a1c0e",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-sysinit-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:4ee2bd16b0321e89607019cc53a5972625f11e331f0a4e9af57e990bb6d6485a",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-util-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:4b1739660922063971de03928e8cd7154d96b703099e669e8a9b5523c1522310",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-2022.5.17-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2240717e975e4f42f07025fe33240470aef04dd9da9eeda02e7dc5e806bea24b",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-libs-2022.5.17-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c4bf6b2c21cfae19a0f3f4b0279823d1d7958c40b9bb483b825d30a1d9279ecb",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-system-compression-1.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:e03035313c0396abf2c9acb21bbb5b303cc73726473ab115d1ba58aa1e3c7fb0",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfsprogs-2022.5.17-1.fc36.x86_64.rpm",
+        "checksum": "sha256:429e1f761cf68fc139e64dd6bc3cbedfec8a10f244db9c87d2368cbefae73d20",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/oniguruma-6.9.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:aa6dc185c17dd7421299c069850cb22fcc68ed34a9a5ff720ff03269b3d874cc",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap-compat",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-compat-2.6.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:db4eb4ae787ee174d1d2957c80b0413ccf31e0bb539d70ba7e0c606f102bb2de",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e7090f335d0d210b20ec4b8ac8adb1b801c51eea363d52d3b48f821512e38500",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:901a4d6e3875a08f48665f5ddb9d169d75639f85d93e1a877a155c026eaceada",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-dnf-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-dnf-plugins-core-4.2.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-gobject-base-3.42.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:77d143afad8d60b1ed9a206e8a1e2c1211218e709eb2c830c8f07744b06aef1b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-gobject-base-noarch-3.42.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-hawkey-0.67.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:05a455a9892b4c4c77255f1d396c738e2e46291e8c4ac381f2a343b8d98e1873",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libdnf-0.67.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:b9ad1c81ed20265422b5fcc8865f055a4172bc3325b9cb212ad073266057aab5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-unbound-1.16.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:5b276451caa30f1ce4739822473100781b3810423528a170c4ddd8405d1689f8",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/shim-x64-15.6-1.x86_64.rpm",
+        "checksum": "sha256:fc9e1d57af84ad965d533c76162c1d31808b96705a085e679e061f1385acb70e",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-client-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:ef1f95d053d7c6dc6a2fc14039358f2db3db91b42ce79194a98c28a0c34376bd",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-common-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:b0580325e7f48f65cee2a914fb36712f068eb6202a607f962ee36b6e3cd9605c",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-kcm-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e37d6a627ace13dd51f94114e5c669fa8a5a6f695bb9dc446eed1b9a9bd6919f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-oomd-defaults-250.7-1.fc36.noarch.rpm",
+        "checksum": "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/unbound-libs-1.16.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9bfc17431245ff01b7431893884275d6357138d014d4634c073b20bb5007d798",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.5172",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/v/vim-data-8.2.5172-1.fc36.noarch.rpm",
+        "checksum": "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.5172",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/v/vim-minimal-8.2.5172-1.fc36.x86_64.rpm",
+        "checksum": "sha256:853e915ae73a3b0a08f3cb36a8289552e488f99a4245c4bc431ff8ac531138bd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/y/yum-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_37-aarch64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-minimal_raw-boot.json
@@ -1,0 +1,11392 @@
+{
+  "compose-request": {
+    "distro": "fedora-37",
+    "arch": "aarch64",
+    "image-type": "minimal-raw",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-modular-development-20221025/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "raw.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora37",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:539903a5db9dac34cd633a95db47af0c932118567e759108ec8b05f91992857f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3f64a9b092e5c9b829b955a2a63532462facd0cc967131211f0a90a6ed5453f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178c233d007c00f14ec0c0a5083907f3cf2889b998c8e7eefe25c8b04ebe1aef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e2ac5ec02616313b2c7a6d6ba73d860c4cc2380c2a7aa6336b3ed89c67c1392",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5676237d61fba60ed5fb483b792111aa397faf464460222438130b0f3bbbe609",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1050a9675979c8ea71d673034094281225dfb6252814a6a4b959cc89a3fa467a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d57265c3bb44d183f7f619d7bf92f375bcbbc30e242d6df66e2533e5e9f84f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f83d5f59d9e289df361e2d46bf18143245b1324f3e2fb71b91ff7740a897a215",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ad7f1bfee28c80f9d4282aa9f0e5d8fada533111fc03fd9c33e988766c6c380",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5547ad7034b539388be34c3c44c054fb7d99a98a372733283305a023387670a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea7104bffcc6792553e51c8bb8898c4c8649eb76055dd56e58d558e33d6a78ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04d878eeb31722ad495b34edd6bacafeffd5d13d39dfea5edff49daee5f28c58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4716da965a3141394efc6cfca127880bbab451c7cb285bfc48d1911d8402164",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c83fc74498fb51302e56cf23f60712493d3003a25c44cb19b60aca5b1a683705",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59d84b98e1a0066e0cfc7ddb4f2559ded9803f7fef0c8b52d1ad0693b8f4dbae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51f204b5187519266c3496cc970150cb41fd23f07ff58c3ee6d8b44a319fb455",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76df070766b1d7460c3edf04cb404046a9b999e68dde6598c090140995a49dde",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:185ffaca4bf6de8e14842027e4c2258409619b16b7d05d2a5df1100d187024dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f12b98bc656a67fc7b378870598993e010e4df843fb998f7a439a0a14bc391ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:266dbc27e73ef589066244029bbf09de65d11ec1711fc76094694a74512e33c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f27c1dea30a1eaeeaf6e69f30d30e0097aabf4f3a99413c3c4a47f90fcfa2a18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e410d25f43c86de6f76542b336aa40dd0a1c6d84a8fdbeff9ef2a2379ee4e45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60c9b8479deee53528d17e3ddf0d1dce61ca74036bf5d35038fea901b61f60c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26948aaefdcef47d8f73cae1f4ddede5853ccf6a5d4e2ef5d4a6d921547cef46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3133da3cef48ae829fc6853acfa42c12c6dce9f8ebfd0b0318e81d728d90f228",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a19c9814acd3a96a1c6af95220a2e9e72242a2c653a38ef2964b711e509fc84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f53bd8e9f409439671de3762d5cf348fbffd7d97885c5de3953964fd7a148ea1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0e859a97a8167af62e273093e454a01bfd64b9ff60897bc97711f3591970106",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88b28b9729a393374ffbce10301fc1829133dba58487caa525aaebc8fa070f56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9d09656e98dd744599be50d553e059d5b3c5236b617c5d05de9f0b2f505ff86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e40045d6d88a1a5bedeaf60f1391cad60bce787dda76fc5ad297fe3c98bf168",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ef2400ff36fe50c2c2c33d503de10333c5b2be498791694b96d52a05949589d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c71a3884722bdeeccbbcef5d9fcffa4c265d6486acb0f164d70c682bd91e1fdc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ccf5a8e68247b63ac2f4cc27db3d0d3eba7a93570e2a00125d327ac2606d8c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e18c452746d0c9be98e298d7282f0f2c3f86fac4b1e78e6d4c9901a0b2f5656",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1c8670422ebe5aab49614e5264a61bc90ecc67e8ace5258ac94a04c8d8ecb7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e3fbeb8bd1e999cd741083ef4235c4087988e1c6d75e24b784b2ddf7c5193de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0131393ab117eb26be5e55451753229122f6ca97aa5b7872e65c9d691c0059d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4be185da5192918b485b25030b36f3e478bdc4bde19ebed1f80476931233ad30",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2b276a42f94d7982e5e2ef72d59b73b9313ea83792ea9bb35e2e5cb4fa5988d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72906b5aa7cc9f416f704bb0071972ddce6a08d251b1dcdf7253478153e8a20e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6aaae0fb24af1e41f043b5f782f0bd02bc88eb6d8de53c849d628bb03671b6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b1232e992e46c3897eaea57866d1ac655ebeff36448813fc5ddd84cd00da49a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18aac772a8f18c064c422f3c3d3be7a9f4756029f288a5b281e1da816b47f938",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cc7e6a19b5627e3e3bf941d5bef3ded55458eb226ed6e523e9a0d6a836b249f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a08019ab8471eb8e8bb8382acc0b8ea145852369d63293466a4af8ff2221263",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8cc5b5b5df546ba2a71ff6fd25adbeb01a27c7c503d53946463cc6108d4ff9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff00ca33d2a696f3b438a85da657f900df56d743f06a0163df3b051e74d9d9dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f81833addc3924f97efebcf3390fd375339a7e752e7b6ba9003162a248ec7b0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97b664f921653bc6d22abec3d906ff58a7a1d568a4e2f24a638b15f46ed8e058",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61eb54379561ee89f973c58c10b8507f64fc0d1b3bf11cb5624b236365eecc9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a34c6b913b7810ddef0831adefe154fb68150ead286b750a3dc3e15b56c75e9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c712e9a4fdd669f1bd5be16b453b5fe22ca6c7265845833086334ab73144fc89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d060e4e89bafa0e342cfdca9136c72c8d3f6af2adaecf2ef47e530c5edc8985",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2b8068fbb2231a515c60c491eb5b08808af1eb6d497eb33039125aac3eb7d63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce155c86d0bd2ff0bf29a3ffd454fcf085389e2568a6d158cad79c55f895d683",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9f91971d2e252f6fd49c40b9feb62beda46c268f0ce1903e6396f7a0d35cc39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48410dce2b1c514e23d2e9e067714be0eb2923ff44e3ac7dde373a92474ff642",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9013badfcf2a78e4dd4a1f6ada593f3d1f9dd5935814abde7dd7de1fa9bb8c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5caf8f150fec9e984d40ae7efac186450be8ce215eda8a6f864606c10bce798c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbef4adf7285d497ec92e10715866a15648100373e579947afa1c28862cbca44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8eaa5255d8f5cd3a8f854c4de6082158fd6294bf779b654d5bc270906a425ebe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c2c0413d99049dd00a1f5ba19dc53f3ac0efecd31f315da2f2f9a987300ca05",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1764513e83380dcdc272841ee7ed52e118c1672d593f6632166bfe5ef955f6b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1090174c3e6dfd17771c8368e16e191fbdeb69d075e22347becec5262f39bb3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:377612c800325778fedc210ccf925125dff0f8515c5bad99ac48df1c35d79a46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2dac60f8875f9ae0aff2da3840d9e878a48650aa4c6d04ae6cc0b668aa7ba2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf7a37c0aeb74a472c54d948e2cd3978b813891402b76c5013929255b43de54c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d650642e10443dbb860a185980f3119518e8fffe3952535accec681fbd8ad8ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6738cecbdf2248efba296597ce75313a70219901923a2f3aef52af4825029409",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c616cd07150cb3de1e62b6b710f1405106c7310927076aa6cf89a2c94ffd13f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47c981aa9da90d9280f04145f13b7f771d3ccd74d9a776f438dcd10072bb4ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ebf16596928342c62b0abc250f56f778e7b6428e0273ae5da88493d9effe2e3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8650dafee9357adb6e6f878e5c3eb32aeb72ccce5bf68056920e77c7abc8da9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db2227729ac01ec1712cb3630ae3ac81fbe6094b5d40f9a91690b1b8dd413eaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:660c430d505999d24d2c0cc023d6b6af1c691db8bfaf62d10d38963627b4a664",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbf24d19205ce8b9c2da7655d859f4c4e7753b5794bc90db3aabdf3e7784bc84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:b25b2a6aa9d67b105201ef7f90154da99e683b8a3a64f6f1ec17d1300dcd2e22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd54dcc38550baa9597e79a96c6860106f9d2770feede4edbb3e7a5329c9a033",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:009ab9b4d04db2fb308c06d856926c7d2cef00deece56967dc561fe60380e211",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:539903a5db9dac34cd633a95db47af0c932118567e759108ec8b05f91992857f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85698713589960a8b6821a4a56bc7b5af4df9977e86cad103cb9512ba7177d2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28833e1258d7c690c2cf813a00c793be63188153a638997dc53f8a7c12bccf6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3f64a9b092e5c9b829b955a2a63532462facd0cc967131211f0a90a6ed5453f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178c233d007c00f14ec0c0a5083907f3cf2889b998c8e7eefe25c8b04ebe1aef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e2ac5ec02616313b2c7a6d6ba73d860c4cc2380c2a7aa6336b3ed89c67c1392",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5676237d61fba60ed5fb483b792111aa397faf464460222438130b0f3bbbe609",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:671c739218458160f75916559582811f416b9224a840945a236aa52523f072c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c1347d36ff1258ef9bc3d015506677837976932928df4b8174e84667a161660",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1050a9675979c8ea71d673034094281225dfb6252814a6a4b959cc89a3fa467a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d57265c3bb44d183f7f619d7bf92f375bcbbc30e242d6df66e2533e5e9f84f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f83d5f59d9e289df361e2d46bf18143245b1324f3e2fb71b91ff7740a897a215",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:162c1a1b7c420d6a68eefa26936cac74a378ddfc268b4e48058be0773601d808",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ad7f1bfee28c80f9d4282aa9f0e5d8fada533111fc03fd9c33e988766c6c380",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5547ad7034b539388be34c3c44c054fb7d99a98a372733283305a023387670a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea7104bffcc6792553e51c8bb8898c4c8649eb76055dd56e58d558e33d6a78ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04d878eeb31722ad495b34edd6bacafeffd5d13d39dfea5edff49daee5f28c58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:330d0d56aa39a90d15ccb3cebf3bf403a7e6744c24cd1b3b78f9439bf4a97742",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7221f9c4b4c980552dffc75a08e413d794d2c52812b3778b6b0127f801c80eff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e880db493868227fd230555c23b06fe23c69fdb003552f5d00ee036104a8ad65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7ba853b07a46efda355edc72f74c9e356a2e60c3e4f934b0cefb9d347f20a53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1225d8d1f0752e8e529ef7257f235b9189c1f85fa361883a9d40f768da0eb2c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e7cf0116ffdcf0c673d155a24c70e1483305d6ec50ad8b7d1d4ad224e4e88bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e694ef5ad5f16b497d4bdeca3c0a0c49fd6d01442e87f5c302dcadab0af2657b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b75e3acf6f11c8584c7e38718a295503c09c0acd4b9dd245b287ab3357d245d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4716da965a3141394efc6cfca127880bbab451c7cb285bfc48d1911d8402164",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:171856671d92ec11433940b504eb84f496f3132921b020dbb66172a5c7e1b138",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4b232fd35e5ef6f65be42bab721dab5f736309c37fa1508f28c8cdf4b7911af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3bdc032c960668daf5ba86e7d695924879a21e939aee174858b5cbe2f4f0d3f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:130fca628d199df219a2c49dac899bd881abe73839e839e78d0e6754fe3336bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c83fc74498fb51302e56cf23f60712493d3003a25c44cb19b60aca5b1a683705",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59d84b98e1a0066e0cfc7ddb4f2559ded9803f7fef0c8b52d1ad0693b8f4dbae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51f204b5187519266c3496cc970150cb41fd23f07ff58c3ee6d8b44a319fb455",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76df070766b1d7460c3edf04cb404046a9b999e68dde6598c090140995a49dde",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f4a1bfa873f3a019aef82c02e5713ff67cca7942d7351002e01a0defb8c0cbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f730ab54689ca4dfc727425636a636d35a6d7bbe4985420cb5ff35ec6eef0307",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b1529cbd75e33f5e9e220b868a68a95d807855cb462afe8f15a37da2e88cf5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b269e1f4fbfcd3fcfc78f42b8045f5f32e98808b7e841940aa066a74fc49e2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15aa94c5c68a12d000a2897d78f7775fd53ae2555789a8493874bffec978f773",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f5f3953da57fbc1aab1d723cedfeca5c3536c66d479335af6173ca50c54bd5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:472e8442bed37275ec0dbf3783d701d759145b663d96a4dd2bcb6b357699b079",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7f426539476633d5abdb3ed81918a9311aaaffc2eb243b628cb738925bb5f37",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:156bc28039d28bb3237af60f3dd7bef761987336d1ce4641bd94a4975958b695",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a71f25e9551c607d79645e785d5554292f15fb9c7d45bb9b92de91766825f3bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f52edeae190ea55635b96cb8a5fb81ecd9a2ca900fa65c4403e4890c2d70da83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aef4052ca482ce6d1e8400191a2791a635415868e7aa36d3efbea546f710df11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:185ffaca4bf6de8e14842027e4c2258409619b16b7d05d2a5df1100d187024dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f12b98bc656a67fc7b378870598993e010e4df843fb998f7a439a0a14bc391ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:266dbc27e73ef589066244029bbf09de65d11ec1711fc76094694a74512e33c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59d4bbec71e99f25ac89228d5528aa56c2eeff0a2e8e83d405d3e378955cbae9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f27c1dea30a1eaeeaf6e69f30d30e0097aabf4f3a99413c3c4a47f90fcfa2a18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e410d25f43c86de6f76542b336aa40dd0a1c6d84a8fdbeff9ef2a2379ee4e45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60c9b8479deee53528d17e3ddf0d1dce61ca74036bf5d35038fea901b61f60c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26948aaefdcef47d8f73cae1f4ddede5853ccf6a5d4e2ef5d4a6d921547cef46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be9a015662acc23d54474a01f81a8f321359006b22850edcb41fdddc6f01b1cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c18091220a104278225bea1573077d807d205e2392f693bcb63a70c4387f141",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1c0880f9180fd54c99e2340fc9a0001bc489f5ff3ed8ab405cce9e35707c01b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:edb75a2c48205e923649a0ff2a5d41bf943cf35d16d272785d095f33afcd7b84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99bc383fa8558a73027e63ff75f0978e4e2ff6b26be55f384c3f52e5aee97527",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b875744ecefb91efbe7d05df252768f666bf220d23f865d7df9b15e58dc86631",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:112978b8c5807ecf490d3559b1d701b48d75ff38dee451e4394584e2adff408c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3133da3cef48ae829fc6853acfa42c12c6dce9f8ebfd0b0318e81d728d90f228",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a19c9814acd3a96a1c6af95220a2e9e72242a2c653a38ef2964b711e509fc84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:445cda1792047a2c4bd2172c4a2ef0c175096a848a856cb053bc42d6fb2c595b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:44a972be5ba2b774ecbe02a5773ab63e64dae3961de4fc0b36667d42f1c0a4cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34e078e9be9cbe997458a72e35718feaff49a1cbaf8a8582b30fd0c744b03105",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8adebc901848979df7c1c96c51055426c0ac7212b536a5cf82bd650dbbb322cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98caa3b739e76b8b725a9952231c463b3a46bf056942211f90505e61ea631111",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:941ce3e47a525ae3e39f79a7df7d8e11a313a30a45b5b773233fc5f0ce6fba84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3baa59082b57d8303f92d493ee2a4d85592b31a89b6598b3c8b1e01efbe2f15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd1fc5195580df7a72cb38e87f05343e2d381c7a171ae867b802aadb0bf98c4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2493a908ded67cb218dfd26609d197e2d687af31b56f47124c577a0912ab9b5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ccf0d18c15586c0a7ad9e7e69551fa9b997c25970701b5e635a981878c8a9dfe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:040f180295b3e082728cc9725aa5a15556920bdddf6e229c7693b4ec80fd935a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ec90e98535f2ba20e2ebc46824e08834a7f6d0239d425c1868ddc7fc57cf677",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3db34fee176285b0e73890ac0864c748bb091c256df197f885b31455dbb041f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17f5276639d9353dd06539d02d936a2b36793003d9ffd12ae0b557b35743290e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f53bd8e9f409439671de3762d5cf348fbffd7d97885c5de3953964fd7a148ea1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dd5dd23c799bcec2ddccba07a99aff77a244c3a85717a307592ca6d3bc5f202",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0e859a97a8167af62e273093e454a01bfd64b9ff60897bc97711f3591970106",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce1a77c4b97b190ca56c4548ddab041eeb989df4faeb3c87cdf43d28f491ad29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c49a2ec0463320a4a18fa94e20ffe4ffd0714b26f9b16710a2902ffaad3937bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7da174a3093695f29b8ada7193aeefef71746a4b8fdd9c1e043aa458f368e058",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88b28b9729a393374ffbce10301fc1829133dba58487caa525aaebc8fa070f56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9d09656e98dd744599be50d553e059d5b3c5236b617c5d05de9f0b2f505ff86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3063bbcd07caea5dcdb242471047b2a77264ed33bf004ddf7405cab70c6bfe1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e40045d6d88a1a5bedeaf60f1391cad60bce787dda76fc5ad297fe3c98bf168",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4718a79261fa3420e90a53b57cc5d25ef92e11e6ff30d089cce717114fce679c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b97c4e4b98b93adb07c985a362e7216298fb7527f1887626597cc2ef2796de8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef495449eaf292fe2bf17066a5bc006c357804d207f7bcdc16e65d40ec827206",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12b48f78affdd8a09738ff74425d911f1c2404753046b8d07aa8705c7dac4994",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d62d62208b3bf57c6692ec986e5a0299315bfd09f499338fd8aea3bfb430827",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5593981668684f5757b4ceb377fc4f3442c597daa21566e614f6ecd955f0d3d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b9438f0c427e8b56f8ca1cfbdb557d8d8c7c92b60e1a2adb9e39adf4a495d32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:001e161a91500f4dda475cc30dd26b48c4299cba488cb0deaaad17dca3f407a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00f0f27fb9b6195e3059d816cf361240a0d3fd07e9d5c100ccbb4aacc7bc9ce1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6523ca88e57d5e5f610a3d5fad22b2d005248e500d660946553c8f9e60d6a67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef0020c1d9d4afab7b4d9515d97d9d2081f679587f61c8481c808e9f0e3c059c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b6cbd8f1bcd9e058f975f5b2b2e19a075dd6c28e2e8a67feaa337737b542fbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b6b0aa91236f4fe07ebd5fd5154cbcb8c7ecca90ba9af7808c8820454c173f75",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70702e8555203b90abd08f8c407a872640ed19a9e9d53869950cf56c594540e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46ffbcbb2b1f414985b2824965e759104fd9c108cb8140cab2a2e4ee421daf6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ef2400ff36fe50c2c2c33d503de10333c5b2be498791694b96d52a05949589d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4092137b8adddb11ff22705fb37255f70a6cf1c26dd44a33410a1d0c3ab7c8a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e5d3c2263a0958574d26b7afe5c5341d7bf80c0986f5e6116e4dd4e312a03f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:add56e5fb7330c434a8f6e2fcccf6bf817ae396b9c3c419e2b3c5eb2046b6812",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c71a3884722bdeeccbbcef5d9fcffa4c265d6486acb0f164d70c682bd91e1fdc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2090e6e4ab40eecb80944093cfd6dcee965cb27803e59c207c28692e8f4c5d7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56b548b06112a037121a913157b0e4c08dce4bb0511843f652e99960e657d13b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0843f8805c84f780715c402544d9ce7255f773d2cdbfe64f2aeb50a5085689ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ccf5a8e68247b63ac2f4cc27db3d0d3eba7a93570e2a00125d327ac2606d8c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f55ce59e067b48e1148a5e40b09c7223804540bf1593fb3bcb687c252a074c40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e18c452746d0c9be98e298d7282f0f2c3f86fac4b1e78e6d4c9901a0b2f5656",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9176c93af66866fce7b6c0ddc2426bbb88d83d6d091da663ad8c4cb8f8b2615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6bcdcac414f4e313ae3527d3993f17bf38d296fdc556c10e738177fb5621a245",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23ddd80f270d4a9a2d91e6c5f8d8741e58473e373841a26c6b0f85e79b65565f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a78e507d71c85c273d3aa7e0d7f151b342a508fbfe85717cf760ee172ef9d37",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2bd8534e896f251cd58b8cbb0b069fcaa464aa2a84fbd9d8187690f3c979fdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1c8670422ebe5aab49614e5264a61bc90ecc67e8ace5258ac94a04c8d8ecb7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c635414b909a2b7ea49bd815c0261f4d30d13d871346906501d7316af3ba1772",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d09e7caa4cd299e32a105bb5ae68a53a2b7ea92f145306bbb563fc3a3af9245d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee50ad1b7ba00ffed8c17a1df7b42800c3462a040281afd3500e1f7dd768c75b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d582315683769a0456d5ec9f85939f75f8df5055f3ac4110f28cdbea9ca9cf69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2805493afc174e4d7588202a2aaab0108d176b62ba856cf45eb8625279a4ceae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0fec5b7c7c8482cb9642dad77eeedadefe7dda70ed7b53d44fb5a6bd1ea2749",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45c5b537992ff64548b4ebf9b1e9c0f06fc77e895261e94c5a97e44d0773cc98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e40e9aaada115819d974b933bb33e6600d39fe13a91a9b4d5aa27c4decb06155",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95d136f0a45ecec0f319ac888010a2961d32d31a4cbc7c63aa5f5d128b9619e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:932f1548d9ca07579d56cf1ce527b34786cfebe8e07fc86106ac9d7a803ccfbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b3936a76dfa4094d9133ee6fbb8f0a58d41d54dc81f874bdb9086f06711112d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a96cd1a8ad454befdee1c14e9224dcc35949cce18f197f2f0841e03ac4d6e65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e3fbeb8bd1e999cd741083ef4235c4087988e1c6d75e24b784b2ddf7c5193de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f5d9782065476a664f6e4d450404858e175f75b055f844f8a939623854ef615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4e372e626eca2c917309767102294dd75e83ae3d4583e90ee5ac4d1b5032e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a16500df314e37275aaab3de6fff5f4211d65b44fa9c6ee9ba74e718101a10e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80e767ec60eb6cbbe095ef2917e2a8d022d98a5f334df0c1c3a14e27bdf03f4e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0131393ab117eb26be5e55451753229122f6ca97aa5b7872e65c9d691c0059d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62dfa5a36a42f97393cf948694764acd5bf102eb91e0e85b1b2d565fa0450823",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc9ddf08ea0c691edaa5f2072667d11715a6349f5745f3d2b6e6713bda1858f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0944d0fd2d273c99f6ab808111d4db455fc9ba8489714aabdeda5729977c004",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af36734e49f06f79fee74fbeafb555b24fd7473d915a580d7fc3f1359d63eb88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b85b1faebfc05f8f362dd59c53429328f787cd2fd60cb03432e259b0e5294bff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dcf4b614ac88e26b9b344e0d6f3da257555f4402742e27abca969b0f439d6211",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4be185da5192918b485b25030b36f3e478bdc4bde19ebed1f80476931233ad30",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2b276a42f94d7982e5e2ef72d59b73b9313ea83792ea9bb35e2e5cb4fa5988d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72906b5aa7cc9f416f704bb0071972ddce6a08d251b1dcdf7253478153e8a20e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6aaae0fb24af1e41f043b5f782f0bd02bc88eb6d8de53c849d628bb03671b6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b9082cd1e6c405c75d7cfe43595b066a80226942da5ddc714b1e6309bcf44e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b1232e992e46c3897eaea57866d1ac655ebeff36448813fc5ddd84cd00da49a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27722776153aa4e16edde96b069f2d249838c401a58824205f3d37160bc53438",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72aaa5d89982fed7efc80d190f9bee4c0006cf69773a942f5de2566ca666f0e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d023cb3d1d313c3c21136cd59f6a1d103ff16d260e9b8a52dbfebfc663952e9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a2e8b1aa352391b389df8624412ce22b31e0729b027c1bdf20d505d2ce1da60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18aac772a8f18c064c422f3c3d3be7a9f4756029f288a5b281e1da816b47f938",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b43f129f65128a6477ed7d55f7c8a0a1359bd6eec8bc162480ef21d2366e6de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cc7e6a19b5627e3e3bf941d5bef3ded55458eb226ed6e523e9a0d6a836b249f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adf4bb4c6f00d4d335a8cf6c6cbb3919aa3381752edde9a16bd810600e38f8aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed050e88e1fb2f8d2cdfb83075e79eb868decf66ec51ee4bca29d35e849f5247",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a08019ab8471eb8e8bb8382acc0b8ea145852369d63293466a4af8ff2221263",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6ee284dcef741c4de7ef51f540ce8144cfc5f2937dd7da0c1c857d96cb5ecb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37ccd2182f8ca4f3843cd79dffd129efe19691b963f80d06cc990d74284e7674",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9748ea51ee4285b0442abae84beb3b0ef9e747b322310b0891f001718ec60237",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8cc5b5b5df546ba2a71ff6fd25adbeb01a27c7c503d53946463cc6108d4ff9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff00ca33d2a696f3b438a85da657f900df56d743f06a0163df3b051e74d9d9dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:633b5de9ea8d4a98180fcf2c2f93e9e0e16e751061f755c5265abd4887030dec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5466c4dc934d5abc1eb1a8ed1028e1f78fd4eea87ecc5954fa491a0879c0fe5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f81833addc3924f97efebcf3390fd375339a7e752e7b6ba9003162a248ec7b0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e5480b45c64f05340cbdac2bb0354b5593aa8da16690a0b0e188a1842920af3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b322703e97a772ad667f9361e64caedd6b1ff8b26882447aa4083c6ac4bc047",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5059e977d0f0fb2f8e00201efc16c9e75198d23a5aaaef146e042d845a69e97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97b664f921653bc6d22abec3d906ff58a7a1d568a4e2f24a638b15f46ed8e058",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61eb54379561ee89f973c58c10b8507f64fc0d1b3bf11cb5624b236365eecc9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2536982a47df91b0763fd31226c2ff6f2247c1d028686e0201ba4b3aba45570b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:052d5277d62271b6d02095046f52a865e5a196be847e0e99d9e257d798c6167b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a34c6b913b7810ddef0831adefe154fb68150ead286b750a3dc3e15b56c75e9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76ed672b87d410a259b09885e8ad7a88b28f181a268c3b401356a43e41d38141",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:621a5f7a8b6f53c8b35225ee0112ec80f17cd317247faa2e4c083653f32f4d4b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a89bdeff8ea373ce88d147a5f017e7f342c1c79fdf615a88f2396e980638feda",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18b46fafae10d86249df30a025faf411cb1369ddd2d2ade738f9cc4b45ab6f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f787566fa6d4c0a2f5067b98195f3697a4e9c65a8227b6598f0d0fd778da571",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c712e9a4fdd669f1bd5be16b453b5fe22ca6c7265845833086334ab73144fc89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c4160ab5e8672d41f10f4fe52f0b59cc28b21cd3a681ecd2ccd8dbcab56ed73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28392dd7269733e1b069c3111b9eee10ec590f7d58408c0b7e46e78923bc5fc1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64a7dd77389ef15d39b87388aa8c1b51186accd702fb91989ddbe729060adb55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7bd13c90588b99b7a150452490c1cf43117ed01d68b4e301fda14b5d5c2a8465",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8413d88829a4d9487404720494e2bc4339e2d5bccc3c179bdf00d1f33a557269",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfaa73e218017bc791a08821e5f2e4c74776bac5e3e950a69338fa0c823c8058",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b72d8df75158aaca80e356401b9970d1f04726e019675f24057b560ba6ebff0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24f3d5654667b73965727da7830103c2130c7958e6fe70b27644681cb0dc304b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3303f9003ae7e80e1beb4d70681ea7633dbd5477d55c042264ef7770bd9107f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7844c090147f6e04cb219d39eb76341b08ec0bbea3b51c51aac925301fb7c677",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eff91da3adf84b15e85b72b907d7b233adbea9d78ecf0db75d9c3a6c9c0e43da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d6c6889c78933703fc54b965fe1cebd52f08e7780093e71b21fbe10586f2aee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b56b7ca059afbe4a7ba86d30b7b324e639df618276cf45b46d3e315cf0718fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b3b3f611f93e849b5c03219fb2a28b63ac4215ebe28a8219da5e5be15e5ed52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c61932cab67782a94abb02cdeb1c1b64c0161a0331b1905f8826233d7ccc7ad4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d060e4e89bafa0e342cfdca9136c72c8d3f6af2adaecf2ef47e530c5edc8985",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75833cca024e8367727abdb7c363832e445b8e461bdeea9f74ee6f27701ef806",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee09c79ac0d3cfa76c1565f1727de2734cda082f657e80c881c93aaafcb9bb06",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c624985f09a77982fab2c04a5dbdee38f69777b93c0d59d0c05e7dd0d384c9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2b8068fbb2231a515c60c491eb5b08808af1eb6d497eb33039125aac3eb7d63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce155c86d0bd2ff0bf29a3ffd454fcf085389e2568a6d158cad79c55f895d683",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f23bbbb8abeccfae1758e2eef3a676c956f2df47ab4ab559eaff52afa1f809b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ead18c632b1aedd94d6d722f8317c2618165b9bc0532fea4ba5a10b642e4766",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba7fe160856cb5c4385d6cd5ed9b2973de52521e3a944dacf221eacc77dc44de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85746399da551cfc335f2a4b156460b4903a277861077cf919b3f5ecd7689e97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bef843589abaf3dfb3ff5c72b6630f5b6e6ec8d706f2d569d6b503385844444",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cc444fb3971b6889d20cb009bbe91cc464c2fc027e6aacd6927a13d3bbb10be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8aef705ac6c83a97e41f60b13c7f8f38a53126b22390a691f48a2f77621b3218",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e10408f24fd79fc501590bde5e8bdfb0fde0add0c734c503eb3c328d6e34630",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f76a449595a1225fe34753ba26e1830609789848e3f7eb6424348dbdf63e1046",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9f91971d2e252f6fd49c40b9feb62beda46c268f0ce1903e6396f7a0d35cc39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9cfbaf8447ef22431bcefb1542a31badae1a33de764e4cbb88e90faf42827519",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7f51a01499b5ad345c10a790688ff8837d894b8608daf0fd27250d8a20afa77",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3011b8c219f9f86fadd7bf1ae600db59364b5e425ae47117d090635812dccbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48410dce2b1c514e23d2e9e067714be0eb2923ff44e3ac7dde373a92474ff642",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9013badfcf2a78e4dd4a1f6ada593f3d1f9dd5935814abde7dd7de1fa9bb8c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae6fe8d3375b9cab9cbc289118654227b84d353d8102273d15600e403ccfbe3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c9c7520371594e7072d9cee9fe6df88e1de32c9f39eea0e6b13a447fc04ca86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5caf8f150fec9e984d40ae7efac186450be8ce215eda8a6f864606c10bce798c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e1b3ebb0f9945593365eaf0bc01d052d2e221e930d5731d1bd8276289194ba1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e51a6aa0c2acf0913d7aa70eca38a11492de9ce863bd2f4955ae09c3ceda37a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6427a8b877a51be140e06665b3680a911816c9eb581aa54ecf29c77f51b6e898",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20c744f2ca0c36933f151c9436bc67c0db461e26c97eaad10726e3e42a169012",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21de93c6eaee8efe68ce326aa4a8c9819fb9c8a87ef153fe3be473076890db7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c462e7efdf7650c49e4d0af6aa59bf555db59bedf0a30e75ffbec4b2af5c5901",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dec644503915a6e2e256de5993a746379f871b241d81d0a0296c3f9478bf84a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9bbf1cbf6b2df49cf17585f3913a9064f7b0c3c56b116a92e9f242a3676efde",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec395c3a160470a6da63ac1298a540a93a2adee4d29c4f78c24330dbbfba12b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b9a2c3db5e64b6c33eb7f5b2f2f63cf127626548540bb6333e0c1fbc415ab9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55ff17ec31466bd748005cf65cd687af61b0aeb3ad343e8d0c2d9a24f8a1286c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:378607a741f61282ed8243ca0f2164fa521ff02983e0eb1289d4350b7c781602",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbef4adf7285d497ec92e10715866a15648100373e579947afa1c28862cbca44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22768251ebf30802c0bce3fe0bd9d4092bf56bff6036dd655684612949c112af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e49fe2ec10deebf89c5b9465db6e18ac99493ce1996ef5a28ba7e9e193f5aff1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f33292317a057dd50fd05ad00e5495a866a3df35d8acd83efdb592fb90c603e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4747539099204c21a9de066f81acc9235c684f0f3060ce84e1a0f2c10862b5a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8eaa5255d8f5cd3a8f854c4de6082158fd6294bf779b654d5bc270906a425ebe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c0e32d108fcf6ac2f4c61aecc03163168337179b861786abd206ae58535a0e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c2c0413d99049dd00a1f5ba19dc53f3ac0efecd31f315da2f2f9a987300ca05",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:012609d6708ad27db0098e6d6529bfe63b7a3ffecbf8c67bc5d8b2059f9bc7f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1764513e83380dcdc272841ee7ed52e118c1672d593f6632166bfe5ef955f6b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1090174c3e6dfd17771c8368e16e191fbdeb69d075e22347becec5262f39bb3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6c2be7edf77d8e3e7c53574d7e3c7284bdd11d084296bdf7acade081b6d169e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb3791b4d97a2d8b71268d808f50b3f8a1358e7a7d3cf66d8882b886d08c525d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:377612c800325778fedc210ccf925125dff0f8515c5bad99ac48df1c35d79a46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eed9d47041b04ea6c49408f4d71cc0190b699c51c1a89de4c6fdd676cd1777a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e6fb2a961d9e9823380d329642b68e752d56018b6f5ad0a7856a8fda723a9e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2dac60f8875f9ae0aff2da3840d9e878a48650aa4c6d04ae6cc0b668aa7ba2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:517d1129b28f53a15b66aad1ea5da4e6f45ca51c0329a66967b58c1cdf21bf9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba8364ee984a89ba421c4bef52fb867f7260789d4c4381ab208c139cb1054dfc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83a66501f3f273b184e8161039ca17fbd2b91c4acb2b0f0226593aa83cc47701",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:388def347af7b9811dc79872bbb55f1ae433bde1cc4b28e8b3ccc03eeab80a1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c8c5a7d8a7bde6cd7413c745ea8f81f728169d2e4e96327a86f41019b8390de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf7a37c0aeb74a472c54d948e2cd3978b813891402b76c5013929255b43de54c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d650642e10443dbb860a185980f3119518e8fffe3952535accec681fbd8ad8ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6738cecbdf2248efba296597ce75313a70219901923a2f3aef52af4825029409",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c616cd07150cb3de1e62b6b710f1405106c7310927076aa6cf89a2c94ffd13f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47c981aa9da90d9280f04145f13b7f771d3ccd74d9a776f438dcd10072bb4ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ebf16596928342c62b0abc250f56f778e7b6428e0273ae5da88493d9effe2e3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8650dafee9357adb6e6f878e5c3eb32aeb72ccce5bf68056920e77c7abc8da9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db2227729ac01ec1712cb3630ae3ac81fbe6094b5d40f9a91690b1b8dd413eaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5eff8b70f05717621b31b0c0c8fbdfa6bfbec81d38c7b98cc214a33dba9bde67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:047216e22e398523f2e1a08516407fc622ded70855c7b7a5a21b1c957e41363b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4523cbae9f86f48f4bd7266d931bf81afd007ac17d6af33d6ae782ce2579db1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e85f2257c7cb41df273ffdea56daef73e44bb7bfe79befa296f700e60c49548",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:92841df883b69d4edb23b0834936717b0ca61b50391174f2c919978051f736a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a9bd9e833edad84033eb47d19575344a44369c392b09f82fbd8d9cff3db71d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6fa6669abe6413582fb6edb939ff8e897a71c9e054a6839516cf9a6b11eb6c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:788976a6dfe6796fa08ba5f52c17af923044473b481a75be9bb695e8fa7d5a16",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:660c430d505999d24d2c0cc023d6b6af1c691db8bfaf62d10d38963627b4a664",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbf24d19205ce8b9c2da7655d859f4c4e7753b5794bc90db3aabdf3e7784bc84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbe8a6957b2a00bf0117c5cb08affc8abdc2dad02edd1113b463412b9bc2238d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1734d5da50fb27abe9208444bdc99f65c382790150492152b891d2d501d7bf9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c7be4066ad8a69c7b4ef73706b1c0591361b522f22a1ad969f2e128992ecdd8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c492273497329d9a1ea2293d0f668edf953e18830f7d49797f7ff8412ea76da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.19.15-301.fc37.aarch64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "raw.img",
+              "size": "3957325824"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 409600,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 411648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1435648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 2048,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 411648,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 1435648,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 411648,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 2048,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 1435648,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:001e161a91500f4dda475cc30dd26b48c4299cba488cb0deaaad17dca3f407a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-mdraid-2.28-2.fc37.aarch64.rpm"
+          },
+          "sha256:009ab9b4d04db2fb308c06d856926c7d2cef00deece56967dc561fe60380e211": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/NetworkManager-libnm-1.40.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:00f0f27fb9b6195e3059d816cf361240a0d3fd07e9d5c100ccbb4aacc7bc9ce1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-part-2.28-2.fc37.aarch64.rpm"
+          },
+          "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm"
+          },
+          "sha256:012609d6708ad27db0098e6d6529bfe63b7a3ffecbf8c67bc5d8b2059f9bc7f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-build-libs-4.18.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:0131393ab117eb26be5e55451753229122f6ca97aa5b7872e65c9d691c0059d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm"
+          },
+          "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:040f180295b3e082728cc9725aa5a15556920bdddf6e229c7693b4ec80fd935a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/iptables-nft-1.8.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:047216e22e398523f2e1a08516407fc622ded70855c7b7a5a21b1c957e41363b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/unbound-anchor-1.16.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:04d878eeb31722ad495b34edd6bacafeffd5d13d39dfea5edff49daee5f28c58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm"
+          },
+          "sha256:052d5277d62271b6d02095046f52a865e5a196be847e0e99d9e257d798c6167b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mdadm-4.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm"
+          },
+          "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/selinux-policy-targeted-37.12-2.fc37.noarch.rpm"
+          },
+          "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc37.noarch.rpm"
+          },
+          "sha256:0843f8805c84f780715c402544d9ce7255f773d2cdbfe64f2aeb50a5085689ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgcab1-1.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cpio-2.13-13.fc37.aarch64.rpm"
+          },
+          "sha256:0c0e32d108fcf6ac2f4c61aecc03163168337179b861786abd206ae58535a0e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm"
+          },
+          "sha256:0c18091220a104278225bea1573077d807d205e2392f693bcb63a70c4387f141": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gnupg2-smime-2.3.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:0c2c0413d99049dd00a1f5ba19dc53f3ac0efecd31f315da2f2f9a987300ca05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-4.18.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:0c4160ab5e8672d41f10f4fe52f0b59cc28b21cd3a681ecd2ccd8dbcab56ed73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nettle-3.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:0d060e4e89bafa0e342cfdca9136c72c8d3f6af2adaecf2ef47e530c5edc8985": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openldap-2.6.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:0ead18c632b1aedd94d6d722f8317c2618165b9bc0532fea4ba5a10b642e4766": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/passwd-0.80-13.fc37.aarch64.rpm"
+          },
+          "sha256:1050a9675979c8ea71d673034094281225dfb6252814a6a4b959cc89a3fa467a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/coreutils-9.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:1090174c3e6dfd17771c8368e16e191fbdeb69d075e22347becec5262f39bb3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-plugin-selinux-4.18.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:112978b8c5807ecf490d3559b1d701b48d75ff38dee451e4394584e2adff408c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-efi-aa64-2.06-58.fc37.aarch64.rpm"
+          },
+          "sha256:1225d8d1f0752e8e529ef7257f235b9189c1f85fa361883a9d40f768da0eb2c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dmidecode-3.4-2.fc37.aarch64.rpm"
+          },
+          "sha256:12b48f78affdd8a09738ff74425d911f1c2404753046b8d07aa8705c7dac4994": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-2.28-2.fc37.aarch64.rpm"
+          },
+          "sha256:130fca628d199df219a2c49dac899bd881abe73839e839e78d0e6754fe3336bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/efivar-libs-38-5.fc37.aarch64.rpm"
+          },
+          "sha256:156bc28039d28bb3237af60f3dd7bef761987336d1ce4641bd94a4975958b695": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:15aa94c5c68a12d000a2897d78f7775fd53ae2555789a8493874bffec978f773": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fwupd-1.8.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/setup-2.14.1-2.fc37.noarch.rpm"
+          },
+          "sha256:162c1a1b7c420d6a68eefa26936cac74a378ddfc268b4e48058be0773601d808": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cracklib-dicts-2.9.7-30.fc37.aarch64.rpm"
+          },
+          "sha256:171856671d92ec11433940b504eb84f496f3132921b020dbb66172a5c7e1b138": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dracut-config-generic-057-3.fc37.aarch64.rpm"
+          },
+          "sha256:1764513e83380dcdc272841ee7ed52e118c1672d593f6632166bfe5ef955f6b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-libs-4.18.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:178c233d007c00f14ec0c0a5083907f3cf2889b998c8e7eefe25c8b04ebe1aef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:17f5276639d9353dd06539d02d936a2b36793003d9ffd12ae0b557b35743290e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/jq-1.6-14.fc37.aarch64.rpm"
+          },
+          "sha256:185ffaca4bf6de8e14842027e4c2258409619b16b7d05d2a5df1100d187024dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-envsubst-0.21-19.0.20220203.fc37.aarch64.rpm"
+          },
+          "sha256:18aac772a8f18c064c422f3c3d3be7a9f4756029f288a5b281e1da816b47f938": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libstdc++-12.2.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:18b46fafae10d86249df30a025faf411cb1369ddd2d2ade738f9cc4b45ab6f8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm"
+          },
+          "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm"
+          },
+          "sha256:1b269e1f4fbfcd3fcfc78f42b8045f5f32e98808b7e841940aa066a74fc49e2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/flashrom-1.2-9.fc37.aarch64.rpm"
+          },
+          "sha256:1b97c4e4b98b93adb07c985a362e7216298fb7527f1887626597cc2ef2796de8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libatasmart-0.19-23.fc37.aarch64.rpm"
+          },
+          "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:1ccf5a8e68247b63ac2f4cc27db3d0d3eba7a93570e2a00125d327ac2606d8c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgcc-12.2.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:1d6c6889c78933703fc54b965fe1cebd52f08e7780093e71b21fbe10586f2aee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.aarch64.rpm"
+          },
+          "sha256:1dec644503915a6e2e256de5993a746379f871b241d81d0a0296c3f9478bf84a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-gobject-base-3.42.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:1f787566fa6d4c0a2f5067b98195f3697a4e9c65a8227b6598f0d0fd778da571": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ncurses-6.3-3.20220501.fc37.aarch64.rpm"
+          },
+          "sha256:2090e6e4ab40eecb80944093cfd6dcee965cb27803e59c207c28692e8f4c5d7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libfsverity-1.4-8.fc37.aarch64.rpm"
+          },
+          "sha256:20c744f2ca0c36933f151c9436bc67c0db461e26c97eaad10726e3e42a169012": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-dnf-4.14.0-1.fc37.noarch.rpm"
+          },
+          "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:21de93c6eaee8efe68ce326aa4a8c9819fb9c8a87ef153fe3be473076890db7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-dnf-plugins-core-4.3.1-1.fc37.noarch.rpm"
+          },
+          "sha256:22768251ebf30802c0bce3fe0bd9d4092bf56bff6036dd655684612949c112af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-nftables-1.0.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:23ddd80f270d4a9a2d91e6c5f8d8741e58473e373841a26c6b0f85e79b65565f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgusb-0.4.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:2493a908ded67cb218dfd26609d197e2d687af31b56f47124c577a0912ab9b5a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/ipset-libs-7.15-5.fc37.aarch64.rpm"
+          },
+          "sha256:24f3d5654667b73965727da7830103c2130c7958e6fe70b27644681cb0dc304b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nss-sysinit-3.83.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:2536982a47df91b0763fd31226c2ff6f2247c1d028686e0201ba4b3aba45570b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/man-db-2.10.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libfido2-1.11.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:266dbc27e73ef589066244029bbf09de65d11ec1711fc76094694a74512e33c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-runtime-0.21-19.0.20220203.fc37.aarch64.rpm"
+          },
+          "sha256:26948aaefdcef47d8f73cae1f4ddede5853ccf6a5d4e2ef5d4a6d921547cef46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-minimal-langpack-2.36-7.fc37.aarch64.rpm"
+          },
+          "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-common-2.06-58.fc37.noarch.rpm"
+          },
+          "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:27722776153aa4e16edde96b069f2d249838c401a58824205f3d37160bc53438": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsss_certmap-2.7.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:2805493afc174e4d7588202a2aaab0108d176b62ba856cf45eb8625279a4ceae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmaxminddb-1.7.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:28392dd7269733e1b069c3111b9eee10ec590f7d58408c0b7e46e78923bc5fc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nftables-1.0.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:28833e1258d7c690c2cf813a00c793be63188153a638997dc53f8a7c12bccf6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/audit-3.0.9-1.fc37.aarch64.rpm"
+          },
+          "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:2a96cd1a8ad454befdee1c14e9224dcc35949cce18f197f2f0841e03ac4d6e65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnftnl-1.2.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:2c1347d36ff1258ef9bc3d015506677837976932928df4b8174e84667a161660": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/c-ares-1.17.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:2c492273497329d9a1ea2293d0f668edf953e18830f7d49797f7ff8412ea76da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm"
+          },
+          "sha256:2c624985f09a77982fab2c04a5dbdee38f69777b93c0d59d0c05e7dd0d384c9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssh-server-8.8p1-7.fc37.aarch64.rpm"
+          },
+          "sha256:2c9c7520371594e7072d9cee9fe6df88e1de32c9f39eea0e6b13a447fc04ca86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/psmisc-23.4-4.fc37.aarch64.rpm"
+          },
+          "sha256:2dd5dd23c799bcec2ddccba07a99aff77a244c3a85717a307592ca6d3bc5f202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm"
+          },
+          "sha256:2e40045d6d88a1a5bedeaf60f1391cad60bce787dda76fc5ad297fe3c98bf168": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:2ec90e98535f2ba20e2ebc46824e08834a7f6d0239d425c1868ddc7fc57cf677": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/iputils-20211215-3.fc37.aarch64.rpm"
+          },
+          "sha256:3133da3cef48ae829fc6853acfa42c12c6dce9f8ebfd0b0318e81d728d90f228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-tools-2.06-58.fc37.aarch64.rpm"
+          },
+          "sha256:330d0d56aa39a90d15ccb3cebf3bf403a7e6744c24cd1b3b78f9439bf4a97742": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-libs-1.14.2-1.fc37.aarch64.rpm"
+          },
+          "sha256:34e078e9be9cbe997458a72e35718feaff49a1cbaf8a8582b30fd0c744b03105": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/inih-56-2.fc37.aarch64.rpm"
+          },
+          "sha256:377612c800325778fedc210ccf925125dff0f8515c5bad99ac48df1c35d79a46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/shadow-utils-4.12.3-2.fc37.aarch64.rpm"
+          },
+          "sha256:378607a741f61282ed8243ca0f2164fa521ff02983e0eb1289d4350b7c781602": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-libdnf-0.68.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:37ccd2182f8ca4f3843cd79dffd129efe19691b963f80d06cc990d74284e7674": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libusb1-1.0.25-9.fc37.aarch64.rpm"
+          },
+          "sha256:388def347af7b9811dc79872bbb55f1ae433bde1cc4b28e8b3ccc03eeab80a1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sudo-1.9.11-4.p3.fc37.aarch64.rpm"
+          },
+          "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm"
+          },
+          "sha256:3b43f129f65128a6477ed7d55f7c8a0a1359bd6eec8bc162480ef21d2366e6de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtalloc-2.3.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:3baa59082b57d8303f92d493ee2a4d85592b31a89b6598b3c8b1e01efbe2f15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/iproute-5.18.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:3bdc032c960668daf5ba86e7d695924879a21e939aee174858b5cbe2f4f0d3f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm"
+          },
+          "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/file-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:3f33292317a057dd50fd05ad00e5495a866a3df35d8acd83efdb592fb90c603e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm"
+          },
+          "sha256:3f5d9782065476a664f6e4d450404858e175f75b055f844f8a939623854ef615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnl3-3.7.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:4092137b8adddb11ff22705fb37255f70a6cf1c26dd44a33410a1d0c3ab7c8a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libdhash-0.5.0-52.fc37.aarch64.rpm"
+          },
+          "sha256:445cda1792047a2c4bd2172c4a2ef0c175096a848a856cb053bc42d6fb2c595b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/h/hostname-3.23-7.fc37.aarch64.rpm"
+          },
+          "sha256:44a972be5ba2b774ecbe02a5773ab63e64dae3961de4fc0b36667d42f1c0a4cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/ima-evm-utils-1.4-6.fc37.aarch64.rpm"
+          },
+          "sha256:45c5b537992ff64548b4ebf9b1e9c0f06fc77e895261e94c5a97e44d0773cc98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmnl-1.0.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm"
+          },
+          "sha256:46ffbcbb2b1f414985b2824965e759104fd9c108cb8140cab2a2e4ee421daf6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcomps-0.1.18-4.fc37.aarch64.rpm"
+          },
+          "sha256:4718a79261fa3420e90a53b57cc5d25ef92e11e6ff30d089cce717114fce679c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:472e8442bed37275ec0dbf3783d701d759145b663d96a4dd2bcb6b357699b079": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fwupd-plugin-flashrom-1.8.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:4747539099204c21a9de066f81acc9235c684f0f3060ce84e1a0f2c10862b5a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-unbound-1.16.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:47c981aa9da90d9280f04145f13b7f771d3ccd74d9a776f438dcd10072bb4ae4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-resolved-251.6-609.fc37.aarch64.rpm"
+          },
+          "sha256:48410dce2b1c514e23d2e9e067714be0eb2923ff44e3ac7dde373a92474ff642": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/popt-1.19-1.fc37.aarch64.rpm"
+          },
+          "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc37.noarch.rpm"
+          },
+          "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm"
+          },
+          "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libuuid-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:4b322703e97a772ad667f9361e64caedd6b1ff8b26882447aa4083c6ac4bc047": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/linux-firmware-whence-20220913-140.fc37.noarch.rpm"
+          },
+          "sha256:4b3936a76dfa4094d9133ee6fbb8f0a58d41d54dc81f874bdb9086f06711112d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnfnetlink-1.0.1-22.fc37.aarch64.rpm"
+          },
+          "sha256:4b6cbd8f1bcd9e058f975f5b2b2e19a075dd6c28e2e8a67feaa337737b542fbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbytesize-2.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:4b72d8df75158aaca80e356401b9970d1f04726e019675f24057b560ba6ebff0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nss-softokn-freebl-3.83.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:4be185da5192918b485b25030b36f3e478bdc4bde19ebed1f80476931233ad30": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:4cc7e6a19b5627e3e3bf941d5bef3ded55458eb226ed6e523e9a0d6a836b249f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:4d62d62208b3bf57c6692ec986e5a0299315bfd09f499338fd8aea3bfb430827": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-crypto-2.28-2.fc37.aarch64.rpm"
+          },
+          "sha256:4e18c452746d0c9be98e298d7282f0f2c3f86fac4b1e78e6d4c9901a0b2f5656": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgomp-12.2.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:517d1129b28f53a15b66aad1ea5da4e6f45ca51c0329a66967b58c1cdf21bf9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sssd-client-2.7.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:51f204b5187519266c3496cc970150cb41fd23f07ff58c3ee6d8b44a319fb455": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-libs-0.187-8.fc37.aarch64.rpm"
+          },
+          "sha256:539903a5db9dac34cd633a95db47af0c932118567e759108ec8b05f91992857f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/alternatives-1.19-3.fc37.aarch64.rpm"
+          },
+          "sha256:5547ad7034b539388be34c3c44c054fb7d99a98a372733283305a023387670a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/curl-7.85.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:55ff17ec31466bd748005cf65cd687af61b0aeb3ad343e8d0c2d9a24f8a1286c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-libcomps-0.1.18-4.fc37.aarch64.rpm"
+          },
+          "sha256:5676237d61fba60ed5fb483b792111aa397faf464460222438130b0f3bbbe609": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bash-5.1.16-4.fc37.aarch64.rpm"
+          },
+          "sha256:56b548b06112a037121a913157b0e4c08dce4bb0511843f652e99960e657d13b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libftdi-1.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm"
+          },
+          "sha256:58b9082cd1e6c405c75d7cfe43595b066a80226942da5ddc714b1e6309bcf44e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm"
+          },
+          "sha256:58b9a2c3db5e64b6c33eb7f5b2f2f63cf127626548540bb6333e0c1fbc415ab9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-hawkey-0.68.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pigz-2.7-2.fc37.aarch64.rpm"
+          },
+          "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmount-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:59d4bbec71e99f25ac89228d5528aa56c2eeff0a2e8e83d405d3e378955cbae9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glib2-2.74.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:59d84b98e1a0066e0cfc7ddb4f2559ded9803f7fef0c8b52d1ad0693b8f4dbae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-libelf-0.187-8.fc37.aarch64.rpm"
+          },
+          "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:5a9bd9e833edad84033eb47d19575344a44369c392b09f82fbd8d9cff3db71d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/v/vim-minimal-9.0.475-1.fc37.aarch64.rpm"
+          },
+          "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm"
+          },
+          "sha256:5ad7f1bfee28c80f9d4282aa9f0e5d8fada533111fc03fd9c33e988766c6c380": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:5b75e3acf6f11c8584c7e38718a295503c09c0acd4b9dd245b287ab3357d245d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dnf-plugins-core-4.3.1-1.fc37.noarch.rpm"
+          },
+          "sha256:5caf8f150fec9e984d40ae7efac186450be8ce215eda8a6f864606c10bce798c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-3.11.0~rc2-1.fc37.aarch64.rpm"
+          },
+          "sha256:5cc444fb3971b6889d20cb009bbe91cc464c2fc027e6aacd6927a13d3bbb10be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pinentry-1.2.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:5e2ac5ec02616313b2c7a6d6ba73d860c4cc2380c2a7aa6336b3ed89c67c1392": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:5e51a6aa0c2acf0913d7aa70eca38a11492de9ce863bd2f4955ae09c3ceda37a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-dbus-1.2.18-5.fc37.aarch64.rpm"
+          },
+          "sha256:5e5d3c2263a0958574d26b7afe5c5341d7bf80c0986f5e6116e4dd4e312a03f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libdnf-0.68.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:5e6fb2a961d9e9823380d329642b68e752d56018b6f5ad0a7856a8fda723a9e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/shim-aa64-15.6-2.aarch64.rpm"
+          },
+          "sha256:5e7cf0116ffdcf0c673d155a24c70e1483305d6ec50ad8b7d1d4ad224e4e88bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dnf-4.14.0-1.fc37.noarch.rpm"
+          },
+          "sha256:5eff8b70f05717621b31b0c0c8fbdfa6bfbec81d38c7b98cc214a33dba9bde67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/udisks2-2.9.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-common-1.14.2-1.fc37.noarch.rpm"
+          },
+          "sha256:60c9b8479deee53528d17e3ddf0d1dce61ca74036bf5d35038fea901b61f60c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-gconv-extra-2.36-7.fc37.aarch64.rpm"
+          },
+          "sha256:61eb54379561ee89f973c58c10b8507f64fc0d1b3bf11cb5624b236365eecc9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm"
+          },
+          "sha256:621a5f7a8b6f53c8b35225ee0112ec80f17cd317247faa2e4c083653f32f4d4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mozjs102-102.3.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:62dfa5a36a42f97393cf948694764acd5bf102eb91e0e85b1b2d565fa0450823": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libqmi-1.30.6-2.fc37.aarch64.rpm"
+          },
+          "sha256:633b5de9ea8d4a98180fcf2c2f93e9e0e16e751061f755c5265abd4887030dec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxmlb-0.3.10-1.fc37.aarch64.rpm"
+          },
+          "sha256:6427a8b877a51be140e06665b3680a911816c9eb581aa54ecf29c77f51b6e898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-distro-1.7.0-3.fc37.noarch.rpm"
+          },
+          "sha256:64a7dd77389ef15d39b87388aa8c1b51186accd702fb91989ddbe729060adb55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/npth-1.6-9.fc37.aarch64.rpm"
+          },
+          "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm"
+          },
+          "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sed-4.8-11.fc37.aarch64.rpm"
+          },
+          "sha256:660c430d505999d24d2c0cc023d6b6af1c691db8bfaf62d10d38963627b4a664": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xz-5.2.5-10.fc37.aarch64.rpm"
+          },
+          "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm"
+          },
+          "sha256:671c739218458160f75916559582811f416b9224a840945a236aa52523f072c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bluez-5.65-3.fc37.aarch64.rpm"
+          },
+          "sha256:6738cecbdf2248efba296597ce75313a70219901923a2f3aef52af4825029409": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-networkd-251.6-609.fc37.aarch64.rpm"
+          },
+          "sha256:6a16500df314e37275aaab3de6fff5f4211d65b44fa9c6ee9ba74e718101a10e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpcap-1.10.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:6b1232e992e46c3897eaea57866d1ac655ebeff36448813fc5ddd84cd00da49a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libssh-0.10.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:6bcdcac414f4e313ae3527d3993f17bf38d296fdc556c10e738177fb5621a245": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgudev-237-3.fc37.aarch64.rpm"
+          },
+          "sha256:6c7be4066ad8a69c7b4ef73706b1c0591361b522f22a1ad969f2e128992ecdd8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zram-generator-1.1.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:6d57265c3bb44d183f7f619d7bf92f375bcbbc30e242d6df66e2533e5e9f84f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/coreutils-common-9.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:6e1b3ebb0f9945593365eaf0bc01d052d2e221e930d5731d1bd8276289194ba1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm"
+          },
+          "sha256:6e5480b45c64f05340cbdac2bb0354b5593aa8da16690a0b0e188a1842920af3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/linux-firmware-20220913-140.fc37.noarch.rpm"
+          },
+          "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm"
+          },
+          "sha256:70702e8555203b90abd08f8c407a872640ed19a9e9d53869950cf56c594540e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcollection-0.7.0-52.fc37.aarch64.rpm"
+          },
+          "sha256:7221f9c4b4c980552dffc75a08e413d794d2c52812b3778b6b0127f801c80eff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/deltarpm-3.6.3-4.fc37.aarch64.rpm"
+          },
+          "sha256:72906b5aa7cc9f416f704bb0071972ddce6a08d251b1dcdf7253478153e8a20e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:72aaa5d89982fed7efc80d190f9bee4c0006cf69773a942f5de2566ca666f0e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsss_idmap-2.7.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libssh-config-0.10.4-1.fc37.noarch.rpm"
+          },
+          "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:75833cca024e8367727abdb7c363832e445b8e461bdeea9f74ee6f27701ef806": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssh-8.8p1-7.fc37.aarch64.rpm"
+          },
+          "sha256:76df070766b1d7460c3edf04cb404046a9b999e68dde6598c090140995a49dde": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:76ed672b87d410a259b09885e8ad7a88b28f181a268c3b401356a43e41d38141": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/util-linux-core-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:7844c090147f6e04cb219d39eb76341b08ec0bbea3b51c51aac925301fb7c677": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ntfs-3g-2022.5.17-2.fc37.aarch64.rpm"
+          },
+          "sha256:788976a6dfe6796fa08ba5f52c17af923044473b481a75be9bb695e8fa7d5a16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xfsprogs-5.18.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:7a2e8b1aa352391b389df8624412ce22b31e0729b027c1bdf20d505d2ce1da60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsss_sudo-2.7.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:7a78e507d71c85c273d3aa7e0d7f151b342a508fbfe85717cf760ee172ef9d37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libibverbs-41.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:7bd13c90588b99b7a150452490c1cf43117ed01d68b4e301fda14b5d5c2a8465": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nspr-4.35.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:7da174a3093695f29b8ada7193aeefef71746a4b8fdd9c1e043aa458f368e058": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kernel-modules-5.19.15-301.fc37.aarch64.rpm"
+          },
+          "sha256:7e10408f24fd79fc501590bde5e8bdfb0fde0add0c734c503eb3c328d6e34630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/plymouth-core-libs-22.02.122-3.fc37.aarch64.rpm"
+          },
+          "sha256:7e3fbeb8bd1e999cd741083ef4235c4087988e1c6d75e24b784b2ddf7c5193de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnghttp2-1.49.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.aarch64.rpm"
+          },
+          "sha256:7f5f3953da57fbc1aab1d723cedfeca5c3536c66d479335af6173ca50c54bd5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fwupd-efi-1.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:80e767ec60eb6cbbe095ef2917e2a8d022d98a5f334df0c1c3a14e27bdf03f4e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpipeline-1.5.6-2.fc37.aarch64.rpm"
+          },
+          "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-common-37-14.noarch.rpm"
+          },
+          "sha256:83a66501f3f273b184e8161039ca17fbd2b91c4acb2b0f0226593aa83cc47701": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sssd-kcm-2.7.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:8413d88829a4d9487404720494e2bc4339e2d5bccc3c179bdf00d1f33a557269": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nss-3.83.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:85698713589960a8b6821a4a56bc7b5af4df9977e86cad103cb9512ba7177d2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/amd-gpu-firmware-20220913-140.fc37.noarch.rpm"
+          },
+          "sha256:85746399da551cfc335f2a4b156460b4903a277861077cf919b3f5ecd7689e97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:88b28b9729a393374ffbce10301fc1829133dba58487caa525aaebc8fa070f56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kpartx-0.9.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:8a08019ab8471eb8e8bb8382acc0b8ea145852369d63293466a4af8ff2221263": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm"
+          },
+          "sha256:8adebc901848979df7c1c96c51055426c0ac7212b536a5cf82bd650dbbb322cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/initscripts-service-10.17-1.fc37.noarch.rpm"
+          },
+          "sha256:8aef705ac6c83a97e41f60b13c7f8f38a53126b22390a691f48a2f77621b3218": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/plymouth-22.02.122-3.fc37.aarch64.rpm"
+          },
+          "sha256:8b3b3f611f93e849b5c03219fb2a28b63ac4215ebe28a8219da5e5be15e5ed52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nvidia-gpu-firmware-20220913-140.fc37.noarch.rpm"
+          },
+          "sha256:8b56b7ca059afbe4a7ba86d30b7b324e639df618276cf45b46d3e315cf0718fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ntfsprogs-2022.5.17-2.fc37.aarch64.rpm"
+          },
+          "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm"
+          },
+          "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grep-3.7-4.fc37.aarch64.rpm"
+          },
+          "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc37.noarch.rpm"
+          },
+          "sha256:8c8c5a7d8a7bde6cd7413c745ea8f81f728169d2e4e96327a86f41019b8390de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.aarch64.rpm"
+          },
+          "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm"
+          },
+          "sha256:8e410d25f43c86de6f76542b336aa40dd0a1c6d84a8fdbeff9ef2a2379ee4e45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-common-2.36-7.fc37.aarch64.rpm"
+          },
+          "sha256:8e85f2257c7cb41df273ffdea56daef73e44bb7bfe79befa296f700e60c49548": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/userspace-rcu-0.13.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:8eaa5255d8f5cd3a8f854c4de6082158fd6294bf779b654d5bc270906a425ebe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/readline-8.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:8ef2400ff36fe50c2c2c33d503de10333c5b2be498791694b96d52a05949589d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcurl-7.85.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:8f4a1bfa873f3a019aef82c02e5713ff67cca7942d7351002e01a0defb8c0cbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-repos-modular-37-1.noarch.rpm"
+          },
+          "sha256:92841df883b69d4edb23b0834936717b0ca61b50391174f2c919978051f736a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/v/vim-data-9.0.475-1.fc37.noarch.rpm"
+          },
+          "sha256:932f1548d9ca07579d56cf1ce527b34786cfebe8e07fc86106ac9d7a803ccfbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.aarch64.rpm"
+          },
+          "sha256:941ce3e47a525ae3e39f79a7df7d8e11a313a30a45b5b773233fc5f0ce6fba84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/ipcalc-1.0.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:95d136f0a45ecec0f319ac888010a2961d32d31a4cbc7c63aa5f5d128b9619e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libndp-1.8-4.fc37.aarch64.rpm"
+          },
+          "sha256:9748ea51ee4285b0442abae84beb3b0ef9e747b322310b0891f001718ec60237": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libuser-0.63-13.fc37.aarch64.rpm"
+          },
+          "sha256:97b664f921653bc6d22abec3d906ff58a7a1d568a4e2f24a638b15f46ed8e058": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/lua-libs-5.4.4-4.fc37.aarch64.rpm"
+          },
+          "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm"
+          },
+          "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-repos-37-1.noarch.rpm"
+          },
+          "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblkid-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:98caa3b739e76b8b725a9952231c463b3a46bf056942211f90505e61ea631111": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/intel-gpu-firmware-20220913-140.fc37.noarch.rpm"
+          },
+          "sha256:99bc383fa8558a73027e63ff75f0978e4e2ff6b26be55f384c3f52e5aee97527": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:9a19c9814acd3a96a1c6af95220a2e9e72242a2c653a38ef2964b711e509fc84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-tools-minimal-2.06-58.fc37.aarch64.rpm"
+          },
+          "sha256:9b1529cbd75e33f5e9e220b868a68a95d807855cb462afe8f15a37da2e88cf5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/firewalld-filesystem-1.2.1-1.fc37.noarch.rpm"
+          },
+          "sha256:9b9438f0c427e8b56f8ca1cfbdb557d8d8c7c92b60e1a2adb9e39adf4a495d32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-loop-2.28-2.fc37.aarch64.rpm"
+          },
+          "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-37-14.noarch.rpm"
+          },
+          "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm"
+          },
+          "sha256:9bef843589abaf3dfb3ff5c72b6630f5b6e6ec8d706f2d569d6b503385844444": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc37.aarch64.rpm"
+          },
+          "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:9cfbaf8447ef22431bcefb1542a31badae1a33de764e4cbb88e90faf42827519": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/polkit-121-4.fc37.aarch64.rpm"
+          },
+          "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/device-mapper-libs-1.02.175-9.fc37.aarch64.rpm"
+          },
+          "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm"
+          },
+          "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/selinux-policy-37.12-2.fc37.noarch.rpm"
+          },
+          "sha256:a2b276a42f94d7982e5e2ef72d59b73b9313ea83792ea9bb35e2e5cb4fa5988d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:a3303f9003ae7e80e1beb4d70681ea7633dbd5477d55c042264ef7770bd9107f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nss-util-3.83.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:a34c6b913b7810ddef0831adefe154fb68150ead286b750a3dc3e15b56c75e9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mkpasswd-5.5.13-2.fc37.aarch64.rpm"
+          },
+          "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm"
+          },
+          "sha256:a3db34fee176285b0e73890ac0864c748bb091c256df197f885b31455dbb041f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/jansson-2.13.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/device-mapper-1.02.175-9.fc37.aarch64.rpm"
+          },
+          "sha256:a5593981668684f5757b4ceb377fc4f3442c597daa21566e614f6ecd955f0d3d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-fs-2.28-2.fc37.aarch64.rpm"
+          },
+          "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsmartcols-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:a6aaae0fb24af1e41f043b5f782f0bd02bc88eb6d8de53c849d628bb03671b6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm"
+          },
+          "sha256:a71f25e9551c607d79645e785d5554292f15fb9c7d45bb9b92de91766825f3bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gdisk-1.0.9-4.fc37.aarch64.rpm"
+          },
+          "sha256:a89bdeff8ea373ce88d147a5f017e7f342c1c79fdf615a88f2396e980638feda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nano-6.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kmod-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:add56e5fb7330c434a8f6e2fcccf6bf817ae396b9c3c419e2b3c5eb2046b6812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libedit-3.1-42.20210910cvs.fc37.aarch64.rpm"
+          },
+          "sha256:adf4bb4c6f00d4d335a8cf6c6cbb3919aa3381752edde9a16bd810600e38f8aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtdb-1.4.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:ae6fe8d3375b9cab9cbc289118654227b84d353d8102273d15600e403ccfbe3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/protobuf-c-1.4.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:aef4052ca482ce6d1e8400191a2791a635415868e7aa36d3efbea546f710df11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:af36734e49f06f79fee74fbeafb555b24fd7473d915a580d7fc3f1359d63eb88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/librepo-1.14.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:b1c0880f9180fd54c99e2340fc9a0001bc489f5ff3ed8ab405cce9e35707c01b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gnutls-3.7.7-1.fc37.aarch64.rpm"
+          },
+          "sha256:b25b2a6aa9d67b105201ef7f90154da99e683b8a3a64f6f1ec17d1300dcd2e22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/ModemManager-glib-1.18.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.aarch64.rpm"
+          },
+          "sha256:b3f64a9b092e5c9b829b955a2a63532462facd0cc967131211f0a90a6ed5453f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/audit-libs-3.0.9-1.fc37.aarch64.rpm"
+          },
+          "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:b6b0aa91236f4fe07ebd5fd5154cbcb8c7ecca90ba9af7808c8820454c173f75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcap-ng-python3-0.8.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm"
+          },
+          "sha256:b7ba853b07a46efda355edc72f74c9e356a2e60c3e4f934b0cefb9d347f20a53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dhcp-common-4.4.3-4.P1.fc37.noarch.rpm"
+          },
+          "sha256:b7f51a01499b5ad345c10a790688ff8837d894b8608daf0fd27250d8a20afa77": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/polkit-libs-121-4.fc37.aarch64.rpm"
+          },
+          "sha256:b85b1faebfc05f8f362dd59c53429328f787cd2fd60cb03432e259b0e5294bff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libreport-filesystem-2.17.4-1.fc37.noarch.rpm"
+          },
+          "sha256:b875744ecefb91efbe7d05df252768f666bf220d23f865d7df9b15e58dc86631": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/groff-base-1.22.4-10.fc37.aarch64.rpm"
+          },
+          "sha256:b9d09656e98dd744599be50d553e059d5b3c5236b617c5d05de9f0b2f505ff86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm"
+          },
+          "sha256:ba7fe160856cb5c4385d6cd5ed9b2973de52521e3a944dacf221eacc77dc44de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcsc-lite-1.9.9-1.fc37.aarch64.rpm"
+          },
+          "sha256:ba8364ee984a89ba421c4bef52fb867f7260789d4c4381ab208c139cb1054dfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sssd-common-2.7.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm"
+          },
+          "sha256:bbef4adf7285d497ec92e10715866a15648100373e579947afa1c28862cbca44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc37.aarch64.rpm"
+          },
+          "sha256:be9a015662acc23d54474a01f81a8f321359006b22850edcb41fdddc6f01b1cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gnupg2-2.3.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-gpg-keys-37-1.noarch.rpm"
+          },
+          "sha256:bf7a37c0aeb74a472c54d948e2cd3978b813891402b76c5013929255b43de54c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-251.6-609.fc37.aarch64.rpm"
+          },
+          "sha256:bfaa73e218017bc791a08821e5f2e4c74776bac5e3e950a69338fa0c823c8058": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nss-softokn-3.83.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcap-2.48-5.fc37.aarch64.rpm"
+          },
+          "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gzip-1.12-2.fc37.aarch64.rpm"
+          },
+          "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre-8.45-1.fc37.2.aarch64.rpm"
+          },
+          "sha256:c3063bbcd07caea5dcdb242471047b2a77264ed33bf004ddf7405cab70c6bfe1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/less-590-5.fc37.aarch64.rpm"
+          },
+          "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:c462e7efdf7650c49e4d0af6aa59bf555db59bedf0a30e75ffbec4b2af5c5901": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-firewall-1.2.1-1.fc37.noarch.rpm"
+          },
+          "sha256:c49a2ec0463320a4a18fa94e20ffe4ffd0714b26f9b16710a2902ffaad3937bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kernel-core-5.19.15-301.fc37.aarch64.rpm"
+          },
+          "sha256:c4e372e626eca2c917309767102294dd75e83ae3d4583e90ee5ac4d1b5032e12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpath_utils-0.2.1-52.fc37.aarch64.rpm"
+          },
+          "sha256:c616cd07150cb3de1e62b6b710f1405106c7310927076aa6cf89a2c94ffd13f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-pam-251.6-609.fc37.aarch64.rpm"
+          },
+          "sha256:c61932cab67782a94abb02cdeb1c1b64c0161a0331b1905f8826233d7ccc7ad4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/oniguruma-6.9.8-2.D20220919gitb041f6d.fc37.aarch64.rpm"
+          },
+          "sha256:c635414b909a2b7ea49bd815c0261f4d30d13d871346906501d7316af3ba1772": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libini_config-1.3.1-52.fc37.aarch64.rpm"
+          },
+          "sha256:c6c2be7edf77d8e3e7c53574d7e3c7284bdd11d084296bdf7acade081b6d169e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:c6fa6669abe6413582fb6edb939ff8e897a71c9e054a6839516cf9a6b11eb6c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/v/volume_key-libs-0.3.12-17.fc37.aarch64.rpm"
+          },
+          "sha256:c712e9a4fdd669f1bd5be16b453b5fe22ca6c7265845833086334ab73144fc89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm"
+          },
+          "sha256:c71a3884722bdeeccbbcef5d9fcffa4c265d6486acb0f164d70c682bd91e1fdc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm"
+          },
+          "sha256:c7f426539476633d5abdb3ed81918a9311aaaffc2eb243b628cb738925bb5f37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fwupd-plugin-modem-manager-1.8.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:c83fc74498fb51302e56cf23f60712493d3003a25c44cb19b60aca5b1a683705": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc37.aarch64.rpm"
+          },
+          "sha256:c8650dafee9357adb6e6f878e5c3eb32aeb72ccce5bf68056920e77c7abc8da9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tpm2-tools-5.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:cbe8a6957b2a00bf0117c5cb08affc8abdc2dad02edd1113b463412b9bc2238d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/y/yum-4.14.0-1.fc37.noarch.rpm"
+          },
+          "sha256:cc9ddf08ea0c691edaa5f2072667d11715a6349f5745f3d2b6e6713bda1858f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libqrtr-glib-1.0.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:ccf0d18c15586c0a7ad9e7e69551fa9b997c25970701b5e635a981878c8a9dfe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/iptables-libs-1.8.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:cd1fc5195580df7a72cb38e87f05343e2d381c7a171ae867b802aadb0bf98c4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/ipset-7.15-5.fc37.aarch64.rpm"
+          },
+          "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:cd54dcc38550baa9597e79a96c6860106f9d2770feede4edbb3e7a5329c9a033": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/NetworkManager-1.40.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:ce155c86d0bd2ff0bf29a3ffd454fcf085389e2568a6d158cad79c55f895d683": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm"
+          },
+          "sha256:ce1a77c4b97b190ca56c4548ddab041eeb989df4faeb3c87cdf43d28f491ad29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kernel-5.19.15-301.fc37.aarch64.rpm"
+          },
+          "sha256:d023cb3d1d313c3c21136cd59f6a1d103ff16d260e9b8a52dbfebfc663952e9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsss_nss_idmap-2.7.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:d09e7caa4cd299e32a105bb5ae68a53a2b7ea92f145306bbb563fc3a3af9245d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libjcat-0.1.12-1.fc37.aarch64.rpm"
+          },
+          "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:d0e859a97a8167af62e273093e454a01bfd64b9ff60897bc97711f3591970106": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-2.5.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:d3011b8c219f9f86fadd7bf1ae600db59364b5e425ae47117d090635812dccbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm"
+          },
+          "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm"
+          },
+          "sha256:d5059e977d0f0fb2f8e00201efc16c9e75198d23a5aaaef146e042d845a69e97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/lmdb-libs-0.9.29-4.fc37.aarch64.rpm"
+          },
+          "sha256:d582315683769a0456d5ec9f85939f75f8df5055f3ac4110f28cdbea9ca9cf69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libldb-2.6.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm"
+          },
+          "sha256:d650642e10443dbb860a185980f3119518e8fffe3952535accec681fbd8ad8ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-libs-251.6-609.fc37.aarch64.rpm"
+          },
+          "sha256:d6523ca88e57d5e5f610a3d5fad22b2d005248e500d660946553c8f9e60d6a67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-swap-2.28-2.fc37.aarch64.rpm"
+          },
+          "sha256:d6ee284dcef741c4de7ef51f540ce8144cfc5f2937dd7da0c1c857d96cb5ecb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libudisks2-2.9.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:db2227729ac01ec1712cb3630ae3ac81fbe6094b5d40f9a91690b1b8dd413eaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:dcf4b614ac88e26b9b344e0d6f3da257555f4402742e27abca969b0f439d6211": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:e1c8670422ebe5aab49614e5264a61bc90ecc67e8ace5258ac94a04c8d8ecb7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libidn2-2.3.3-2.fc37.aarch64.rpm"
+          },
+          "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm"
+          },
+          "sha256:e2dac60f8875f9ae0aff2da3840d9e878a48650aa4c6d04ae6cc0b668aa7ba2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sqlite-libs-3.39.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:e40e9aaada115819d974b933bb33e6600d39fe13a91a9b4d5aa27c4decb06155": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:e4523cbae9f86f48f4bd7266d931bf81afd007ac17d6af33d6ae782ce2579db1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/unbound-libs-1.16.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:e4716da965a3141394efc6cfca127880bbab451c7cb285bfc48d1911d8402164": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dracut-057-3.fc37.aarch64.rpm"
+          },
+          "sha256:e49fe2ec10deebf89c5b9465db6e18ac99493ce1996ef5a28ba7e9e193f5aff1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-rpm-4.18.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:e694ef5ad5f16b497d4bdeca3c0a0c49fd6d01442e87f5c302dcadab0af2657b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dnf-data-4.14.0-1.fc37.noarch.rpm"
+          },
+          "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:e880db493868227fd230555c23b06fe23c69fdb003552f5d00ee036104a8ad65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dhcp-client-4.4.3-4.P1.fc37.aarch64.rpm"
+          },
+          "sha256:e8cc5b5b5df546ba2a71ff6fd25adbeb01a27c7c503d53946463cc6108d4ff9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxcrypt-4.4.28-3.fc37.aarch64.rpm"
+          },
+          "sha256:e9bbf1cbf6b2df49cf17585f3913a9064f7b0c3c56b116a92e9f242a3676efde": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm"
+          },
+          "sha256:ea7104bffcc6792553e51c8bb8898c4c8649eb76055dd56e58d558e33d6a78ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-1.14.2-1.fc37.aarch64.rpm"
+          },
+          "sha256:eb3791b4d97a2d8b71268d808f50b3f8a1358e7a7d3cf66d8882b886d08c525d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-sign-libs-4.18.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:ebf16596928342c62b0abc250f56f778e7b6428e0273ae5da88493d9effe2e3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-udev-251.6-609.fc37.aarch64.rpm"
+          },
+          "sha256:ec395c3a160470a6da63ac1298a540a93a2adee4d29c4f78c24330dbbfba12b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-gpg-1.17.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:ed050e88e1fb2f8d2cdfb83075e79eb868decf66ec51ee4bca29d35e849f5247": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtevent-0.13.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:edb75a2c48205e923649a0ff2a5d41bf943cf35d16d272785d095f33afcd7b84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gobject-introspection-1.74.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:ee09c79ac0d3cfa76c1565f1727de2734cda082f657e80c881c93aaafcb9bb06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssh-clients-8.8p1-7.fc37.aarch64.rpm"
+          },
+          "sha256:ee50ad1b7ba00ffed8c17a1df7b42800c3462a040281afd3500e1f7dd768c75b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libksba-1.6.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:eed9d47041b04ea6c49408f4d71cc0190b699c51c1a89de4c6fdd676cd1777a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/shared-mime-info-2.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:ef0020c1d9d4afab7b4d9515d97d9d2081f679587f61c8481c808e9f0e3c059c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-utils-2.28-2.fc37.aarch64.rpm"
+          },
+          "sha256:ef495449eaf292fe2bf17066a5bc006c357804d207f7bcdc16e65d40ec827206": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbasicobjects-0.1.1-52.fc37.aarch64.rpm"
+          },
+          "sha256:eff91da3adf84b15e85b72b907d7b233adbea9d78ecf0db75d9c3a6c9c0e43da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.aarch64.rpm"
+          },
+          "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-identity-basic-37-14.noarch.rpm"
+          },
+          "sha256:f0944d0fd2d273c99f6ab808111d4db455fc9ba8489714aabdeda5729977c004": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libref_array-0.1.5-52.fc37.aarch64.rpm"
+          },
+          "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tzdata-2022d-1.fc37.noarch.rpm"
+          },
+          "sha256:f0fec5b7c7c8482cb9642dad77eeedadefe7dda70ed7b53d44fb5a6bd1ea2749": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmbim-1.26.4-2.fc37.aarch64.rpm"
+          },
+          "sha256:f12b98bc656a67fc7b378870598993e010e4df843fb998f7a439a0a14bc391ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-libs-0.21-19.0.20220203.fc37.aarch64.rpm"
+          },
+          "sha256:f1734d5da50fb27abe9208444bdc99f65c382790150492152b891d2d501d7bf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zchunk-libs-1.2.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libkcapi-1.4.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:f23bbbb8abeccfae1758e2eef3a676c956f2df47ab4ab559eaff52afa1f809b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/parted-3.5-6.fc37.aarch64.rpm"
+          },
+          "sha256:f27c1dea30a1eaeeaf6e69f30d30e0097aabf4f3a99413c3c4a47f90fcfa2a18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-2.36-7.fc37.aarch64.rpm"
+          },
+          "sha256:f2b8068fbb2231a515c60c491eb5b08808af1eb6d497eb33039125aac3eb7d63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssl-libs-3.0.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:f2bd8534e896f251cd58b8cbb0b069fcaa464aa2a84fbd9d8187690f3c979fdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libicu-71.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm"
+          },
+          "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grubby-8.40-66.fc37.aarch64.rpm"
+          },
+          "sha256:f4b232fd35e5ef6f65be42bab721dab5f736309c37fa1508f28c8cdf4b7911af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dracut-config-rescue-057-3.fc37.aarch64.rpm"
+          },
+          "sha256:f52edeae190ea55635b96cb8a5fb81ecd9a2ca900fa65c4403e4890c2d70da83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:f53bd8e9f409439671de3762d5cf348fbffd7d97885c5de3953964fd7a148ea1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/json-c-0.16-2.fc37.aarch64.rpm"
+          },
+          "sha256:f5466c4dc934d5abc1eb1a8ed1028e1f78fd4eea87ecc5954fa491a0879c0fe5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm"
+          },
+          "sha256:f55ce59e067b48e1148a5e40b09c7223804540bf1593fb3bcb687c252a074c40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm"
+          },
+          "sha256:f730ab54689ca4dfc727425636a636d35a6d7bbe4985420cb5ff35ec6eef0307": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/firewalld-1.2.1-1.fc37.noarch.rpm"
+          },
+          "sha256:f76a449595a1225fe34753ba26e1830609789848e3f7eb6424348dbdf63e1046": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/plymouth-scripts-22.02.122-3.fc37.aarch64.rpm"
+          },
+          "sha256:f81833addc3924f97efebcf3390fd375339a7e752e7b6ba9003162a248ec7b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:f83d5f59d9e289df361e2d46bf18143245b1324f3e2fb71b91ff7740a897a215": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cracklib-2.9.7-30.fc37.aarch64.rpm"
+          },
+          "sha256:f9013badfcf2a78e4dd4a1f6ada593f3d1f9dd5935814abde7dd7de1fa9bb8c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/procps-ng-3.3.17-6.fc37.aarch64.rpm"
+          },
+          "sha256:f9176c93af66866fce7b6c0ddc2426bbb88d83d6d091da663ad8c4cb8f8b2615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgpg-error-1.45-2.fc37.aarch64.rpm"
+          },
+          "sha256:f9f91971d2e252f6fd49c40b9feb62beda46c268f0ce1903e6396f7a0d35cc39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm"
+          },
+          "sha256:fbf24d19205ce8b9c2da7655d859f4c4e7753b5794bc90db3aabdf3e7784bc84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xz-libs-5.2.5-10.fc37.aarch64.rpm"
+          },
+          "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libfdisk-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/util-linux-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:ff00ca33d2a696f3b438a85da657f900df56d743f06a0163df3b051e74d9d9dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxml2-2.9.14-3.fc37.aarch64.rpm"
+          },
+          "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm"
+          },
+          "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/alternatives-1.19-3.fc37.aarch64.rpm",
+        "checksum": "sha256:539903a5db9dac34cd633a95db47af0c932118567e759108ec8b05f91992857f",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/audit-libs-3.0.9-1.fc37.aarch64.rpm",
+        "checksum": "sha256:b3f64a9b092e5c9b829b955a2a63532462facd0cc967131211f0a90a6ed5453f",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:178c233d007c00f14ec0c0a5083907f3cf2889b998c8e7eefe25c8b04ebe1aef",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:5e2ac5ec02616313b2c7a6d6ba73d860c4cc2380c2a7aa6336b3ed89c67c1392",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bash-5.1.16-4.fc37.aarch64.rpm",
+        "checksum": "sha256:5676237d61fba60ed5fb483b792111aa397faf464460222438130b0f3bbbe609",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm",
+        "checksum": "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/coreutils-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:1050a9675979c8ea71d673034094281225dfb6252814a6a4b959cc89a3fa467a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/coreutils-common-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:6d57265c3bb44d183f7f619d7bf92f375bcbbc30e242d6df66e2533e5e9f84f0",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cpio-2.13-13.fc37.aarch64.rpm",
+        "checksum": "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cracklib-2.9.7-30.fc37.aarch64.rpm",
+        "checksum": "sha256:f83d5f59d9e289df361e2d46bf18143245b1324f3e2fb71b91ff7740a897a215",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5ad7f1bfee28c80f9d4282aa9f0e5d8fada533111fc03fd9c33e988766c6c380",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/curl-7.85.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5547ad7034b539388be34c3c44c054fb7d99a98a372733283305a023387670a9",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.aarch64.rpm",
+        "checksum": "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-1.14.2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ea7104bffcc6792553e51c8bb8898c4c8649eb76055dd56e58d558e33d6a78ac",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm",
+        "checksum": "sha256:04d878eeb31722ad495b34edd6bacafeffd5d13d39dfea5edff49daee5f28c58",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-common-1.14.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/device-mapper-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/device-mapper-libs-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dracut-057-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e4716da965a3141394efc6cfca127880bbab451c7cb285bfc48d1911d8402164",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc37.aarch64.rpm",
+        "checksum": "sha256:c83fc74498fb51302e56cf23f60712493d3003a25c44cb19b60aca5b1a683705",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc37.noarch.rpm",
+        "checksum": "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-libelf-0.187-8.fc37.aarch64.rpm",
+        "checksum": "sha256:59d84b98e1a0066e0cfc7ddb4f2559ded9803f7fef0c8b52d1ad0693b8f4dbae",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-libs-0.187-8.fc37.aarch64.rpm",
+        "checksum": "sha256:51f204b5187519266c3496cc970150cb41fd23f07ff58c3ee6d8b44a319fb455",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:76df070766b1d7460c3edf04cb404046a9b999e68dde6598c090140995a49dde",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-gpg-keys-37-1.noarch.rpm",
+        "checksum": "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-37-14.noarch.rpm",
+        "checksum": "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-common-37-14.noarch.rpm",
+        "checksum": "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-identity-basic-37-14.noarch.rpm",
+        "checksum": "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-repos-37-1.noarch.rpm",
+        "checksum": "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/file-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm",
+        "checksum": "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-envsubst-0.21-19.0.20220203.fc37.aarch64.rpm",
+        "checksum": "sha256:185ffaca4bf6de8e14842027e4c2258409619b16b7d05d2a5df1100d187024dd",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-libs-0.21-19.0.20220203.fc37.aarch64.rpm",
+        "checksum": "sha256:f12b98bc656a67fc7b378870598993e010e4df843fb998f7a439a0a14bc391ff",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-runtime-0.21-19.0.20220203.fc37.aarch64.rpm",
+        "checksum": "sha256:266dbc27e73ef589066244029bbf09de65d11ec1711fc76094694a74512e33c2",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-2.36-7.fc37.aarch64.rpm",
+        "checksum": "sha256:f27c1dea30a1eaeeaf6e69f30d30e0097aabf4f3a99413c3c4a47f90fcfa2a18",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-common-2.36-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8e410d25f43c86de6f76542b336aa40dd0a1c6d84a8fdbeff9ef2a2379ee4e45",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-gconv-extra-2.36-7.fc37.aarch64.rpm",
+        "checksum": "sha256:60c9b8479deee53528d17e3ddf0d1dce61ca74036bf5d35038fea901b61f60c2",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-minimal-langpack-2.36-7.fc37.aarch64.rpm",
+        "checksum": "sha256:26948aaefdcef47d8f73cae1f4ddede5853ccf6a5d4e2ef5d4a6d921547cef46",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grep-3.7-4.fc37.aarch64.rpm",
+        "checksum": "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-common-2.06-58.fc37.noarch.rpm",
+        "checksum": "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-tools-2.06-58.fc37.aarch64.rpm",
+        "checksum": "sha256:3133da3cef48ae829fc6853acfa42c12c6dce9f8ebfd0b0318e81d728d90f228",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-tools-minimal-2.06-58.fc37.aarch64.rpm",
+        "checksum": "sha256:9a19c9814acd3a96a1c6af95220a2e9e72242a2c653a38ef2964b711e509fc84",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "66.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grubby-8.40-66.fc37.aarch64.rpm",
+        "checksum": "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gzip-1.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/json-c-0.16-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f53bd8e9f409439671de3762d5cf348fbffd7d97885c5de3953964fd7a148ea1",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-2.5.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d0e859a97a8167af62e273093e454a01bfd64b9ff60897bc97711f3591970106",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kmod-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kpartx-0.9.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:88b28b9729a393374ffbce10301fc1829133dba58487caa525aaebc8fa070f56",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm",
+        "checksum": "sha256:b9d09656e98dd744599be50d553e059d5b3c5236b617c5d05de9f0b2f505ff86",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2e40045d6d88a1a5bedeaf60f1391cad60bce787dda76fc5ad297fe3c98bf168",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblkid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm",
+        "checksum": "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcap-2.48-5.fc37.aarch64.rpm",
+        "checksum": "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm",
+        "checksum": "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcurl-7.85.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:8ef2400ff36fe50c2c2c33d503de10333c5b2be498791694b96d52a05949589d",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm",
+        "checksum": "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libfdisk-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:c71a3884722bdeeccbbcef5d9fcffa4c265d6486acb0f164d70c682bd91e1fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libfido2-1.11.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgcc-12.2.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:1ccf5a8e68247b63ac2f4cc27db3d0d3eba7a93570e2a00125d327ac2606d8c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgomp-12.2.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4e18c452746d0c9be98e298d7282f0f2c3f86fac4b1e78e6d4c9901a0b2f5656",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libidn2-2.3.3-2.fc37.aarch64.rpm",
+        "checksum": "sha256:e1c8670422ebe5aab49614e5264a61bc90ecc67e8ace5258ac94a04c8d8ecb7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libkcapi-1.4.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmount-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.49.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnghttp2-1.49.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7e3fbeb8bd1e999cd741083ef4235c4087988e1c6d75e24b784b2ddf7c5193de",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm",
+        "checksum": "sha256:0131393ab117eb26be5e55451753229122f6ca97aa5b7872e65c9d691c0059d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:4be185da5192918b485b25030b36f3e478bdc4bde19ebed1f80476931233ad30",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a2b276a42f94d7982e5e2ef72d59b73b9313ea83792ea9bb35e2e5cb4fa5988d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:72906b5aa7cc9f416f704bb0071972ddce6a08d251b1dcdf7253478153e8a20e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:a6aaae0fb24af1e41f043b5f782f0bd02bc88eb6d8de53c849d628bb03671b6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsmartcols-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libssh-0.10.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:6b1232e992e46c3897eaea57866d1ac655ebeff36448813fc5ddd84cd00da49a",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libssh-config-0.10.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libstdc++-12.2.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:18aac772a8f18c064c422f3c3d3be7a9f4756029f288a5b281e1da816b47f938",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4cc7e6a19b5627e3e3bf941d5bef3ded55458eb226ed6e523e9a0d6a836b249f",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm",
+        "checksum": "sha256:8a08019ab8471eb8e8bb8382acc0b8ea145852369d63293466a4af8ff2221263",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libuuid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxcrypt-4.4.28-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e8cc5b5b5df546ba2a71ff6fd25adbeb01a27c7c503d53946463cc6108d4ff9a",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxml2-2.9.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ff00ca33d2a696f3b438a85da657f900df56d743f06a0163df3b051e74d9d9dc",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f81833addc3924f97efebcf3390fd375339a7e752e7b6ba9003162a248ec7b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/lua-libs-5.4.4-4.fc37.aarch64.rpm",
+        "checksum": "sha256:97b664f921653bc6d22abec3d906ff58a7a1d568a4e2f24a638b15f46ed8e058",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm",
+        "checksum": "sha256:61eb54379561ee89f973c58c10b8507f64fc0d1b3bf11cb5624b236365eecc9f",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mkpasswd-5.5.13-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a34c6b913b7810ddef0831adefe154fb68150ead286b750a3dc3e15b56c75e9d",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:c712e9a4fdd669f1bd5be16b453b5fe22ca6c7265845833086334ab73144fc89",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openldap-2.6.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0d060e4e89bafa0e342cfdca9136c72c8d3f6af2adaecf2ef47e530c5edc8985",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssl-libs-3.0.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f2b8068fbb2231a515c60c491eb5b08808af1eb6d497eb33039125aac3eb7d63",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ce155c86d0bd2ff0bf29a3ffd454fcf085389e2568a6d158cad79c55f895d683",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm",
+        "checksum": "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre-8.45-1.fc37.2.aarch64.rpm",
+        "checksum": "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm",
+        "checksum": "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pigz-2.7-2.fc37.aarch64.rpm",
+        "checksum": "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:f9f91971d2e252f6fd49c40b9feb62beda46c268f0ce1903e6396f7a0d35cc39",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/popt-1.19-1.fc37.aarch64.rpm",
+        "checksum": "sha256:48410dce2b1c514e23d2e9e067714be0eb2923ff44e3ac7dde373a92474ff642",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/procps-ng-3.3.17-6.fc37.aarch64.rpm",
+        "checksum": "sha256:f9013badfcf2a78e4dd4a1f6ada593f3d1f9dd5935814abde7dd7de1fa9bb8c3",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc37.noarch.rpm",
+        "checksum": "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-3.11.0~rc2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5caf8f150fec9e984d40ae7efac186450be8ce215eda8a6f864606c10bce798c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:bbef4adf7285d497ec92e10715866a15648100373e579947afa1c28862cbca44",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/readline-8.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8eaa5255d8f5cd3a8f854c4de6082158fd6294bf779b654d5bc270906a425ebe",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-4.18.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0c2c0413d99049dd00a1f5ba19dc53f3ac0efecd31f315da2f2f9a987300ca05",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-libs-4.18.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:1764513e83380dcdc272841ee7ed52e118c1672d593f6632166bfe5ef955f6b1",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-plugin-selinux-4.18.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:1090174c3e6dfd17771c8368e16e191fbdeb69d075e22347becec5262f39bb3a",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sed-4.8-11.fc37.aarch64.rpm",
+        "checksum": "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.12",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/selinux-policy-37.12-2.fc37.noarch.rpm",
+        "checksum": "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.12",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/selinux-policy-targeted-37.12-2.fc37.noarch.rpm",
+        "checksum": "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.12.3",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/shadow-utils-4.12.3-2.fc37.aarch64.rpm",
+        "checksum": "sha256:377612c800325778fedc210ccf925125dff0f8515c5bad99ac48df1c35d79a46",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sqlite-libs-3.39.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:e2dac60f8875f9ae0aff2da3840d9e878a48650aa4c6d04ae6cc0b668aa7ba2b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:bf7a37c0aeb74a472c54d948e2cd3978b813891402b76c5013929255b43de54c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-libs-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:d650642e10443dbb860a185980f3119518e8fffe3952535accec681fbd8ad8ea",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-networkd-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:6738cecbdf2248efba296597ce75313a70219901923a2f3aef52af4825029409",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-pam-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:c616cd07150cb3de1e62b6b710f1405106c7310927076aa6cf89a2c94ffd13f6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-resolved-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:47c981aa9da90d9280f04145f13b7f771d3ccd74d9a776f438dcd10072bb4ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-udev-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:ebf16596928342c62b0abc250f56f778e7b6428e0273ae5da88493d9effe2e3f",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tpm2-tools-5.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:c8650dafee9357adb6e6f878e5c3eb32aeb72ccce5bf68056920e77c7abc8da9",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:db2227729ac01ec1712cb3630ae3ac81fbe6094b5d40f9a91690b1b8dd413eaa",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022d",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tzdata-2022d-1.fc37.noarch.rpm",
+        "checksum": "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/util-linux-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/util-linux-core-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xz-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:660c430d505999d24d2c0cc023d6b6af1c691db8bfaf62d10d38963627b4a664",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xz-libs-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:fbf24d19205ce8b9c2da7655d859f4c4e7753b5794bc90db3aabdf3e7784bc84",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/ModemManager-glib-1.18.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:b25b2a6aa9d67b105201ef7f90154da99e683b8a3a64f6f1ec17d1300dcd2e22",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.40.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/NetworkManager-1.40.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:cd54dcc38550baa9597e79a96c6860106f9d2770feede4edbb3e7a5329c9a033",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.40.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/NetworkManager-libnm-1.40.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:009ab9b4d04db2fb308c06d856926c7d2cef00deece56967dc561fe60380e211",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/alternatives-1.19-3.fc37.aarch64.rpm",
+        "checksum": "sha256:539903a5db9dac34cd633a95db47af0c932118567e759108ec8b05f91992857f",
+        "check_gpg": true
+      },
+      {
+        "name": "amd-gpu-firmware",
+        "epoch": 0,
+        "version": "20220913",
+        "release": "140.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/amd-gpu-firmware-20220913-140.fc37.noarch.rpm",
+        "checksum": "sha256:85698713589960a8b6821a4a56bc7b5af4df9977e86cad103cb9512ba7177d2d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/audit-3.0.9-1.fc37.aarch64.rpm",
+        "checksum": "sha256:28833e1258d7c690c2cf813a00c793be63188153a638997dc53f8a7c12bccf6b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/audit-libs-3.0.9-1.fc37.aarch64.rpm",
+        "checksum": "sha256:b3f64a9b092e5c9b829b955a2a63532462facd0cc967131211f0a90a6ed5453f",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:178c233d007c00f14ec0c0a5083907f3cf2889b998c8e7eefe25c8b04ebe1aef",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:5e2ac5ec02616313b2c7a6d6ba73d860c4cc2380c2a7aa6336b3ed89c67c1392",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bash-5.1.16-4.fc37.aarch64.rpm",
+        "checksum": "sha256:5676237d61fba60ed5fb483b792111aa397faf464460222438130b0f3bbbe609",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.65",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bluez-5.65-3.fc37.aarch64.rpm",
+        "checksum": "sha256:671c739218458160f75916559582811f416b9224a840945a236aa52523f072c7",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm",
+        "checksum": "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/c-ares-1.17.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2c1347d36ff1258ef9bc3d015506677837976932928df4b8174e84667a161660",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/coreutils-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:1050a9675979c8ea71d673034094281225dfb6252814a6a4b959cc89a3fa467a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/coreutils-common-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:6d57265c3bb44d183f7f619d7bf92f375bcbbc30e242d6df66e2533e5e9f84f0",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cpio-2.13-13.fc37.aarch64.rpm",
+        "checksum": "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cracklib-2.9.7-30.fc37.aarch64.rpm",
+        "checksum": "sha256:f83d5f59d9e289df361e2d46bf18143245b1324f3e2fb71b91ff7740a897a215",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cracklib-dicts-2.9.7-30.fc37.aarch64.rpm",
+        "checksum": "sha256:162c1a1b7c420d6a68eefa26936cac74a378ddfc268b4e48058be0773601d808",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5ad7f1bfee28c80f9d4282aa9f0e5d8fada533111fc03fd9c33e988766c6c380",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/curl-7.85.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5547ad7034b539388be34c3c44c054fb7d99a98a372733283305a023387670a9",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.aarch64.rpm",
+        "checksum": "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-1.14.2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ea7104bffcc6792553e51c8bb8898c4c8649eb76055dd56e58d558e33d6a78ac",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm",
+        "checksum": "sha256:04d878eeb31722ad495b34edd6bacafeffd5d13d39dfea5edff49daee5f28c58",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-common-1.14.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-libs-1.14.2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:330d0d56aa39a90d15ccb3cebf3bf403a7e6744c24cd1b3b78f9439bf4a97742",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.3",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/deltarpm-3.6.3-4.fc37.aarch64.rpm",
+        "checksum": "sha256:7221f9c4b4c980552dffc75a08e413d794d2c52812b3778b6b0127f801c80eff",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/device-mapper-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/device-mapper-libs-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "4.P1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dhcp-client-4.4.3-4.P1.fc37.aarch64.rpm",
+        "checksum": "sha256:e880db493868227fd230555c23b06fe23c69fdb003552f5d00ee036104a8ad65",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "4.P1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dhcp-common-4.4.3-4.P1.fc37.noarch.rpm",
+        "checksum": "sha256:b7ba853b07a46efda355edc72f74c9e356a2e60c3e4f934b0cefb9d347f20a53",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.4",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dmidecode-3.4-2.fc37.aarch64.rpm",
+        "checksum": "sha256:1225d8d1f0752e8e529ef7257f235b9189c1f85fa361883a9d40f768da0eb2c6",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dnf-4.14.0-1.fc37.noarch.rpm",
+        "checksum": "sha256:5e7cf0116ffdcf0c673d155a24c70e1483305d6ec50ad8b7d1d4ad224e4e88bc",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dnf-data-4.14.0-1.fc37.noarch.rpm",
+        "checksum": "sha256:e694ef5ad5f16b497d4bdeca3c0a0c49fd6d01442e87f5c302dcadab0af2657b",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dnf-plugins-core-4.3.1-1.fc37.noarch.rpm",
+        "checksum": "sha256:5b75e3acf6f11c8584c7e38718a295503c09c0acd4b9dd245b287ab3357d245d",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dracut-057-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e4716da965a3141394efc6cfca127880bbab451c7cb285bfc48d1911d8402164",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "057",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dracut-config-generic-057-3.fc37.aarch64.rpm",
+        "checksum": "sha256:171856671d92ec11433940b504eb84f496f3132921b020dbb66172a5c7e1b138",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "057",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dracut-config-rescue-057-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f4b232fd35e5ef6f65be42bab721dab5f736309c37fa1508f28c8cdf4b7911af",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm",
+        "checksum": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:3bdc032c960668daf5ba86e7d695924879a21e939aee174858b5cbe2f4f0d3f9",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/efivar-libs-38-5.fc37.aarch64.rpm",
+        "checksum": "sha256:130fca628d199df219a2c49dac899bd881abe73839e839e78d0e6754fe3336bf",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc37.aarch64.rpm",
+        "checksum": "sha256:c83fc74498fb51302e56cf23f60712493d3003a25c44cb19b60aca5b1a683705",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc37.noarch.rpm",
+        "checksum": "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-libelf-0.187-8.fc37.aarch64.rpm",
+        "checksum": "sha256:59d84b98e1a0066e0cfc7ddb4f2559ded9803f7fef0c8b52d1ad0693b8f4dbae",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-libs-0.187-8.fc37.aarch64.rpm",
+        "checksum": "sha256:51f204b5187519266c3496cc970150cb41fd23f07ff58c3ee6d8b44a319fb455",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:76df070766b1d7460c3edf04cb404046a9b999e68dde6598c090140995a49dde",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-gpg-keys-37-1.noarch.rpm",
+        "checksum": "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-37-14.noarch.rpm",
+        "checksum": "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-common-37-14.noarch.rpm",
+        "checksum": "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-identity-basic-37-14.noarch.rpm",
+        "checksum": "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-repos-37-1.noarch.rpm",
+        "checksum": "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-repos-modular-37-1.noarch.rpm",
+        "checksum": "sha256:8f4a1bfa873f3a019aef82c02e5713ff67cca7942d7351002e01a0defb8c0cbb",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/file-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/firewalld-1.2.1-1.fc37.noarch.rpm",
+        "checksum": "sha256:f730ab54689ca4dfc727425636a636d35a6d7bbe4985420cb5ff35ec6eef0307",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/firewalld-filesystem-1.2.1-1.fc37.noarch.rpm",
+        "checksum": "sha256:9b1529cbd75e33f5e9e220b868a68a95d807855cb462afe8f15a37da2e88cf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/flashrom-1.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:1b269e1f4fbfcd3fcfc78f42b8045f5f32e98808b7e841940aa066a74fc49e2b",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fwupd-1.8.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:15aa94c5c68a12d000a2897d78f7775fd53ae2555789a8493874bffec978f773",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fwupd-efi-1.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7f5f3953da57fbc1aab1d723cedfeca5c3536c66d479335af6173ca50c54bd5f",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fwupd-plugin-flashrom-1.8.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:472e8442bed37275ec0dbf3783d701d759145b663d96a4dd2bcb6b357699b079",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fwupd-plugin-modem-manager-1.8.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:c7f426539476633d5abdb3ed81918a9311aaaffc2eb243b628cb738925bb5f37",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:156bc28039d28bb3237af60f3dd7bef761987336d1ce4641bd94a4975958b695",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm",
+        "checksum": "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gdisk-1.0.9-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a71f25e9551c607d79645e785d5554292f15fb9c7d45bb9b92de91766825f3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:f52edeae190ea55635b96cb8a5fb81ecd9a2ca900fa65c4403e4890c2d70da83",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:aef4052ca482ce6d1e8400191a2791a635415868e7aa36d3efbea546f710df11",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-envsubst-0.21-19.0.20220203.fc37.aarch64.rpm",
+        "checksum": "sha256:185ffaca4bf6de8e14842027e4c2258409619b16b7d05d2a5df1100d187024dd",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-libs-0.21-19.0.20220203.fc37.aarch64.rpm",
+        "checksum": "sha256:f12b98bc656a67fc7b378870598993e010e4df843fb998f7a439a0a14bc391ff",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-runtime-0.21-19.0.20220203.fc37.aarch64.rpm",
+        "checksum": "sha256:266dbc27e73ef589066244029bbf09de65d11ec1711fc76094694a74512e33c2",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.74.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glib2-2.74.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:59d4bbec71e99f25ac89228d5528aa56c2eeff0a2e8e83d405d3e378955cbae9",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-2.36-7.fc37.aarch64.rpm",
+        "checksum": "sha256:f27c1dea30a1eaeeaf6e69f30d30e0097aabf4f3a99413c3c4a47f90fcfa2a18",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-common-2.36-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8e410d25f43c86de6f76542b336aa40dd0a1c6d84a8fdbeff9ef2a2379ee4e45",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-gconv-extra-2.36-7.fc37.aarch64.rpm",
+        "checksum": "sha256:60c9b8479deee53528d17e3ddf0d1dce61ca74036bf5d35038fea901b61f60c2",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-minimal-langpack-2.36-7.fc37.aarch64.rpm",
+        "checksum": "sha256:26948aaefdcef47d8f73cae1f4ddede5853ccf6a5d4e2ef5d4a6d921547cef46",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gnupg2-2.3.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:be9a015662acc23d54474a01f81a8f321359006b22850edcb41fdddc6f01b1cf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gnupg2-smime-2.3.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:0c18091220a104278225bea1573077d807d205e2392f693bcb63a70c4387f141",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.7",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gnutls-3.7.7-1.fc37.aarch64.rpm",
+        "checksum": "sha256:b1c0880f9180fd54c99e2340fc9a0001bc489f5ff3ed8ab405cce9e35707c01b",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.74.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gobject-introspection-1.74.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:edb75a2c48205e923649a0ff2a5d41bf943cf35d16d272785d095f33afcd7b84",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:99bc383fa8558a73027e63ff75f0978e4e2ff6b26be55f384c3f52e5aee97527",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grep-3.7-4.fc37.aarch64.rpm",
+        "checksum": "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/groff-base-1.22.4-10.fc37.aarch64.rpm",
+        "checksum": "sha256:b875744ecefb91efbe7d05df252768f666bf220d23f865d7df9b15e58dc86631",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-common-2.06-58.fc37.noarch.rpm",
+        "checksum": "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-efi-aa64-2.06-58.fc37.aarch64.rpm",
+        "checksum": "sha256:112978b8c5807ecf490d3559b1d701b48d75ff38dee451e4394584e2adff408c",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-tools-2.06-58.fc37.aarch64.rpm",
+        "checksum": "sha256:3133da3cef48ae829fc6853acfa42c12c6dce9f8ebfd0b0318e81d728d90f228",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-tools-minimal-2.06-58.fc37.aarch64.rpm",
+        "checksum": "sha256:9a19c9814acd3a96a1c6af95220a2e9e72242a2c653a38ef2964b711e509fc84",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "66.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grubby-8.40-66.fc37.aarch64.rpm",
+        "checksum": "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gzip-1.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/h/hostname-3.23-7.fc37.aarch64.rpm",
+        "checksum": "sha256:445cda1792047a2c4bd2172c4a2ef0c175096a848a856cb053bc42d6fb2c595b",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/ima-evm-utils-1.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:44a972be5ba2b774ecbe02a5773ab63e64dae3961de4fc0b36667d42f1c0a4cb",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "56",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/inih-56-2.fc37.aarch64.rpm",
+        "checksum": "sha256:34e078e9be9cbe997458a72e35718feaff49a1cbaf8a8582b30fd0c744b03105",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.17",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/initscripts-service-10.17-1.fc37.noarch.rpm",
+        "checksum": "sha256:8adebc901848979df7c1c96c51055426c0ac7212b536a5cf82bd650dbbb322cd",
+        "check_gpg": true
+      },
+      {
+        "name": "intel-gpu-firmware",
+        "epoch": 0,
+        "version": "20220913",
+        "release": "140.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/intel-gpu-firmware-20220913-140.fc37.noarch.rpm",
+        "checksum": "sha256:98caa3b739e76b8b725a9952231c463b3a46bf056942211f90505e61ea631111",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/ipcalc-1.0.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:941ce3e47a525ae3e39f79a7df7d8e11a313a30a45b5b773233fc5f0ce6fba84",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.18.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/iproute-5.18.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:3baa59082b57d8303f92d493ee2a4d85592b31a89b6598b3c8b1e01efbe2f15f",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/ipset-7.15-5.fc37.aarch64.rpm",
+        "checksum": "sha256:cd1fc5195580df7a72cb38e87f05343e2d381c7a171ae867b802aadb0bf98c4a",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/ipset-libs-7.15-5.fc37.aarch64.rpm",
+        "checksum": "sha256:2493a908ded67cb218dfd26609d197e2d687af31b56f47124c577a0912ab9b5a",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/iptables-libs-1.8.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ccf0d18c15586c0a7ad9e7e69551fa9b997c25970701b5e635a981878c8a9dfe",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/iptables-nft-1.8.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:040f180295b3e082728cc9725aa5a15556920bdddf6e229c7693b4ec80fd935a",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/iputils-20211215-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2ec90e98535f2ba20e2ebc46824e08834a7f6d0239d425c1868ddc7fc57cf677",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/jansson-2.13.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a3db34fee176285b0e73890ac0864c748bb091c256df197f885b31455dbb041f",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/jq-1.6-14.fc37.aarch64.rpm",
+        "checksum": "sha256:17f5276639d9353dd06539d02d936a2b36793003d9ffd12ae0b557b35743290e",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/json-c-0.16-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f53bd8e9f409439671de3762d5cf348fbffd7d97885c5de3953964fd7a148ea1",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2dd5dd23c799bcec2ddccba07a99aff77a244c3a85717a307592ca6d3bc5f202",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-2.5.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d0e859a97a8167af62e273093e454a01bfd64b9ff60897bc97711f3591970106",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.19.15",
+        "release": "301.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kernel-5.19.15-301.fc37.aarch64.rpm",
+        "checksum": "sha256:ce1a77c4b97b190ca56c4548ddab041eeb989df4faeb3c87cdf43d28f491ad29",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.19.15",
+        "release": "301.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kernel-core-5.19.15-301.fc37.aarch64.rpm",
+        "checksum": "sha256:c49a2ec0463320a4a18fa94e20ffe4ffd0714b26f9b16710a2902ffaad3937bd",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.19.15",
+        "release": "301.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kernel-modules-5.19.15-301.fc37.aarch64.rpm",
+        "checksum": "sha256:7da174a3093695f29b8ada7193aeefef71746a4b8fdd9c1e043aa458f368e058",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kmod-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kpartx-0.9.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:88b28b9729a393374ffbce10301fc1829133dba58487caa525aaebc8fa070f56",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm",
+        "checksum": "sha256:b9d09656e98dd744599be50d553e059d5b3c5236b617c5d05de9f0b2f505ff86",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/less-590-5.fc37.aarch64.rpm",
+        "checksum": "sha256:c3063bbcd07caea5dcdb242471047b2a77264ed33bf004ddf7405cab70c6bfe1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2e40045d6d88a1a5bedeaf60f1391cad60bce787dda76fc5ad297fe3c98bf168",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:4718a79261fa3420e90a53b57cc5d25ef92e11e6ff30d089cce717114fce679c",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "23.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libatasmart-0.19-23.fc37.aarch64.rpm",
+        "checksum": "sha256:1b97c4e4b98b93adb07c985a362e7216298fb7527f1887626597cc2ef2796de8",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbasicobjects-0.1.1-52.fc37.aarch64.rpm",
+        "checksum": "sha256:ef495449eaf292fe2bf17066a5bc006c357804d207f7bcdc16e65d40ec827206",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblkid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-2.28-2.fc37.aarch64.rpm",
+        "checksum": "sha256:12b48f78affdd8a09738ff74425d911f1c2404753046b8d07aa8705c7dac4994",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-crypto-2.28-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4d62d62208b3bf57c6692ec986e5a0299315bfd09f499338fd8aea3bfb430827",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-fs-2.28-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a5593981668684f5757b4ceb377fc4f3442c597daa21566e614f6ecd955f0d3d",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-loop-2.28-2.fc37.aarch64.rpm",
+        "checksum": "sha256:9b9438f0c427e8b56f8ca1cfbdb557d8d8c7c92b60e1a2adb9e39adf4a495d32",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-mdraid-2.28-2.fc37.aarch64.rpm",
+        "checksum": "sha256:001e161a91500f4dda475cc30dd26b48c4299cba488cb0deaaad17dca3f407a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-part-2.28-2.fc37.aarch64.rpm",
+        "checksum": "sha256:00f0f27fb9b6195e3059d816cf361240a0d3fd07e9d5c100ccbb4aacc7bc9ce1",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-swap-2.28-2.fc37.aarch64.rpm",
+        "checksum": "sha256:d6523ca88e57d5e5f610a3d5fad22b2d005248e500d660946553c8f9e60d6a67",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblockdev-utils-2.28-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ef0020c1d9d4afab7b4d9515d97d9d2081f679587f61c8481c808e9f0e3c059c",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm",
+        "checksum": "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbytesize-2.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4b6cbd8f1bcd9e058f975f5b2b2e19a075dd6c28e2e8a67feaa337737b542fbc",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcap-2.48-5.fc37.aarch64.rpm",
+        "checksum": "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcap-ng-python3-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:b6b0aa91236f4fe07ebd5fd5154cbcb8c7ecca90ba9af7808c8820454c173f75",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm",
+        "checksum": "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcollection-0.7.0-52.fc37.aarch64.rpm",
+        "checksum": "sha256:70702e8555203b90abd08f8c407a872640ed19a9e9d53869950cf56c594540e2",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcomps-0.1.18-4.fc37.aarch64.rpm",
+        "checksum": "sha256:46ffbcbb2b1f414985b2824965e759104fd9c108cb8140cab2a2e4ee421daf6a",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcurl-7.85.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:8ef2400ff36fe50c2c2c33d503de10333c5b2be498791694b96d52a05949589d",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm",
+        "checksum": "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libdhash-0.5.0-52.fc37.aarch64.rpm",
+        "checksum": "sha256:4092137b8adddb11ff22705fb37255f70a6cf1c26dd44a33410a1d0c3ab7c8a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libdnf-0.68.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5e5d3c2263a0958574d26b7afe5c5341d7bf80c0986f5e6116e4dd4e312a03f1",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "42.20210910cvs.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libedit-3.1-42.20210910cvs.fc37.aarch64.rpm",
+        "checksum": "sha256:add56e5fb7330c434a8f6e2fcccf6bf817ae396b9c3c419e2b3c5eb2046b6812",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libfdisk-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:c71a3884722bdeeccbbcef5d9fcffa4c265d6486acb0f164d70c682bd91e1fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libfido2-1.11.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libfsverity-1.4-8.fc37.aarch64.rpm",
+        "checksum": "sha256:2090e6e4ab40eecb80944093cfd6dcee965cb27803e59c207c28692e8f4c5d7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libftdi-1.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:56b548b06112a037121a913157b0e4c08dce4bb0511843f652e99960e657d13b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgcab1-1.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0843f8805c84f780715c402544d9ce7255f773d2cdbfe64f2aeb50a5085689ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgcc-12.2.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:1ccf5a8e68247b63ac2f4cc27db3d0d3eba7a93570e2a00125d327ac2606d8c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:f55ce59e067b48e1148a5e40b09c7223804540bf1593fb3bcb687c252a074c40",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgomp-12.2.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4e18c452746d0c9be98e298d7282f0f2c3f86fac4b1e78e6d4c9901a0b2f5656",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgpg-error-1.45-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f9176c93af66866fce7b6c0ddc2426bbb88d83d6d091da663ad8c4cb8f8b2615",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgudev-237-3.fc37.aarch64.rpm",
+        "checksum": "sha256:6bcdcac414f4e313ae3527d3993f17bf38d296fdc556c10e738177fb5621a245",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.4.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgusb-0.4.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:23ddd80f270d4a9a2d91e6c5f8d8741e58473e373841a26c6b0f85e79b65565f",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "41.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libibverbs-41.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7a78e507d71c85c273d3aa7e0d7f151b342a508fbfe85717cf760ee172ef9d37",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "71.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libicu-71.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f2bd8534e896f251cd58b8cbb0b069fcaa464aa2a84fbd9d8187690f3c979fdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libidn2-2.3.3-2.fc37.aarch64.rpm",
+        "checksum": "sha256:e1c8670422ebe5aab49614e5264a61bc90ecc67e8ace5258ac94a04c8d8ecb7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libini_config-1.3.1-52.fc37.aarch64.rpm",
+        "checksum": "sha256:c635414b909a2b7ea49bd815c0261f4d30d13d871346906501d7316af3ba1772",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.12",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libjcat-0.1.12-1.fc37.aarch64.rpm",
+        "checksum": "sha256:d09e7caa4cd299e32a105bb5ae68a53a2b7ea92f145306bbb563fc3a3af9245d",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libkcapi-1.4.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libksba-1.6.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ee50ad1b7ba00ffed8c17a1df7b42800c3462a040281afd3500e1f7dd768c75b",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libldb-2.6.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:d582315683769a0456d5ec9f85939f75f8df5055f3ac4110f28cdbea9ca9cf69",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmaxminddb-1.7.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:2805493afc174e4d7588202a2aaab0108d176b62ba856cf45eb8625279a4ceae",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmbim-1.26.4-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f0fec5b7c7c8482cb9642dad77eeedadefe7dda70ed7b53d44fb5a6bd1ea2749",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmnl-1.0.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:45c5b537992ff64548b4ebf9b1e9c0f06fc77e895261e94c5a97e44d0773cc98",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:e40e9aaada115819d974b933bb33e6600d39fe13a91a9b4d5aa27c4decb06155",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmount-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libndp-1.8-4.fc37.aarch64.rpm",
+        "checksum": "sha256:95d136f0a45ecec0f319ac888010a2961d32d31a4cbc7c63aa5f5d128b9619e8",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.aarch64.rpm",
+        "checksum": "sha256:932f1548d9ca07579d56cf1ce527b34786cfebe8e07fc86106ac9d7a803ccfbb",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "22.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnfnetlink-1.0.1-22.fc37.aarch64.rpm",
+        "checksum": "sha256:4b3936a76dfa4094d9133ee6fbb8f0a58d41d54dc81f874bdb9086f06711112d",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnftnl-1.2.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2a96cd1a8ad454befdee1c14e9224dcc35949cce18f197f2f0841e03ac4d6e65",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.49.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnghttp2-1.49.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7e3fbeb8bd1e999cd741083ef4235c4087988e1c6d75e24b784b2ddf7c5193de",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnl3-3.7.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:3f5d9782065476a664f6e4d450404858e175f75b055f844f8a939623854ef615",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpath_utils-0.2.1-52.fc37.aarch64.rpm",
+        "checksum": "sha256:c4e372e626eca2c917309767102294dd75e83ae3d4583e90ee5ac4d1b5032e12",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpcap-1.10.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:6a16500df314e37275aaab3de6fff5f4211d65b44fa9c6ee9ba74e718101a10e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.6",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpipeline-1.5.6-2.fc37.aarch64.rpm",
+        "checksum": "sha256:80e767ec60eb6cbbe095ef2917e2a8d022d98a5f334df0c1c3a14e27bdf03f4e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm",
+        "checksum": "sha256:0131393ab117eb26be5e55451753229122f6ca97aa5b7872e65c9d691c0059d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libqmi-1.30.6-2.fc37.aarch64.rpm",
+        "checksum": "sha256:62dfa5a36a42f97393cf948694764acd5bf102eb91e0e85b1b2d565fa0450823",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libqrtr-glib-1.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:cc9ddf08ea0c691edaa5f2072667d11715a6349f5745f3d2b6e6713bda1858f2",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libref_array-0.1.5-52.fc37.aarch64.rpm",
+        "checksum": "sha256:f0944d0fd2d273c99f6ab808111d4db455fc9ba8489714aabdeda5729977c004",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/librepo-1.14.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:af36734e49f06f79fee74fbeafb555b24fd7473d915a580d7fc3f1359d63eb88",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libreport-filesystem-2.17.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:b85b1faebfc05f8f362dd59c53429328f787cd2fd60cb03432e259b0e5294bff",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:dcf4b614ac88e26b9b344e0d6f3da257555f4402742e27abca969b0f439d6211",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:4be185da5192918b485b25030b36f3e478bdc4bde19ebed1f80476931233ad30",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a2b276a42f94d7982e5e2ef72d59b73b9313ea83792ea9bb35e2e5cb4fa5988d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:72906b5aa7cc9f416f704bb0071972ddce6a08d251b1dcdf7253478153e8a20e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:a6aaae0fb24af1e41f043b5f782f0bd02bc88eb6d8de53c849d628bb03671b6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsmartcols-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm",
+        "checksum": "sha256:58b9082cd1e6c405c75d7cfe43595b066a80226942da5ddc714b1e6309bcf44e",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libssh-0.10.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:6b1232e992e46c3897eaea57866d1ac655ebeff36448813fc5ddd84cd00da49a",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libssh-config-0.10.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsss_certmap-2.7.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:27722776153aa4e16edde96b069f2d249838c401a58824205f3d37160bc53438",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsss_idmap-2.7.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:72aaa5d89982fed7efc80d190f9bee4c0006cf69773a942f5de2566ca666f0e4",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsss_nss_idmap-2.7.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:d023cb3d1d313c3c21136cd59f6a1d103ff16d260e9b8a52dbfebfc663952e9b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsss_sudo-2.7.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7a2e8b1aa352391b389df8624412ce22b31e0729b027c1bdf20d505d2ce1da60",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libstdc++-12.2.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:18aac772a8f18c064c422f3c3d3be7a9f4756029f288a5b281e1da816b47f938",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtalloc-2.3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:3b43f129f65128a6477ed7d55f7c8a0a1359bd6eec8bc162480ef21d2366e6de",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4cc7e6a19b5627e3e3bf941d5bef3ded55458eb226ed6e523e9a0d6a836b249f",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtdb-1.4.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:adf4bb4c6f00d4d335a8cf6c6cbb3919aa3381752edde9a16bd810600e38f8aa",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtevent-0.13.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ed050e88e1fb2f8d2cdfb83075e79eb868decf66ec51ee4bca29d35e849f5247",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm",
+        "checksum": "sha256:8a08019ab8471eb8e8bb8382acc0b8ea145852369d63293466a4af8ff2221263",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libudisks2-2.9.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:d6ee284dcef741c4de7ef51f540ce8144cfc5f2937dd7da0c1c857d96cb5ecb9",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libusb1-1.0.25-9.fc37.aarch64.rpm",
+        "checksum": "sha256:37ccd2182f8ca4f3843cd79dffd129efe19691b963f80d06cc990d74284e7674",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libuser-0.63-13.fc37.aarch64.rpm",
+        "checksum": "sha256:9748ea51ee4285b0442abae84beb3b0ef9e747b322310b0891f001718ec60237",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libuuid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxcrypt-4.4.28-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e8cc5b5b5df546ba2a71ff6fd25adbeb01a27c7c503d53946463cc6108d4ff9a",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxml2-2.9.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ff00ca33d2a696f3b438a85da657f900df56d743f06a0163df3b051e74d9d9dc",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxmlb-0.3.10-1.fc37.aarch64.rpm",
+        "checksum": "sha256:633b5de9ea8d4a98180fcf2c2f93e9e0e16e751061f755c5265abd4887030dec",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm",
+        "checksum": "sha256:f5466c4dc934d5abc1eb1a8ed1028e1f78fd4eea87ecc5954fa491a0879c0fe5",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f81833addc3924f97efebcf3390fd375339a7e752e7b6ba9003162a248ec7b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20220913",
+        "release": "140.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/linux-firmware-20220913-140.fc37.noarch.rpm",
+        "checksum": "sha256:6e5480b45c64f05340cbdac2bb0354b5593aa8da16690a0b0e188a1842920af3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20220913",
+        "release": "140.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/linux-firmware-whence-20220913-140.fc37.noarch.rpm",
+        "checksum": "sha256:4b322703e97a772ad667f9361e64caedd6b1ff8b26882447aa4083c6ac4bc047",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/lmdb-libs-0.9.29-4.fc37.aarch64.rpm",
+        "checksum": "sha256:d5059e977d0f0fb2f8e00201efc16c9e75198d23a5aaaef146e042d845a69e97",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/lua-libs-5.4.4-4.fc37.aarch64.rpm",
+        "checksum": "sha256:97b664f921653bc6d22abec3d906ff58a7a1d568a4e2f24a638b15f46ed8e058",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm",
+        "checksum": "sha256:61eb54379561ee89f973c58c10b8507f64fc0d1b3bf11cb5624b236365eecc9f",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.10.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/man-db-2.10.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2536982a47df91b0763fd31226c2ff6f2247c1d028686e0201ba4b3aba45570b",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mdadm-4.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:052d5277d62271b6d02095046f52a865e5a196be847e0e99d9e257d798c6167b",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mkpasswd-5.5.13-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a34c6b913b7810ddef0831adefe154fb68150ead286b750a3dc3e15b56c75e9d",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:76ed672b87d410a259b09885e8ad7a88b28f181a268c3b401356a43e41d38141",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs102",
+        "epoch": 0,
+        "version": "102.3.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mozjs102-102.3.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:621a5f7a8b6f53c8b35225ee0112ec80f17cd317247faa2e4c083653f32f4d4b",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nano-6.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a89bdeff8ea373ce88d147a5f017e7f342c1c79fdf615a88f2396e980638feda",
+        "check_gpg": true
+      },
+      {
+        "name": "nano-default-editor",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:18b46fafae10d86249df30a025faf411cb1369ddd2d2ade738f9cc4b45ab6f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ncurses-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:1f787566fa6d4c0a2f5067b98195f3697a4e9c65a8227b6598f0d0fd778da571",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:c712e9a4fdd669f1bd5be16b453b5fe22ca6c7265845833086334ab73144fc89",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nettle-3.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0c4160ab5e8672d41f10f4fe52f0b59cc28b21cd3a681ecd2ccd8dbcab56ed73",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nftables-1.0.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:28392dd7269733e1b069c3111b9eee10ec590f7d58408c0b7e46e78923bc5fc1",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/npth-1.6-9.fc37.aarch64.rpm",
+        "checksum": "sha256:64a7dd77389ef15d39b87388aa8c1b51186accd702fb91989ddbe729060adb55",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.35.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nspr-4.35.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7bd13c90588b99b7a150452490c1cf43117ed01d68b4e301fda14b5d5c2a8465",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nss-3.83.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:8413d88829a4d9487404720494e2bc4339e2d5bccc3c179bdf00d1f33a557269",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nss-softokn-3.83.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:bfaa73e218017bc791a08821e5f2e4c74776bac5e3e950a69338fa0c823c8058",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nss-softokn-freebl-3.83.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:4b72d8df75158aaca80e356401b9970d1f04726e019675f24057b560ba6ebff0",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nss-sysinit-3.83.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:24f3d5654667b73965727da7830103c2130c7958e6fe70b27644681cb0dc304b",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nss-util-3.83.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a3303f9003ae7e80e1beb4d70681ea7633dbd5477d55c042264ef7770bd9107f",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ntfs-3g-2022.5.17-2.fc37.aarch64.rpm",
+        "checksum": "sha256:7844c090147f6e04cb219d39eb76341b08ec0bbea3b51c51aac925301fb7c677",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.aarch64.rpm",
+        "checksum": "sha256:eff91da3adf84b15e85b72b907d7b233adbea9d78ecf0db75d9c3a6c9c0e43da",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:1d6c6889c78933703fc54b965fe1cebd52f08e7780093e71b21fbe10586f2aee",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ntfsprogs-2022.5.17-2.fc37.aarch64.rpm",
+        "checksum": "sha256:8b56b7ca059afbe4a7ba86d30b7b324e639df618276cf45b46d3e315cf0718fc",
+        "check_gpg": true
+      },
+      {
+        "name": "nvidia-gpu-firmware",
+        "epoch": 0,
+        "version": "20220913",
+        "release": "140.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nvidia-gpu-firmware-20220913-140.fc37.noarch.rpm",
+        "checksum": "sha256:8b3b3f611f93e849b5c03219fb2a28b63ac4215ebe28a8219da5e5be15e5ed52",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "2.D20220919gitb041f6d.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/oniguruma-6.9.8-2.D20220919gitb041f6d.fc37.aarch64.rpm",
+        "checksum": "sha256:c61932cab67782a94abb02cdeb1c1b64c0161a0331b1905f8826233d7ccc7ad4",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openldap-2.6.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0d060e4e89bafa0e342cfdca9136c72c8d3f6af2adaecf2ef47e530c5edc8985",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssh-8.8p1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:75833cca024e8367727abdb7c363832e445b8e461bdeea9f74ee6f27701ef806",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssh-clients-8.8p1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:ee09c79ac0d3cfa76c1565f1727de2734cda082f657e80c881c93aaafcb9bb06",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssh-server-8.8p1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:2c624985f09a77982fab2c04a5dbdee38f69777b93c0d59d0c05e7dd0d384c9a",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssl-libs-3.0.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f2b8068fbb2231a515c60c491eb5b08808af1eb6d497eb33039125aac3eb7d63",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ce155c86d0bd2ff0bf29a3ffd454fcf085389e2568a6d158cad79c55f895d683",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm",
+        "checksum": "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/parted-3.5-6.fc37.aarch64.rpm",
+        "checksum": "sha256:f23bbbb8abeccfae1758e2eef3a676c956f2df47ab4ab559eaff52afa1f809b9",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/passwd-0.80-13.fc37.aarch64.rpm",
+        "checksum": "sha256:0ead18c632b1aedd94d6d722f8317c2618165b9bc0532fea4ba5a10b642e4766",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre-8.45-1.fc37.2.aarch64.rpm",
+        "checksum": "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm",
+        "checksum": "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcsc-lite-1.9.9-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ba7fe160856cb5c4385d6cd5ed9b2973de52521e3a944dacf221eacc77dc44de",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:85746399da551cfc335f2a4b156460b4903a277861077cf919b3f5ecd7689e97",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc37.aarch64.rpm",
+        "checksum": "sha256:9bef843589abaf3dfb3ff5c72b6630f5b6e6ec8d706f2d569d6b503385844444",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pigz-2.7-2.fc37.aarch64.rpm",
+        "checksum": "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pinentry-1.2.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5cc444fb3971b6889d20cb009bbe91cc464c2fc027e6aacd6927a13d3bbb10be",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/plymouth-22.02.122-3.fc37.aarch64.rpm",
+        "checksum": "sha256:8aef705ac6c83a97e41f60b13c7f8f38a53126b22390a691f48a2f77621b3218",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/plymouth-core-libs-22.02.122-3.fc37.aarch64.rpm",
+        "checksum": "sha256:7e10408f24fd79fc501590bde5e8bdfb0fde0add0c734c503eb3c328d6e34630",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/plymouth-scripts-22.02.122-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f76a449595a1225fe34753ba26e1830609789848e3f7eb6424348dbdf63e1046",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:f9f91971d2e252f6fd49c40b9feb62beda46c268f0ce1903e6396f7a0d35cc39",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/polkit-121-4.fc37.aarch64.rpm",
+        "checksum": "sha256:9cfbaf8447ef22431bcefb1542a31badae1a33de764e4cbb88e90faf42827519",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/polkit-libs-121-4.fc37.aarch64.rpm",
+        "checksum": "sha256:b7f51a01499b5ad345c10a790688ff8837d894b8608daf0fd27250d8a20afa77",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "22.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm",
+        "checksum": "sha256:d3011b8c219f9f86fadd7bf1ae600db59364b5e425ae47117d090635812dccbf",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/popt-1.19-1.fc37.aarch64.rpm",
+        "checksum": "sha256:48410dce2b1c514e23d2e9e067714be0eb2923ff44e3ac7dde373a92474ff642",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/procps-ng-3.3.17-6.fc37.aarch64.rpm",
+        "checksum": "sha256:f9013badfcf2a78e4dd4a1f6ada593f3d1f9dd5935814abde7dd7de1fa9bb8c3",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/protobuf-c-1.4.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ae6fe8d3375b9cab9cbc289118654227b84d353d8102273d15600e403ccfbe3b",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/psmisc-23.4-4.fc37.aarch64.rpm",
+        "checksum": "sha256:2c9c7520371594e7072d9cee9fe6df88e1de32c9f39eea0e6b13a447fc04ca86",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc37.noarch.rpm",
+        "checksum": "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-3.11.0~rc2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5caf8f150fec9e984d40ae7efac186450be8ce215eda8a6f864606c10bce798c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.2",
+        "release": "4.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm",
+        "checksum": "sha256:6e1b3ebb0f9945593365eaf0bc01d052d2e221e930d5731d1bd8276289194ba1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-dbus-1.2.18-5.fc37.aarch64.rpm",
+        "checksum": "sha256:5e51a6aa0c2acf0913d7aa70eca38a11492de9ce863bd2f4955ae09c3ceda37a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-distro-1.7.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:6427a8b877a51be140e06665b3680a911816c9eb581aa54ecf29c77f51b6e898",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-dnf-4.14.0-1.fc37.noarch.rpm",
+        "checksum": "sha256:20c744f2ca0c36933f151c9436bc67c0db461e26c97eaad10726e3e42a169012",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-dnf-plugins-core-4.3.1-1.fc37.noarch.rpm",
+        "checksum": "sha256:21de93c6eaee8efe68ce326aa4a8c9819fb9c8a87ef153fe3be473076890db7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-firewall-1.2.1-1.fc37.noarch.rpm",
+        "checksum": "sha256:c462e7efdf7650c49e4d0af6aa59bf555db59bedf0a30e75ffbec4b2af5c5901",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-gobject-base-3.42.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:1dec644503915a6e2e256de5993a746379f871b241d81d0a0296c3f9478bf84a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:e9bbf1cbf6b2df49cf17585f3913a9064f7b0c3c56b116a92e9f242a3676efde",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-gpg-1.17.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:ec395c3a160470a6da63ac1298a540a93a2adee4d29c4f78c24330dbbfba12b3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-hawkey-0.68.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:58b9a2c3db5e64b6c33eb7f5b2f2f63cf127626548540bb6333e0c1fbc415ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-libcomps-0.1.18-4.fc37.aarch64.rpm",
+        "checksum": "sha256:55ff17ec31466bd748005cf65cd687af61b0aeb3ad343e8d0c2d9a24f8a1286c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-libdnf-0.68.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:378607a741f61282ed8243ca0f2164fa521ff02983e0eb1289d4350b7c781602",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:bbef4adf7285d497ec92e10715866a15648100373e579947afa1c28862cbca44",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-nftables-1.0.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:22768251ebf30802c0bce3fe0bd9d4092bf56bff6036dd655684612949c112af",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-rpm-4.18.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:e49fe2ec10deebf89c5b9465db6e18ac99493ce1996ef5a28ba7e9e193f5aff1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm",
+        "checksum": "sha256:3f33292317a057dd50fd05ad00e5495a866a3df35d8acd83efdb592fb90c603e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-unbound-1.16.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:4747539099204c21a9de066f81acc9235c684f0f3060ce84e1a0f2c10862b5a9",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/readline-8.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8eaa5255d8f5cd3a8f854c4de6082158fd6294bf779b654d5bc270906a425ebe",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "32.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm",
+        "checksum": "sha256:0c0e32d108fcf6ac2f4c61aecc03163168337179b861786abd206ae58535a0e2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-4.18.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0c2c0413d99049dd00a1f5ba19dc53f3ac0efecd31f315da2f2f9a987300ca05",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-build-libs-4.18.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:012609d6708ad27db0098e6d6529bfe63b7a3ffecbf8c67bc5d8b2059f9bc7f4",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-libs-4.18.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:1764513e83380dcdc272841ee7ed52e118c1672d593f6632166bfe5ef955f6b1",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-plugin-selinux-4.18.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:1090174c3e6dfd17771c8368e16e191fbdeb69d075e22347becec5262f39bb3a",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:c6c2be7edf77d8e3e7c53574d7e3c7284bdd11d084296bdf7acade081b6d169e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-sign-libs-4.18.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:eb3791b4d97a2d8b71268d808f50b3f8a1358e7a7d3cf66d8882b886d08c525d",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sed-4.8-11.fc37.aarch64.rpm",
+        "checksum": "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.12",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/selinux-policy-37.12-2.fc37.noarch.rpm",
+        "checksum": "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.12",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/selinux-policy-targeted-37.12-2.fc37.noarch.rpm",
+        "checksum": "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.12.3",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/shadow-utils-4.12.3-2.fc37.aarch64.rpm",
+        "checksum": "sha256:377612c800325778fedc210ccf925125dff0f8515c5bad99ac48df1c35d79a46",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/shared-mime-info-2.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:eed9d47041b04ea6c49408f4d71cc0190b699c51c1a89de4c6fdd676cd1777a2",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/shim-aa64-15.6-2.aarch64.rpm",
+        "checksum": "sha256:5e6fb2a961d9e9823380d329642b68e752d56018b6f5ad0a7856a8fda723a9e3",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sqlite-libs-3.39.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:e2dac60f8875f9ae0aff2da3840d9e878a48650aa4c6d04ae6cc0b668aa7ba2b",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sssd-client-2.7.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:517d1129b28f53a15b66aad1ea5da4e6f45ca51c0329a66967b58c1cdf21bf9a",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sssd-common-2.7.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ba8364ee984a89ba421c4bef52fb867f7260789d4c4381ab208c139cb1054dfc",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sssd-kcm-2.7.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:83a66501f3f273b184e8161039ca17fbd2b91c4acb2b0f0226593aa83cc47701",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sudo-1.9.11-4.p3.fc37.aarch64.rpm",
+        "checksum": "sha256:388def347af7b9811dc79872bbb55f1ae433bde1cc4b28e8b3ccc03eeab80a1e",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.aarch64.rpm",
+        "checksum": "sha256:8c8c5a7d8a7bde6cd7413c745ea8f81f728169d2e4e96327a86f41019b8390de",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:bf7a37c0aeb74a472c54d948e2cd3978b813891402b76c5013929255b43de54c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-libs-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:d650642e10443dbb860a185980f3119518e8fffe3952535accec681fbd8ad8ea",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-networkd-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:6738cecbdf2248efba296597ce75313a70219901923a2f3aef52af4825029409",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-pam-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:c616cd07150cb3de1e62b6b710f1405106c7310927076aa6cf89a2c94ffd13f6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-resolved-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:47c981aa9da90d9280f04145f13b7f771d3ccd74d9a776f438dcd10072bb4ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-udev-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:ebf16596928342c62b0abc250f56f778e7b6428e0273ae5da88493d9effe2e3f",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tpm2-tools-5.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:c8650dafee9357adb6e6f878e5c3eb32aeb72ccce5bf68056920e77c7abc8da9",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:db2227729ac01ec1712cb3630ae3ac81fbe6094b5d40f9a91690b1b8dd413eaa",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022d",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tzdata-2022d-1.fc37.noarch.rpm",
+        "checksum": "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/udisks2-2.9.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:5eff8b70f05717621b31b0c0c8fbdfa6bfbec81d38c7b98cc214a33dba9bde67",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-anchor",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/unbound-anchor-1.16.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:047216e22e398523f2e1a08516407fc622ded70855c7b7a5a21b1c957e41363b",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/unbound-libs-1.16.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:e4523cbae9f86f48f4bd7266d931bf81afd007ac17d6af33d6ae782ce2579db1",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/userspace-rcu-0.13.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:8e85f2257c7cb41df273ffdea56daef73e44bb7bfe79befa296f700e60c49548",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/util-linux-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/util-linux-core-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "9.0.475",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/v/vim-data-9.0.475-1.fc37.noarch.rpm",
+        "checksum": "sha256:92841df883b69d4edb23b0834936717b0ca61b50391174f2c919978051f736a9",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "9.0.475",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/v/vim-minimal-9.0.475-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5a9bd9e833edad84033eb47d19575344a44369c392b09f82fbd8d9cff3db71d8",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "17.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/v/volume_key-libs-0.3.12-17.fc37.aarch64.rpm",
+        "checksum": "sha256:c6fa6669abe6413582fb6edb939ff8e897a71c9e054a6839516cf9a6b11eb6c0",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.18.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xfsprogs-5.18.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:788976a6dfe6796fa08ba5f52c17af923044473b481a75be9bb695e8fa7d5a16",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xz-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:660c430d505999d24d2c0cc023d6b6af1c691db8bfaf62d10d38963627b4a664",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xz-libs-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:fbf24d19205ce8b9c2da7655d859f4c4e7753b5794bc90db3aabdf3e7784bc84",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/y/yum-4.14.0-1.fc37.noarch.rpm",
+        "checksum": "sha256:cbe8a6957b2a00bf0117c5cb08affc8abdc2dad02edd1113b463412b9bc2238d",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zchunk-libs-1.2.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f1734d5da50fb27abe9208444bdc99f65c382790150492152b891d2d501d7bf9",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zram-generator-1.1.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:6c7be4066ad8a69c7b4ef73706b1c0591361b522f22a1ad969f2e128992ecdd8",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:2c492273497329d9a1ea2293d0f668edf953e18830f7d49797f7ff8412ea76da",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_37-x86_64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-minimal_raw-boot.json
@@ -1,0 +1,11501 @@
+{
+  "compose-request": {
+    "distro": "fedora-37",
+    "arch": "x86_64",
+    "image-type": "minimal-raw",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-modular-development-20221025/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "raw.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora37",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:a9ca97b6dc978f2a3895963780b0a99c794e5db5ce3f18e16951449fb11c74c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23cda2a639c358757ee35ce6270ba3d0c6cd779309ff528e7c08c0239737dffb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74ee0b4664d9300b0538372064e74e1609f5bf89a4cef76c7849d774af7295cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:68e0f60ad19cf5f0f211f0e14b96b42db87806d9536eb05386cf9bf168891c2f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21ab08a6ce4ff5213d541878e456f7c1ea9da5b76c342fe1c55641a77e187b23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd4d0c1b5490e1cee5e461b89eb1b1e7bb40c40de981cfd73ac060103a5c42a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31af27f44c4a8d06068389731d3a5adc0fd45b1c8ce4d28163f938e68fa58cbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3847abdc8ff973aeb0fb7e681bdf7c37b19cd49e5df17e8bf6bc35f34615c88f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a9c9f908326ce672180964c0dee6a387fefce9f4e49dacbca87f4aa8bf1e31f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec82b6cad1b898aaa474a6f68aa67840cbb1d70b515c2255ade5ada88cb3d587",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b1e2c27345206db40bd782541b00575f3d36e238a6905c75d67c2407ca4adbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5bbfce30b88c0b4f06c4ad0c80645cfec9c23248d7c734d76607d8bc500c43f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8914ca12a258fb7729a231325e4c269a97d38d6d6961dfebaa4a74d92babad8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce9deb715d28bc1ef130ebf8c7d8f28fd774123da3e6d60eecaaca887d0a5f4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad9b6aeba4041769fbb2d9f3aeb72e3534c7f572f2021ec309e337efb4fe5b64",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3ef7332845114c912be8ba53e198af4e92edb5475809e9d3e6a2ad3202380d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b9b252702c66da50fde953741fe5470d53cb955dddf6a50d890002927517f0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f197117a201e561bc919198df573394e7c97dce2fda2382e3a2495c7ab9e8cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b9c5fe598d258b0dbbf454b01ba844aa678bf5c7333bd16e98ba4c62a242f9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bad0c7e6a8c83996b3aa2056481ea9e1868a3b5f01608c2e1b4364e7b365415e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6dec8d3c7b09c9e9114d18081660c5d01b82a34986db43f437aef2a28163fcf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c309c850576d198d785c6f4b36fb5a30705983851cc846075c26bb51d2007de1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd59eec6fc00b4f8adff9031597fbceca1f7ef0aef5e5a7a68f275056713e2fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b62248de9e972c39877fa9e4aeb91ef46b7436d5e92624efc9154f6fa6b9e88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f560288796308a8a5c85ecc3be5214d76cca7d9a69db29981de11910c989ab4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3a149d5a46833b3e166c4610649954e9dcf78a1960f107ea74145a41e06e2d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae406fca4514b396783fc79f20f20501eaf357389ccbb0b0c6207bdaadbf236",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c660eada8cb6e2d2b0c035a9d1696db945761c07e7900b8003b1b405243adef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ccf3b0e27bcba1698f7e14b1f52743ef4d59833b41cf24dd5b1aa490c389b22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:159f17086ec145c629cedca9a038bc0c8fa38b4a8f7f0f0e9bedba0f3e76af28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e41b0d094a6635221cc015437ce4131c9ce502a4d4d2a5c1b51ac36ad0ccd21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff2ca237124563e6c9490abd6802f8d83f66d147e7fd60f8b5196bf78a8ba72e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc5f7ca1ce86cd9380525b383624bdc1afa52d98db624cfdece7b08086f829d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9978e30981c695105d1ecc67ef0b3216ab3413a9d93907390e8577de3b11c478",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63a20a87a52e9ab38a252c30f4ef64ad836340d4209dbfcf91c0b869798a3fb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e022d35d3834e81cdb7c9582086acce4dff74a026ea600f6a5cb86388d231423",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52447c45094ab085c5883024b1788e66a7d60d425f48d4dcf6683cd5be0ec087",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddc6d5cb5a094abc04b93e4018dd178aa1c527c80f2059c21963d3621a428989",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a5b4e2e1dd388c3c13d79af971fb8efd522f5c2ba8d257875f02c16b4858214",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7c409363b5a1a459b8ceb987866fc54e1feee5d4d2919d31295c8526b7d96f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66305d7a3ca92165f1c17e14cc29ea70280fa1c1fd3bf223b5b1d4f7d1ce0dd8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e918bc5b11c8abfec9343e1b0bd88087b792e85c604427d5cdc32733f70b3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1adc02db53d619c3afe65182be399a9d08a7bcdf8cb9be04edc4b5c99da5cf42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aa568fef0ff3141c9deb6a0e8cfe1e3649d8efbbe04cd7390c0681c447748fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9546058ef3561af0a5e24d50469fc2317afb6aa760363c9348bd2374a31cb5e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76dcdfd95452e176f64d6008d114e9415cd8384c5c0d3300fe644c137b6917fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ce5fc1b93217cd4b9db8b47bcd548ac401047ac73f48d1bfd66f0ffb91fd21a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7d0f5ded000fe57622ed2e551dbfad3b86b6bfdcd7d33a5e3c0862b9fcf6dfd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:539f9b54e9f497f0d40374f3d863a62c6fcc4e54a7336ac54445344612fc151c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c105f54738fba9793dad9b6ab2e88b4ae05cc47b9ea062cd7215b69d11ce0e1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffbcf2d3558dec17023a930d8e278756ffec150d943b66239085043e06fbce59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93476a87e1531898ab2a95a701d918ce589c4da252aac2c615ba650138664feb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08c7782ae9fe49cbec8db74d566061656689bf48cc2977bd0dd8daf3d645133c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47a3ce5b9228ccb688da7458828fef2138f6e4215e73941922dda962aecd14f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c42642046bf068a2d0cc32f38cdc56d0c92af48eb131fc8dce55a997142f2e88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7bff42a7164385e2ca87fe11bfc8ff6e50d56f8da32b5ebd1e5f0a4508b66b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:557322822a4aa090b2c4d24154f25a7417b1015327c92f463d98161e46f65c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20b825188654b5b5d17340ce6a78cbd3504e74729f8cfb83150b6798db4a586f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3c9a6a1611d967fbff4321b5b1ae54377fed22454298859108138c1f64b0c63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64112ed94189c99bddc05003aa3bdea8a5486e8cf056678512586864b41985ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:128b958d194fd77cb888807aa6bf46c3ebcec2e345ce2cefc202def4b8d678a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62ee4e0aa9f6ba95aacb3a62f2221acfff510f6cd4cfa870cf68cbb9f9d42201",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed6c8cd71a52822a69c6dd28d2a112a0f772983a20e037884c7821d9eddef6ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7eb9468d77618514bf861da405e2c85b2411efe81577ebc586fd9c25e5ae4194",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:359602208228e24f4d2b4f0ab057ad7ca604ed3f23b0873e7efe395a0c3df25e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ab8c75a2f9ee929bbfdb722abc00fb96252e4e76c66f1d292cfe01330f3d56a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b59985bde8c374933ce87766de67f010fd10e0d43803b2d792c34f64f923bac1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8958e57d4f99bea5bd52c17f26ff5973dabe941aaa279cfca576c3b7c055c4b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc8e6626c3c8ea2dc183400a6f3a98de9eecd237e099bf589e42b24881256770",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b2bd8783d542d769eb6c440974af90451fd44353f291b9f89873b56b20490ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b392a609fd5f688d073dcade1548fb15f7d7a2b3b37e235aaae9ae07ccecbfb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18188e5455ce48c41c2aa87d9c28a6b0d632e7372d6284455f1a982676f8dccc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1838a0aa547578b45ead6c5f1ccb66493ba06d881e5d4163309f8333b4b74988",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9da9b36d4a3a55ee49e582743900a561093e3625b1e0a90f80e36797de7baa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80b1424e54ba0e84149d8ab536b7fc3e31469a571ae3f0e11077bee8b663af9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4d4230f282f18fcd120bdbff40382d8c04d322675612d9fd85e1461c62b66c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d5c9d11876f3a1688d31fa669986eaaa4c0717435ca99e78fb86bf5ddc193cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f9541ae85dcbefd66fd88c014ccf176b8a6b32788443981490d3a76381c2cc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e56dc2a37766276593c4f40c9d588defc5ba66ab29ae90ee03480c8bcfba459b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25ea22f713c6c2a2ff164c3a5b6f625d70b2a399d5d0ba0796d96942777e756f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24c5926ad780d9e90bde6cbe605543d00b776a9cba53d3e063606c093fab3557",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9ca97b6dc978f2a3895963780b0a99c794e5db5ce3f18e16951449fb11c74c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85698713589960a8b6821a4a56bc7b5af4df9977e86cad103cb9512ba7177d2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:994af8949fcaac8a808ca00ba4d423e4b8b091c6643b7c49c8eb148b3954cf18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23cda2a639c358757ee35ce6270ba3d0c6cd779309ff528e7c08c0239737dffb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74ee0b4664d9300b0538372064e74e1609f5bf89a4cef76c7849d774af7295cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:68e0f60ad19cf5f0f211f0e14b96b42db87806d9536eb05386cf9bf168891c2f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21ab08a6ce4ff5213d541878e456f7c1ea9da5b76c342fe1c55641a77e187b23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1502c8529c0e0e9e57c9a1a1635fd28fdcfc1f63004b1d5aa667baa868ea41fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:558476ce7be43951868fef0c6216a99ff0a5ecfbb69e68785172b3a9a627b28b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd4d0c1b5490e1cee5e461b89eb1b1e7bb40c40de981cfd73ac060103a5c42a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31af27f44c4a8d06068389731d3a5adc0fd45b1c8ce4d28163f938e68fa58cbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3847abdc8ff973aeb0fb7e681bdf7c37b19cd49e5df17e8bf6bc35f34615c88f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a2829a5012094cf436e39495f0fd8f14604f8f295e98b8bb6e85eab9e0472f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a9c9f908326ce672180964c0dee6a387fefce9f4e49dacbca87f4aa8bf1e31f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec82b6cad1b898aaa474a6f68aa67840cbb1d70b515c2255ade5ada88cb3d587",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b1e2c27345206db40bd782541b00575f3d36e238a6905c75d67c2407ca4adbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5bbfce30b88c0b4f06c4ad0c80645cfec9c23248d7c734d76607d8bc500c43f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd187adda52038f138b4d7fb632699088109311a4da39bd8e28e57858487c4eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ec2fe94d7573b61068710179c7588dec264198fd55a04247bb1cf9a1f925cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b51055715d002d05e5c90fa52f4cdfdecfebcb324ff532f84547a72586c7362f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7ba853b07a46efda355edc72f74c9e356a2e60c3e4f934b0cefb9d347f20a53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19b7e1385a12e9196622d1549ebee9a2254656300a530a9abb824737950571ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e7cf0116ffdcf0c673d155a24c70e1483305d6ec50ad8b7d1d4ad224e4e88bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e694ef5ad5f16b497d4bdeca3c0a0c49fd6d01442e87f5c302dcadab0af2657b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b75e3acf6f11c8584c7e38718a295503c09c0acd4b9dd245b287ab3357d245d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8914ca12a258fb7729a231325e4c269a97d38d6d6961dfebaa4a74d92babad8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e3ddc2f83def37e6c6799890e4a3c12220491045a656e308b2d306e165e64bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3a520ff09e426914c103a156c4df4323a0e2fe4e469bdb7cf307fa57f8f1f9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:157a95e5d0a70dcb97682ae484d6238e99db218071855483283c61486029ce8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1333de1f729a9f570251d37764c5c20faf596e9cff41643832d33f74bae24a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce9deb715d28bc1ef130ebf8c7d8f28fd774123da3e6d60eecaaca887d0a5f4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad9b6aeba4041769fbb2d9f3aeb72e3534c7f572f2021ec309e337efb4fe5b64",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3ef7332845114c912be8ba53e198af4e92edb5475809e9d3e6a2ad3202380d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b9b252702c66da50fde953741fe5470d53cb955dddf6a50d890002927517f0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f4a1bfa873f3a019aef82c02e5713ff67cca7942d7351002e01a0defb8c0cbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f730ab54689ca4dfc727425636a636d35a6d7bbe4985420cb5ff35ec6eef0307",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b1529cbd75e33f5e9e220b868a68a95d807855cb462afe8f15a37da2e88cf5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3d72ee9f04141387d75d3e8ec9fe3a720ad40eaa815ffcb9e18f5e98e2353d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6b266b19cc93b1039758006f02679223535a3f86b04ccdfc848aa8d61575723",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f863051b731a75ea7443c096b1a0e236fa4b285b08b3dd7175d68c228eea1dbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00eaeeac4eac4944832ff4821ca821de222b598a07b6fd368b11e3143a58ee02",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f33244be0eb788290d8ecc1e8b170af24fa51b64ed264bebbc84a352be4560da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c576f1b14afe9222d7c4e0007d58a3c998b5416b5aa1fdcfddbff264747787b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d10d3576f631d1005ac681c79c517218715c65dcc194520a1d6cc688a0d6fcde",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f52edeae190ea55635b96cb8a5fb81ecd9a2ca900fa65c4403e4890c2d70da83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aef4052ca482ce6d1e8400191a2791a635415868e7aa36d3efbea546f710df11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f197117a201e561bc919198df573394e7c97dce2fda2382e3a2495c7ab9e8cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b9c5fe598d258b0dbbf454b01ba844aa678bf5c7333bd16e98ba4c62a242f9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bad0c7e6a8c83996b3aa2056481ea9e1868a3b5f01608c2e1b4364e7b365415e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0cdff45179a19a455bef375aed366f9323397a05bc7850a52fd2a106f34cc7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6dec8d3c7b09c9e9114d18081660c5d01b82a34986db43f437aef2a28163fcf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c309c850576d198d785c6f4b36fb5a30705983851cc846075c26bb51d2007de1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd59eec6fc00b4f8adff9031597fbceca1f7ef0aef5e5a7a68f275056713e2fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b62248de9e972c39877fa9e4aeb91ef46b7436d5e92624efc9154f6fa6b9e88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c688de5844e5bbe41b94e7f84612d96c59e4d1348f7c8f596baaa5227e871ed7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5081d23a1ae79d9ce3abb22648a358c1d07d55e03c1aa2ffa9f920a9871344aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31c439058714931736b9a7e4bc5b2c70d47ed188721c40cb8b8839bb3c5ee732",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9977ab99bccde6c58ec85fec01afd8a8e5cb9395bbc0a67aba49cdd320b40ff5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03209772270d0f1fcac1b006d2d4b4bff967a001e7c9fdc6ed97950fede5e3cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5b4e759d1c56188fb777926de0d17498c25d3234d2635ce5a8e7b000bfaf7f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94bce8259108638ea7232af46208addfea8da92027b2bcfba5477e72403c75ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f560288796308a8a5c85ecc3be5214d76cca7d9a69db29981de11910c989ab4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3a149d5a46833b3e166c4610649954e9dcf78a1960f107ea74145a41e06e2d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:840438421f3c7e28e49fa1327480ff7eb7780bcdbf605caf35ec0115bf4d7d9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72b2fbe65f24fa2dc41109cb0bd47b0962824847ac802a3c0160d832ee1e75f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28d630dae78579725857e2242ce2ce01e6748a20c538554a36b628157a7ea1c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8adebc901848979df7c1c96c51055426c0ac7212b536a5cf82bd650dbbb322cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98caa3b739e76b8b725a9952231c463b3a46bf056942211f90505e61ea631111",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea37bbc4022aa6e266e0ec601d97620574c12c8b898b3ffb8ae8baffe553745f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:960633a9035f8fe02d49ba6713f240363383d5dc3b3f862d28e9b211fd34fea3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f13a478a33985292da87fe93f42165f28534da027abffe942de5c5ea1388c487",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89d348fb8c40d1a4fc0ce2a217892a73d3bcfa183379af8ab2826d1e47b87e9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:57a1d67b5a9c1151e3f3c9401ff7f4704f91307f0d95d5ea7b276e9095748e20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae1fef40fd8a0c5bf8c4aa74625119132b9564fabe2d84ae7856b39805b014d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9cf89d7e274a5ddf55fc4b97974c7aa33f50379c8ed50f6cb458b7286c89af7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c63e2ad394b69e31da35ddb4578c8b0c45b7d1bbf6015c92434627ad4b243263",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad14549b59bcc2c3c2ed6152c0a3a2d4aebac3ae06ab5dc451659060f380624a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae406fca4514b396783fc79f20f20501eaf357389ccbb0b0c6207bdaadbf236",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:598ddb966e5ac4f664f2cbe9d0087b62c1a4067a1f1af24f290d7f681956e29c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c660eada8cb6e2d2b0c035a9d1696db945761c07e7900b8003b1b405243adef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a13299c491c03c409b982ef670a4ec5f1642388da24b4624add8126a6b637e15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c5c57fc5ab7e4045f84e96e68bb811eda6335897bea41a1576708cc01593894",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9278077f283c20321a550da3faa0e03cd58f56459940cfdf6d7e05c0c1016688",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ccf3b0e27bcba1698f7e14b1f52743ef4d59833b41cf24dd5b1aa490c389b22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:159f17086ec145c629cedca9a038bc0c8fa38b4a8f7f0f0e9bedba0f3e76af28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f03d62bf2ab0c2606a64a4326934765ae6d25afabe7cc7b77e44445c49fa4ac2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e41b0d094a6635221cc015437ce4131c9ce502a4d4d2a5c1b51ac36ad0ccd21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:337900b23fc2550547c243e11b7a65284c53c844a3882e0b67e2fbb93f8bf1db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f52405026bce203a5a1dd62b533f9e6c61a68bba6271d2f7de3948dcb1a47fd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:364011baa5e293baae2e60992fd1241f6c822d7c7e48c259d3e6abb0530036af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:feca19ad021eb5d691d05cd11833a908eb8da2abb9acb1938cd8d3fcf40eef4e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:add50027ca1a47e15088520f579e2e2384eecf0bb82e2f02339f6da2c4ac9416",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8971dffd7d3ce1547a16bd17bd8d7745ccbfbed897021c504303c3f40f6920b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d8ff5893280eba8e73458be4d5db1032c79c0fa0e0d08c1f55434cb05e8d5e44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67f00ad99cede36aea285c6ccdcc713d5519d6bda710e5a340cb2886d87aa228",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:703ba79af214b62786b19e0f58c7e842e04de852145a5f1971beb4fe6f24d563",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8122523c26fb300520670cd3ef4da1a81d9272501faf1c7db9670628ced5165e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5eb771630565b940d76a67db7ae2bf986a30d45f4930c80e9aae9ed634adbc43",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40bdee106c7d9df3c4b2a39289b247635450d763fb84cd5e63e2493f9519b58d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:278bfd824633a3c49357342679e9dd5864a33bcda5d25986bf3e6030bed4987e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32e67e6a70e493c52515626820cef9d3df6457f111004483fe6a8657255f4ba7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e14f25f5cdbbb523cfc3f7381b8c053a26f05f61666fb1f86fecda50d3764a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff2ca237124563e6c9490abd6802f8d83f66d147e7fd60f8b5196bf78a8ba72e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1698a5eace8302ba8cd5b09c23b4c8d2ca4c9647a83ef92e03caed5ff066fa0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5efb96c9ce79c98fae0297f5fc2d6740a5f2c167d64020d18876d9e842e8d32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d81e04636fdf51ce19c3647652e37fa7775dad171ac563ac97fae4636ce6c6e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc5f7ca1ce86cd9380525b383624bdc1afa52d98db624cfdece7b08086f829d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dcdb39155a419f86e3070329e0c9ef19f1c6b605bad1e7af9309fcaf8d718195",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dfbe63bdf373f8a141954f84aff98d3f044ba936c80e201c4755efcc6b1a9d82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2aac86cd8a7197d3ce75797501dfd5ff3bd77b3c92f9c975e63efabd5e941d1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9978e30981c695105d1ecc67ef0b3216ab3413a9d93907390e8577de3b11c478",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca802ad5d10b2728ba10bf98bb16796585d69ec775f5452b3a43718e07c4667a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63a20a87a52e9ab38a252c30f4ef64ad836340d4209dbfcf91c0b869798a3fb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7cb7fd8b0694ff882c9ce27b14e93d91f25469547d5f76e55d113aae6c3b5fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0bd6b3f97c370399de8aad7e37d1195d3be5f3aa66c3ab4c83eeb42e4cde23ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d5945969342c0fba61cb9bf33140a6070c4465ac1809758465d64e369a25111",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58fc922b01b99cf99809121ca2d3134853a5cc06ec5b8b5f6a0de7eec5c12202",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1a35de9152869803d6667926c330f7e0bffdb52c0d513ee0f3ecdc25f289aff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e022d35d3834e81cdb7c9582086acce4dff74a026ea600f6a5cb86388d231423",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adf559f274af1e1a4facb1cc93e3840e83ba429513df55bdb79baa6508423e42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4b47992384c822ee021452275896dfebc302ccf9f054d5d6975a364214d4f9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3e29963774a559bcdd22a6bd8a017dd2650e362a5c9b6dc029cf9eebd144761",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b47b9de40f3d89a23347d11bdec27879263d0cc4a76eef57ba93fda2cebf617e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89ac04873c24d8d89c1b60e5cec35544756507fb1be2c2556b92af8bdfcc2a7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d549ff8d5d7e5c61ae8b6a352c2cd341740c2b60e69738499c0c604e7930674",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9577665c819179202b3439b7be4c69052df5ed79c9812be5ebb51fcbdfc8330f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6aa832d8cc2c70fe044fec76c5769f282a0c2c92749591e96b7d2e6053393eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7bd0358110b6b80f3e4facb097746b19c8d82b3fa079a6dddb80582aae42cad9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ba1fb96a5e6b78dde962d5b9fe97726a393c977e9a9106e896dceeefffc6472",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e5767c70bc9f6429b6e9a66ce2cb75e90eea0d9a48392e1e9eb54480fcabd8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:44e396c693edeea0a6db316428af4bd7b2c0df41ce562e2f951b871b70a10bc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ea5031e6eb8d915f4c2910527c3cac1c7cb969fded5057f21be5873a22bad3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52447c45094ab085c5883024b1788e66a7d60d425f48d4dcf6683cd5be0ec087",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4543c991e6f536468d9d47527a201b58b9bc049364a6bdfe15a2f910a02e68f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:932abcd232d522bb508daa2c9e6f4a3ea79039ad80a6478e6384d517c1d6698c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:213ea8f5cd8ed07a61d13e3e32b66f9f9d3e992b121414ae6fd9d3af3cf49e5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e748380f1796e2a7be2137cecd8a1662fcdfdbc858d27b218c931350e296240",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddc6d5cb5a094abc04b93e4018dd178aa1c527c80f2059c21963d3621a428989",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01a2ac7dc3829b47eb0d188909175b806a1e93eb1aefad2737f8fe07e42972e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5fd8bb0bc2edd80b13c0d3ac38cf26b1ad94736fbf1b4b37ee6433772d6f18e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69ca0883e3929168bc8eb555463ae051fc38afedae0fa98d566bc22388304a91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d36aae2debf54b1eae06fe21f3cd7e2f904810f618c987372b14e94097bbef3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b85b1faebfc05f8f362dd59c53429328f787cd2fd60cb03432e259b0e5294bff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0de55e331087a0c931dbff4ff4973dfd54b190b2ba112e6c22ea8f13dd0329d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a5b4e2e1dd388c3c13d79af971fb8efd522f5c2ba8d257875f02c16b4858214",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7c409363b5a1a459b8ceb987866fc54e1feee5d4d2919d31295c8526b7d96f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66305d7a3ca92165f1c17e14cc29ea70280fa1c1fd3bf223b5b1d4f7d1ce0dd8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e918bc5b11c8abfec9343e1b0bd88087b792e85c604427d5cdc32733f70b3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c203ba66a8da80ad3f21305dd932073c1ede06cfa2d1b267ccb28089596094bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e45a35d7f68a2657719b18ad53c9efd5a2ca86deab37a886ddc1d1515593ce33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1adc02db53d619c3afe65182be399a9d08a7bcdf8cb9be04edc4b5c99da5cf42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6679c7a9931ca457f6ad81e0aa00818f8b13558bed11ae6206d0cc05920260f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d3039dc249a944cb984a469f543de6c47f413a6c82df6a58103509d3f11c1e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1af59da686191daa47e66c9cb3b250d37da6df464e2f631550b46c32169e2bfe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4d3a29cc8c0ac2ed9e1e44342d98eac20da1519e889610a1668e57caa154a94",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aa568fef0ff3141c9deb6a0e8cfe1e3649d8efbbe04cd7390c0681c447748fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d71c5fc0e75b48b330cfc391920b8b2dd32c5c844202ba134172a31630a29460",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9546058ef3561af0a5e24d50469fc2317afb6aa760363c9348bd2374a31cb5e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b772806fa1412ba843d87d2a84ed9c087880f3c9e7ded3f6035718f83888efbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:744cf61b729b0516567b9e622244f21d7dc6d44c35bbc507e5ae1b49f791e7df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76dcdfd95452e176f64d6008d114e9415cd8384c5c0d3300fe644c137b6917fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c966372c322648dcf3e0b84dd0a7bdb92031270de243640739cb5c735cb6cef1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:012a7fbcbffc0c6d9a7101fb29eef81cd7ba18d3bb427b3aa0c9ae3a27ba2b2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f61270c6844a8b400abff35a5edcd72ca1f2db057e3a9fa38713cdca449eed9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ce5fc1b93217cd4b9db8b47bcd548ac401047ac73f48d1bfd66f0ffb91fd21a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7d0f5ded000fe57622ed2e551dbfad3b86b6bfdcd7d33a5e3c0862b9fcf6dfd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:539f9b54e9f497f0d40374f3d863a62c6fcc4e54a7336ac54445344612fc151c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be94c8ec5d3bcec45fd4376d60703cb3832473b4111b0d8208f8832f055d9db2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54ebc02523f7b85a9b790aec6be0b6ef01e377216bd76fc0ada4354fa0f0d8e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c105f54738fba9793dad9b6ab2e88b4ae05cc47b9ea062cd7215b69d11ce0e1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e5480b45c64f05340cbdac2bb0354b5593aa8da16690a0b0e188a1842920af3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b322703e97a772ad667f9361e64caedd6b1ff8b26882447aa4083c6ac4bc047",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:57b0cbd11daab17a9b9486f89545407de965d26029938e991f1aefdaf0e48614",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffbcf2d3558dec17023a930d8e278756ffec150d943b66239085043e06fbce59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93476a87e1531898ab2a95a701d918ce589c4da252aac2c615ba650138664feb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d53b6b5f20e16b95bdf743f3962f45911577e1a483c756971405f5ef0506772f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf997d2d6fa655ec7e03fc58769e29770409254861d75c3732fcd9a264cc2820",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08c7782ae9fe49cbec8db74d566061656689bf48cc2977bd0dd8daf3d645133c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9af923799a1ee9a07dbfe10ba28c3a28bc081d77648b1b5f6271f426af7212b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad6916df8df2312e346eca458eb7d21394618e559db385a1059609b93839ccb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e5281196fd18f90f4204d2104354936cd8f6fa88c209638f690134e61572b5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18b46fafae10d86249df30a025faf411cb1369ddd2d2ade738f9cc4b45ab6f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8057ff6e5fa3339726c83173fdd11898b5f7545e72d81503f8c6660c4404885",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47a3ce5b9228ccb688da7458828fef2138f6e4215e73941922dda962aecd14f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fe2d98578b0c4454536faacbaafd66d1754b8439bb6332d7576a741f4c72208",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:763343a0a0c30885b064b920ceaee7b4846298d07c8975ca5e2a0ce72e0982a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6bf0c6a9c2a00e9e06988299543a9bb1aec4445014b11216db6d6c2e2253bda9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39ac563bdb726187651898cf17b368a818f984c4795b39bdf41f254c3cbd4889",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25e6fed9e3aadb313770fa676e43f5978f581d07bc6504b66c373f5fb42f9250",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6166c7179e4a8d2504e385ffbd36dbfdf62795000665584f2ae4895ba5ba94fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9d52411d5e3188b9a89b35a15ae13d7fb4be3365cdcad82db139d98e3537b6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21a0812602d0f42e8da8760f6a5fdc002fc93e054639bea5f21ccba9cffd9a5b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49bdfe2732098f5eee53c78ce36dfcb56f12c182698cda3b0f624b4b2f5db7a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4df07c734a7b4135d6b5dd73f72cbc188763a09457f3bf24f893fc178fd89d9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cdba0d602a32cb4b90461bd7dbdfacf0bc30f63ee5dd8f460d5bee3dc4cb586",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b776d46067bf44c37801e19b243572feb26aae0fee721e061207a80873da1f46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5d3c81dc359adc676afc9044743aeaf8fbc924e019b093084035413716e78f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b3b3f611f93e849b5c03219fb2a28b63ac4215ebe28a8219da5e5be15e5ed52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3afd73ae4e359216ff2b3a5d06cef58b6a82661ea9fd3496e5c66ba574a8af82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c42642046bf068a2d0cc32f38cdc56d0c92af48eb131fc8dce55a997142f2e88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:503d66de89be6300652f88a12013ff9b999012f6be0fa92fc8e9a2ea2913b284",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5fc1a6f13d268443d17c263afbcbdfd249ff86961f439a184591035e19885e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc8e3e173f88c245d311b899eb9d457d66c3b9026e9917e7a2e9c532e7dbba18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7bff42a7164385e2ca87fe11bfc8ff6e50d56f8da32b5ebd1e5f0a4508b66b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:557322822a4aa090b2c4d24154f25a7417b1015327c92f463d98161e46f65c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cba7fbe4f72489a2fb27429ecfdf8b0177ac8cc4fa30aa7baaa8ce1a0dc4f5ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e733d49496689131148b00a233229e484b5b622f9cb8c230230a05117763065e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d45acd2ae98e922732fc9c4966c3bb8d570f4185122d766a83199955b96cad7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2662ac74bdff1706965ab83236c1c65c34287e8008eac2785b9b52ffe01816dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b01cb100fa03ec4ac41532662cda8aa9f47ff4abe5f33b2cbf682c311fba841",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de4dcfa7271758f759bfa291ac552eccb586047ee0b91471991bb46b2161b2a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c562efa8f886aa0ca1d6bb55b532f88f8030bf6400e14e65f5a6601df1c0f8a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:066773d5ff149af0ee912ae22f0121ac86e097c4c2829ed30b6683c874596d7c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a0d58a999f992a11b1c54986a7c253b74403bbbb328ab2aa2d21df6b33313b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66e3422ca28c563ee8acf56b79a248218fd5db18314ec828875105c187dd0c92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20b825188654b5b5d17340ce6a78cbd3504e74729f8cfb83150b6798db4a586f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3df7fd45694c994a41077966f80f48d28a5466c21e161c92d05629cc64efe0e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e16b0c15a0820ca0795ac8e5cd196c4c8bef3dfebd70eef28a5152a2c69a9386",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd67360c39e9d4bd6eb9c6179ec2fa68382715129a8a43972e9fe63ee870f420",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3c9a6a1611d967fbff4321b5b1ae54377fed22454298859108138c1f64b0c63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64112ed94189c99bddc05003aa3bdea8a5486e8cf056678512586864b41985ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46a9be44b3444815a0197dd85953bf87710d3ea3d8f9fbfff23068ca85885070",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a50276d2a8bd7f2b16cbdf6592ea365c19fa9f9bd33b5cfa1ab4bbd5ca89c69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:128b958d194fd77cb888807aa6bf46c3ebcec2e345ce2cefc202def4b8d678a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e1b3ebb0f9945593365eaf0bc01d052d2e221e930d5731d1bd8276289194ba1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa30a837be5cce2abf071c4afead1af95faf7d87c05e390404aa0de3b10b8046",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6427a8b877a51be140e06665b3680a911816c9eb581aa54ecf29c77f51b6e898",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20c744f2ca0c36933f151c9436bc67c0db461e26c97eaad10726e3e42a169012",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21de93c6eaee8efe68ce326aa4a8c9819fb9c8a87ef153fe3be473076890db7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c462e7efdf7650c49e4d0af6aa59bf555db59bedf0a30e75ffbec4b2af5c5901",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec583a673d3ba649d69246fc67455f01c2431bc8e80b14b724117ce709b317ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9bbf1cbf6b2df49cf17585f3913a9064f7b0c3c56b116a92e9f242a3676efde",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09bd56123cc38e0b6eca84a97848f3985caa421e0879345b89c42e726a19b49b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:91daae949ff91b3d96865ee10b99376b9db82bf62d4ee77123572345dbf586dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f6d6c53e06ada97d73329dc360393e493dae399f8f669efc1f0099e17192d898",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb156348e3350bec888a272bd31a5fb113585432ec3c3276fdb05c6561169eb1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62ee4e0aa9f6ba95aacb3a62f2221acfff510f6cd4cfa870cf68cbb9f9d42201",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:250cc6648ef7fbb6c209f83805e7cf2a16ff8fb98725c6945df9f085998cbb05",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4136d198050e7527929e1289c1ebd6475e2e8235513749debceb2be26a33fa56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f33292317a057dd50fd05ad00e5495a866a3df35d8acd83efdb592fb90c603e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b22f6fd6b29c6ef4ce070cd4d4d2d823525a9ce07ceb552b4391ea9c5fc35fb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed6c8cd71a52822a69c6dd28d2a112a0f772983a20e037884c7821d9eddef6ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c0e32d108fcf6ac2f4c61aecc03163168337179b861786abd206ae58535a0e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7eb9468d77618514bf861da405e2c85b2411efe81577ebc586fd9c25e5ae4194",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18cba4823772a73049f6c288b9c739bb0f60c9ac428d1d9128a127dad46cbc88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:359602208228e24f4d2b4f0ab057ad7ca604ed3f23b0873e7efe395a0c3df25e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ab8c75a2f9ee929bbfdb722abc00fb96252e4e76c66f1d292cfe01330f3d56a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89fd6a8b16942c4499a24cdffc7007a8e316c3119df111016881ae67fa99a6fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8cf9c48cb43b6fcd2d4dba6e31ce74cd31d38f307563efe83884395d4ce83f62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b59985bde8c374933ce87766de67f010fd10e0d43803b2d792c34f64f923bac1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c471712a2998682347e1680ef1d5a652b48c12502f19e8d39354c4083af91d8a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4da0677be2e68ab8e7d9132c6350186cf7c1116f545515fc16a43f6daaa92ddf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8958e57d4f99bea5bd52c17f26ff5973dabe941aaa279cfca576c3b7c055c4b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40d4af423ad279f9f956b640311c026717ff9e152dcf0452fdcfcd2f2196f56e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17f9a62eb7ff845279fbcc09d7380aff07f754f1d916276342ad982d122ded2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:348ced5b0ee17eb1f2ae4925e3baca86bc0d11e10e59a2731e73227974eeac45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e33050f1d6ff44a889213a947f6bc9f905336d4d89723ee6a50a51fd8ac10d9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:229d197810a5e64665283e0f2e1b4268f4dc7514fff803e99c1b862201d6d827",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc8e6626c3c8ea2dc183400a6f3a98de9eecd237e099bf589e42b24881256770",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b2bd8783d542d769eb6c440974af90451fd44353f291b9f89873b56b20490ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b392a609fd5f688d073dcade1548fb15f7d7a2b3b37e235aaae9ae07ccecbfb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18188e5455ce48c41c2aa87d9c28a6b0d632e7372d6284455f1a982676f8dccc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1838a0aa547578b45ead6c5f1ccb66493ba06d881e5d4163309f8333b4b74988",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9da9b36d4a3a55ee49e582743900a561093e3625b1e0a90f80e36797de7baa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80b1424e54ba0e84149d8ab536b7fc3e31469a571ae3f0e11077bee8b663af9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4d4230f282f18fcd120bdbff40382d8c04d322675612d9fd85e1461c62b66c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f12d5e9f0294047cbb3a07018df31df5a6eeac754fe8e6b4a21749a5c6f8acb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c4449f25a6119b82042f9c602549d1fc31b8203e64a813138ea2131958fc4fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f76ebdec7991b3383b5dc3b8bf284f7a5190965453af086978e98a355b3ab977",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7e7d3793988a51ea308b7e9bf9882fa35d1b44a27da67e64c4b5a6eed34f792",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:92841df883b69d4edb23b0834936717b0ca61b50391174f2c919978051f736a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0819fc90d62f977b1e2605d7910349da79713edf6995abb022e81d89a00ed20e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3fc4908c11bf3f85bbf51a14a79d4bead80ae7035cae607f7580ba7d7dad58a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ed93771948eba20a48a5c824079710be94d927aeaf7c2d0db1a5a402b2eb923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d5c9d11876f3a1688d31fa669986eaaa4c0717435ca99e78fb86bf5ddc193cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f9541ae85dcbefd66fd88c014ccf176b8a6b32788443981490d3a76381c2cc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbe8a6957b2a00bf0117c5cb08affc8abdc2dad02edd1113b463412b9bc2238d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b6ec4b5e92ae158d215c9f419173bf825870677717fe4a1375fc16e38cd479b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:330e209e3700c12717c686796717e947796c71d914bb32719ab7213e556b642c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c492273497329d9a1ea2293d0f668edf953e18830f7d49797f7ff8412ea76da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.19.15-301.fc37.x86_64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "raw.img",
+              "size": "3958374400"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 2048,
+                  "start": 2048,
+                  "type": "21686148-6449-6E6F-744E-656564454649",
+                  "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+                },
+                {
+                  "size": 409600,
+                  "start": 4096,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 413696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1437696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 4096,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 413696,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 1437696,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 413696,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 4096,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 1437696,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:00eaeeac4eac4944832ff4821ca821de222b598a07b6fd368b11e3143a58ee02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fwupd-plugin-flashrom-1.8.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:012a7fbcbffc0c6d9a7101fb29eef81cd7ba18d3bb427b3aa0c9ae3a27ba2b2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libusb1-1.0.25-9.fc37.x86_64.rpm"
+          },
+          "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:01a2ac7dc3829b47eb0d188909175b806a1e93eb1aefad2737f8fe07e42972e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libqmi-1.30.6-2.fc37.x86_64.rpm"
+          },
+          "sha256:03209772270d0f1fcac1b006d2d4b4bff967a001e7c9fdc6ed97950fede5e3cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gpgme-1.17.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:066773d5ff149af0ee912ae22f0121ac86e097c4c2829ed30b6683c874596d7c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/plymouth-22.02.122-3.fc37.x86_64.rpm"
+          },
+          "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/selinux-policy-targeted-37.12-2.fc37.noarch.rpm"
+          },
+          "sha256:0819fc90d62f977b1e2605d7910349da79713edf6995abb022e81d89a00ed20e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/v/vim-minimal-9.0.475-1.fc37.x86_64.rpm"
+          },
+          "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc37.noarch.rpm"
+          },
+          "sha256:08c7782ae9fe49cbec8db74d566061656689bf48cc2977bd0dd8daf3d645133c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mkpasswd-5.5.13-2.fc37.x86_64.rpm"
+          },
+          "sha256:09bd56123cc38e0b6eca84a97848f3985caa421e0879345b89c42e726a19b49b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-gpg-1.17.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:0b01cb100fa03ec4ac41532662cda8aa9f47ff4abe5f33b2cbf682c311fba841": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:0b2bd8783d542d769eb6c440974af90451fd44353f291b9f89873b56b20490ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-libs-251.6-609.fc37.x86_64.rpm"
+          },
+          "sha256:0bd6b3f97c370399de8aad7e37d1195d3be5f3aa66c3ab4c83eeb42e4cde23ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgudev-237-3.fc37.x86_64.rpm"
+          },
+          "sha256:0c0e32d108fcf6ac2f4c61aecc03163168337179b861786abd206ae58535a0e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm"
+          },
+          "sha256:0de55e331087a0c931dbff4ff4973dfd54b190b2ba112e6c22ea8f13dd0329d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsecret-0.20.5-2.fc37.x86_64.rpm"
+          },
+          "sha256:0e3ddc2f83def37e6c6799890e4a3c12220491045a656e308b2d306e165e64bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dracut-config-generic-057-3.fc37.x86_64.rpm"
+          },
+          "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm"
+          },
+          "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:128b958d194fd77cb888807aa6bf46c3ebcec2e345ce2cefc202def4b8d678a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-3.11.0~rc2-1.fc37.x86_64.rpm"
+          },
+          "sha256:1502c8529c0e0e9e57c9a1a1635fd28fdcfc1f63004b1d5aa667baa868ea41fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bluez-5.65-3.fc37.x86_64.rpm"
+          },
+          "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:157a95e5d0a70dcb97682ae484d6238e99db218071855483283c61486029ce8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/efibootmgr-18-2.fc37.x86_64.rpm"
+          },
+          "sha256:159f17086ec145c629cedca9a038bc0c8fa38b4a8f7f0f0e9bedba0f3e76af28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm"
+          },
+          "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/setup-2.14.1-2.fc37.noarch.rpm"
+          },
+          "sha256:17f9a62eb7ff845279fbcc09d7380aff07f754f1d916276342ad982d122ded2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sssd-common-2.7.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:18188e5455ce48c41c2aa87d9c28a6b0d632e7372d6284455f1a982676f8dccc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-pam-251.6-609.fc37.x86_64.rpm"
+          },
+          "sha256:1838a0aa547578b45ead6c5f1ccb66493ba06d881e5d4163309f8333b4b74988": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-resolved-251.6-609.fc37.x86_64.rpm"
+          },
+          "sha256:18b46fafae10d86249df30a025faf411cb1369ddd2d2ade738f9cc4b45ab6f8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm"
+          },
+          "sha256:18cba4823772a73049f6c288b9c739bb0f60c9ac428d1d9128a127dad46cbc88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-build-libs-4.18.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:19b7e1385a12e9196622d1549ebee9a2254656300a530a9abb824737950571ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dmidecode-3.4-2.fc37.x86_64.rpm"
+          },
+          "sha256:1a0d58a999f992a11b1c54986a7c253b74403bbbb328ab2aa2d21df6b33313b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/plymouth-core-libs-22.02.122-3.fc37.x86_64.rpm"
+          },
+          "sha256:1ab8c75a2f9ee929bbfdb722abc00fb96252e4e76c66f1d292cfe01330f3d56a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-plugin-selinux-4.18.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:1adc02db53d619c3afe65182be399a9d08a7bcdf8cb9be04edc4b5c99da5cf42": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libssh-0.10.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:1af59da686191daa47e66c9cb3b250d37da6df464e2f631550b46c32169e2bfe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsss_nss_idmap-2.7.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:1b1e2c27345206db40bd782541b00575f3d36e238a6905c75d67c2407ca4adbd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-1.14.2-1.fc37.x86_64.rpm"
+          },
+          "sha256:1b9c5fe598d258b0dbbf454b01ba844aa678bf5c7333bd16e98ba4c62a242f9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-libs-0.21-19.0.20220203.fc37.x86_64.rpm"
+          },
+          "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm"
+          },
+          "sha256:1ce5fc1b93217cd4b9db8b47bcd548ac401047ac73f48d1bfd66f0ffb91fd21a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxcrypt-4.4.28-3.fc37.x86_64.rpm"
+          },
+          "sha256:1d549ff8d5d7e5c61ae8b6a352c2cd341740c2b60e69738499c0c604e7930674": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmaxminddb-1.7.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:1e14f25f5cdbbb523cfc3f7381b8c053a26f05f61666fb1f86fecda50d3764a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcomps-0.1.18-4.fc37.x86_64.rpm"
+          },
+          "sha256:1e7bff42a7164385e2ca87fe11bfc8ff6e50d56f8da32b5ebd1e5f0a4508b66b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssl-libs-3.0.5-2.fc37.x86_64.rpm"
+          },
+          "sha256:20b825188654b5b5d17340ce6a78cbd3504e74729f8cfb83150b6798db4a586f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm"
+          },
+          "sha256:20c744f2ca0c36933f151c9436bc67c0db461e26c97eaad10726e3e42a169012": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-dnf-4.14.0-1.fc37.noarch.rpm"
+          },
+          "sha256:213ea8f5cd8ed07a61d13e3e32b66f9f9d3e992b121414ae6fd9d3af3cf49e5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpcap-1.10.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:21a0812602d0f42e8da8760f6a5fdc002fc93e054639bea5f21ccba9cffd9a5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nss-sysinit-3.83.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:21ab08a6ce4ff5213d541878e456f7c1ea9da5b76c342fe1c55641a77e187b23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bash-5.1.16-4.fc37.x86_64.rpm"
+          },
+          "sha256:21de93c6eaee8efe68ce326aa4a8c9819fb9c8a87ef153fe3be473076890db7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-dnf-plugins-core-4.3.1-1.fc37.noarch.rpm"
+          },
+          "sha256:229d197810a5e64665283e0f2e1b4268f4dc7514fff803e99c1b862201d6d827": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.x86_64.rpm"
+          },
+          "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sed-4.8-11.fc37.x86_64.rpm"
+          },
+          "sha256:23cda2a639c358757ee35ce6270ba3d0c6cd779309ff528e7c08c0239737dffb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/audit-libs-3.0.9-1.fc37.x86_64.rpm"
+          },
+          "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/util-linux-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:24c5926ad780d9e90bde6cbe605543d00b776a9cba53d3e063606c093fab3557": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/NetworkManager-libnm-1.40.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:250cc6648ef7fbb6c209f83805e7cf2a16ff8fb98725c6945df9f085998cbb05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-nftables-1.0.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:25e6fed9e3aadb313770fa676e43f5978f581d07bc6504b66c373f5fb42f9250": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nss-3.83.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:25ea22f713c6c2a2ff164c3a5b6f625d70b2a399d5d0ba0796d96942777e756f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/NetworkManager-1.40.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:2662ac74bdff1706965ab83236c1c65c34287e8008eac2785b9b52ffe01816dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcsc-lite-1.9.9-1.fc37.x86_64.rpm"
+          },
+          "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-common-2.06-58.fc37.noarch.rpm"
+          },
+          "sha256:278bfd824633a3c49357342679e9dd5864a33bcda5d25986bf3e6030bed4987e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcap-ng-python3-0.8.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:28d630dae78579725857e2242ce2ce01e6748a20c538554a36b628157a7ea1c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/inih-56-2.fc37.x86_64.rpm"
+          },
+          "sha256:2a5b4e2e1dd388c3c13d79af971fb8efd522f5c2ba8d257875f02c16b4858214": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm"
+          },
+          "sha256:2aac86cd8a7197d3ce75797501dfd5ff3bd77b3c92f9c975e63efabd5e941d1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgcab1-1.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libkcapi-1.4.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:2c492273497329d9a1ea2293d0f668edf953e18830f7d49797f7ff8412ea76da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm"
+          },
+          "sha256:2e5281196fd18f90f4204d2104354936cd8f6fa88c209638f690134e61572b5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nano-6.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:2f12d5e9f0294047cbb3a07018df31df5a6eeac754fe8e6b4a21749a5c6f8acb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/udisks2-2.9.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:31af27f44c4a8d06068389731d3a5adc0fd45b1c8ce4d28163f938e68fa58cbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/coreutils-common-9.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:31c439058714931736b9a7e4bc5b2c70d47ed188721c40cb8b8839bb3c5ee732": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gnutls-3.7.7-1.fc37.x86_64.rpm"
+          },
+          "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm"
+          },
+          "sha256:32e67e6a70e493c52515626820cef9d3df6457f111004483fe6a8657255f4ba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcollection-0.7.0-52.fc37.x86_64.rpm"
+          },
+          "sha256:330e209e3700c12717c686796717e947796c71d914bb32719ab7213e556b642c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zram-generator-1.1.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:337900b23fc2550547c243e11b7a65284c53c844a3882e0b67e2fbb93f8bf1db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libassuan-2.5.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:348ced5b0ee17eb1f2ae4925e3baca86bc0d11e10e59a2731e73227974eeac45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sssd-kcm-2.7.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:359602208228e24f4d2b4f0ab057ad7ca604ed3f23b0873e7efe395a0c3df25e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-libs-4.18.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:364011baa5e293baae2e60992fd1241f6c822d7c7e48c259d3e6abb0530036af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbasicobjects-0.1.1-52.fc37.x86_64.rpm"
+          },
+          "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:3847abdc8ff973aeb0fb7e681bdf7c37b19cd49e5df17e8bf6bc35f34615c88f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cracklib-2.9.7-30.fc37.x86_64.rpm"
+          },
+          "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm"
+          },
+          "sha256:39ac563bdb726187651898cf17b368a818f984c4795b39bdf41f254c3cbd4889": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nspr-4.35.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:3afd73ae4e359216ff2b3a5d06cef58b6a82661ea9fd3496e5c66ba574a8af82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/oniguruma-6.9.8-2.D20220919gitb041f6d.fc37.x86_64.rpm"
+          },
+          "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm"
+          },
+          "sha256:3d3039dc249a944cb984a469f543de6c47f413a6c82df6a58103509d3f11c1e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsss_idmap-2.7.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:3d36aae2debf54b1eae06fe21f3cd7e2f904810f618c987372b14e94097bbef3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/librepo-1.14.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:3d5945969342c0fba61cb9bf33140a6070c4465ac1809758465d64e369a25111": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgusb-0.4.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:3df7fd45694c994a41077966f80f48d28a5466c21e161c92d05629cc64efe0e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/polkit-121-4.fc37.x86_64.rpm"
+          },
+          "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gzip-1.12-2.fc37.x86_64.rpm"
+          },
+          "sha256:3f33292317a057dd50fd05ad00e5495a866a3df35d8acd83efdb592fb90c603e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm"
+          },
+          "sha256:3fc4908c11bf3f85bbf51a14a79d4bead80ae7035cae607f7580ba7d7dad58a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/v/volume_key-libs-0.3.12-17.fc37.x86_64.rpm"
+          },
+          "sha256:40bdee106c7d9df3c4b2a39289b247635450d763fb84cd5e63e2493f9519b58d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbytesize-2.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:40d4af423ad279f9f956b640311c026717ff9e152dcf0452fdcfcd2f2196f56e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sssd-client-2.7.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:4136d198050e7527929e1289c1ebd6475e2e8235513749debceb2be26a33fa56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-rpm-4.18.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm"
+          },
+          "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:44e396c693edeea0a6db316428af4bd7b2c0df41ce562e2f951b871b70a10bc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnfnetlink-1.0.1-22.fc37.x86_64.rpm"
+          },
+          "sha256:4543c991e6f536468d9d47527a201b58b9bc049364a6bdfe15a2f910a02e68f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnl3-3.7.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:46a9be44b3444815a0197dd85953bf87710d3ea3d8f9fbfff23068ca85885070": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/protobuf-c-1.4.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:47a3ce5b9228ccb688da7458828fef2138f6e4215e73941922dda962aecd14f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm"
+          },
+          "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grubby-8.40-66.fc37.x86_64.rpm"
+          },
+          "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc37.noarch.rpm"
+          },
+          "sha256:49bdfe2732098f5eee53c78ce36dfcb56f12c182698cda3b0f624b4b2f5db7a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nss-util-3.83.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:4a50276d2a8bd7f2b16cbdf6592ea365c19fa9f9bd33b5cfa1ab4bbd5ca89c69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/psmisc-23.4-4.fc37.x86_64.rpm"
+          },
+          "sha256:4aa568fef0ff3141c9deb6a0e8cfe1e3649d8efbbe04cd7390c0681c447748fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libstdc++-12.2.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:4b322703e97a772ad667f9361e64caedd6b1ff8b26882447aa4083c6ac4bc047": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/linux-firmware-whence-20220913-140.fc37.noarch.rpm"
+          },
+          "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm"
+          },
+          "sha256:4cdba0d602a32cb4b90461bd7dbdfacf0bc30f63ee5dd8f460d5bee3dc4cb586": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.x86_64.rpm"
+          },
+          "sha256:4d5c9d11876f3a1688d31fa669986eaaa4c0717435ca99e78fb86bf5ddc193cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xz-5.2.5-10.fc37.x86_64.rpm"
+          },
+          "sha256:4da0677be2e68ab8e7d9132c6350186cf7c1116f545515fc16a43f6daaa92ddf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/shim-x64-15.6-2.x86_64.rpm"
+          },
+          "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:4df07c734a7b4135d6b5dd73f72cbc188763a09457f3bf24f893fc178fd89d9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ntfs-3g-2022.5.17-2.fc37.x86_64.rpm"
+          },
+          "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.x86_64.rpm"
+          },
+          "sha256:4ed93771948eba20a48a5c824079710be94d927aeaf7c2d0db1a5a402b2eb923": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xfsprogs-5.18.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:4f197117a201e561bc919198df573394e7c97dce2fda2382e3a2495c7ab9e8cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-envsubst-0.21-19.0.20220203.fc37.x86_64.rpm"
+          },
+          "sha256:503d66de89be6300652f88a12013ff9b999012f6be0fa92fc8e9a2ea2913b284": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssh-8.8p1-7.fc37.x86_64.rpm"
+          },
+          "sha256:5081d23a1ae79d9ce3abb22648a358c1d07d55e03c1aa2ffa9f920a9871344aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gnupg2-smime-2.3.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmount-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:52447c45094ab085c5883024b1788e66a7d60d425f48d4dcf6683cd5be0ec087": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnghttp2-1.49.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:539f9b54e9f497f0d40374f3d863a62c6fcc4e54a7336ac54445344612fc151c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxml2-2.9.14-3.fc37.x86_64.rpm"
+          },
+          "sha256:54ebc02523f7b85a9b790aec6be0b6ef01e377216bd76fc0ada4354fa0f0d8e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libyaml-0.2.5-8.fc37.x86_64.rpm"
+          },
+          "sha256:557322822a4aa090b2c4d24154f25a7417b1015327c92f463d98161e46f65c1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.x86_64.rpm"
+          },
+          "sha256:558476ce7be43951868fef0c6216a99ff0a5ecfbb69e68785172b3a9a627b28b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/c-ares-1.17.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cpio-2.13-13.fc37.x86_64.rpm"
+          },
+          "sha256:57a1d67b5a9c1151e3f3c9401ff7f4704f91307f0d95d5ea7b276e9095748e20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/iptables-libs-1.8.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:57b0cbd11daab17a9b9486f89545407de965d26029938e991f1aefdaf0e48614": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/lmdb-libs-0.9.29-4.fc37.x86_64.rpm"
+          },
+          "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm"
+          },
+          "sha256:58fc922b01b99cf99809121ca2d3134853a5cc06ec5b8b5f6a0de7eec5c12202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libibverbs-41.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:598ddb966e5ac4f664f2cbe9d0087b62c1a4067a1f1af24f290d7f681956e29c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/json-glib-1.6.6-3.fc37.x86_64.rpm"
+          },
+          "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm"
+          },
+          "sha256:5b75e3acf6f11c8584c7e38718a295503c09c0acd4b9dd245b287ab3357d245d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dnf-plugins-core-4.3.1-1.fc37.noarch.rpm"
+          },
+          "sha256:5c4449f25a6119b82042f9c602549d1fc31b8203e64a813138ea2131958fc4fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/unbound-anchor-1.16.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:5e748380f1796e2a7be2137cecd8a1662fcdfdbc858d27b218c931350e296240": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpipeline-1.5.6-2.fc37.x86_64.rpm"
+          },
+          "sha256:5e7cf0116ffdcf0c673d155a24c70e1483305d6ec50ad8b7d1d4ad224e4e88bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dnf-4.14.0-1.fc37.noarch.rpm"
+          },
+          "sha256:5ea5031e6eb8d915f4c2910527c3cac1c7cb969fded5057f21be5873a22bad3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnftnl-1.2.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:5eb771630565b940d76a67db7ae2bf986a30d45f4930c80e9aae9ed634adbc43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-utils-2.28-2.fc37.x86_64.rpm"
+          },
+          "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libfido2-1.11.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-common-1.14.2-1.fc37.noarch.rpm"
+          },
+          "sha256:5fd8bb0bc2edd80b13c0d3ac38cf26b1ad94736fbf1b4b37ee6433772d6f18e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libqrtr-glib-1.0.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:6166c7179e4a8d2504e385ffbd36dbfdf62795000665584f2ae4895ba5ba94fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nss-softokn-3.83.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:62ee4e0aa9f6ba95aacb3a62f2221acfff510f6cd4cfa870cf68cbb9f9d42201": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc37.x86_64.rpm"
+          },
+          "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:63a20a87a52e9ab38a252c30f4ef64ad836340d4209dbfcf91c0b869798a3fb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgomp-12.2.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:64112ed94189c99bddc05003aa3bdea8a5486e8cf056678512586864b41985ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/procps-ng-3.3.17-6.fc37.x86_64.rpm"
+          },
+          "sha256:6427a8b877a51be140e06665b3680a911816c9eb581aa54ecf29c77f51b6e898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-distro-1.7.0-3.fc37.noarch.rpm"
+          },
+          "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm"
+          },
+          "sha256:66305d7a3ca92165f1c17e14cc29ea70280fa1c1fd3bf223b5b1d4f7d1ce0dd8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:66e3422ca28c563ee8acf56b79a248218fd5db18314ec828875105c187dd0c92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/plymouth-scripts-22.02.122-3.fc37.x86_64.rpm"
+          },
+          "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm"
+          },
+          "sha256:67f00ad99cede36aea285c6ccdcc713d5519d6bda710e5a340cb2886d87aa228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-mdraid-2.28-2.fc37.x86_64.rpm"
+          },
+          "sha256:68e0f60ad19cf5f0f211f0e14b96b42db87806d9536eb05386cf9bf168891c2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:69ca0883e3929168bc8eb555463ae051fc38afedae0fa98d566bc22388304a91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libref_array-0.1.5-52.fc37.x86_64.rpm"
+          },
+          "sha256:6b392a609fd5f688d073dcade1548fb15f7d7a2b3b37e235aaae9ae07ccecbfb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-networkd-251.6-609.fc37.x86_64.rpm"
+          },
+          "sha256:6b9b252702c66da50fde953741fe5470d53cb955dddf6a50d890002927517f0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:6bf0c6a9c2a00e9e06988299543a9bb1aec4445014b11216db6d6c2e2253bda9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/npth-1.6-9.fc37.x86_64.rpm"
+          },
+          "sha256:6c5c57fc5ab7e4045f84e96e68bb811eda6335897bea41a1576708cc01593894": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kernel-core-5.19.15-301.fc37.x86_64.rpm"
+          },
+          "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:6dec8d3c7b09c9e9114d18081660c5d01b82a34986db43f437aef2a28163fcf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-2.36-7.fc37.x86_64.rpm"
+          },
+          "sha256:6e1b3ebb0f9945593365eaf0bc01d052d2e221e930d5731d1bd8276289194ba1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm"
+          },
+          "sha256:6e5480b45c64f05340cbdac2bb0354b5593aa8da16690a0b0e188a1842920af3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/linux-firmware-20220913-140.fc37.noarch.rpm"
+          },
+          "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm"
+          },
+          "sha256:703ba79af214b62786b19e0f58c7e842e04de852145a5f1971beb4fe6f24d563": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-part-2.28-2.fc37.x86_64.rpm"
+          },
+          "sha256:72b2fbe65f24fa2dc41109cb0bd47b0962824847ac802a3c0160d832ee1e75f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/ima-evm-utils-1.4-6.fc37.x86_64.rpm"
+          },
+          "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm"
+          },
+          "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libssh-config-0.10.4-1.fc37.noarch.rpm"
+          },
+          "sha256:744cf61b729b0516567b9e622244f21d7dc6d44c35bbc507e5ae1b49f791e7df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtevent-0.13.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:74ee0b4664d9300b0538372064e74e1609f5bf89a4cef76c7849d774af7295cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:763343a0a0c30885b064b920ceaee7b4846298d07c8975ca5e2a0ce72e0982a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nftables-1.0.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:76dcdfd95452e176f64d6008d114e9415cd8384c5c0d3300fe644c137b6917fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm"
+          },
+          "sha256:7a2829a5012094cf436e39495f0fd8f14604f8f295e98b8bb6e85eab9e0472f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cracklib-dicts-2.9.7-30.fc37.x86_64.rpm"
+          },
+          "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libfdisk-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.x86_64.rpm"
+          },
+          "sha256:7b62248de9e972c39877fa9e4aeb91ef46b7436d5e92624efc9154f6fa6b9e88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-minimal-langpack-2.36-7.fc37.x86_64.rpm"
+          },
+          "sha256:7b6ec4b5e92ae158d215c9f419173bf825870677717fe4a1375fc16e38cd479b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zchunk-libs-1.2.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:7bd0358110b6b80f3e4facb097746b19c8d82b3fa079a6dddb80582aae42cad9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/device-mapper-libs-1.02.175-9.fc37.x86_64.rpm"
+          },
+          "sha256:7c576f1b14afe9222d7c4e0007d58a3c998b5416b5aa1fdcfddbff264747787b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:7c660eada8cb6e2d2b0c035a9d1696db945761c07e7900b8003b1b405243adef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-2.5.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:7c7c409363b5a1a459b8ceb987866fc54e1feee5d4d2919d31295c8526b7d96f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:7e5767c70bc9f6429b6e9a66ce2cb75e90eea0d9a48392e1e9eb54480fcabd8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.x86_64.rpm"
+          },
+          "sha256:7eb9468d77618514bf861da405e2c85b2411efe81577ebc586fd9c25e5ae4194": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-4.18.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:80b1424e54ba0e84149d8ab536b7fc3e31469a571ae3f0e11077bee8b663af9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tpm2-tools-5.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-common-37-14.noarch.rpm"
+          },
+          "sha256:8122523c26fb300520670cd3ef4da1a81d9272501faf1c7db9670628ced5165e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-swap-2.28-2.fc37.x86_64.rpm"
+          },
+          "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pigz-2.7-2.fc37.x86_64.rpm"
+          },
+          "sha256:840438421f3c7e28e49fa1327480ff7eb7780bcdbf605caf35ec0115bf4d7d9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/h/hostname-3.23-7.fc37.x86_64.rpm"
+          },
+          "sha256:85698713589960a8b6821a4a56bc7b5af4df9977e86cad103cb9512ba7177d2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/amd-gpu-firmware-20220913-140.fc37.noarch.rpm"
+          },
+          "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre-8.45-1.fc37.2.x86_64.rpm"
+          },
+          "sha256:8971dffd7d3ce1547a16bd17bd8d7745ccbfbed897021c504303c3f40f6920b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-fs-2.28-2.fc37.x86_64.rpm"
+          },
+          "sha256:89ac04873c24d8d89c1b60e5cec35544756507fb1be2c2556b92af8bdfcc2a7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libldb-2.6.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:89d348fb8c40d1a4fc0ce2a217892a73d3bcfa183379af8ab2826d1e47b87e9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/ipset-libs-7.15-5.fc37.x86_64.rpm"
+          },
+          "sha256:89fd6a8b16942c4499a24cdffc7007a8e316c3119df111016881ae67fa99a6fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:8adebc901848979df7c1c96c51055426c0ac7212b536a5cf82bd650dbbb322cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/initscripts-service-10.17-1.fc37.noarch.rpm"
+          },
+          "sha256:8b3b3f611f93e849b5c03219fb2a28b63ac4215ebe28a8219da5e5be15e5ed52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nvidia-gpu-firmware-20220913-140.fc37.noarch.rpm"
+          },
+          "sha256:8ba1fb96a5e6b78dde962d5b9fe97726a393c977e9a9106e896dceeefffc6472": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libndp-1.8-4.fc37.x86_64.rpm"
+          },
+          "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc37.noarch.rpm"
+          },
+          "sha256:8cf9c48cb43b6fcd2d4dba6e31ce74cd31d38f307563efe83884395d4ce83f62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-sign-libs-4.18.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:8d45acd2ae98e922732fc9c4966c3bb8d570f4185122d766a83199955b96cad7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pciutils-libs-3.8.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:8e41b0d094a6635221cc015437ce4131c9ce502a4d4d2a5c1b51ac36ad0ccd21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:8f4a1bfa873f3a019aef82c02e5713ff67cca7942d7351002e01a0defb8c0cbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-repos-modular-37-1.noarch.rpm"
+          },
+          "sha256:8f61270c6844a8b400abff35a5edcd72ca1f2db057e3a9fa38713cdca449eed9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libuser-0.63-13.fc37.x86_64.rpm"
+          },
+          "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:8fe2d98578b0c4454536faacbaafd66d1754b8439bb6332d7576a741f4c72208": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nettle-3.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:91daae949ff91b3d96865ee10b99376b9db82bf62d4ee77123572345dbf586dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-hawkey-0.68.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:9278077f283c20321a550da3faa0e03cd58f56459940cfdf6d7e05c0c1016688": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kernel-modules-5.19.15-301.fc37.x86_64.rpm"
+          },
+          "sha256:92841df883b69d4edb23b0834936717b0ca61b50391174f2c919978051f736a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/v/vim-data-9.0.475-1.fc37.noarch.rpm"
+          },
+          "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsmartcols-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:932abcd232d522bb508daa2c9e6f4a3ea79039ad80a6478e6384d517c1d6698c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpath_utils-0.2.1-52.fc37.x86_64.rpm"
+          },
+          "sha256:93476a87e1531898ab2a95a701d918ce589c4da252aac2c615ba650138664feb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm"
+          },
+          "sha256:94bce8259108638ea7232af46208addfea8da92027b2bcfba5477e72403c75ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-efi-x64-2.06-58.fc37.x86_64.rpm"
+          },
+          "sha256:9546058ef3561af0a5e24d50469fc2317afb6aa760363c9348bd2374a31cb5e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:9577665c819179202b3439b7be4c69052df5ed79c9812be5ebb51fcbdfc8330f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmbim-1.26.4-2.fc37.x86_64.rpm"
+          },
+          "sha256:960633a9035f8fe02d49ba6713f240363383d5dc3b3f862d28e9b211fd34fea3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/iproute-5.18.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm"
+          },
+          "sha256:97e918bc5b11c8abfec9343e1b0bd88087b792e85c604427d5cdc32733f70b3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-repos-37-1.noarch.rpm"
+          },
+          "sha256:98caa3b739e76b8b725a9952231c463b3a46bf056942211f90505e61ea631111": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/intel-gpu-firmware-20220913-140.fc37.noarch.rpm"
+          },
+          "sha256:994af8949fcaac8a808ca00ba4d423e4b8b091c6643b7c49c8eb148b3954cf18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/audit-3.0.9-1.fc37.x86_64.rpm"
+          },
+          "sha256:9977ab99bccde6c58ec85fec01afd8a8e5cb9395bbc0a67aba49cdd320b40ff5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gobject-introspection-1.74.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:9978e30981c695105d1ecc67ef0b3216ab3413a9d93907390e8577de3b11c478": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgcc-12.2.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:9a9c9f908326ce672180964c0dee6a387fefce9f4e49dacbca87f4aa8bf1e31f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:9af923799a1ee9a07dbfe10ba28c3a28bc081d77648b1b5f6271f426af7212b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mokutil-0.6.0-5.fc37.x86_64.rpm"
+          },
+          "sha256:9b1529cbd75e33f5e9e220b868a68a95d807855cb462afe8f15a37da2e88cf5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/firewalld-filesystem-1.2.1-1.fc37.noarch.rpm"
+          },
+          "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-37-14.noarch.rpm"
+          },
+          "sha256:9ccf3b0e27bcba1698f7e14b1f52743ef4d59833b41cf24dd5b1aa490c389b22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kpartx-0.9.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:9cf89d7e274a5ddf55fc4b97974c7aa33f50379c8ed50f6cb458b7286c89af7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/iputils-20211215-3.fc37.x86_64.rpm"
+          },
+          "sha256:9ec2fe94d7573b61068710179c7588dec264198fd55a04247bb1cf9a1f925cc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/deltarpm-3.6.3-4.fc37.x86_64.rpm"
+          },
+          "sha256:9f560288796308a8a5c85ecc3be5214d76cca7d9a69db29981de11910c989ab4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-tools-2.06-58.fc37.x86_64.rpm"
+          },
+          "sha256:9f9541ae85dcbefd66fd88c014ccf176b8a6b32788443981490d3a76381c2cc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xz-libs-5.2.5-10.fc37.x86_64.rpm"
+          },
+          "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm"
+          },
+          "sha256:a13299c491c03c409b982ef670a4ec5f1642388da24b4624add8126a6b637e15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kernel-5.19.15-301.fc37.x86_64.rpm"
+          },
+          "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/selinux-policy-37.12-2.fc37.noarch.rpm"
+          },
+          "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:a3a149d5a46833b3e166c4610649954e9dcf78a1960f107ea74145a41e06e2d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-tools-minimal-2.06-58.fc37.x86_64.rpm"
+          },
+          "sha256:a5d3c81dc359adc676afc9044743aeaf8fbc924e019b093084035413716e78f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ntfsprogs-2022.5.17-2.fc37.x86_64.rpm"
+          },
+          "sha256:a5fc1a6f13d268443d17c263afbcbdfd249ff86961f439a184591035e19885e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssh-clients-8.8p1-7.fc37.x86_64.rpm"
+          },
+          "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm"
+          },
+          "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm"
+          },
+          "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm"
+          },
+          "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:a9ca97b6dc978f2a3895963780b0a99c794e5db5ce3f18e16951449fb11c74c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/alternatives-1.19-3.fc37.x86_64.rpm"
+          },
+          "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcap-2.48-5.fc37.x86_64.rpm"
+          },
+          "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:ad14549b59bcc2c3c2ed6152c0a3a2d4aebac3ae06ab5dc451659060f380624a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/jq-1.6-14.fc37.x86_64.rpm"
+          },
+          "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:ad6916df8df2312e346eca458eb7d21394618e559db385a1059609b93839ccb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mozjs102-102.3.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:ad9b6aeba4041769fbb2d9f3aeb72e3534c7f572f2021ec309e337efb4fe5b64": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-libelf-0.187-8.fc37.x86_64.rpm"
+          },
+          "sha256:add50027ca1a47e15088520f579e2e2384eecf0bb82e2f02339f6da2c4ac9416": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-crypto-2.28-2.fc37.x86_64.rpm"
+          },
+          "sha256:adf559f274af1e1a4facb1cc93e3840e83ba429513df55bdb79baa6508423e42": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libini_config-1.3.1-52.fc37.x86_64.rpm"
+          },
+          "sha256:ae1fef40fd8a0c5bf8c4aa74625119132b9564fabe2d84ae7856b39805b014d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/iptables-nft-1.8.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:aef4052ca482ce6d1e8400191a2791a635415868e7aa36d3efbea546f710df11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblkid-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libuuid-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:b0cdff45179a19a455bef375aed366f9323397a05bc7850a52fd2a106f34cc7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glib2-2.74.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:b22f6fd6b29c6ef4ce070cd4d4d2d823525a9ce07ceb552b4391ea9c5fc35fb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-unbound-1.16.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:b47b9de40f3d89a23347d11bdec27879263d0cc4a76eef57ba93fda2cebf617e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libksba-1.6.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:b4b47992384c822ee021452275896dfebc302ccf9f054d5d6975a364214d4f9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libjaylink-0.3.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:b51055715d002d05e5c90fa52f4cdfdecfebcb324ff532f84547a72586c7362f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dhcp-client-4.4.3-4.P1.fc37.x86_64.rpm"
+          },
+          "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kmod-30-2.fc37.x86_64.rpm"
+          },
+          "sha256:b59985bde8c374933ce87766de67f010fd10e0d43803b2d792c34f64f923bac1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/shadow-utils-4.12.3-2.fc37.x86_64.rpm"
+          },
+          "sha256:b5b4e759d1c56188fb777926de0d17498c25d3234d2635ce5a8e7b000bfaf7f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/groff-base-1.22.4-10.fc37.x86_64.rpm"
+          },
+          "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm"
+          },
+          "sha256:b772806fa1412ba843d87d2a84ed9c087880f3c9e7ded3f6035718f83888efbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtdb-1.4.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:b776d46067bf44c37801e19b243572feb26aae0fee721e061207a80873da1f46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.x86_64.rpm"
+          },
+          "sha256:b7ba853b07a46efda355edc72f74c9e356a2e60c3e4f934b0cefb9d347f20a53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dhcp-common-4.4.3-4.P1.fc37.noarch.rpm"
+          },
+          "sha256:b7e7d3793988a51ea308b7e9bf9882fa35d1b44a27da67e64c4b5a6eed34f792": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/userspace-rcu-0.13.0-5.fc37.x86_64.rpm"
+          },
+          "sha256:b85b1faebfc05f8f362dd59c53429328f787cd2fd60cb03432e259b0e5294bff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libreport-filesystem-2.17.4-1.fc37.noarch.rpm"
+          },
+          "sha256:b8914ca12a258fb7729a231325e4c269a97d38d6d6961dfebaa4a74d92babad8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dracut-057-3.fc37.x86_64.rpm"
+          },
+          "sha256:b8958e57d4f99bea5bd52c17f26ff5973dabe941aaa279cfca576c3b7c055c4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sqlite-libs-3.39.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:bad0c7e6a8c83996b3aa2056481ea9e1868a3b5f01608c2e1b4364e7b365415e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-runtime-0.21-19.0.20220203.fc37.x86_64.rpm"
+          },
+          "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:be94c8ec5d3bcec45fd4376d60703cb3832473b4111b0d8208f8832f055d9db2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxmlb-0.3.10-1.fc37.x86_64.rpm"
+          },
+          "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm"
+          },
+          "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-gpg-keys-37-1.noarch.rpm"
+          },
+          "sha256:c105f54738fba9793dad9b6ab2e88b4ae05cc47b9ea062cd7215b69d11ce0e1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:c1698a5eace8302ba8cd5b09c23b4c8d2ca4c9647a83ef92e03caed5ff066fa0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libdhash-0.5.0-52.fc37.x86_64.rpm"
+          },
+          "sha256:c203ba66a8da80ad3f21305dd932073c1ede06cfa2d1b267ccb28089596094bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsmbios-2.4.3-7.fc37.x86_64.rpm"
+          },
+          "sha256:c309c850576d198d785c6f4b36fb5a30705983851cc846075c26bb51d2007de1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-common-2.36-7.fc37.x86_64.rpm"
+          },
+          "sha256:c42642046bf068a2d0cc32f38cdc56d0c92af48eb131fc8dce55a997142f2e88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openldap-2.6.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:c462e7efdf7650c49e4d0af6aa59bf555db59bedf0a30e75ffbec4b2af5c5901": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-firewall-1.2.1-1.fc37.noarch.rpm"
+          },
+          "sha256:c471712a2998682347e1680ef1d5a652b48c12502f19e8d39354c4083af91d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/shared-mime-info-2.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:c4d3a29cc8c0ac2ed9e1e44342d98eac20da1519e889610a1668e57caa154a94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsss_sudo-2.7.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:c562efa8f886aa0ca1d6bb55b532f88f8030bf6400e14e65f5a6601df1c0f8a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pinentry-1.2.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/device-mapper-1.02.175-9.fc37.x86_64.rpm"
+          },
+          "sha256:c5efb96c9ce79c98fae0297f5fc2d6740a5f2c167d64020d18876d9e842e8d32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libdnf-0.68.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:c63e2ad394b69e31da35ddb4578c8b0c45b7d1bbf6015c92434627ad4b243263": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/jansson-2.13.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:c6679c7a9931ca457f6ad81e0aa00818f8b13558bed11ae6206d0cc05920260f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsss_certmap-2.7.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:c688de5844e5bbe41b94e7f84612d96c59e4d1348f7c8f596baaa5227e871ed7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gnupg2-2.3.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:c6b266b19cc93b1039758006f02679223535a3f86b04ccdfc848aa8d61575723": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fwupd-1.8.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:c8057ff6e5fa3339726c83173fdd11898b5f7545e72d81503f8c6660c4404885": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ncurses-6.3-3.20220501.fc37.x86_64.rpm"
+          },
+          "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/file-5.42-4.fc37.x86_64.rpm"
+          },
+          "sha256:c966372c322648dcf3e0b84dd0a7bdb92031270de243640739cb5c735cb6cef1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libudisks2-2.9.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:c9da9b36d4a3a55ee49e582743900a561093e3625b1e0a90f80e36797de7baa1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-udev-251.6-609.fc37.x86_64.rpm"
+          },
+          "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm"
+          },
+          "sha256:ca802ad5d10b2728ba10bf98bb16796585d69ec775f5452b3a43718e07c4667a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:cba7fbe4f72489a2fb27429ecfdf8b0177ac8cc4fa30aa7baaa8ce1a0dc4f5ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/parted-3.5-6.fc37.x86_64.rpm"
+          },
+          "sha256:cbe8a6957b2a00bf0117c5cb08affc8abdc2dad02edd1113b463412b9bc2238d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/y/yum-4.14.0-1.fc37.noarch.rpm"
+          },
+          "sha256:cd4d0c1b5490e1cee5e461b89eb1b1e7bb40c40de981cfd73ac060103a5c42a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/coreutils-9.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:cd59eec6fc00b4f8adff9031597fbceca1f7ef0aef5e5a7a68f275056713e2fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-gconv-extra-2.36-7.fc37.x86_64.rpm"
+          },
+          "sha256:ce9deb715d28bc1ef130ebf8c7d8f28fd774123da3e6d60eecaaca887d0a5f4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc37.x86_64.rpm"
+          },
+          "sha256:cf997d2d6fa655ec7e03fc58769e29770409254861d75c3732fcd9a264cc2820": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mdadm-4.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:d10d3576f631d1005ac681c79c517218715c65dcc194520a1d6cc688a0d6fcde": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gdisk-1.0.9-4.fc37.x86_64.rpm"
+          },
+          "sha256:d1a35de9152869803d6667926c330f7e0bffdb52c0d513ee0f3ecdc25f289aff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libicu-71.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm"
+          },
+          "sha256:d4d4230f282f18fcd120bdbff40382d8c04d322675612d9fd85e1461c62b66c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:d53b6b5f20e16b95bdf743f3962f45911577e1a483c756971405f5ef0506772f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/man-db-2.10.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm"
+          },
+          "sha256:d6aa832d8cc2c70fe044fec76c5769f282a0c2c92749591e96b7d2e6053393eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmnl-1.0.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:d71c5fc0e75b48b330cfc391920b8b2dd32c5c844202ba134172a31630a29460": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtalloc-2.3.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:d7cb7fd8b0694ff882c9ce27b14e93d91f25469547d5f76e55d113aae6c3b5fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgpg-error-1.45-2.fc37.x86_64.rpm"
+          },
+          "sha256:d7d0f5ded000fe57622ed2e551dbfad3b86b6bfdcd7d33a5e3c0862b9fcf6dfd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxcrypt-compat-4.4.28-3.fc37.x86_64.rpm"
+          },
+          "sha256:d81e04636fdf51ce19c3647652e37fa7775dad171ac563ac97fae4636ce6c6e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libedit-3.1-42.20210910cvs.fc37.x86_64.rpm"
+          },
+          "sha256:d8ff5893280eba8e73458be4d5db1032c79c0fa0e0d08c1f55434cb05e8d5e44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-loop-2.28-2.fc37.x86_64.rpm"
+          },
+          "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grep-3.7-4.fc37.x86_64.rpm"
+          },
+          "sha256:d9d52411d5e3188b9a89b35a15ae13d7fb4be3365cdcad82db139d98e3537b6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nss-softokn-freebl-3.83.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:dae406fca4514b396783fc79f20f20501eaf357389ccbb0b0c6207bdaadbf236": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/json-c-0.16-2.fc37.x86_64.rpm"
+          },
+          "sha256:dc5f7ca1ce86cd9380525b383624bdc1afa52d98db624cfdece7b08086f829d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm"
+          },
+          "sha256:dc8e3e173f88c245d311b899eb9d457d66c3b9026e9917e7a2e9c532e7dbba18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssh-server-8.8p1-7.fc37.x86_64.rpm"
+          },
+          "sha256:dc8e6626c3c8ea2dc183400a6f3a98de9eecd237e099bf589e42b24881256770": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-251.6-609.fc37.x86_64.rpm"
+          },
+          "sha256:dcdb39155a419f86e3070329e0c9ef19f1c6b605bad1e7af9309fcaf8d718195": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libfsverity-1.4-8.fc37.x86_64.rpm"
+          },
+          "sha256:ddc6d5cb5a094abc04b93e4018dd178aa1c527c80f2059c21963d3621a428989": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm"
+          },
+          "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm"
+          },
+          "sha256:de4dcfa7271758f759bfa291ac552eccb586047ee0b91471991bb46b2161b2a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc37.x86_64.rpm"
+          },
+          "sha256:dfbe63bdf373f8a141954f84aff98d3f044ba936c80e201c4755efcc6b1a9d82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libftdi-1.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:e022d35d3834e81cdb7c9582086acce4dff74a026ea600f6a5cb86388d231423": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libidn2-2.3.3-2.fc37.x86_64.rpm"
+          },
+          "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm"
+          },
+          "sha256:e16b0c15a0820ca0795ac8e5cd196c4c8bef3dfebd70eef28a5152a2c69a9386": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/polkit-libs-121-4.fc37.x86_64.rpm"
+          },
+          "sha256:e33050f1d6ff44a889213a947f6bc9f905336d4d89723ee6a50a51fd8ac10d9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sudo-1.9.11-4.p3.fc37.x86_64.rpm"
+          },
+          "sha256:e3c9a6a1611d967fbff4321b5b1ae54377fed22454298859108138c1f64b0c63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/popt-1.19-1.fc37.x86_64.rpm"
+          },
+          "sha256:e3e29963774a559bcdd22a6bd8a017dd2650e362a5c9b6dc029cf9eebd144761": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libjcat-0.1.12-1.fc37.x86_64.rpm"
+          },
+          "sha256:e3ef7332845114c912be8ba53e198af4e92edb5475809e9d3e6a2ad3202380d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-libs-0.187-8.fc37.x86_64.rpm"
+          },
+          "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:e45a35d7f68a2657719b18ad53c9efd5a2ca86deab37a886ddc1d1515593ce33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsolv-0.7.22-3.fc37.x86_64.rpm"
+          },
+          "sha256:e56dc2a37766276593c4f40c9d588defc5ba66ab29ae90ee03480c8bcfba459b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/ModemManager-glib-1.18.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:e5bbfce30b88c0b4f06c4ad0c80645cfec9c23248d7c734d76607d8bc500c43f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm"
+          },
+          "sha256:e694ef5ad5f16b497d4bdeca3c0a0c49fd6d01442e87f5c302dcadab0af2657b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dnf-data-4.14.0-1.fc37.noarch.rpm"
+          },
+          "sha256:e733d49496689131148b00a233229e484b5b622f9cb8c230230a05117763065e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/passwd-0.80-13.fc37.x86_64.rpm"
+          },
+          "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm"
+          },
+          "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:e9bbf1cbf6b2df49cf17585f3913a9064f7b0c3c56b116a92e9f242a3676efde": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm"
+          },
+          "sha256:ea37bbc4022aa6e266e0ec601d97620574c12c8b898b3ffb8ae8baffe553745f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/ipcalc-1.0.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm"
+          },
+          "sha256:eb156348e3350bec888a272bd31a5fb113585432ec3c3276fdb05c6561169eb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-libdnf-0.68.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:ec583a673d3ba649d69246fc67455f01c2431bc8e80b14b724117ce709b317ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-gobject-base-3.42.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:ec82b6cad1b898aaa474a6f68aa67840cbb1d70b515c2255ade5ada88cb3d587": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/curl-7.85.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:ed6c8cd71a52822a69c6dd28d2a112a0f772983a20e037884c7821d9eddef6ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/readline-8.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm"
+          },
+          "sha256:f03d62bf2ab0c2606a64a4326934765ae6d25afabe7cc7b77e44445c49fa4ac2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/less-590-5.fc37.x86_64.rpm"
+          },
+          "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-identity-basic-37-14.noarch.rpm"
+          },
+          "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tzdata-2022d-1.fc37.noarch.rpm"
+          },
+          "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:f1333de1f729a9f570251d37764c5c20faf596e9cff41643832d33f74bae24a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/efivar-libs-38-5.fc37.x86_64.rpm"
+          },
+          "sha256:f13a478a33985292da87fe93f42165f28534da027abffe942de5c5ea1388c487": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/ipset-7.15-5.fc37.x86_64.rpm"
+          },
+          "sha256:f33244be0eb788290d8ecc1e8b170af24fa51b64ed264bebbc84a352be4560da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fwupd-plugin-modem-manager-1.8.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:f3a520ff09e426914c103a156c4df4323a0e2fe4e469bdb7cf307fa57f8f1f9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dracut-config-rescue-057-3.fc37.x86_64.rpm"
+          },
+          "sha256:f3d72ee9f04141387d75d3e8ec9fe3a720ad40eaa815ffcb9e18f5e98e2353d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/flashrom-1.2-9.fc37.x86_64.rpm"
+          },
+          "sha256:f52405026bce203a5a1dd62b533f9e6c61a68bba6271d2f7de3948dcb1a47fd9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libatasmart-0.19-23.fc37.x86_64.rpm"
+          },
+          "sha256:f52edeae190ea55635b96cb8a5fb81ecd9a2ca900fa65c4403e4890c2d70da83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm"
+          },
+          "sha256:f6d6c53e06ada97d73329dc360393e493dae399f8f669efc1f0099e17192d898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-libcomps-0.1.18-4.fc37.x86_64.rpm"
+          },
+          "sha256:f730ab54689ca4dfc727425636a636d35a6d7bbe4985420cb5ff35ec6eef0307": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/firewalld-1.2.1-1.fc37.noarch.rpm"
+          },
+          "sha256:f76ebdec7991b3383b5dc3b8bf284f7a5190965453af086978e98a355b3ab977": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/unbound-libs-1.16.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:f863051b731a75ea7443c096b1a0e236fa4b285b08b3dd7175d68c228eea1dbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fwupd-efi-1.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/util-linux-core-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:fa30a837be5cce2abf071c4afead1af95faf7d87c05e390404aa0de3b10b8046": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-dbus-1.2.18-5.fc37.x86_64.rpm"
+          },
+          "sha256:fd187adda52038f138b4d7fb632699088109311a4da39bd8e28e57858487c4eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-libs-1.14.2-1.fc37.x86_64.rpm"
+          },
+          "sha256:fd67360c39e9d4bd6eb9c6179ec2fa68382715129a8a43972e9fe63ee870f420": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.x86_64.rpm"
+          },
+          "sha256:feca19ad021eb5d691d05cd11833a908eb8da2abb9acb1938cd8d3fcf40eef4e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-2.28-2.fc37.x86_64.rpm"
+          },
+          "sha256:ff2ca237124563e6c9490abd6802f8d83f66d147e7fd60f8b5196bf78a8ba72e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcurl-7.85.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:ffbcf2d3558dec17023a930d8e278756ffec150d943b66239085043e06fbce59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/lua-libs-5.4.4-4.fc37.x86_64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/alternatives-1.19-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a9ca97b6dc978f2a3895963780b0a99c794e5db5ce3f18e16951449fb11c74c4",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/audit-libs-3.0.9-1.fc37.x86_64.rpm",
+        "checksum": "sha256:23cda2a639c358757ee35ce6270ba3d0c6cd779309ff528e7c08c0239737dffb",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:74ee0b4664d9300b0538372064e74e1609f5bf89a4cef76c7849d774af7295cf",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:68e0f60ad19cf5f0f211f0e14b96b42db87806d9536eb05386cf9bf168891c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bash-5.1.16-4.fc37.x86_64.rpm",
+        "checksum": "sha256:21ab08a6ce4ff5213d541878e456f7c1ea9da5b76c342fe1c55641a77e187b23",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm",
+        "checksum": "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/coreutils-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:cd4d0c1b5490e1cee5e461b89eb1b1e7bb40c40de981cfd73ac060103a5c42a0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/coreutils-common-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:31af27f44c4a8d06068389731d3a5adc0fd45b1c8ce4d28163f938e68fa58cbf",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cpio-2.13-13.fc37.x86_64.rpm",
+        "checksum": "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cracklib-2.9.7-30.fc37.x86_64.rpm",
+        "checksum": "sha256:3847abdc8ff973aeb0fb7e681bdf7c37b19cd49e5df17e8bf6bc35f34615c88f",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:9a9c9f908326ce672180964c0dee6a387fefce9f4e49dacbca87f4aa8bf1e31f",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/curl-7.85.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:ec82b6cad1b898aaa474a6f68aa67840cbb1d70b515c2255ade5ada88cb3d587",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.x86_64.rpm",
+        "checksum": "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-1.14.2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:1b1e2c27345206db40bd782541b00575f3d36e238a6905c75d67c2407ca4adbd",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e5bbfce30b88c0b4f06c4ad0c80645cfec9c23248d7c734d76607d8bc500c43f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-common-1.14.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/device-mapper-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/device-mapper-libs-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dracut-057-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b8914ca12a258fb7729a231325e4c269a97d38d6d6961dfebaa4a74d92babad8",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc37.x86_64.rpm",
+        "checksum": "sha256:ce9deb715d28bc1ef130ebf8c7d8f28fd774123da3e6d60eecaaca887d0a5f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc37.noarch.rpm",
+        "checksum": "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-libelf-0.187-8.fc37.x86_64.rpm",
+        "checksum": "sha256:ad9b6aeba4041769fbb2d9f3aeb72e3534c7f572f2021ec309e337efb4fe5b64",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-libs-0.187-8.fc37.x86_64.rpm",
+        "checksum": "sha256:e3ef7332845114c912be8ba53e198af4e92edb5475809e9d3e6a2ad3202380d8",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:6b9b252702c66da50fde953741fe5470d53cb955dddf6a50d890002927517f0b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-gpg-keys-37-1.noarch.rpm",
+        "checksum": "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-37-14.noarch.rpm",
+        "checksum": "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-common-37-14.noarch.rpm",
+        "checksum": "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-identity-basic-37-14.noarch.rpm",
+        "checksum": "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-repos-37-1.noarch.rpm",
+        "checksum": "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/file-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm",
+        "checksum": "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm",
+        "checksum": "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-envsubst-0.21-19.0.20220203.fc37.x86_64.rpm",
+        "checksum": "sha256:4f197117a201e561bc919198df573394e7c97dce2fda2382e3a2495c7ab9e8cd",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-libs-0.21-19.0.20220203.fc37.x86_64.rpm",
+        "checksum": "sha256:1b9c5fe598d258b0dbbf454b01ba844aa678bf5c7333bd16e98ba4c62a242f9f",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-runtime-0.21-19.0.20220203.fc37.x86_64.rpm",
+        "checksum": "sha256:bad0c7e6a8c83996b3aa2056481ea9e1868a3b5f01608c2e1b4364e7b365415e",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-2.36-7.fc37.x86_64.rpm",
+        "checksum": "sha256:6dec8d3c7b09c9e9114d18081660c5d01b82a34986db43f437aef2a28163fcf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-common-2.36-7.fc37.x86_64.rpm",
+        "checksum": "sha256:c309c850576d198d785c6f4b36fb5a30705983851cc846075c26bb51d2007de1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-gconv-extra-2.36-7.fc37.x86_64.rpm",
+        "checksum": "sha256:cd59eec6fc00b4f8adff9031597fbceca1f7ef0aef5e5a7a68f275056713e2fc",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-minimal-langpack-2.36-7.fc37.x86_64.rpm",
+        "checksum": "sha256:7b62248de9e972c39877fa9e4aeb91ef46b7436d5e92624efc9154f6fa6b9e88",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grep-3.7-4.fc37.x86_64.rpm",
+        "checksum": "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-common-2.06-58.fc37.noarch.rpm",
+        "checksum": "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-tools-2.06-58.fc37.x86_64.rpm",
+        "checksum": "sha256:9f560288796308a8a5c85ecc3be5214d76cca7d9a69db29981de11910c989ab4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-tools-minimal-2.06-58.fc37.x86_64.rpm",
+        "checksum": "sha256:a3a149d5a46833b3e166c4610649954e9dcf78a1960f107ea74145a41e06e2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "66.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grubby-8.40-66.fc37.x86_64.rpm",
+        "checksum": "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gzip-1.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/json-c-0.16-2.fc37.x86_64.rpm",
+        "checksum": "sha256:dae406fca4514b396783fc79f20f20501eaf357389ccbb0b0c6207bdaadbf236",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-2.5.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:7c660eada8cb6e2d2b0c035a9d1696db945761c07e7900b8003b1b405243adef",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kmod-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kpartx-0.9.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9ccf3b0e27bcba1698f7e14b1f52743ef4d59833b41cf24dd5b1aa490c389b22",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm",
+        "checksum": "sha256:159f17086ec145c629cedca9a038bc0c8fa38b4a8f7f0f0e9bedba0f3e76af28",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8e41b0d094a6635221cc015437ce4131c9ce502a4d4d2a5c1b51ac36ad0ccd21",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm",
+        "checksum": "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblkid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm",
+        "checksum": "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcap-2.48-5.fc37.x86_64.rpm",
+        "checksum": "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm",
+        "checksum": "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcurl-7.85.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:ff2ca237124563e6c9490abd6802f8d83f66d147e7fd60f8b5196bf78a8ba72e",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm",
+        "checksum": "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm",
+        "checksum": "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libfdisk-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm",
+        "checksum": "sha256:dc5f7ca1ce86cd9380525b383624bdc1afa52d98db624cfdece7b08086f829d6",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libfido2-1.11.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgcc-12.2.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:9978e30981c695105d1ecc67ef0b3216ab3413a9d93907390e8577de3b11c478",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgomp-12.2.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:63a20a87a52e9ab38a252c30f4ef64ad836340d4209dbfcf91c0b869798a3fb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libidn2-2.3.3-2.fc37.x86_64.rpm",
+        "checksum": "sha256:e022d35d3834e81cdb7c9582086acce4dff74a026ea600f6a5cb86388d231423",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libkcapi-1.4.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmount-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.49.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnghttp2-1.49.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:52447c45094ab085c5883024b1788e66a7d60d425f48d4dcf6683cd5be0ec087",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm",
+        "checksum": "sha256:ddc6d5cb5a094abc04b93e4018dd178aa1c527c80f2059c21963d3621a428989",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:2a5b4e2e1dd388c3c13d79af971fb8efd522f5c2ba8d257875f02c16b4858214",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7c7c409363b5a1a459b8ceb987866fc54e1feee5d4d2919d31295c8526b7d96f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:66305d7a3ca92165f1c17e14cc29ea70280fa1c1fd3bf223b5b1d4f7d1ce0dd8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:97e918bc5b11c8abfec9343e1b0bd88087b792e85c604427d5cdc32733f70b3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsmartcols-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libssh-0.10.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:1adc02db53d619c3afe65182be399a9d08a7bcdf8cb9be04edc4b5c99da5cf42",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libssh-config-0.10.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libstdc++-12.2.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:4aa568fef0ff3141c9deb6a0e8cfe1e3649d8efbbe04cd7390c0681c447748fe",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9546058ef3561af0a5e24d50469fc2317afb6aa760363c9348bd2374a31cb5e1",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm",
+        "checksum": "sha256:76dcdfd95452e176f64d6008d114e9415cd8384c5c0d3300fe644c137b6917fa",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libuuid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxcrypt-4.4.28-3.fc37.x86_64.rpm",
+        "checksum": "sha256:1ce5fc1b93217cd4b9db8b47bcd548ac401047ac73f48d1bfd66f0ffb91fd21a",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxcrypt-compat-4.4.28-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d7d0f5ded000fe57622ed2e551dbfad3b86b6bfdcd7d33a5e3c0862b9fcf6dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxml2-2.9.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:539f9b54e9f497f0d40374f3d863a62c6fcc4e54a7336ac54445344612fc151c",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c105f54738fba9793dad9b6ab2e88b4ae05cc47b9ea062cd7215b69d11ce0e1c",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/lua-libs-5.4.4-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ffbcf2d3558dec17023a930d8e278756ffec150d943b66239085043e06fbce59",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm",
+        "checksum": "sha256:93476a87e1531898ab2a95a701d918ce589c4da252aac2c615ba650138664feb",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mkpasswd-5.5.13-2.fc37.x86_64.rpm",
+        "checksum": "sha256:08c7782ae9fe49cbec8db74d566061656689bf48cc2977bd0dd8daf3d645133c",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:47a3ce5b9228ccb688da7458828fef2138f6e4215e73941922dda962aecd14f8",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openldap-2.6.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c42642046bf068a2d0cc32f38cdc56d0c92af48eb131fc8dce55a997142f2e88",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssl-libs-3.0.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1e7bff42a7164385e2ca87fe11bfc8ff6e50d56f8da32b5ebd1e5f0a4508b66b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:557322822a4aa090b2c4d24154f25a7417b1015327c92f463d98161e46f65c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm",
+        "checksum": "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre-8.45-1.fc37.2.x86_64.rpm",
+        "checksum": "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm",
+        "checksum": "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pigz-2.7-2.fc37.x86_64.rpm",
+        "checksum": "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm",
+        "checksum": "sha256:20b825188654b5b5d17340ce6a78cbd3504e74729f8cfb83150b6798db4a586f",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/popt-1.19-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e3c9a6a1611d967fbff4321b5b1ae54377fed22454298859108138c1f64b0c63",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/procps-ng-3.3.17-6.fc37.x86_64.rpm",
+        "checksum": "sha256:64112ed94189c99bddc05003aa3bdea8a5486e8cf056678512586864b41985ad",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc37.noarch.rpm",
+        "checksum": "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-3.11.0~rc2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:128b958d194fd77cb888807aa6bf46c3ebcec2e345ce2cefc202def4b8d678a2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:62ee4e0aa9f6ba95aacb3a62f2221acfff510f6cd4cfa870cf68cbb9f9d42201",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/readline-8.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:ed6c8cd71a52822a69c6dd28d2a112a0f772983a20e037884c7821d9eddef6ba",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-4.18.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7eb9468d77618514bf861da405e2c85b2411efe81577ebc586fd9c25e5ae4194",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-libs-4.18.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:359602208228e24f4d2b4f0ab057ad7ca604ed3f23b0873e7efe395a0c3df25e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-plugin-selinux-4.18.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:1ab8c75a2f9ee929bbfdb722abc00fb96252e4e76c66f1d292cfe01330f3d56a",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sed-4.8-11.fc37.x86_64.rpm",
+        "checksum": "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.12",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/selinux-policy-37.12-2.fc37.noarch.rpm",
+        "checksum": "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.12",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/selinux-policy-targeted-37.12-2.fc37.noarch.rpm",
+        "checksum": "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.12.3",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/shadow-utils-4.12.3-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b59985bde8c374933ce87766de67f010fd10e0d43803b2d792c34f64f923bac1",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sqlite-libs-3.39.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b8958e57d4f99bea5bd52c17f26ff5973dabe941aaa279cfca576c3b7c055c4b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:dc8e6626c3c8ea2dc183400a6f3a98de9eecd237e099bf589e42b24881256770",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-libs-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:0b2bd8783d542d769eb6c440974af90451fd44353f291b9f89873b56b20490ea",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-networkd-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:6b392a609fd5f688d073dcade1548fb15f7d7a2b3b37e235aaae9ae07ccecbfb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-pam-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:18188e5455ce48c41c2aa87d9c28a6b0d632e7372d6284455f1a982676f8dccc",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-resolved-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:1838a0aa547578b45ead6c5f1ccb66493ba06d881e5d4163309f8333b4b74988",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-udev-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:c9da9b36d4a3a55ee49e582743900a561093e3625b1e0a90f80e36797de7baa1",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tpm2-tools-5.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:80b1424e54ba0e84149d8ab536b7fc3e31469a571ae3f0e11077bee8b663af9b",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d4d4230f282f18fcd120bdbff40382d8c04d322675612d9fd85e1461c62b66c7",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022d",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tzdata-2022d-1.fc37.noarch.rpm",
+        "checksum": "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/util-linux-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/util-linux-core-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xz-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:4d5c9d11876f3a1688d31fa669986eaaa4c0717435ca99e78fb86bf5ddc193cf",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xz-libs-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:9f9541ae85dcbefd66fd88c014ccf176b8a6b32788443981490d3a76381c2cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/ModemManager-glib-1.18.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:e56dc2a37766276593c4f40c9d588defc5ba66ab29ae90ee03480c8bcfba459b",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.40.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/NetworkManager-1.40.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:25ea22f713c6c2a2ff164c3a5b6f625d70b2a399d5d0ba0796d96942777e756f",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.40.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/NetworkManager-libnm-1.40.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:24c5926ad780d9e90bde6cbe605543d00b776a9cba53d3e063606c093fab3557",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/alternatives-1.19-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a9ca97b6dc978f2a3895963780b0a99c794e5db5ce3f18e16951449fb11c74c4",
+        "check_gpg": true
+      },
+      {
+        "name": "amd-gpu-firmware",
+        "epoch": 0,
+        "version": "20220913",
+        "release": "140.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/amd-gpu-firmware-20220913-140.fc37.noarch.rpm",
+        "checksum": "sha256:85698713589960a8b6821a4a56bc7b5af4df9977e86cad103cb9512ba7177d2d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/audit-3.0.9-1.fc37.x86_64.rpm",
+        "checksum": "sha256:994af8949fcaac8a808ca00ba4d423e4b8b091c6643b7c49c8eb148b3954cf18",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/audit-libs-3.0.9-1.fc37.x86_64.rpm",
+        "checksum": "sha256:23cda2a639c358757ee35ce6270ba3d0c6cd779309ff528e7c08c0239737dffb",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:74ee0b4664d9300b0538372064e74e1609f5bf89a4cef76c7849d774af7295cf",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:68e0f60ad19cf5f0f211f0e14b96b42db87806d9536eb05386cf9bf168891c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bash-5.1.16-4.fc37.x86_64.rpm",
+        "checksum": "sha256:21ab08a6ce4ff5213d541878e456f7c1ea9da5b76c342fe1c55641a77e187b23",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.65",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bluez-5.65-3.fc37.x86_64.rpm",
+        "checksum": "sha256:1502c8529c0e0e9e57c9a1a1635fd28fdcfc1f63004b1d5aa667baa868ea41fd",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm",
+        "checksum": "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/c-ares-1.17.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:558476ce7be43951868fef0c6216a99ff0a5ecfbb69e68785172b3a9a627b28b",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/coreutils-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:cd4d0c1b5490e1cee5e461b89eb1b1e7bb40c40de981cfd73ac060103a5c42a0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/coreutils-common-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:31af27f44c4a8d06068389731d3a5adc0fd45b1c8ce4d28163f938e68fa58cbf",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cpio-2.13-13.fc37.x86_64.rpm",
+        "checksum": "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cracklib-2.9.7-30.fc37.x86_64.rpm",
+        "checksum": "sha256:3847abdc8ff973aeb0fb7e681bdf7c37b19cd49e5df17e8bf6bc35f34615c88f",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cracklib-dicts-2.9.7-30.fc37.x86_64.rpm",
+        "checksum": "sha256:7a2829a5012094cf436e39495f0fd8f14604f8f295e98b8bb6e85eab9e0472f1",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:9a9c9f908326ce672180964c0dee6a387fefce9f4e49dacbca87f4aa8bf1e31f",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/curl-7.85.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:ec82b6cad1b898aaa474a6f68aa67840cbb1d70b515c2255ade5ada88cb3d587",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.x86_64.rpm",
+        "checksum": "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-1.14.2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:1b1e2c27345206db40bd782541b00575f3d36e238a6905c75d67c2407ca4adbd",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e5bbfce30b88c0b4f06c4ad0c80645cfec9c23248d7c734d76607d8bc500c43f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-common-1.14.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-libs-1.14.2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:fd187adda52038f138b4d7fb632699088109311a4da39bd8e28e57858487c4eb",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.3",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/deltarpm-3.6.3-4.fc37.x86_64.rpm",
+        "checksum": "sha256:9ec2fe94d7573b61068710179c7588dec264198fd55a04247bb1cf9a1f925cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/device-mapper-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/device-mapper-libs-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "4.P1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dhcp-client-4.4.3-4.P1.fc37.x86_64.rpm",
+        "checksum": "sha256:b51055715d002d05e5c90fa52f4cdfdecfebcb324ff532f84547a72586c7362f",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "4.P1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dhcp-common-4.4.3-4.P1.fc37.noarch.rpm",
+        "checksum": "sha256:b7ba853b07a46efda355edc72f74c9e356a2e60c3e4f934b0cefb9d347f20a53",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.4",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dmidecode-3.4-2.fc37.x86_64.rpm",
+        "checksum": "sha256:19b7e1385a12e9196622d1549ebee9a2254656300a530a9abb824737950571ef",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dnf-4.14.0-1.fc37.noarch.rpm",
+        "checksum": "sha256:5e7cf0116ffdcf0c673d155a24c70e1483305d6ec50ad8b7d1d4ad224e4e88bc",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dnf-data-4.14.0-1.fc37.noarch.rpm",
+        "checksum": "sha256:e694ef5ad5f16b497d4bdeca3c0a0c49fd6d01442e87f5c302dcadab0af2657b",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dnf-plugins-core-4.3.1-1.fc37.noarch.rpm",
+        "checksum": "sha256:5b75e3acf6f11c8584c7e38718a295503c09c0acd4b9dd245b287ab3357d245d",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dracut-057-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b8914ca12a258fb7729a231325e4c269a97d38d6d6961dfebaa4a74d92babad8",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "057",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dracut-config-generic-057-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0e3ddc2f83def37e6c6799890e4a3c12220491045a656e308b2d306e165e64bb",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "057",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dracut-config-rescue-057-3.fc37.x86_64.rpm",
+        "checksum": "sha256:f3a520ff09e426914c103a156c4df4323a0e2fe4e469bdb7cf307fa57f8f1f9f",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm",
+        "checksum": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/efibootmgr-18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:157a95e5d0a70dcb97682ae484d6238e99db218071855483283c61486029ce8e",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/efivar-libs-38-5.fc37.x86_64.rpm",
+        "checksum": "sha256:f1333de1f729a9f570251d37764c5c20faf596e9cff41643832d33f74bae24a3",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc37.x86_64.rpm",
+        "checksum": "sha256:ce9deb715d28bc1ef130ebf8c7d8f28fd774123da3e6d60eecaaca887d0a5f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc37.noarch.rpm",
+        "checksum": "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-libelf-0.187-8.fc37.x86_64.rpm",
+        "checksum": "sha256:ad9b6aeba4041769fbb2d9f3aeb72e3534c7f572f2021ec309e337efb4fe5b64",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-libs-0.187-8.fc37.x86_64.rpm",
+        "checksum": "sha256:e3ef7332845114c912be8ba53e198af4e92edb5475809e9d3e6a2ad3202380d8",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:6b9b252702c66da50fde953741fe5470d53cb955dddf6a50d890002927517f0b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-gpg-keys-37-1.noarch.rpm",
+        "checksum": "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-37-14.noarch.rpm",
+        "checksum": "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-common-37-14.noarch.rpm",
+        "checksum": "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-identity-basic-37-14.noarch.rpm",
+        "checksum": "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-repos-37-1.noarch.rpm",
+        "checksum": "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-repos-modular-37-1.noarch.rpm",
+        "checksum": "sha256:8f4a1bfa873f3a019aef82c02e5713ff67cca7942d7351002e01a0defb8c0cbb",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/file-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/firewalld-1.2.1-1.fc37.noarch.rpm",
+        "checksum": "sha256:f730ab54689ca4dfc727425636a636d35a6d7bbe4985420cb5ff35ec6eef0307",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/firewalld-filesystem-1.2.1-1.fc37.noarch.rpm",
+        "checksum": "sha256:9b1529cbd75e33f5e9e220b868a68a95d807855cb462afe8f15a37da2e88cf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/flashrom-1.2-9.fc37.x86_64.rpm",
+        "checksum": "sha256:f3d72ee9f04141387d75d3e8ec9fe3a720ad40eaa815ffcb9e18f5e98e2353d6",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm",
+        "checksum": "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fwupd-1.8.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c6b266b19cc93b1039758006f02679223535a3f86b04ccdfc848aa8d61575723",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fwupd-efi-1.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:f863051b731a75ea7443c096b1a0e236fa4b285b08b3dd7175d68c228eea1dbe",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fwupd-plugin-flashrom-1.8.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:00eaeeac4eac4944832ff4821ca821de222b598a07b6fd368b11e3143a58ee02",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fwupd-plugin-modem-manager-1.8.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:f33244be0eb788290d8ecc1e8b170af24fa51b64ed264bebbc84a352be4560da",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7c576f1b14afe9222d7c4e0007d58a3c998b5416b5aa1fdcfddbff264747787b",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm",
+        "checksum": "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gdisk-1.0.9-4.fc37.x86_64.rpm",
+        "checksum": "sha256:d10d3576f631d1005ac681c79c517218715c65dcc194520a1d6cc688a0d6fcde",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:f52edeae190ea55635b96cb8a5fb81ecd9a2ca900fa65c4403e4890c2d70da83",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:aef4052ca482ce6d1e8400191a2791a635415868e7aa36d3efbea546f710df11",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-envsubst-0.21-19.0.20220203.fc37.x86_64.rpm",
+        "checksum": "sha256:4f197117a201e561bc919198df573394e7c97dce2fda2382e3a2495c7ab9e8cd",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-libs-0.21-19.0.20220203.fc37.x86_64.rpm",
+        "checksum": "sha256:1b9c5fe598d258b0dbbf454b01ba844aa678bf5c7333bd16e98ba4c62a242f9f",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-runtime-0.21-19.0.20220203.fc37.x86_64.rpm",
+        "checksum": "sha256:bad0c7e6a8c83996b3aa2056481ea9e1868a3b5f01608c2e1b4364e7b365415e",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.74.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glib2-2.74.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b0cdff45179a19a455bef375aed366f9323397a05bc7850a52fd2a106f34cc7d",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-2.36-7.fc37.x86_64.rpm",
+        "checksum": "sha256:6dec8d3c7b09c9e9114d18081660c5d01b82a34986db43f437aef2a28163fcf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-common-2.36-7.fc37.x86_64.rpm",
+        "checksum": "sha256:c309c850576d198d785c6f4b36fb5a30705983851cc846075c26bb51d2007de1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-gconv-extra-2.36-7.fc37.x86_64.rpm",
+        "checksum": "sha256:cd59eec6fc00b4f8adff9031597fbceca1f7ef0aef5e5a7a68f275056713e2fc",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-minimal-langpack-2.36-7.fc37.x86_64.rpm",
+        "checksum": "sha256:7b62248de9e972c39877fa9e4aeb91ef46b7436d5e92624efc9154f6fa6b9e88",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gnupg2-2.3.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c688de5844e5bbe41b94e7f84612d96c59e4d1348f7c8f596baaa5227e871ed7",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gnupg2-smime-2.3.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:5081d23a1ae79d9ce3abb22648a358c1d07d55e03c1aa2ffa9f920a9871344aa",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.7",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gnutls-3.7.7-1.fc37.x86_64.rpm",
+        "checksum": "sha256:31c439058714931736b9a7e4bc5b2c70d47ed188721c40cb8b8839bb3c5ee732",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.74.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gobject-introspection-1.74.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:9977ab99bccde6c58ec85fec01afd8a8e5cb9395bbc0a67aba49cdd320b40ff5",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gpgme-1.17.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:03209772270d0f1fcac1b006d2d4b4bff967a001e7c9fdc6ed97950fede5e3cf",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grep-3.7-4.fc37.x86_64.rpm",
+        "checksum": "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/groff-base-1.22.4-10.fc37.x86_64.rpm",
+        "checksum": "sha256:b5b4e759d1c56188fb777926de0d17498c25d3234d2635ce5a8e7b000bfaf7f3",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-common-2.06-58.fc37.noarch.rpm",
+        "checksum": "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-efi-x64-2.06-58.fc37.x86_64.rpm",
+        "checksum": "sha256:94bce8259108638ea7232af46208addfea8da92027b2bcfba5477e72403c75ea",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-tools-2.06-58.fc37.x86_64.rpm",
+        "checksum": "sha256:9f560288796308a8a5c85ecc3be5214d76cca7d9a69db29981de11910c989ab4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-tools-minimal-2.06-58.fc37.x86_64.rpm",
+        "checksum": "sha256:a3a149d5a46833b3e166c4610649954e9dcf78a1960f107ea74145a41e06e2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "66.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grubby-8.40-66.fc37.x86_64.rpm",
+        "checksum": "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gzip-1.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/h/hostname-3.23-7.fc37.x86_64.rpm",
+        "checksum": "sha256:840438421f3c7e28e49fa1327480ff7eb7780bcdbf605caf35ec0115bf4d7d9e",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/ima-evm-utils-1.4-6.fc37.x86_64.rpm",
+        "checksum": "sha256:72b2fbe65f24fa2dc41109cb0bd47b0962824847ac802a3c0160d832ee1e75f6",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "56",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/inih-56-2.fc37.x86_64.rpm",
+        "checksum": "sha256:28d630dae78579725857e2242ce2ce01e6748a20c538554a36b628157a7ea1c7",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.17",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/initscripts-service-10.17-1.fc37.noarch.rpm",
+        "checksum": "sha256:8adebc901848979df7c1c96c51055426c0ac7212b536a5cf82bd650dbbb322cd",
+        "check_gpg": true
+      },
+      {
+        "name": "intel-gpu-firmware",
+        "epoch": 0,
+        "version": "20220913",
+        "release": "140.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/intel-gpu-firmware-20220913-140.fc37.noarch.rpm",
+        "checksum": "sha256:98caa3b739e76b8b725a9952231c463b3a46bf056942211f90505e61ea631111",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/ipcalc-1.0.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ea37bbc4022aa6e266e0ec601d97620574c12c8b898b3ffb8ae8baffe553745f",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.18.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/iproute-5.18.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:960633a9035f8fe02d49ba6713f240363383d5dc3b3f862d28e9b211fd34fea3",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/ipset-7.15-5.fc37.x86_64.rpm",
+        "checksum": "sha256:f13a478a33985292da87fe93f42165f28534da027abffe942de5c5ea1388c487",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/ipset-libs-7.15-5.fc37.x86_64.rpm",
+        "checksum": "sha256:89d348fb8c40d1a4fc0ce2a217892a73d3bcfa183379af8ab2826d1e47b87e9b",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/iptables-libs-1.8.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:57a1d67b5a9c1151e3f3c9401ff7f4704f91307f0d95d5ea7b276e9095748e20",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/iptables-nft-1.8.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:ae1fef40fd8a0c5bf8c4aa74625119132b9564fabe2d84ae7856b39805b014d5",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/iputils-20211215-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9cf89d7e274a5ddf55fc4b97974c7aa33f50379c8ed50f6cb458b7286c89af7e",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/jansson-2.13.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:c63e2ad394b69e31da35ddb4578c8b0c45b7d1bbf6015c92434627ad4b243263",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/jq-1.6-14.fc37.x86_64.rpm",
+        "checksum": "sha256:ad14549b59bcc2c3c2ed6152c0a3a2d4aebac3ae06ab5dc451659060f380624a",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/json-c-0.16-2.fc37.x86_64.rpm",
+        "checksum": "sha256:dae406fca4514b396783fc79f20f20501eaf357389ccbb0b0c6207bdaadbf236",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/json-glib-1.6.6-3.fc37.x86_64.rpm",
+        "checksum": "sha256:598ddb966e5ac4f664f2cbe9d0087b62c1a4067a1f1af24f290d7f681956e29c",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-2.5.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:7c660eada8cb6e2d2b0c035a9d1696db945761c07e7900b8003b1b405243adef",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.19.15",
+        "release": "301.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kernel-5.19.15-301.fc37.x86_64.rpm",
+        "checksum": "sha256:a13299c491c03c409b982ef670a4ec5f1642388da24b4624add8126a6b637e15",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.19.15",
+        "release": "301.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kernel-core-5.19.15-301.fc37.x86_64.rpm",
+        "checksum": "sha256:6c5c57fc5ab7e4045f84e96e68bb811eda6335897bea41a1576708cc01593894",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.19.15",
+        "release": "301.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kernel-modules-5.19.15-301.fc37.x86_64.rpm",
+        "checksum": "sha256:9278077f283c20321a550da3faa0e03cd58f56459940cfdf6d7e05c0c1016688",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kmod-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kpartx-0.9.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9ccf3b0e27bcba1698f7e14b1f52743ef4d59833b41cf24dd5b1aa490c389b22",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm",
+        "checksum": "sha256:159f17086ec145c629cedca9a038bc0c8fa38b4a8f7f0f0e9bedba0f3e76af28",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/less-590-5.fc37.x86_64.rpm",
+        "checksum": "sha256:f03d62bf2ab0c2606a64a4326934765ae6d25afabe7cc7b77e44445c49fa4ac2",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8e41b0d094a6635221cc015437ce4131c9ce502a4d4d2a5c1b51ac36ad0ccd21",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm",
+        "checksum": "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libassuan-2.5.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:337900b23fc2550547c243e11b7a65284c53c844a3882e0b67e2fbb93f8bf1db",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "23.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libatasmart-0.19-23.fc37.x86_64.rpm",
+        "checksum": "sha256:f52405026bce203a5a1dd62b533f9e6c61a68bba6271d2f7de3948dcb1a47fd9",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbasicobjects-0.1.1-52.fc37.x86_64.rpm",
+        "checksum": "sha256:364011baa5e293baae2e60992fd1241f6c822d7c7e48c259d3e6abb0530036af",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblkid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-2.28-2.fc37.x86_64.rpm",
+        "checksum": "sha256:feca19ad021eb5d691d05cd11833a908eb8da2abb9acb1938cd8d3fcf40eef4e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-crypto-2.28-2.fc37.x86_64.rpm",
+        "checksum": "sha256:add50027ca1a47e15088520f579e2e2384eecf0bb82e2f02339f6da2c4ac9416",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-fs-2.28-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8971dffd7d3ce1547a16bd17bd8d7745ccbfbed897021c504303c3f40f6920b7",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-loop-2.28-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d8ff5893280eba8e73458be4d5db1032c79c0fa0e0d08c1f55434cb05e8d5e44",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-mdraid-2.28-2.fc37.x86_64.rpm",
+        "checksum": "sha256:67f00ad99cede36aea285c6ccdcc713d5519d6bda710e5a340cb2886d87aa228",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-part-2.28-2.fc37.x86_64.rpm",
+        "checksum": "sha256:703ba79af214b62786b19e0f58c7e842e04de852145a5f1971beb4fe6f24d563",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-swap-2.28-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8122523c26fb300520670cd3ef4da1a81d9272501faf1c7db9670628ced5165e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblockdev-utils-2.28-2.fc37.x86_64.rpm",
+        "checksum": "sha256:5eb771630565b940d76a67db7ae2bf986a30d45f4930c80e9aae9ed634adbc43",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm",
+        "checksum": "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbytesize-2.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:40bdee106c7d9df3c4b2a39289b247635450d763fb84cd5e63e2493f9519b58d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcap-2.48-5.fc37.x86_64.rpm",
+        "checksum": "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcap-ng-python3-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:278bfd824633a3c49357342679e9dd5864a33bcda5d25986bf3e6030bed4987e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm",
+        "checksum": "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcollection-0.7.0-52.fc37.x86_64.rpm",
+        "checksum": "sha256:32e67e6a70e493c52515626820cef9d3df6457f111004483fe6a8657255f4ba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcomps-0.1.18-4.fc37.x86_64.rpm",
+        "checksum": "sha256:1e14f25f5cdbbb523cfc3f7381b8c053a26f05f61666fb1f86fecda50d3764a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcurl-7.85.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:ff2ca237124563e6c9490abd6802f8d83f66d147e7fd60f8b5196bf78a8ba72e",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm",
+        "checksum": "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libdhash-0.5.0-52.fc37.x86_64.rpm",
+        "checksum": "sha256:c1698a5eace8302ba8cd5b09c23b4c8d2ca4c9647a83ef92e03caed5ff066fa0",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libdnf-0.68.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c5efb96c9ce79c98fae0297f5fc2d6740a5f2c167d64020d18876d9e842e8d32",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "42.20210910cvs.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libedit-3.1-42.20210910cvs.fc37.x86_64.rpm",
+        "checksum": "sha256:d81e04636fdf51ce19c3647652e37fa7775dad171ac563ac97fae4636ce6c6e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm",
+        "checksum": "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libfdisk-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm",
+        "checksum": "sha256:dc5f7ca1ce86cd9380525b383624bdc1afa52d98db624cfdece7b08086f829d6",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libfido2-1.11.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libfsverity-1.4-8.fc37.x86_64.rpm",
+        "checksum": "sha256:dcdb39155a419f86e3070329e0c9ef19f1c6b605bad1e7af9309fcaf8d718195",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libftdi-1.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:dfbe63bdf373f8a141954f84aff98d3f044ba936c80e201c4755efcc6b1a9d82",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgcab1-1.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:2aac86cd8a7197d3ce75797501dfd5ff3bd77b3c92f9c975e63efabd5e941d1b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgcc-12.2.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:9978e30981c695105d1ecc67ef0b3216ab3413a9d93907390e8577de3b11c478",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ca802ad5d10b2728ba10bf98bb16796585d69ec775f5452b3a43718e07c4667a",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgomp-12.2.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:63a20a87a52e9ab38a252c30f4ef64ad836340d4209dbfcf91c0b869798a3fb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgpg-error-1.45-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d7cb7fd8b0694ff882c9ce27b14e93d91f25469547d5f76e55d113aae6c3b5fd",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgudev-237-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0bd6b3f97c370399de8aad7e37d1195d3be5f3aa66c3ab4c83eeb42e4cde23ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.4.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgusb-0.4.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:3d5945969342c0fba61cb9bf33140a6070c4465ac1809758465d64e369a25111",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "41.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libibverbs-41.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:58fc922b01b99cf99809121ca2d3134853a5cc06ec5b8b5f6a0de7eec5c12202",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "71.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libicu-71.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d1a35de9152869803d6667926c330f7e0bffdb52c0d513ee0f3ecdc25f289aff",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libidn2-2.3.3-2.fc37.x86_64.rpm",
+        "checksum": "sha256:e022d35d3834e81cdb7c9582086acce4dff74a026ea600f6a5cb86388d231423",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libini_config-1.3.1-52.fc37.x86_64.rpm",
+        "checksum": "sha256:adf559f274af1e1a4facb1cc93e3840e83ba429513df55bdb79baa6508423e42",
+        "check_gpg": true
+      },
+      {
+        "name": "libjaylink",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libjaylink-0.3.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b4b47992384c822ee021452275896dfebc302ccf9f054d5d6975a364214d4f9a",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.12",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libjcat-0.1.12-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e3e29963774a559bcdd22a6bd8a017dd2650e362a5c9b6dc029cf9eebd144761",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libkcapi-1.4.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libksba-1.6.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b47b9de40f3d89a23347d11bdec27879263d0cc4a76eef57ba93fda2cebf617e",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libldb-2.6.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:89ac04873c24d8d89c1b60e5cec35544756507fb1be2c2556b92af8bdfcc2a7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmaxminddb-1.7.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:1d549ff8d5d7e5c61ae8b6a352c2cd341740c2b60e69738499c0c604e7930674",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmbim-1.26.4-2.fc37.x86_64.rpm",
+        "checksum": "sha256:9577665c819179202b3439b7be4c69052df5ed79c9812be5ebb51fcbdfc8330f",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmnl-1.0.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:d6aa832d8cc2c70fe044fec76c5769f282a0c2c92749591e96b7d2e6053393eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:7bd0358110b6b80f3e4facb097746b19c8d82b3fa079a6dddb80582aae42cad9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmount-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libndp-1.8-4.fc37.x86_64.rpm",
+        "checksum": "sha256:8ba1fb96a5e6b78dde962d5b9fe97726a393c977e9a9106e896dceeefffc6472",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7e5767c70bc9f6429b6e9a66ce2cb75e90eea0d9a48392e1e9eb54480fcabd8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "22.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnfnetlink-1.0.1-22.fc37.x86_64.rpm",
+        "checksum": "sha256:44e396c693edeea0a6db316428af4bd7b2c0df41ce562e2f951b871b70a10bc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnftnl-1.2.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:5ea5031e6eb8d915f4c2910527c3cac1c7cb969fded5057f21be5873a22bad3c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.49.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnghttp2-1.49.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:52447c45094ab085c5883024b1788e66a7d60d425f48d4dcf6683cd5be0ec087",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnl3-3.7.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:4543c991e6f536468d9d47527a201b58b9bc049364a6bdfe15a2f910a02e68f6",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpath_utils-0.2.1-52.fc37.x86_64.rpm",
+        "checksum": "sha256:932abcd232d522bb508daa2c9e6f4a3ea79039ad80a6478e6384d517c1d6698c",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpcap-1.10.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:213ea8f5cd8ed07a61d13e3e32b66f9f9d3e992b121414ae6fd9d3af3cf49e5d",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.6",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpipeline-1.5.6-2.fc37.x86_64.rpm",
+        "checksum": "sha256:5e748380f1796e2a7be2137cecd8a1662fcdfdbc858d27b218c931350e296240",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm",
+        "checksum": "sha256:ddc6d5cb5a094abc04b93e4018dd178aa1c527c80f2059c21963d3621a428989",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libqmi-1.30.6-2.fc37.x86_64.rpm",
+        "checksum": "sha256:01a2ac7dc3829b47eb0d188909175b806a1e93eb1aefad2737f8fe07e42972e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libqrtr-glib-1.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:5fd8bb0bc2edd80b13c0d3ac38cf26b1ad94736fbf1b4b37ee6433772d6f18e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libref_array-0.1.5-52.fc37.x86_64.rpm",
+        "checksum": "sha256:69ca0883e3929168bc8eb555463ae051fc38afedae0fa98d566bc22388304a91",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/librepo-1.14.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:3d36aae2debf54b1eae06fe21f3cd7e2f904810f618c987372b14e94097bbef3",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libreport-filesystem-2.17.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:b85b1faebfc05f8f362dd59c53429328f787cd2fd60cb03432e259b0e5294bff",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsecret-0.20.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:0de55e331087a0c931dbff4ff4973dfd54b190b2ba112e6c22ea8f13dd0329d2",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:2a5b4e2e1dd388c3c13d79af971fb8efd522f5c2ba8d257875f02c16b4858214",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7c7c409363b5a1a459b8ceb987866fc54e1feee5d4d2919d31295c8526b7d96f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:66305d7a3ca92165f1c17e14cc29ea70280fa1c1fd3bf223b5b1d4f7d1ce0dd8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:97e918bc5b11c8abfec9343e1b0bd88087b792e85c604427d5cdc32733f70b3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsmartcols-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmbios",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsmbios-2.4.3-7.fc37.x86_64.rpm",
+        "checksum": "sha256:c203ba66a8da80ad3f21305dd932073c1ede06cfa2d1b267ccb28089596094bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsolv-0.7.22-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e45a35d7f68a2657719b18ad53c9efd5a2ca86deab37a886ddc1d1515593ce33",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libssh-0.10.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:1adc02db53d619c3afe65182be399a9d08a7bcdf8cb9be04edc4b5c99da5cf42",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libssh-config-0.10.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsss_certmap-2.7.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c6679c7a9931ca457f6ad81e0aa00818f8b13558bed11ae6206d0cc05920260f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsss_idmap-2.7.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:3d3039dc249a944cb984a469f543de6c47f413a6c82df6a58103509d3f11c1e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsss_nss_idmap-2.7.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:1af59da686191daa47e66c9cb3b250d37da6df464e2f631550b46c32169e2bfe",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsss_sudo-2.7.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c4d3a29cc8c0ac2ed9e1e44342d98eac20da1519e889610a1668e57caa154a94",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libstdc++-12.2.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:4aa568fef0ff3141c9deb6a0e8cfe1e3649d8efbbe04cd7390c0681c447748fe",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtalloc-2.3.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d71c5fc0e75b48b330cfc391920b8b2dd32c5c844202ba134172a31630a29460",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9546058ef3561af0a5e24d50469fc2317afb6aa760363c9348bd2374a31cb5e1",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtdb-1.4.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b772806fa1412ba843d87d2a84ed9c087880f3c9e7ded3f6035718f83888efbf",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtevent-0.13.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:744cf61b729b0516567b9e622244f21d7dc6d44c35bbc507e5ae1b49f791e7df",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm",
+        "checksum": "sha256:76dcdfd95452e176f64d6008d114e9415cd8384c5c0d3300fe644c137b6917fa",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libudisks2-2.9.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:c966372c322648dcf3e0b84dd0a7bdb92031270de243640739cb5c735cb6cef1",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libusb1-1.0.25-9.fc37.x86_64.rpm",
+        "checksum": "sha256:012a7fbcbffc0c6d9a7101fb29eef81cd7ba18d3bb427b3aa0c9ae3a27ba2b2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libuser-0.63-13.fc37.x86_64.rpm",
+        "checksum": "sha256:8f61270c6844a8b400abff35a5edcd72ca1f2db057e3a9fa38713cdca449eed9",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libuuid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxcrypt-4.4.28-3.fc37.x86_64.rpm",
+        "checksum": "sha256:1ce5fc1b93217cd4b9db8b47bcd548ac401047ac73f48d1bfd66f0ffb91fd21a",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxcrypt-compat-4.4.28-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d7d0f5ded000fe57622ed2e551dbfad3b86b6bfdcd7d33a5e3c0862b9fcf6dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxml2-2.9.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:539f9b54e9f497f0d40374f3d863a62c6fcc4e54a7336ac54445344612fc151c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxmlb-0.3.10-1.fc37.x86_64.rpm",
+        "checksum": "sha256:be94c8ec5d3bcec45fd4376d60703cb3832473b4111b0d8208f8832f055d9db2",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libyaml-0.2.5-8.fc37.x86_64.rpm",
+        "checksum": "sha256:54ebc02523f7b85a9b790aec6be0b6ef01e377216bd76fc0ada4354fa0f0d8e3",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c105f54738fba9793dad9b6ab2e88b4ae05cc47b9ea062cd7215b69d11ce0e1c",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20220913",
+        "release": "140.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/linux-firmware-20220913-140.fc37.noarch.rpm",
+        "checksum": "sha256:6e5480b45c64f05340cbdac2bb0354b5593aa8da16690a0b0e188a1842920af3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20220913",
+        "release": "140.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/linux-firmware-whence-20220913-140.fc37.noarch.rpm",
+        "checksum": "sha256:4b322703e97a772ad667f9361e64caedd6b1ff8b26882447aa4083c6ac4bc047",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/lmdb-libs-0.9.29-4.fc37.x86_64.rpm",
+        "checksum": "sha256:57b0cbd11daab17a9b9486f89545407de965d26029938e991f1aefdaf0e48614",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/lua-libs-5.4.4-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ffbcf2d3558dec17023a930d8e278756ffec150d943b66239085043e06fbce59",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm",
+        "checksum": "sha256:93476a87e1531898ab2a95a701d918ce589c4da252aac2c615ba650138664feb",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.10.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/man-db-2.10.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d53b6b5f20e16b95bdf743f3962f45911577e1a483c756971405f5ef0506772f",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mdadm-4.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:cf997d2d6fa655ec7e03fc58769e29770409254861d75c3732fcd9a264cc2820",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mkpasswd-5.5.13-2.fc37.x86_64.rpm",
+        "checksum": "sha256:08c7782ae9fe49cbec8db74d566061656689bf48cc2977bd0dd8daf3d645133c",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mokutil-0.6.0-5.fc37.x86_64.rpm",
+        "checksum": "sha256:9af923799a1ee9a07dbfe10ba28c3a28bc081d77648b1b5f6271f426af7212b2",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs102",
+        "epoch": 0,
+        "version": "102.3.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mozjs102-102.3.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:ad6916df8df2312e346eca458eb7d21394618e559db385a1059609b93839ccb9",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nano-6.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:2e5281196fd18f90f4204d2104354936cd8f6fa88c209638f690134e61572b5f",
+        "check_gpg": true
+      },
+      {
+        "name": "nano-default-editor",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:18b46fafae10d86249df30a025faf411cb1369ddd2d2ade738f9cc4b45ab6f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ncurses-6.3-3.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:c8057ff6e5fa3339726c83173fdd11898b5f7545e72d81503f8c6660c4404885",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:47a3ce5b9228ccb688da7458828fef2138f6e4215e73941922dda962aecd14f8",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nettle-3.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8fe2d98578b0c4454536faacbaafd66d1754b8439bb6332d7576a741f4c72208",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nftables-1.0.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:763343a0a0c30885b064b920ceaee7b4846298d07c8975ca5e2a0ce72e0982a2",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/npth-1.6-9.fc37.x86_64.rpm",
+        "checksum": "sha256:6bf0c6a9c2a00e9e06988299543a9bb1aec4445014b11216db6d6c2e2253bda9",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.35.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nspr-4.35.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:39ac563bdb726187651898cf17b368a818f984c4795b39bdf41f254c3cbd4889",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nss-3.83.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:25e6fed9e3aadb313770fa676e43f5978f581d07bc6504b66c373f5fb42f9250",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nss-softokn-3.83.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:6166c7179e4a8d2504e385ffbd36dbfdf62795000665584f2ae4895ba5ba94fd",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nss-softokn-freebl-3.83.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:d9d52411d5e3188b9a89b35a15ae13d7fb4be3365cdcad82db139d98e3537b6a",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nss-sysinit-3.83.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:21a0812602d0f42e8da8760f6a5fdc002fc93e054639bea5f21ccba9cffd9a5b",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nss-util-3.83.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:49bdfe2732098f5eee53c78ce36dfcb56f12c182698cda3b0f624b4b2f5db7a3",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ntfs-3g-2022.5.17-2.fc37.x86_64.rpm",
+        "checksum": "sha256:4df07c734a7b4135d6b5dd73f72cbc188763a09457f3bf24f893fc178fd89d9f",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.x86_64.rpm",
+        "checksum": "sha256:4cdba0d602a32cb4b90461bd7dbdfacf0bc30f63ee5dd8f460d5bee3dc4cb586",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:b776d46067bf44c37801e19b243572feb26aae0fee721e061207a80873da1f46",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ntfsprogs-2022.5.17-2.fc37.x86_64.rpm",
+        "checksum": "sha256:a5d3c81dc359adc676afc9044743aeaf8fbc924e019b093084035413716e78f7",
+        "check_gpg": true
+      },
+      {
+        "name": "nvidia-gpu-firmware",
+        "epoch": 0,
+        "version": "20220913",
+        "release": "140.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nvidia-gpu-firmware-20220913-140.fc37.noarch.rpm",
+        "checksum": "sha256:8b3b3f611f93e849b5c03219fb2a28b63ac4215ebe28a8219da5e5be15e5ed52",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "2.D20220919gitb041f6d.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/oniguruma-6.9.8-2.D20220919gitb041f6d.fc37.x86_64.rpm",
+        "checksum": "sha256:3afd73ae4e359216ff2b3a5d06cef58b6a82661ea9fd3496e5c66ba574a8af82",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openldap-2.6.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c42642046bf068a2d0cc32f38cdc56d0c92af48eb131fc8dce55a997142f2e88",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssh-8.8p1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:503d66de89be6300652f88a12013ff9b999012f6be0fa92fc8e9a2ea2913b284",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssh-clients-8.8p1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:a5fc1a6f13d268443d17c263afbcbdfd249ff86961f439a184591035e19885e3",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssh-server-8.8p1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:dc8e3e173f88c245d311b899eb9d457d66c3b9026e9917e7a2e9c532e7dbba18",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssl-libs-3.0.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1e7bff42a7164385e2ca87fe11bfc8ff6e50d56f8da32b5ebd1e5f0a4508b66b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:557322822a4aa090b2c4d24154f25a7417b1015327c92f463d98161e46f65c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm",
+        "checksum": "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/parted-3.5-6.fc37.x86_64.rpm",
+        "checksum": "sha256:cba7fbe4f72489a2fb27429ecfdf8b0177ac8cc4fa30aa7baaa8ce1a0dc4f5ea",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/passwd-0.80-13.fc37.x86_64.rpm",
+        "checksum": "sha256:e733d49496689131148b00a233229e484b5b622f9cb8c230230a05117763065e",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pciutils-libs-3.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8d45acd2ae98e922732fc9c4966c3bb8d570f4185122d766a83199955b96cad7",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre-8.45-1.fc37.2.x86_64.rpm",
+        "checksum": "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm",
+        "checksum": "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcsc-lite-1.9.9-1.fc37.x86_64.rpm",
+        "checksum": "sha256:2662ac74bdff1706965ab83236c1c65c34287e8008eac2785b9b52ffe01816dd",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:0b01cb100fa03ec4ac41532662cda8aa9f47ff4abe5f33b2cbf682c311fba841",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc37.x86_64.rpm",
+        "checksum": "sha256:de4dcfa7271758f759bfa291ac552eccb586047ee0b91471991bb46b2161b2a3",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pigz-2.7-2.fc37.x86_64.rpm",
+        "checksum": "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pinentry-1.2.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c562efa8f886aa0ca1d6bb55b532f88f8030bf6400e14e65f5a6601df1c0f8a3",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/plymouth-22.02.122-3.fc37.x86_64.rpm",
+        "checksum": "sha256:066773d5ff149af0ee912ae22f0121ac86e097c4c2829ed30b6683c874596d7c",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/plymouth-core-libs-22.02.122-3.fc37.x86_64.rpm",
+        "checksum": "sha256:1a0d58a999f992a11b1c54986a7c253b74403bbbb328ab2aa2d21df6b33313b2",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/plymouth-scripts-22.02.122-3.fc37.x86_64.rpm",
+        "checksum": "sha256:66e3422ca28c563ee8acf56b79a248218fd5db18314ec828875105c187dd0c92",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm",
+        "checksum": "sha256:20b825188654b5b5d17340ce6a78cbd3504e74729f8cfb83150b6798db4a586f",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/polkit-121-4.fc37.x86_64.rpm",
+        "checksum": "sha256:3df7fd45694c994a41077966f80f48d28a5466c21e161c92d05629cc64efe0e6",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/polkit-libs-121-4.fc37.x86_64.rpm",
+        "checksum": "sha256:e16b0c15a0820ca0795ac8e5cd196c4c8bef3dfebd70eef28a5152a2c69a9386",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "22.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.x86_64.rpm",
+        "checksum": "sha256:fd67360c39e9d4bd6eb9c6179ec2fa68382715129a8a43972e9fe63ee870f420",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/popt-1.19-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e3c9a6a1611d967fbff4321b5b1ae54377fed22454298859108138c1f64b0c63",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/procps-ng-3.3.17-6.fc37.x86_64.rpm",
+        "checksum": "sha256:64112ed94189c99bddc05003aa3bdea8a5486e8cf056678512586864b41985ad",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/protobuf-c-1.4.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:46a9be44b3444815a0197dd85953bf87710d3ea3d8f9fbfff23068ca85885070",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/psmisc-23.4-4.fc37.x86_64.rpm",
+        "checksum": "sha256:4a50276d2a8bd7f2b16cbdf6592ea365c19fa9f9bd33b5cfa1ab4bbd5ca89c69",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc37.noarch.rpm",
+        "checksum": "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-3.11.0~rc2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:128b958d194fd77cb888807aa6bf46c3ebcec2e345ce2cefc202def4b8d678a2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.2",
+        "release": "4.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm",
+        "checksum": "sha256:6e1b3ebb0f9945593365eaf0bc01d052d2e221e930d5731d1bd8276289194ba1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-dbus-1.2.18-5.fc37.x86_64.rpm",
+        "checksum": "sha256:fa30a837be5cce2abf071c4afead1af95faf7d87c05e390404aa0de3b10b8046",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-distro-1.7.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:6427a8b877a51be140e06665b3680a911816c9eb581aa54ecf29c77f51b6e898",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-dnf-4.14.0-1.fc37.noarch.rpm",
+        "checksum": "sha256:20c744f2ca0c36933f151c9436bc67c0db461e26c97eaad10726e3e42a169012",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-dnf-plugins-core-4.3.1-1.fc37.noarch.rpm",
+        "checksum": "sha256:21de93c6eaee8efe68ce326aa4a8c9819fb9c8a87ef153fe3be473076890db7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-firewall-1.2.1-1.fc37.noarch.rpm",
+        "checksum": "sha256:c462e7efdf7650c49e4d0af6aa59bf555db59bedf0a30e75ffbec4b2af5c5901",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-gobject-base-3.42.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ec583a673d3ba649d69246fc67455f01c2431bc8e80b14b724117ce709b317ee",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:e9bbf1cbf6b2df49cf17585f3913a9064f7b0c3c56b116a92e9f242a3676efde",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-gpg-1.17.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:09bd56123cc38e0b6eca84a97848f3985caa421e0879345b89c42e726a19b49b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-hawkey-0.68.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:91daae949ff91b3d96865ee10b99376b9db82bf62d4ee77123572345dbf586dc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-libcomps-0.1.18-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f6d6c53e06ada97d73329dc360393e493dae399f8f669efc1f0099e17192d898",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-libdnf-0.68.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:eb156348e3350bec888a272bd31a5fb113585432ec3c3276fdb05c6561169eb1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:62ee4e0aa9f6ba95aacb3a62f2221acfff510f6cd4cfa870cf68cbb9f9d42201",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-nftables-1.0.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:250cc6648ef7fbb6c209f83805e7cf2a16ff8fb98725c6945df9f085998cbb05",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-rpm-4.18.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:4136d198050e7527929e1289c1ebd6475e2e8235513749debceb2be26a33fa56",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm",
+        "checksum": "sha256:3f33292317a057dd50fd05ad00e5495a866a3df35d8acd83efdb592fb90c603e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-unbound-1.16.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b22f6fd6b29c6ef4ce070cd4d4d2d823525a9ce07ceb552b4391ea9c5fc35fb9",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/readline-8.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:ed6c8cd71a52822a69c6dd28d2a112a0f772983a20e037884c7821d9eddef6ba",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "32.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm",
+        "checksum": "sha256:0c0e32d108fcf6ac2f4c61aecc03163168337179b861786abd206ae58535a0e2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-4.18.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7eb9468d77618514bf861da405e2c85b2411efe81577ebc586fd9c25e5ae4194",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-build-libs-4.18.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:18cba4823772a73049f6c288b9c739bb0f60c9ac428d1d9128a127dad46cbc88",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-libs-4.18.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:359602208228e24f4d2b4f0ab057ad7ca604ed3f23b0873e7efe395a0c3df25e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-plugin-selinux-4.18.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:1ab8c75a2f9ee929bbfdb722abc00fb96252e4e76c66f1d292cfe01330f3d56a",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:89fd6a8b16942c4499a24cdffc7007a8e316c3119df111016881ae67fa99a6fa",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-sign-libs-4.18.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:8cf9c48cb43b6fcd2d4dba6e31ce74cd31d38f307563efe83884395d4ce83f62",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sed-4.8-11.fc37.x86_64.rpm",
+        "checksum": "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.12",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/selinux-policy-37.12-2.fc37.noarch.rpm",
+        "checksum": "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.12",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/selinux-policy-targeted-37.12-2.fc37.noarch.rpm",
+        "checksum": "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.12.3",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/shadow-utils-4.12.3-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b59985bde8c374933ce87766de67f010fd10e0d43803b2d792c34f64f923bac1",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/shared-mime-info-2.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c471712a2998682347e1680ef1d5a652b48c12502f19e8d39354c4083af91d8a",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/shim-x64-15.6-2.x86_64.rpm",
+        "checksum": "sha256:4da0677be2e68ab8e7d9132c6350186cf7c1116f545515fc16a43f6daaa92ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sqlite-libs-3.39.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b8958e57d4f99bea5bd52c17f26ff5973dabe941aaa279cfca576c3b7c055c4b",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sssd-client-2.7.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:40d4af423ad279f9f956b640311c026717ff9e152dcf0452fdcfcd2f2196f56e",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sssd-common-2.7.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:17f9a62eb7ff845279fbcc09d7380aff07f754f1d916276342ad982d122ded2a",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.7.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sssd-kcm-2.7.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:348ced5b0ee17eb1f2ae4925e3baca86bc0d11e10e59a2731e73227974eeac45",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sudo-1.9.11-4.p3.fc37.x86_64.rpm",
+        "checksum": "sha256:e33050f1d6ff44a889213a947f6bc9f905336d4d89723ee6a50a51fd8ac10d9f",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.x86_64.rpm",
+        "checksum": "sha256:229d197810a5e64665283e0f2e1b4268f4dc7514fff803e99c1b862201d6d827",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:dc8e6626c3c8ea2dc183400a6f3a98de9eecd237e099bf589e42b24881256770",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-libs-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:0b2bd8783d542d769eb6c440974af90451fd44353f291b9f89873b56b20490ea",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-networkd-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:6b392a609fd5f688d073dcade1548fb15f7d7a2b3b37e235aaae9ae07ccecbfb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-pam-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:18188e5455ce48c41c2aa87d9c28a6b0d632e7372d6284455f1a982676f8dccc",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-resolved-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:1838a0aa547578b45ead6c5f1ccb66493ba06d881e5d4163309f8333b4b74988",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-udev-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:c9da9b36d4a3a55ee49e582743900a561093e3625b1e0a90f80e36797de7baa1",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tpm2-tools-5.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:80b1424e54ba0e84149d8ab536b7fc3e31469a571ae3f0e11077bee8b663af9b",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d4d4230f282f18fcd120bdbff40382d8c04d322675612d9fd85e1461c62b66c7",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022d",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tzdata-2022d-1.fc37.noarch.rpm",
+        "checksum": "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/udisks2-2.9.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:2f12d5e9f0294047cbb3a07018df31df5a6eeac754fe8e6b4a21749a5c6f8acb",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-anchor",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/unbound-anchor-1.16.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:5c4449f25a6119b82042f9c602549d1fc31b8203e64a813138ea2131958fc4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/unbound-libs-1.16.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:f76ebdec7991b3383b5dc3b8bf284f7a5190965453af086978e98a355b3ab977",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/userspace-rcu-0.13.0-5.fc37.x86_64.rpm",
+        "checksum": "sha256:b7e7d3793988a51ea308b7e9bf9882fa35d1b44a27da67e64c4b5a6eed34f792",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/util-linux-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/util-linux-core-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "9.0.475",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/v/vim-data-9.0.475-1.fc37.noarch.rpm",
+        "checksum": "sha256:92841df883b69d4edb23b0834936717b0ca61b50391174f2c919978051f736a9",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "9.0.475",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/v/vim-minimal-9.0.475-1.fc37.x86_64.rpm",
+        "checksum": "sha256:0819fc90d62f977b1e2605d7910349da79713edf6995abb022e81d89a00ed20e",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "17.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/v/volume_key-libs-0.3.12-17.fc37.x86_64.rpm",
+        "checksum": "sha256:3fc4908c11bf3f85bbf51a14a79d4bead80ae7035cae607f7580ba7d7dad58a2",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.18.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xfsprogs-5.18.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4ed93771948eba20a48a5c824079710be94d927aeaf7c2d0db1a5a402b2eb923",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xz-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:4d5c9d11876f3a1688d31fa669986eaaa4c0717435ca99e78fb86bf5ddc193cf",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xz-libs-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:9f9541ae85dcbefd66fd88c014ccf176b8a6b32788443981490d3a76381c2cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/y/yum-4.14.0-1.fc37.noarch.rpm",
+        "checksum": "sha256:cbe8a6957b2a00bf0117c5cb08affc8abdc2dad02edd1113b463412b9bc2238d",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zchunk-libs-1.2.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7b6ec4b5e92ae158d215c9f419173bf825870677717fe4a1375fc16e38cd479b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zram-generator-1.1.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:330e209e3700c12717c686796717e947796c71d914bb32719ab7213e556b642c",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:2c492273497329d9a1ea2293d0f668edf953e18830f7d49797f7ff8412ea76da",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_38-aarch64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-minimal_raw-boot.json
@@ -1,0 +1,11413 @@
+{
+  "compose-request": {
+    "distro": "fedora-38",
+    "arch": "aarch64",
+    "image-type": "minimal-raw",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-modular-20221025/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "raw.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora38",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:ba72fbb32b033ac001d8a410f864e6e2e456dbcb2fba09a4849efc1205e6d0ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2038e0d7d9f572dc7cf4316a026580021b45374e189cf155849f292558e799b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd15bba53fc3e0c82c546a080c6f5441bed7d87587195843516949e230faf66a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7347986518175c4c649d2cdab6378d55a565fdedc1cd6519fc5e8140e06f8ca4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48897ef50d1d7fceced43f3fb3a8159e4aa4eacf87d4ed2a13880a9f6dcec6bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbfa023e35aa0c917ca8b0f451b24af4582c769c65571e4c0d90c7dbbef92615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24ef51235db87f815528627f58d9b7a1720e3984ecc382ec5d5833d2852d5c60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f5b6b7d0c17fb19292cd8fbb5fd4def006eb8ad7b24d8117c1e975322d05891",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13a5171648e217e0d3b3f7021dff491e736a39b5f7162a1c2bd3779bd3bcbd17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7a61dd5759669ca441ff0023eabd9af78d1455d4931ab0a31db0107a54b3fc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c09b8285b4fa856c472ff33e8220186fb35220161fcdd2b6054dc27574cf5066",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df36f338c43b86547adf17d9bfdadcad07f1ac7d6456bc416c29d3373e6287c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca5a06cd3eaa5701c9be12d3fabda97454e9a9e6aca9ffc586b9e14eb3952520",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a4d8cc770e436919ebad73a32168e2cd4da3cad8781d3cce6c9d654a5d3fe59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9828e6e75cd847a6cf4aa0d27d0f4884df5779546ff6b194a759a84e1894e85",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de090ad42c7e36fa7bb2e4408a6bab45e216c0420ae055b9ba1f96c20f804463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3124d8a892116345eab8f50b79835214599ea061cf66665397e9a1cf0f05ba5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:313910bb3c90cc31b7c82212fa71121c54b311f1d9af4eb78e50c7d39446ac86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9cf98847c92321215a42aa1061e143f35d10ac3e738943ce0ce00dafe1df9471",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04296a5d261f241802a92a70c9b000d98e11c0389d689af0bd19bb55abf75bbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786cec3721ba9907a4c69620cee6bc3952de8f27dec33f57d9939619b8514f87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38e6676864f276c4364b6324b787b6e19ad4d160107e9867a57fbbf84530a7ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b25ce7686cc5c1cf3d59e8a9ac89156e9f4bb846de8a6fb44ad33c1a19179067",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34eaff2e19c7ecf3be38670103a4ca8655c5670f42a3c32d4d1fd13de76be842",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdecabcb7a7e24b2c2d52220d2e958b42466e868416553a079a7f01c0d5ff0fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df7f7e1774a64e458e4836972fc09673080e56490ec11b08327cb6137f1b9bd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4cfae4f2e8ebb6772c7c5d6ca6212f776c36e5da5c47bb0ef51f444e4a68d3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3baa568b572643be26056e5f5bebdbb061d726c635c78fc2a8970335c724064",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6dc8ec1d8f370cfb509220b23a418938f44280f4d7d4a92458a78a5980281062",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:503b9b7f3b947c4d1a50dfe8dac8064b726a09beade31f116c0e3fd5df5ad78a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89ef8e879fd7ae5dd9e54405accaf1b558bb98edb423eaf27cd44a45c7c443bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f295d316d8aaa426972fd9fff029497b28f9a7572da5faf7e1b121fc0868bd23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2be19d631bc2c3399af9c4a02a73c882cfc79a0296e3101304f5f41bdd5587a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d7d9e4cc7520cba86f679322b635238761b4a8ffb443cb3b2e8228d88a5bdaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a4df46e9482e6dd68f6ff70603e36aaf846d4767ecb69b034900813566f705d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ccaefa2ac125fc90c752808872eef3f72d0e159e4497a58a2b65ce0ca863ca0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bad9043c625b8d266cf0c817453af694b04d41e204270ce91b02013320e6a66d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7b74094a5e268849ad2d86fbeb78b67b52c8aed96a88c855ac8fc7a274a569",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b162d37fea25914e42e63e6483127b4ac8889e5587f461989e6be6769e5f694",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1520d5466cbb6f853828e3d8454a0a2a255247a2eb08315b35f5e8e147e6504d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7577f8eaa1171a15629ec06c438266b6ce586b59fdf65f8bce8f449a16faea7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae88ef5dda0d2d000080a445ad51747a55df4fa94594fc11b1636639768e87be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6605dc2f943b0b947a19c97fae4bca7608b59f1483c97882686c7ca05c4af7ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd568ab6d1fcc43bf18bc353cbea23fe884c52f54079ee6ad5dfbc921cb72106",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0107618d15c26f2cd52d1c52825e02bb2fdead1fd6449bd670427f5cf880757a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98204d9f002323eb100429184488ca9130659290c4446c974a9346a6e93df889",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2a8f241adc3298633c436f1ca4433a7cd7e9bbcf019865dab9d7e1c1c1094da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07c102c24aaa0e06cccf2968b5da223961571b1a22931834db21295711f94de1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a8c9a2d2b341f6aea2cac2dae0d1cdd01266fbd7cbbf4bc9a044039944f380",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d24979d1cf80f3906eab72efcac23bbbea35ef6eb10475631b5ffc32370621e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1e2e146ad4254ab7bad7ea61acbc7318a9a3bcd254f8c5d06f15a2fa97c5c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:114871e86a9e186ae8ff94ea02235f4d1eb98f7ef22a6945435beb0044f35d7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08fe4ae654a7c12bf80888ad0f52dc8d28ad7cd79c74c2466fcc98ef9b229908",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b817b5ef5565a9190d29d77513dfbae65222fb156f80c4f64a03a12f0b8df52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b850dec7cc93073fd5c1dd6a86fcd4c300d046acb29c81d0cf1c0324a84a13ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f45f46be9bfa2ed73829988839fd2ceca36600e3597605205841255b4556371c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73d3c84d2bd0f897c46f04fd4d3e816b0a77c5e1a5cb3e8b5a5ff22b86065351",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1fb07220d23a99fd4122fe207749d09122b7781719da301a6f43d5bb9f14ca7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:821d92639d372d0a91b18587c5b9c698ab93aa47260f100531ee57cf2d0eb13c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe44f2c8c66aa23acee69b313fae5e001b28d139319677ea4aa6a4d3dc2f134d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48ff03b4055e7d41b519fb552410334f9702a955981b06ef9bedfb7ddcf8181b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdc0d4aeb8f58c2ff8afdd4e4716145c0f6dcf1d71ccc44e3e0c4986e0054913",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07041e5bfeb6f98229333d7a77210942f67a5e6bc82bec5af0f7a51d401a68be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad059e8b67b65d9a0c87f6dab6c27e710c1e232b880475538d7f300cf763855e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5c2231369227e12b0c9e380a8ea0b6459a34eb73469b8e424a7467d11bc125c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33445abbe9ea176b4a1f40a3ad3bdc7aa3efb8398a627cbdc25dacaf5f95a74f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df039113134ebe1450875b29e86003ba6d70fd29ad154d861c7df212e821007c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85a45ca1842eef2537163421043df629daf951705453a8a6ce4c6b4d80c45a31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5319b25ee50ebf4c3e1f0e20a627110459179858455dfe4e5ea9ef98ac3a0f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35d5d6f894585c851435e1eba94c6fc5e9c7cea6eb689f40b560b98d2542ae20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:640116bfdde14e93341912ea1624c7a54944ed5335f79669c8da3c865ef4f900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd1cffeb7fd0ce84ee0223c0fb1325505d96803a781c399181ee8f86a0bac8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fa19567790fa568c37734961a36d3055308b0b640e67f58a5a25c0dd4c8e791",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84d0d30b0bc33e35a1ba0d0b8d7421b7b66242d8a7dee7c0728633201eb8a441",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:659e775e54fc94630a050d8ad717ab4bf60ec1ce5771936233b01764456d8573",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d678daeae88dedc53e06a79694ac5917341c30f2500e5e09928d0ed74c08a59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0dc74a66395954759fab10903160f3643a43d6b26497c68c36588726e2a83e5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53c7deb95ab9e9672f896a86ac4264d45a5ae6618f8aaa121d29acbca4aec9cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a38680aa5eb19d5f694ba4a6c15ba55a2439c29d2003ff7586f2268cb01f14a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f186cac7f4199f6927059b8adb3122c6c15e4f5ab92929aa25456164912c9ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23a74944220bbfc19d5d26ed1ecc24f6f0f3871a33c71569a15aa8d17101885b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9618eabe91acefaa7406a01e8ea2033cf3cf5111ab9e1738b80212b6375d78c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65f0e543799ac1d7b993d4eb44e76e0562f180d0cd108d0bab6574240fca6ea9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3f83992a7dd875f0ab4cdc421e2f96f36ebcdd06077dcf3c685b349fa25a553",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2396e128877a15edb4d75caa013a3bedd1bdc4f923aee8a967c687a702d72892",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:329683a63e8ac4bbc810e06338f0257db0b231f90eb86b19e864d4036b3a7ae3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ce087df2a91fd49e8e796e215d04125eaae9a334d3c55fead4f4eac7142a91e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f04577c4ac4fa114df989e3ff36c69d10cb2e4fdbf75691ac1498c770bc28a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a09e3668ccadb40503e28e2efd8ed3d0dec2946fc551856b25c845d8c6d08794",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbe6fe8f74c609ee672cfb35b75497ace1cdf17501a41f205bef49a806097e67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a685678a81eadc35331a74023672a94d7e8a71ebb15aa19ee3e0c2b79d4c625e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2abcc292c06a17a25e60f0e8151c66943da7559c357e025f6acf0ece1cc1fea9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59035fd7df5f840f60fb189f96c5d12c2f0be34db6d91ba768358f797263d210",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9b3c5a71bd562a3c71f6510b8562ae093a683db22448f03fdf91814123dedf8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6871fd28de18a80a42d8b5a1088210c32e9dbff12c5395d25c76cf8b4e65612",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:044b32d2bb74e2ad1bde221b87c476c83c8274fbf6f30e928c7ef721f59c518a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc2566ef3de1b9983323341861fc4658422161e167eb29419deb2f438dd907e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76382f66152a11217bfc5fa63aa8cc51ee0444bddab95f4810694eb83af21518",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f7e876d7352b9857ca1421b5503d329f4198d287c2cb21d45e77e639f77ccd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f658f37cc911a0ed122c445ee07555c27d8f98ddf30424bdaa528cdf0cfe166",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a73dbf0bb7b043b8469fab0128420673cab87911f9af0befbb12c32123f0374f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d63275a7fba7a2bf7a30df0e4a32f9955eb932bd32d80ccdf70b0ca45f138b90",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89fdf49c17b8e2ddc9b8860ccd6ffddda6656589faa7adf9b0bd701ee89b0e04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b21c89fe2abd9e577631d2541cd7cfb1af5e11e9493c90b354dc772bef35aa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b81eff17b72f9d25482a25eee089dea76ee1c2f853deae9b65e0fcad01bb8b66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90c932fe01f11a1ac5bfeb956aa4bf45570101e0b899e00c9a452e2c5666bea4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f35d38bf1a573e6dec25fab79a39f29dce274b3e617f5628999a3a6ff0bea009",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56ec328ba2bc798113071cb36196e69fff2e5bc3abb48be4cf263bfa101c827c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffa79d41f91cf48696bb9845b87eb8888efad8e52d914087d94de139363012a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5f8a73efcea92b3d5df1e23cbbbf19dc32382bc367632850c3bdb717566beb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:368d069f5630080a91013f51d3a4ecff6dbd4ffe29f667f6b73cfef681780190",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8b26543b81a634855287185000dcefe6c0e09f35bd77347e8215969aeda5959",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09f8de1e0c90ea397c7677df9e550a1296668a3e018bd58eb1f704b77d7e815c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a5c9e303d5586812b4bd3ca7bc1b1af1e1fe80a1764dabd84409468c1acacd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7bfc2e27dc453726495f11d21f2f4e79716be924d744a92d0a4e4fcb96acca8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8753e26208dc659797cafc163c8fa06c3924d2dc9fdf6ccee94647ff4edde735",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3b7939b663a7c169c436d40adcbf78b20386928ffb620e951703ef5e20b3ed8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80947c794b006db9f11bc4b5eade078fb29fcd0f4c44819683b232936fa830bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dff1f45a48b30cbe5b38a98dc4eb38da373f1248dc35f2256d245eb1fa9cfaa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cae55e7380b67c572cd4f793412c604707f77b2ae5e1bbb77133b17f35ab5e92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f811cc8fc811d631471eb6adabcc1014ea329258cf37c2a5f7b936830e3b2e57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c568a007b9dae0d471d6badf723161e565f921c2b1eb04e19aee5fbf7dc6e61b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f54c232b4713ac362a343800003ff7deff1c5e7c75710235b9cab5df55ef94a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c508a709e816951b3650e600925e691f180f25f92b68f2b0433ef3d787137f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff3cb745172d9bd639d22e13dc66e94b2df4dae847cbc55d63ae6a6c1b69bf49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6835ca1b00813eff887ef180d9a41f561f9f096a39a6446e5b25dc9da283f8e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40ee09498cf64c1474ab90c473c9f363bf51611b18d2a929bb57cb8b6be505f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:315ad79fbc53c6098168be87264263dd332e9b8df9fbc29a64b6fc44da182344",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7177fc17d2c1a947b971d5cc8528e477a19cca68000c30552f14f0a8e96b4ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81982f4c377e24e62cc250654706f2236d8c714d3381c48704ba5ea5ebf2a139",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca40dd03fc1eb93703ea43d9a96a70ad87792e1d675f7a9a762be71d8908c33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e915e3507eb1e877251ac175df26c3be8022b31daedc39fcfa2e05c1ef190911",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:310078572de43cf8be4ae7dd9041028fcdf4b4cba315ed3c97a53cf2049d6793",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0749ca93d398834c7e4f2c252100b1fc104a2f4461640ebe18928f2315ee0013",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ae21d35720ece7b6a01da963444603844d323a7d498b7bbcab2aa26aed1117a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a9ff34d2b8abc163eff8534a8798e95e077d77936838930240b6da876cf4c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29f0368744406e96a46faa1601aab4aa62107e232cb19ca72bca5116249acc1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2670a90b97a51893703b9617dc0368b4ec2aee9136f6351b3d06841dff284947",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1e11cf874a9ce02555a090a5bb783562854fbd037216e4c23cfbd1fa7f11ce0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f759215cd4075a109ac771993890b0e42dbdeacd14ffdbd8c81dce12e39dafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2c4f6d1944d3eee2fe5bbd79c89865cc89bde742fdb9538093048cc95ca6d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc7f1b56cadb7d7c1f4b1dba4bca9a87b22071d592f1e06e25d0be7106dd418f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36e6835f02c897ea7d1929163cf0dba9317a9fe38637bfa349ecd291ba4b36ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96f465090b634df32e8d5c1e95e915b82da5537f38c46f9eec88484b719786c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ccbd03bfb04069ba7c0400dd1b6ccd54a8dd83b5cd8881d0c75ed7d8468da1f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cc37b098b36f89cdf93fc6eaf16bd650ab0b5e7040e789b567c42a934c5f03f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ffc6ebe5127bbc38080006a4fdeace052e8ca2765f41a8dd1190eee720b904d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40ea98773d45bd6bd6a1e756afd183711ba5b4d4c1e56777551e9af16c4979b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5fa3bc538b9b2cd12fc597400a656a60772c2874637d4932ae8db60082291d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:decf31a52963be8f8735646a1b51a5e574a2123486ec6813f5ba6e728f5b00c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe3273344f14113724d991eadf8ccfbc945ce7be74c80bfe667d33c0741f5eb3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:430204db219fd88d828a7b1e4ab0f716034128d10226266aa2ec3517ff48c0da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a7e6b04e4e03810cb47b3a028c089de84917b63c03bd8f1bc82322afa59c78f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb62b4c7c08929750ed58268b2552105c360e8c0e8adfc4e1a53bb398e69333c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa71f4f1c3cc79edc9343ea0fcf558bdfed408a094ddda0bbc7582a0c647fc7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30d5904ee6c1e49e2b78fd85c35202658945614fbd4f14b8e12dba342abaaf46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6902ed20a768a81df117a0ceeb0b0494c17966ebec2a2a4fbcb426aa4de60357",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0527ff7d382107084ff5a8d5a5c9c95e4f2b526fbff98dfb251c947f4003efa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1257255c6b7842e0a8901cfc767dae55e22d642b920ef8250e6ded36a2b53615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:109073906a2f705f857104e3505315c122e4faa14142ad90d0bbdabcba257bc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa38c933e194c67185d9982e700bd67f65b9c8fbe23f0146a3a96987516eb668",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:a21e3d9871e35bffbb194952de4bac40bfd2cc4481225c5da610db824d83e3d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:87e6f4a0c2348bece410abe32fd7043a92631a2125913a1027835144844037e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:652651d53baca4887a163eda001cd887b32c72a6eeb999089037353ea550de2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba72fbb32b033ac001d8a410f864e6e2e456dbcb2fba09a4849efc1205e6d0ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b763867cad65628e83ce7bad924692eb5e597bbbea3ad03167c51698f0b15239",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b489d449fd57dd801e6f57fd3f774c0b087c9bf136d5a920084af524ddca588e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2038e0d7d9f572dc7cf4316a026580021b45374e189cf155849f292558e799b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd15bba53fc3e0c82c546a080c6f5441bed7d87587195843516949e230faf66a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7347986518175c4c649d2cdab6378d55a565fdedc1cd6519fc5e8140e06f8ca4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48897ef50d1d7fceced43f3fb3a8159e4aa4eacf87d4ed2a13880a9f6dcec6bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c87edabffda243c7ca7a95e9efc1f389096f2387b493a9f2af14bd3385eaeae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbfa023e35aa0c917ca8b0f451b24af4582c769c65571e4c0d90c7dbbef92615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73793bf267725e2ebbf2fa5d32aff363a614d1cbc98624258ac8df564d158e4b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24ef51235db87f815528627f58d9b7a1720e3984ecc382ec5d5833d2852d5c60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f5b6b7d0c17fb19292cd8fbb5fd4def006eb8ad7b24d8117c1e975322d05891",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13a5171648e217e0d3b3f7021dff491e736a39b5f7162a1c2bd3779bd3bcbd17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7a61dd5759669ca441ff0023eabd9af78d1455d4931ab0a31db0107a54b3fc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6a8703569b259662eda94a475f0c652482613e1449db7bfa5a18c62f89bfe7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c09b8285b4fa856c472ff33e8220186fb35220161fcdd2b6054dc27574cf5066",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df36f338c43b86547adf17d9bfdadcad07f1ac7d6456bc416c29d3373e6287c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca5a06cd3eaa5701c9be12d3fabda97454e9a9e6aca9ffc586b9e14eb3952520",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a4d8cc770e436919ebad73a32168e2cd4da3cad8781d3cce6c9d654a5d3fe59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9828e6e75cd847a6cf4aa0d27d0f4884df5779546ff6b194a759a84e1894e85",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de090ad42c7e36fa7bb2e4408a6bab45e216c0420ae055b9ba1f96c20f804463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3124d8a892116345eab8f50b79835214599ea061cf66665397e9a1cf0f05ba5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:313910bb3c90cc31b7c82212fa71121c54b311f1d9af4eb78e50c7d39446ac86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:651e597e44eb44b6ebcd6d1c834a71d76cb2826c03328e42b0da4d2fc1c4c9e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:608b7df709cddea3a9733e93502f1f1c052d3cd6044f2b00af6116b4cedd10bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9cf98847c92321215a42aa1061e143f35d10ac3e738943ce0ce00dafe1df9471",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04296a5d261f241802a92a70c9b000d98e11c0389d689af0bd19bb55abf75bbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6a4f4f771635485035a2f16b8a152f29aff11dc1f975e78557c7241f0c6722c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:962c21812673023f39908e6872018f254fea94c46312a1d50a5efb0a553ffa25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786cec3721ba9907a4c69620cee6bc3952de8f27dec33f57d9939619b8514f87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d2bf7377a0181175b289acae55b3afad0dfb850ad9f65695818ec80481abccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e204891e00573ee6e4d11ff11f373d345f1694ca657af48d2d3aabf7767ef7ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7191d8248bdd79d99bd96734ccdff48f8396cb8ed2d6e3685e1b26e08574c40d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8dd6e8a9176e9902effd883bf722f9e66cc931df831bd0ac070faf6c51ea9531",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38e6676864f276c4364b6324b787b6e19ad4d160107e9867a57fbbf84530a7ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b25ce7686cc5c1cf3d59e8a9ac89156e9f4bb846de8a6fb44ad33c1a19179067",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15a878661b48b5b4613601eacfc195b812e069a839324dd7d963c7a43d03f1eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83dd30b8a1e0122006e6c7c0d37a96d35084141070e16e32f19da807793a4635",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:015477e0760f1cc1f080ca43716bcf05c9e40ff7394c26f25e5a4e5512f4074a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34eaff2e19c7ecf3be38670103a4ca8655c5670f42a3c32d4d1fd13de76be842",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdecabcb7a7e24b2c2d52220d2e958b42466e868416553a079a7f01c0d5ff0fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:433b6f621d595b607c4a9f73201e4be9b2a54535191b214b5905278e064c32cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19a1bf0b6a02842ec4d86d9a26a0fafb3864b8a18a05eec266d52bb58f3d1feb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b11aea62a9e6e4295e33c6856c1a32b8f50af5ae98750836d1f97163a8a17bdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df7f7e1774a64e458e4836972fc09673080e56490ec11b08327cb6137f1b9bd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4cfae4f2e8ebb6772c7c5d6ca6212f776c36e5da5c47bb0ef51f444e4a68d3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3baa568b572643be26056e5f5bebdbb061d726c635c78fc2a8970335c724064",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6dc8ec1d8f370cfb509220b23a418938f44280f4d7d4a92458a78a5980281062",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:503b9b7f3b947c4d1a50dfe8dac8064b726a09beade31f116c0e3fd5df5ad78a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89ef8e879fd7ae5dd9e54405accaf1b558bb98edb423eaf27cd44a45c7c443bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f295d316d8aaa426972fd9fff029497b28f9a7572da5faf7e1b121fc0868bd23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39b66e5e65abdb4c25ea38a0c70083fbe94a77907388fd521bfcc799494a8d98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2be19d631bc2c3399af9c4a02a73c882cfc79a0296e3101304f5f41bdd5587a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2af1c9ecfcad5bba54169861492eaa97ed3ecd54c295abdc373c226e7879158a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d7d9e4cc7520cba86f679322b635238761b4a8ffb443cb3b2e8228d88a5bdaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a4df46e9482e6dd68f6ff70603e36aaf846d4767ecb69b034900813566f705d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ccaefa2ac125fc90c752808872eef3f72d0e159e4497a58a2b65ce0ca863ca0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bad9043c625b8d266cf0c817453af694b04d41e204270ce91b02013320e6a66d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0654cefcc22d52fcdbf7b3d0a7077babb6491a7d812a7c6caa68652da617672f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6c2d07340d47de477613c6c3ef2f643f26b00d6b47dea2fa6078a076268004d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b4d3978ec7272aedd39b654ca1e360d1d433da76cafc74e5cc0a4271b4f63dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7b74094a5e268849ad2d86fbeb78b67b52c8aed96a88c855ac8fc7a274a569",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12f94a958b034ff0c24f4ccfb2d5f13d42f47702bf61e151fb488323bbe2dd5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6bcc3e1b3b6515466f3f771069003d1a7c28be3adaeecf7afa6318ad0f679fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b5692cf64e00e2aca0b3a13ba133bce77c630c4ee79d34d4d1ca7b585d6fa3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ed3d542c929b09db89bbf79e90929c2069c2bcef6fbf58fea8076d2a69ae9c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6be0a645980cad59105282dfced45f7b3972525fa0a3fd8939c8057ad0e698d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b162d37fea25914e42e63e6483127b4ac8889e5587f461989e6be6769e5f694",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1520d5466cbb6f853828e3d8454a0a2a255247a2eb08315b35f5e8e147e6504d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7577f8eaa1171a15629ec06c438266b6ce586b59fdf65f8bce8f449a16faea7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9eec50a5268e65f02c40bd2fad7849deb6c895b835094d8f4c996824e3fa923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00054d4310ddebcfd966ebcbd42c072bfb69d0709f6165e2c0bc0ee1337efba2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cfd593ae556df6f8e3ace44379261ab2d44044a2ab25c2fd4a4323b73cd17d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae88ef5dda0d2d000080a445ad51747a55df4fa94594fc11b1636639768e87be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6605dc2f943b0b947a19c97fae4bca7608b59f1483c97882686c7ca05c4af7ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd568ab6d1fcc43bf18bc353cbea23fe884c52f54079ee6ad5dfbc921cb72106",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb820f40785631e37e1a023f8494c75feb743e4a172a503ff3feccad1d24f391",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0107618d15c26f2cd52d1c52825e02bb2fdead1fd6449bd670427f5cf880757a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98204d9f002323eb100429184488ca9130659290c4446c974a9346a6e93df889",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2a8f241adc3298633c436f1ca4433a7cd7e9bbcf019865dab9d7e1c1c1094da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07c102c24aaa0e06cccf2968b5da223961571b1a22931834db21295711f94de1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a8c9a2d2b341f6aea2cac2dae0d1cdd01266fbd7cbbf4bc9a044039944f380",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:92b25b91d7e69e1c9ee6dff32948d244776a1ff75cd2eee87c3665cb427a33b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22672c886e6d1f1b49f962ff7258c12ac43b4b65cf60aa44651982ba36b0c973",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c4743682019a693624ede5af59d0eb4b112c3c493f91f0c59ffa7d3e171b301",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0475dd0163729558a14e371351daec7d7bf5fa5fc70436f47c00d0acee7ead8a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12b45030df4dad11f26ed6e6d0c1c749941fcf96dffd72bbd4c122293f85994b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d24979d1cf80f3906eab72efcac23bbbea35ef6eb10475631b5ffc32370621e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d5f46eddc547cddf4a2d33b952322d7cca7d32cb44891490f9de31c75b12652",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e2717a19a4f68657b5b82fccfc85e9bbb6dc3a29d87496b9f96edd3023c029f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1e2e146ad4254ab7bad7ea61acbc7318a9a3bcd254f8c5d06f15a2fa97c5c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:114871e86a9e186ae8ff94ea02235f4d1eb98f7ef22a6945435beb0044f35d7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08fe4ae654a7c12bf80888ad0f52dc8d28ad7cd79c74c2466fcc98ef9b229908",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b817b5ef5565a9190d29d77513dfbae65222fb156f80c4f64a03a12f0b8df52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a77017d08f6b0be4bcf52fbb6b471465a7cf6c6361195167b07e81feaacdb10b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27c7f18e0360f10badc8bd3156fcf255dcfd0500ac86c7793a5edfef02a3647c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7520ccf6e89c32dabf2d57bfaeef54a560bd751c521a045baeb93572489f062b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abfd9ef518fca89f4db8d12165229e5abb5155e187af197617f690512e3af302",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a452e760f5b524cd86b3c2f252816d07bb62e1d59fdda8883148dfd6bbfcb973",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c208a19538792b5664edf16eb9e1fa4e41a362a07879ef452f103eed5e3d9447",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe92321ab2497d6cc37cede52b83fbea4b2ffb16650e88e33bee2d2371bf37cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaae6a0af3ac091fc1a5a85f2a0747f4b0f915eada8396cc02229a28b9cf010a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cfd596aafe85ab76ba6cade515c90be03a63652a09521bd12bf2402cc18e755",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8429326af23a76cb51e2944b846a141b9d3d121a3cc455b4a83e319bd2a1d6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aec24794b31ece49a4cc72a2e038cbf4f58cbe5606a28bf40d231b53e0832542",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d48d0bcb1de7ca243014616e40871ae85fd905923636d46917467f947deef1c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e59f2bf60be15a82c13bf6532a12b19ea2951c6b81f0f07dd110bd9747175c84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36cbb69f70b77ab95176533a4b35ee1cc44755804d958038524222d50edb9238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b850dec7cc93073fd5c1dd6a86fcd4c300d046acb29c81d0cf1c0324a84a13ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:686fab2c75a3ecdc1573396c9dd97e7cdfc86da250bb0c01345ae0f0bb3831e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f45f46be9bfa2ed73829988839fd2ceca36600e3597605205841255b4556371c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b312bd8a2bc1234dd63a701f35bc65bf4fcd8ec290a45debf3515b7f38e95d66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee8965bd1645c1bd864b673ef0e2f869b4a7fce877abb2d4bb515c76d568cf82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75b30fb7fe0a3e842a62dce2a34eb5d3ff740bc8e55cb9cb8e1b479d13fe9121",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73d3c84d2bd0f897c46f04fd4d3e816b0a77c5e1a5cb3e8b5a5ff22b86065351",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1fb07220d23a99fd4122fe207749d09122b7781719da301a6f43d5bb9f14ca7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:821d92639d372d0a91b18587c5b9c698ab93aa47260f100531ee57cf2d0eb13c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe44f2c8c66aa23acee69b313fae5e001b28d139319677ea4aa6a4d3dc2f134d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48ff03b4055e7d41b519fb552410334f9702a955981b06ef9bedfb7ddcf8181b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4623dd1d17576dc75dc5e017429ddad453ae03b424c27b1f119628fa8f7b2c05",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdc0d4aeb8f58c2ff8afdd4e4716145c0f6dcf1d71ccc44e3e0c4986e0054913",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07041e5bfeb6f98229333d7a77210942f67a5e6bc82bec5af0f7a51d401a68be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad059e8b67b65d9a0c87f6dab6c27e710c1e232b880475538d7f300cf763855e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2cef5121f03115ec8c49b55f61ed2a990861b9cde76f89645df461e34478c1f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:44ee380afc6f438f608704b108853ff0d501b700c4a8196fa16a824ac31e777d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83d32dc63c203187bce8ff7534440260235d51e0e9f1b0101d3f01c8adf59a20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5c2231369227e12b0c9e380a8ea0b6459a34eb73469b8e424a7467d11bc125c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33445abbe9ea176b4a1f40a3ad3bdc7aa3efb8398a627cbdc25dacaf5f95a74f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8cf395ef797a9aac4df6b7a02ce18a0032c76092bc9c4afa1471540c263e79ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df039113134ebe1450875b29e86003ba6d70fd29ad154d861c7df212e821007c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58a931d2c06f53b60f7ec8f8f02e475582b763985a41c74d81a62fc28d98e862",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5113ea9d9576c9c8a7a47a815be9477cec5bdedecb717f4ce778d6fce2f89271",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d65784b3cf614b9393ebe68e270b1b2e689dc258daaabaf173ec4934796899bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9585589b8e7587ceb1ae2dfa8f2ef019ee27d4a3f73cfc382edf099934b3e26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:449392dec0fc36be3820157dc7c90a1ea110644ed580483bf6fbf97667cc4dd8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e6b74f7398bf2d4b7aa9bbdcd098c128ed93a961b8c1de18c84f641f3edee1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be3ef20dae96e3eab2f93cb740ede2268ea3cb3f28719666040ba4394c1aa56d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8bdab2683f713bfec8afa396ce5bfd4e6ec9e87adcb5bbd01ca343626c97c726",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85a45ca1842eef2537163421043df629daf951705453a8a6ce4c6b4d80c45a31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5319b25ee50ebf4c3e1f0e20a627110459179858455dfe4e5ea9ef98ac3a0f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f11d4ef320502bcd0fe26ccbe1850a8969bf04cd28f04efe5b9e913054841fa8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35d5d6f894585c851435e1eba94c6fc5e9c7cea6eb689f40b560b98d2542ae20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:640116bfdde14e93341912ea1624c7a54944ed5335f79669c8da3c865ef4f900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:331103386328c4cf8d8620885a847703b5844b568ed842383d4ec454ab8e1846",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd1cffeb7fd0ce84ee0223c0fb1325505d96803a781c399181ee8f86a0bac8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:add4f6ec969242fe36a7c88306688551123f93fcc74864671956683aa1d86339",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fa19567790fa568c37734961a36d3055308b0b640e67f58a5a25c0dd4c8e791",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4ca03301fe8f6074211c3be890a2ff44d14c8d067c469f92b111d7d841da3fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84d0d30b0bc33e35a1ba0d0b8d7421b7b66242d8a7dee7c0728633201eb8a441",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:659e775e54fc94630a050d8ad717ab4bf60ec1ce5771936233b01764456d8573",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72859b9721f0c6e7d2a2fdb5c2e928eec80becbf1761dd723c8ee912dd5e4de9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3794a7c4841e78c4fbd6003a9fae15ea6912cfcb9ba582684e9e606bcf60dd6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d678daeae88dedc53e06a79694ac5917341c30f2500e5e09928d0ed74c08a59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ce21c95f1561f61e01d074200a4f1d5ac96c95e00e2ccecfe12d360a18d804d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0dc74a66395954759fab10903160f3643a43d6b26497c68c36588726e2a83e5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53c7deb95ab9e9672f896a86ac4264d45a5ae6618f8aaa121d29acbca4aec9cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a38680aa5eb19d5f694ba4a6c15ba55a2439c29d2003ff7586f2268cb01f14a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f186cac7f4199f6927059b8adb3122c6c15e4f5ab92929aa25456164912c9ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b6339453924f503b9d3cb4dde921f7b705528e2cb7f562243444121e7dbf19b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d42939c39dc1e978f4fa9530f3253d521cace197a18dc566454b0143c48bb0d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a317432b034404123e89b883bef600c1771247fe09f463fc1b39313bfc2e80bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23a74944220bbfc19d5d26ed1ecc24f6f0f3871a33c71569a15aa8d17101885b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1eeea74b3fe8500ee50fb3ad828ee4b980d41f568ad31c441df42b2daeff71c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9618eabe91acefaa7406a01e8ea2033cf3cf5111ab9e1738b80212b6375d78c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3dc4c94526a92526b1af09a991f588ec4b4143aeadc79866fbd7e1dd021107f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5bdb1c4df2bf524e5800bb8f530181e31842bff8976a14d7c77360352a646f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89a5adf72e69d09062679b566dfb59b93d67d53944b395e4379b4e4d31ff9f0e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7afa5da1ec37dad4230b57f2df4d6c07f404b31248fcd171d330d2f8b7ad148c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65f0e543799ac1d7b993d4eb44e76e0562f180d0cd108d0bab6574240fca6ea9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3db76609448c443df02b8277429507b64f3ac814616778b80a7c5a2a0409cf96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8129f094fe65cead350dabb4078b7c5f108a8108b24be0cb28f5d4ef874748f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3f83992a7dd875f0ab4cdc421e2f96f36ebcdd06077dcf3c685b349fa25a553",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2396e128877a15edb4d75caa013a3bedd1bdc4f923aee8a967c687a702d72892",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:228736bb7c085e000a1c3b104bf5fb38ae2f60be99fe6a62ee67b44e9e571629",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c156e8db644666cd02c17335383f1e33513f71ad05aa279fb47d7746b8ea595",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea6f9c67d170d681d049b1eddafed05dbdb3915160c2b9e7a914863b9f512948",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9b91a1c6f4e194acd077ece95b995b3c0987734d75dfc3a0f2abdcdeedf1be1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc386271543d38280f8c4a28d701b292c8f5722c969e2a46e4fdc8b6f840be62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bb473c20d69060ea166d4e111ac457230d35e8e5a440ed1fae3db4b6da5dc4b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:329683a63e8ac4bbc810e06338f0257db0b231f90eb86b19e864d4036b3a7ae3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9de5d871550544523eb64203df597c0eb2e3b4d4471d0f118eaeadae72055fc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:051a659d539bcbbeb00f6c4f76a927fcf2939cc351302ccec6960d4d92305ea9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d044d167ba9209a4dfe0314501e0f0cc1a589b45a40a65775bf7e433e71cbae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:378bd2a9d051665b960728fd8a562c5b776ede0f8cc4821b5ceb92b470153503",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ce087df2a91fd49e8e796e215d04125eaae9a334d3c55fead4f4eac7142a91e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ade9a1cbf3063e2284c79fb80282dbb176de4578e9de53f96e45bef1a50a6c19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f04577c4ac4fa114df989e3ff36c69d10cb2e4fdbf75691ac1498c770bc28a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b694b01bb2873bcc3585bb65ace24e92948af31e1f1f2a8211dabbea1424188",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1db6355fdeda942720b166dec938b0e7a081cb87de80e72f23d30f5896f3bc97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:875e1ad123d2c83aea326805a53f4140296c2a6afad6c45882e1cae2c8d7ca8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a09e3668ccadb40503e28e2efd8ed3d0dec2946fc551856b25c845d8c6d08794",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbe6fe8f74c609ee672cfb35b75497ace1cdf17501a41f205bef49a806097e67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc3310c7d92abc3e42e89af3afd7b9b050000878db63cf08167d331bf4cc3b76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60cdfaff2b8bd8de04414164dcdbb106e2fdb6846f2b6cb2540bf51eb9a80510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dcc4bd4d5fb72f38b7c23f32047cb820ec2dc2242f08ec69619e62582b909f73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19ba66f8a1b897f620e4bfd5d66bd7e190460f5bc68288d4fda15f9a23063363",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17f2d670442cfb22138f3eaf331e045c2b0526d0d9ec4c68f3b215db15168cd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a685678a81eadc35331a74023672a94d7e8a71ebb15aa19ee3e0c2b79d4c625e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01b4d4c566896c87ea8736a1a0406eb3480e5e9dec581a49c973ea30774cff52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2abcc292c06a17a25e60f0e8151c66943da7559c357e025f6acf0ece1cc1fea9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59035fd7df5f840f60fb189f96c5d12c2f0be34db6d91ba768358f797263d210",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9b3c5a71bd562a3c71f6510b8562ae093a683db22448f03fdf91814123dedf8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6871fd28de18a80a42d8b5a1088210c32e9dbff12c5395d25c76cf8b4e65612",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:044b32d2bb74e2ad1bde221b87c476c83c8274fbf6f30e928c7ef721f59c518a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc2566ef3de1b9983323341861fc4658422161e167eb29419deb2f438dd907e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec60544d1423d5ea064e6edbd7beb3cf98e78fe5de2980cc9200428aa3452516",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76382f66152a11217bfc5fa63aa8cc51ee0444bddab95f4810694eb83af21518",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f7e876d7352b9857ca1421b5503d329f4198d287c2cb21d45e77e639f77ccd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f658f37cc911a0ed122c445ee07555c27d8f98ddf30424bdaa528cdf0cfe166",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb1ace6f27ff1c53520c2004f93389bae355517ff3b0db39d88d26fee2dedc03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3c1e63f22367cf75cc0ddb8555ac07ed638d17e89a774cdd8feb65d00c7fc9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bc9eb309534f402f392c562fab856e209ce615228cc8c2d8f3b25384cd0542b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:665af0acb1360c5efc0ff4e7c5d5b4864bbf77ee94bdc0cb78ba85088de13d45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a73dbf0bb7b043b8469fab0128420673cab87911f9af0befbb12c32123f0374f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbdaa37cc9bf25cabe9cb48e86720efe609bbc2d6244c115d601d932bac0edd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d63275a7fba7a2bf7a30df0e4a32f9955eb932bd32d80ccdf70b0ca45f138b90",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd85247a2b661c62ae903219fa25cff5f583fc2c6b193e02d201dae26f1ce84d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c6c0d8654f12e0f6b2fbb06d8ef55081e97f530a48562d4c844127d1fcf6b7c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89fdf49c17b8e2ddc9b8860ccd6ffddda6656589faa7adf9b0bd701ee89b0e04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3ebf0ae35c1fc16342a8778cc9212b5254c9ee5162cf439dfe66eedfda5c39a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b21c89fe2abd9e577631d2541cd7cfb1af5e11e9493c90b354dc772bef35aa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf2e33036db5d364e097118c03b577f7296786cee248f1ff76a4228db48227c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ecb612b9f4babce896a84ec90ef21ea7dd1ad6f3320d2c54fc1bb2eac4170e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b81eff17b72f9d25482a25eee089dea76ee1c2f853deae9b65e0fcad01bb8b66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90c932fe01f11a1ac5bfeb956aa4bf45570101e0b899e00c9a452e2c5666bea4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f35d38bf1a573e6dec25fab79a39f29dce274b3e617f5628999a3a6ff0bea009",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56ec328ba2bc798113071cb36196e69fff2e5bc3abb48be4cf263bfa101c827c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffa79d41f91cf48696bb9845b87eb8888efad8e52d914087d94de139363012a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8ee4c26b98c6d2c1cbd59aa001871b1e8387e71983c5935ed680767678fd263",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a2b564a7855fd993a70efa5e5b2e8fdc1c5ae8635ab8314eb3a2df544764d60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5f8a73efcea92b3d5df1e23cbbbf19dc32382bc367632850c3bdb717566beb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7011f454ba6e5d9f934fb2ad7c47e5c13e56ce7e9e1ac67f0c81cbca943b2792",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9cecd9c301c808e795c6d33b1440bbd552e71ad20a2bd3e523cdd8459210e62a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dccb33ffe4778bee0967443755e55e7ae96fdda9e827bc61ea6287d11bda1a19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:368d069f5630080a91013f51d3a4ecff6dbd4ffe29f667f6b73cfef681780190",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8b26543b81a634855287185000dcefe6c0e09f35bd77347e8215969aeda5959",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0288a3b93e62a46e4f86ad136efffcbb40ca8ed299aca0e719dadd3630b84b6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03ff91894dcba5710060a913dee3387294d5d918b4d92dab96205afd50459ae0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09f8de1e0c90ea397c7677df9e550a1296668a3e018bd58eb1f704b77d7e815c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a5c9e303d5586812b4bd3ca7bc1b1af1e1fe80a1764dabd84409468c1acacd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6164c42552319cacc4226dbb680be091ac0e0853a91b63c496822daff175b68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7bfc2e27dc453726495f11d21f2f4e79716be924d744a92d0a4e4fcb96acca8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8753e26208dc659797cafc163c8fa06c3924d2dc9fdf6ccee94647ff4edde735",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c55024a1b2106ffdf399590f6ed7ea33f5ae534b601d7eb726a02ac02b687bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60040f8563239848aabd3a655c2bc185a7d7f47dcf59228353a6713eec036269",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2fb53692b291acfb5641ac4128fbf5f34703f04dede9c51994fc247d13739c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3b7939b663a7c169c436d40adcbf78b20386928ffb620e951703ef5e20b3ed8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a17d3ec2925c94030cf456e706bc96b7f4cccfc4119d5b1f5a89aa302da12ea5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cef75ed0e5383138263d81e2cf31d65c1bfb2416f3fa33d91dd56f772a1aa8fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6c268d36a199f6173e6ecc5cdbbc38b0e203d034ecb91ab09cb87d2107f0534",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02c8b71d500f26cf0c1ed100be369307fb8872cec16ccbb413199b7ee6c26f43",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b0701e9c84e575d8902a3a9b67e036fffe8c06620bc26eba52c6a9810edde7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f406e777df209456ce8ddf6a1e091ed20f46d536869345997d692c5aca9b575",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eee8b86ba5a4df490b10f313eff21514290074ba7e7582ae9782a2cac7ed73ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3eb44c8a2d21d2de989c939cf6f25c881d2ddba8c25c81aca4b78f6a0fcbcaa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:078b851568a516e84458ad0631655de6f8e136de0ccd35330b3bc02599887d58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff128f537a012f30dfec9fec00d38f9f50268198a124783e2c2c1dbc54a79873",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89013dbf6d1eda9b50402fbe4691d2d911d7f9a1cf69657cd88e9a3232fa0ab5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03e753dd69715f7b1b4bb994eb3d9a0c9b26fa611603492f6b5554999f8e2114",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73e74e9775bebc30a03b4407bb2b20061c09ee6b354ccac53dfed96205fc092a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff017b16ca598f61547ca1f70a677c8e8bc87794b646686acdd55a70ac12cc48",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:282462c376b6ee60c41d6d3d92369cc99c478bdb88d5b0683acd7188743ac323",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80947c794b006db9f11bc4b5eade078fb29fcd0f4c44819683b232936fa830bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11f41a9c33efe9791f6fb47b8fab84c3dcaffa5bbb9811d96cceed1e03d42470",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c05e5fa84c9bc32032d400b31adc4e6e291ff18029f44d436c3c4c115c5d70af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc4c3c8d3d86e86b9666d819723fa9d0b1bae74a5c517ddb80e57589a57ea690",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dff1f45a48b30cbe5b38a98dc4eb38da373f1248dc35f2256d245eb1fa9cfaa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cae55e7380b67c572cd4f793412c604707f77b2ae5e1bbb77133b17f35ab5e92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f811cc8fc811d631471eb6adabcc1014ea329258cf37c2a5f7b936830e3b2e57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c568a007b9dae0d471d6badf723161e565f921c2b1eb04e19aee5fbf7dc6e61b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f54c232b4713ac362a343800003ff7deff1c5e7c75710235b9cab5df55ef94a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c508a709e816951b3650e600925e691f180f25f92b68f2b0433ef3d787137f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff3cb745172d9bd639d22e13dc66e94b2df4dae847cbc55d63ae6a6c1b69bf49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:818131ccd1235feeeb708903406eba00731ab0028b2272004b06235c75a121b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9e3aa8ab64ac34d90ce78c5911d91d7574de4c42bacd5ae9563b6d945147bf9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6835ca1b00813eff887ef180d9a41f561f9f096a39a6446e5b25dc9da283f8e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11c6ef78372b52968cdea9fd2062bec3fd0cdd77209d5bff8c58da2dbb3f61ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25930a2fdaa748fc28850dc1afd3e02a497b0e4aac518d36be8c80a9fee91a24",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6ccad2fb8b08b10aff2cd6c5bee0d3bbaf839d28872090a616972f1161f1adbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40ee09498cf64c1474ab90c473c9f363bf51611b18d2a929bb57cb8b6be505f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:315097bc4f6f543ef241fe82935e9e89ea9e3e35fdea84a9eeee6dcea75aad70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:576353a8452a5283209f9e63fbb70a3743369580156ddb57f726b00c460b58d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad7e1f3c7eac701c59cdc1251d90c68338d4c4770f7fc1ded5f82286e5ce6da0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4212481acdda13660bb660a7169e44d46c9a8ec95c4f545fad6813553f13a9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:315ad79fbc53c6098168be87264263dd332e9b8df9fbc29a64b6fc44da182344",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:283b9a24381d643403c7957c5df4cb389890564082f1f16f9696ca8b35322930",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d101e3624bb04eee8fedae8425964f6276d2b50badb75b6885ac255ad2101ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1a639fc3080b7266b470b39ddb038e711b1c758e522b5cda2618fa3cc22c433",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7177fc17d2c1a947b971d5cc8528e477a19cca68000c30552f14f0a8e96b4ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81982f4c377e24e62cc250654706f2236d8c714d3381c48704ba5ea5ebf2a139",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:16a2f7b9a34ce32540c6e8a4ab87b68d5cbdc3ae75beae42fc8b83b41711fc8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6a0316b7b4713c22e093abc05a5bf01541c77ed24578fe1f57fe437a4208a25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca40dd03fc1eb93703ea43d9a96a70ad87792e1d675f7a9a762be71d8908c33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e915e3507eb1e877251ac175df26c3be8022b31daedc39fcfa2e05c1ef190911",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:310078572de43cf8be4ae7dd9041028fcdf4b4cba315ed3c97a53cf2049d6793",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0749ca93d398834c7e4f2c252100b1fc104a2f4461640ebe18928f2315ee0013",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9572a1494fa167b5073b7a8633eb278b40d85d9d57426e2fec190cef713551b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a13de4ba06fb2dd33107779691c4d4e04b44af5d6cb8c24ec7ff37c5ad267eb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea22a10ee200ce742b5eb4924e78edbcfb16848853ba4944129a2fe8758e5fb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9c6ccb93cbf9b7a962b10432d64d88f0a91fe856ab104eb04adc31d75dff2f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d59c2e3c373b76eeecff57b35f8839c4b4c9c0eb877de739f582d56ac38a00b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:978de409a64943493b270e96c146b501414df01a880ce29306ef3b48d6346f68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:44eb78b7f830a5cddf847c541080f8d2f54aed8ffbbf9e9e0a82f148893dbe5b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:358de9892f2947ad5ae159ae918e9a568e1ae5f8e8ee56d875e21bc758230914",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c944c353ce1d26e0cafbe1a171d2bd8002d9588e6d217c811e8862ff12aad4dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6230082f2c0be95a69f4d23d0722705cfe8f4c5681573107818c0f4dda626d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a42215e87f56483854177094f00a56dec2355e2cc0346091c0d131696114bd81",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c5fa9bae071ce79c28fffdaf6d1377a5a8bc423cdb18ff83a8aeda51dec5c61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ae21d35720ece7b6a01da963444603844d323a7d498b7bbcab2aa26aed1117a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce92079aa9854b25e8b0179e884c7fac36787f1227f087caddcce1cbc3f42568",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74fc5e5601d6b7f798261c52490dd4283c06fd0a92ed91aefb145cae4dcbbfd8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47a875f1e20f6981847217e875699f645665dc968dd77149289ddff4de1fd76a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7bc94cac34223cdd536ed08b4fe8cdcc3b30fd831995075010cf1499dda82012",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a9ff34d2b8abc163eff8534a8798e95e077d77936838930240b6da876cf4c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29f0368744406e96a46faa1601aab4aa62107e232cb19ca72bca5116249acc1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2d2472284b2f589e360c7c49705812112322e53110b98faee4088f94933e9ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2670a90b97a51893703b9617dc0368b4ec2aee9136f6351b3d06841dff284947",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d212a47eb8c87e62775a24fe1d14073f594897b5191db50efe31ce678f4dab1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1e11cf874a9ce02555a090a5bb783562854fbd037216e4c23cfbd1fa7f11ce0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f759215cd4075a109ac771993890b0e42dbdeacd14ffdbd8c81dce12e39dafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:554f968141a39d70387a507df696d17c013c5fb496911de82fdaa37e5f269961",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47219173bbe39015751d8b33d5f524da87cd0696a307f58fca1e8358c99e1e74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2c4f6d1944d3eee2fe5bbd79c89865cc89bde742fdb9538093048cc95ca6d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc7f1b56cadb7d7c1f4b1dba4bca9a87b22071d592f1e06e25d0be7106dd418f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36e6835f02c897ea7d1929163cf0dba9317a9fe38637bfa349ecd291ba4b36ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96f465090b634df32e8d5c1e95e915b82da5537f38c46f9eec88484b719786c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ccbd03bfb04069ba7c0400dd1b6ccd54a8dd83b5cd8881d0c75ed7d8468da1f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c0d4a908b2cf6051da6d5ce3171f65cf193acc1b10968a376424f11ad7dc60d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:700764e38ea8bc1c019d0aec39542b1af5f0c00f169a2210ff8d80504d0ce2ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cc37b098b36f89cdf93fc6eaf16bd650ab0b5e7040e789b567c42a934c5f03f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b135f59b5f3c6935955ffc36cffd28c59e9678c3551297f689edd708e3910826",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9e8fb55571c6d0431301a842757222f16960a3cbecff50d09a9b1dbd9aee16b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a033496e4f4bea32d9cdced89189040ebf0ab6dbf2fc6f7006b9c56eb2d1530",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:735bcb34d97de94e5515acf7b70bf6680e5f7a7235fe653bae666e9e664d41cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:679728f60d6d1a342c06aebe3830dad314a5e46ef4295ae8a0494c04f34fca08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ffc6ebe5127bbc38080006a4fdeace052e8ca2765f41a8dd1190eee720b904d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40ea98773d45bd6bd6a1e756afd183711ba5b4d4c1e56777551e9af16c4979b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5fa3bc538b9b2cd12fc597400a656a60772c2874637d4932ae8db60082291d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:decf31a52963be8f8735646a1b51a5e574a2123486ec6813f5ba6e728f5b00c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe3273344f14113724d991eadf8ccfbc945ce7be74c80bfe667d33c0741f5eb3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:430204db219fd88d828a7b1e4ab0f716034128d10226266aa2ec3517ff48c0da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a7e6b04e4e03810cb47b3a028c089de84917b63c03bd8f1bc82322afa59c78f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb62b4c7c08929750ed58268b2552105c360e8c0e8adfc4e1a53bb398e69333c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa71f4f1c3cc79edc9343ea0fcf558bdfed408a094ddda0bbc7582a0c647fc7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e33a4dbe7d2fd2760c6912b6a5b8efc055d6ad93c9936689a940f3204aee55b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f08914dbfdc4e8ca31930627a34f2c8f8d10878e4c0531638e540620f6da3918",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8881afbc4b5e0c6db4a7ac69626cb89f7e619eb7af09e8381f8b8ca90033b33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f0f886c8994e9def478076bbc14120da42450dd342b085a99b9ef8084af9aab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30d5904ee6c1e49e2b78fd85c35202658945614fbd4f14b8e12dba342abaaf46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6902ed20a768a81df117a0ceeb0b0494c17966ebec2a2a4fbcb426aa4de60357",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59f140bbc5ba53d4b5c7aac0012bfc4c6d638047e3c335f46cb532bb884b46ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fd1e29103ddcd00cffceb8044353a62236466327c6cdbf737cb44fd1cf2faa8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72e04c6d932e87f097a4bc344d67c2fdb383f5f5a7a532a236321f6a4dcfbb66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0527ff7d382107084ff5a8d5a5c9c95e4f2b526fbff98dfb251c947f4003efa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f99af7003a71fc0afacf96968a740ea2892b2fc8c6b45ed8321fe7fe0260c4b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1257255c6b7842e0a8901cfc767dae55e22d642b920ef8250e6ded36a2b53615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:109073906a2f705f857104e3505315c122e4faa14142ad90d0bbdabcba257bc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28dae95fc01ad9a74e93e6c4a76ba4807cc2d920aaf99c2124133a2fc5a4e54d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b990ceb0f22e2147777ceace7f486a6021e9373a5ece97feee463bbc9793cb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa38c933e194c67185d9982e700bd67f65b9c8fbe23f0146a3a96987516eb668",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37596c9b03d1beac82964c6cf5b1e5abe75c4a6975d82973ab2d4dda90a2faef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae6ef1c1cfb61f9940bb23f79d271e8b6e4ca7cec9825dfe992cb8ef7a2b1aa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
+              "saved_entry": "ffffffffffffffffffffffffffffffff-6.1.0-0.rc2.21.fc38.aarch64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "raw.img",
+              "size": "3957325824"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 409600,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 411648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1435648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 2048,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 411648,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 1435648,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 411648,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 2048,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 1435648,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:00054d4310ddebcfd966ebcbd42c072bfb69d0709f6165e2c0bc0ee1337efba2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:0107618d15c26f2cd52d1c52825e02bb2fdead1fd6449bd670427f5cf880757a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-2.36.9000-10.fc38.aarch64.rpm"
+          },
+          "sha256:015477e0760f1cc1f080ca43716bcf05c9e40ff7394c26f25e5a4e5512f4074a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/duktape-2.6.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:01b4d4c566896c87ea8736a1a0406eb3480e5e9dec581a49c973ea30774cff52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:0288a3b93e62a46e4f86ad136efffcbb40ca8ed299aca0e719dadd3630b84b6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/man-db-2.11.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:02c8b71d500f26cf0c1ed100be369307fb8872cec16ccbb413199b7ee6c26f43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nspr-4.35.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:03e753dd69715f7b1b4bb994eb3d9a0c9b26fa611603492f6b5554999f8e2114": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.aarch64.rpm"
+          },
+          "sha256:03ff91894dcba5710060a913dee3387294d5d918b4d92dab96205afd50459ae0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mdadm-4.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:04296a5d261f241802a92a70c9b000d98e11c0389d689af0bd19bb55abf75bbd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/device-mapper-libs-1.02.185-1.fc38.aarch64.rpm"
+          },
+          "sha256:044b32d2bb74e2ad1bde221b87c476c83c8274fbf6f30e928c7ef721f59c518a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm"
+          },
+          "sha256:0475dd0163729558a14e371351daec7d7bf5fa5fc70436f47c00d0acee7ead8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gobject-introspection-1.74.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:051a659d539bcbbeb00f6c4f76a927fcf2939cc351302ccec6960d4d92305ea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.aarch64.rpm"
+          },
+          "sha256:0654cefcc22d52fcdbf7b3d0a7077babb6491a7d812a7c6caa68652da617672f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/firewalld-1.2.1-1.fc38.noarch.rpm"
+          },
+          "sha256:07041e5bfeb6f98229333d7a77210942f67a5e6bc82bec5af0f7a51d401a68be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:0749ca93d398834c7e4f2c252100b1fc104a2f4461640ebe18928f2315ee0013": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-3.11.0~rc2-1.fc38.aarch64.rpm"
+          },
+          "sha256:078b851568a516e84458ad0631655de6f8e136de0ccd35330b3bc02599887d58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nss-util-3.83.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm"
+          },
+          "sha256:07c102c24aaa0e06cccf2968b5da223961571b1a22931834db21295711f94de1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-minimal-langpack-2.36.9000-10.fc38.aarch64.rpm"
+          },
+          "sha256:08fe4ae654a7c12bf80888ad0f52dc8d28ad7cd79c74c2466fcc98ef9b229908": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grubby-8.40-67.fc38.aarch64.rpm"
+          },
+          "sha256:09f8de1e0c90ea397c7677df9e550a1296668a3e018bd58eb1f704b77d7e815c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:0a38680aa5eb19d5f694ba4a6c15ba55a2439c29d2003ff7586f2268cb01f14a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm"
+          },
+          "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-common-2.06-60.fc38.noarch.rpm"
+          },
+          "sha256:0b694b01bb2873bcc3585bb65ace24e92948af31e1f1f2a8211dabbea1424188": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpath_utils-0.2.1-52.fc37.aarch64.rpm"
+          },
+          "sha256:0ccaefa2ac125fc90c752808872eef3f72d0e159e4497a58a2b65ce0ca863ca0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm"
+          },
+          "sha256:0dc74a66395954759fab10903160f3643a43d6b26497c68c36588726e2a83e5a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm"
+          },
+          "sha256:0ed3d542c929b09db89bbf79e90929c2069c2bcef6fbf58fea8076d2a69ae9c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fwupd-plugin-modem-manager-1.8.6-1.fc38.aarch64.rpm"
+          },
+          "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-common-38-0.4.noarch.rpm"
+          },
+          "sha256:0f658f37cc911a0ed122c445ee07555c27d8f98ddf30424bdaa528cdf0cfe166": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libssh-config-0.10.4-2.fc38.noarch.rpm"
+          },
+          "sha256:0ffc6ebe5127bbc38080006a4fdeace052e8ca2765f41a8dd1190eee720b904d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-252~rc2-612.fc38.aarch64.rpm"
+          },
+          "sha256:109073906a2f705f857104e3505315c122e4faa14142ad90d0bbdabcba257bc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xz-libs-5.2.7-1.fc38.aarch64.rpm"
+          },
+          "sha256:114871e86a9e186ae8ff94ea02235f4d1eb98f7ef22a6945435beb0044f35d7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-tools-minimal-2.06-60.fc38.aarch64.rpm"
+          },
+          "sha256:11c6ef78372b52968cdea9fd2062bec3fd0cdd77209d5bff8c58da2dbb3f61ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcsc-lite-1.9.9-1.fc38.aarch64.rpm"
+          },
+          "sha256:11f41a9c33efe9791f6fb47b8fab84c3dcaffa5bbb9811d96cceed1e03d42470": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssh-9.0p1-8.fc38.aarch64.rpm"
+          },
+          "sha256:1257255c6b7842e0a8901cfc767dae55e22d642b920ef8250e6ded36a2b53615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xz-5.2.7-1.fc38.aarch64.rpm"
+          },
+          "sha256:12b45030df4dad11f26ed6e6d0c1c749941fcf96dffd72bbd4c122293f85994b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:12f94a958b034ff0c24f4ccfb2d5f13d42f47702bf61e151fb488323bbe2dd5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fwupd-1.8.6-1.fc38.aarch64.rpm"
+          },
+          "sha256:13a5171648e217e0d3b3f7021dff491e736a39b5f7162a1c2bd3779bd3bcbd17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cpio-2.13-13.fc38.aarch64.rpm"
+          },
+          "sha256:1520d5466cbb6f853828e3d8454a0a2a255247a2eb08315b35f5e8e147e6504d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:15a878661b48b5b4613601eacfc195b812e069a839324dd7d963c7a43d03f1eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dracut-config-generic-057-4.fc38.aarch64.rpm"
+          },
+          "sha256:16a2f7b9a34ce32540c6e8a4ab87b68d5cbdc3ae75beae42fc8b83b41711fc8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/protobuf-c-1.4.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:17f2d670442cfb22138f3eaf331e045c2b0526d0d9ec4c68f3b215db15168cd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libreport-filesystem-2.17.5-2.fc38.noarch.rpm"
+          },
+          "sha256:19a1bf0b6a02842ec4d86d9a26a0fafb3864b8a18a05eec266d52bb58f3d1feb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm"
+          },
+          "sha256:19ba66f8a1b897f620e4bfd5d66bd7e190460f5bc68288d4fda15f9a23063363": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/librepo-1.14.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:1a4d8cc770e436919ebad73a32168e2cd4da3cad8781d3cce6c9d654a5d3fe59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/curl-7.85.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:1b162d37fea25914e42e63e6483127b4ac8889e5587f461989e6be6769e5f694": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:1b4d3978ec7272aedd39b654ca1e360d1d433da76cafc74e5cc0a4271b4f63dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/flashrom-1.2-9.fc37.aarch64.rpm"
+          },
+          "sha256:1bc9eb309534f402f392c562fab856e209ce615228cc8c2d8f3b25384cd0542b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsss_nss_idmap-2.8.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:1db6355fdeda942720b166dec938b0e7a081cb87de80e72f23d30f5896f3bc97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpcap-1.10.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:1f186cac7f4199f6927059b8adb3122c6c15e4f5ab92929aa25456164912c9ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libfido2-1.12.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:1fa19567790fa568c37734961a36d3055308b0b640e67f58a5a25c0dd4c8e791": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:22672c886e6d1f1b49f962ff7258c12ac43b4b65cf60aa44651982ba36b0c973": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gnupg2-smime-2.3.8-1.fc38.aarch64.rpm"
+          },
+          "sha256:228736bb7c085e000a1c3b104bf5fb38ae2f60be99fe6a62ee67b44e9e571629": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libksba-1.6.2-1.fc38.aarch64.rpm"
+          },
+          "sha256:2396e128877a15edb4d75caa013a3bedd1bdc4f923aee8a967c687a702d72892": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:23a74944220bbfc19d5d26ed1ecc24f6f0f3871a33c71569a15aa8d17101885b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgcc-12.2.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:24ef51235db87f815528627f58d9b7a1720e3984ecc382ec5d5833d2852d5c60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/coreutils-9.1-8.fc38.aarch64.rpm"
+          },
+          "sha256:25930a2fdaa748fc28850dc1afd3e02a497b0e4aac518d36be8c80a9fee91a24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:25a5c9e303d5586812b4bd3ca7bc1b1af1e1fe80a1764dabd84409468c1acacd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mkpasswd-5.5.14-1.fc38.aarch64.rpm"
+          },
+          "sha256:25a8c9a2d2b341f6aea2cac2dae0d1cdd01266fbd7cbbf4bc9a044039944f380": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:2670a90b97a51893703b9617dc0368b4ec2aee9136f6351b3d06841dff284947": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-4.18.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:27c7f18e0360f10badc8bd3156fcf255dcfd0500ac86c7793a5edfef02a3647c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/ima-evm-utils-1.4-6.fc37.aarch64.rpm"
+          },
+          "sha256:282462c376b6ee60c41d6d3d92369cc99c478bdb88d5b0683acd7188743ac323": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/oniguruma-6.9.8-2.D20220919gitb041f6d.fc38.aarch64.rpm"
+          },
+          "sha256:283b9a24381d643403c7957c5df4cb389890564082f1f16f9696ca8b35322930": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/polkit-121-4.fc38.aarch64.rpm"
+          },
+          "sha256:28dae95fc01ad9a74e93e6c4a76ba4807cc2d920aaf99c2124133a2fc5a4e54d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/y/yum-4.14.0-1.fc38.noarch.rpm"
+          },
+          "sha256:29f0368744406e96a46faa1601aab4aa62107e232cb19ca72bca5116249acc1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/readline-8.2-2.fc38.aarch64.rpm"
+          },
+          "sha256:2a033496e4f4bea32d9cdced89189040ebf0ab6dbf2fc6f7006b9c56eb2d1530": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sssd-kcm-2.8.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:2abcc292c06a17a25e60f0e8151c66943da7559c357e025f6acf0ece1cc1fea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:2af1c9ecfcad5bba54169861492eaa97ed3ecd54c295abdc373c226e7879158a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-rawhide-modular-38-0.3.noarch.rpm"
+          },
+          "sha256:2b817b5ef5565a9190d29d77513dfbae65222fb156f80c4f64a03a12f0b8df52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gzip-1.12-2.fc37.aarch64.rpm"
+          },
+          "sha256:2b990ceb0f22e2147777ceace7f486a6021e9373a5ece97feee463bbc9793cb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zchunk-libs-1.2.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:2be19d631bc2c3399af9c4a02a73c882cfc79a0296e3101304f5f41bdd5587a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-rawhide-38-0.3.noarch.rpm"
+          },
+          "sha256:2cef5121f03115ec8c49b55f61ed2a990861b9cde76f89645df461e34478c1f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:2d24979d1cf80f3906eab72efcac23bbbea35ef6eb10475631b5ffc32370621e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grep-3.8-1.fc38.aarch64.rpm"
+          },
+          "sha256:2d2bf7377a0181175b289acae55b3afad0dfb850ad9f65695818ec80481abccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dmidecode-3.4-2.fc37.aarch64.rpm"
+          },
+          "sha256:2f04577c4ac4fa114df989e3ff36c69d10cb2e4fdbf75691ac1498c770bc28a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:30d5904ee6c1e49e2b78fd85c35202658945614fbd4f14b8e12dba342abaaf46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/util-linux-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:310078572de43cf8be4ae7dd9041028fcdf4b4cba315ed3c97a53cf2049d6793": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc38.noarch.rpm"
+          },
+          "sha256:313910bb3c90cc31b7c82212fa71121c54b311f1d9af4eb78e50c7d39446ac86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-common-1.14.4-1.fc38.noarch.rpm"
+          },
+          "sha256:315097bc4f6f543ef241fe82935e9e89ea9e3e35fdea84a9eeee6dcea75aad70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pinentry-1.2.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:315ad79fbc53c6098168be87264263dd332e9b8df9fbc29a64b6fc44da182344": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm"
+          },
+          "sha256:329683a63e8ac4bbc810e06338f0257db0b231f90eb86b19e864d4036b3a7ae3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmount-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:331103386328c4cf8d8620885a847703b5844b568ed842383d4ec454ab8e1846": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcap-ng-python3-0.8.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:33445abbe9ea176b4a1f40a3ad3bdc7aa3efb8398a627cbdc25dacaf5f95a74f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:34eaff2e19c7ecf3be38670103a4ca8655c5670f42a3c32d4d1fd13de76be842": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:358de9892f2947ad5ae159ae918e9a568e1ae5f8e8ee56d875e21bc758230914": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm"
+          },
+          "sha256:35d5d6f894585c851435e1eba94c6fc5e9c7cea6eb689f40b560b98d2542ae20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcap-2.48-5.fc37.aarch64.rpm"
+          },
+          "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-38-0.4.noarch.rpm"
+          },
+          "sha256:368d069f5630080a91013f51d3a4ecff6dbd4ffe29f667f6b73cfef681780190": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/lua-libs-5.4.4-6.fc38.aarch64.rpm"
+          },
+          "sha256:36cbb69f70b77ab95176533a4b35ee1cc44755804d958038524222d50edb9238": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/j/jq-1.6-14.fc37.aarch64.rpm"
+          },
+          "sha256:36e6835f02c897ea7d1929163cf0dba9317a9fe38637bfa349ecd291ba4b36ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/selinux-policy-targeted-37.13-1.fc38.noarch.rpm"
+          },
+          "sha256:37596c9b03d1beac82964c6cf5b1e5abe75c4a6975d82973ab2d4dda90a2faef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zram-generator-1.1.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:378bd2a9d051665b960728fd8a562c5b776ede0f8cc4821b5ceb92b470153503": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnftnl-1.2.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:3794a7c4841e78c4fbd6003a9fae15ea6912cfcb9ba582684e9e606bcf60dd6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libdnf-0.68.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:38e6676864f276c4364b6324b787b6e19ad4d160107e9867a57fbbf84530a7ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:39b66e5e65abdb4c25ea38a0c70083fbe94a77907388fd521bfcc799494a8d98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-modular-38-0.3.noarch.rpm"
+          },
+          "sha256:3a4df46e9482e6dd68f6ff70603e36aaf846d4767ecb69b034900813566f705d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:3a7e6b04e4e03810cb47b3a028c089de84917b63c03bd8f1bc82322afa59c78f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tpm2-tools-5.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:3ae21d35720ece7b6a01da963444603844d323a7d498b7bbcab2aa26aed1117a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc38.aarch64.rpm"
+          },
+          "sha256:3c156e8db644666cd02c17335383f1e33513f71ad05aa279fb47d7746b8ea595": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libldb-2.6.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:3c55024a1b2106ffdf399590f6ed7ea33f5ae534b601d7eb726a02ac02b687bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nano-6.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:3cc37b098b36f89cdf93fc6eaf16bd650ab0b5e7040e789b567c42a934c5f03f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sqlite-libs-3.39.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:3cfd596aafe85ab76ba6cade515c90be03a63652a09521bd12bf2402cc18e755": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/ipset-libs-7.15-5.fc38.aarch64.rpm"
+          },
+          "sha256:3d7d9e4cc7520cba86f679322b635238761b4a8ffb443cb3b2e8228d88a5bdaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/file-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:3db76609448c443df02b8277429507b64f3ac814616778b80a7c5a2a0409cf96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libini_config-1.3.1-52.fc37.aarch64.rpm"
+          },
+          "sha256:3dc4c94526a92526b1af09a991f588ec4b4143aeadc79866fbd7e1dd021107f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgpg-error-1.46-1.fc38.aarch64.rpm"
+          },
+          "sha256:3eb44c8a2d21d2de989c939cf6f25c881d2ddba8c25c81aca4b78f6a0fcbcaa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nss-sysinit-3.83.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:40ea98773d45bd6bd6a1e756afd183711ba5b4d4c1e56777551e9af16c4979b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-libs-252~rc2-612.fc38.aarch64.rpm"
+          },
+          "sha256:40ee09498cf64c1474ab90c473c9f363bf51611b18d2a929bb57cb8b6be505f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pigz-2.7-2.fc37.aarch64.rpm"
+          },
+          "sha256:430204db219fd88d828a7b1e4ab0f716034128d10226266aa2ec3517ff48c0da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-udev-252~rc2-612.fc38.aarch64.rpm"
+          },
+          "sha256:433b6f621d595b607c4a9f73201e4be9b2a54535191b214b5905278e064c32cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm"
+          },
+          "sha256:449392dec0fc36be3820157dc7c90a1ea110644ed580483bf6fbf97667cc4dd8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-mdraid-2.28-2.fc38.aarch64.rpm"
+          },
+          "sha256:44eb78b7f830a5cddf847c541080f8d2f54aed8ffbbf9e9e0a82f148893dbe5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-gobject-base-3.42.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:44ee380afc6f438f608704b108853ff0d501b700c4a8196fa16a824ac31e777d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libatasmart-0.19-23.fc37.aarch64.rpm"
+          },
+          "sha256:4623dd1d17576dc75dc5e017429ddad453ae03b424c27b1f119628fa8f7b2c05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/less-590-5.fc37.aarch64.rpm"
+          },
+          "sha256:47219173bbe39015751d8b33d5f524da87cd0696a307f58fca1e8358c99e1e74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-sign-libs-4.18.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:47a875f1e20f6981847217e875699f645665dc968dd77149289ddff4de1fd76a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm"
+          },
+          "sha256:48897ef50d1d7fceced43f3fb3a8159e4aa4eacf87d4ed2a13880a9f6dcec6bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bash-5.2.2-2.fc38.aarch64.rpm"
+          },
+          "sha256:48ff03b4055e7d41b519fb552410334f9702a955981b06ef9bedfb7ddcf8181b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm"
+          },
+          "sha256:4a9ff34d2b8abc163eff8534a8798e95e077d77936838930240b6da876cf4c1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:4b0701e9c84e575d8902a3a9b67e036fffe8c06620bc26eba52c6a9810edde7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nss-3.83.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:4c6c0d8654f12e0f6b2fbb06d8ef55081e97f530a48562d4c844127d1fcf6b7c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtevent-0.13.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:4cfd593ae556df6f8e3ace44379261ab2d44044a2ab25c2fd4a4323b73cd17d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:4d59c2e3c373b76eeecff57b35f8839c4b4c9c0eb877de739f582d56ac38a00b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-dnf-plugins-core-4.3.1-1.fc38.noarch.rpm"
+          },
+          "sha256:4f759215cd4075a109ac771993890b0e42dbdeacd14ffdbd8c81dce12e39dafa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-plugin-selinux-4.18.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:4fd1e29103ddcd00cffceb8044353a62236466327c6cdbf737cb44fd1cf2faa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/v/vim-minimal-9.0.803-1.fc38.aarch64.rpm"
+          },
+          "sha256:503b9b7f3b947c4d1a50dfe8dac8064b726a09beade31f116c0e3fd5df5ad78a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:5113ea9d9576c9c8a7a47a815be9477cec5bdedecb717f4ce778d6fce2f89271": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-crypto-2.28-2.fc38.aarch64.rpm"
+          },
+          "sha256:53c7deb95ab9e9672f896a86ac4264d45a5ae6618f8aaa121d29acbca4aec9cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libfdisk-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:554f968141a39d70387a507df696d17c013c5fb496911de82fdaa37e5f269961": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:56ec328ba2bc798113071cb36196e69fff2e5bc3abb48be4cf263bfa101c827c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:576353a8452a5283209f9e63fbb70a3743369580156ddb57f726b00c460b58d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/plymouth-22.02.122-3.fc38.aarch64.rpm"
+          },
+          "sha256:58a931d2c06f53b60f7ec8f8f02e475582b763985a41c74d81a62fc28d98e862": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-2.28-2.fc38.aarch64.rpm"
+          },
+          "sha256:59035fd7df5f840f60fb189f96c5d12c2f0be34db6d91ba768358f797263d210": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:59f140bbc5ba53d4b5c7aac0012bfc4c6d638047e3c335f46cb532bb884b46ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/v/vim-data-9.0.803-1.fc38.noarch.rpm"
+          },
+          "sha256:5c5fa9bae071ce79c28fffdaf6d1377a5a8bc423cdb18ff83a8aeda51dec5c61": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-libdnf-0.68.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:5d678daeae88dedc53e06a79694ac5917341c30f2500e5e09928d0ed74c08a59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:5f0f886c8994e9def478076bbc14120da42450dd342b085a99b9ef8084af9aab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/userspace-rcu-0.13.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:60040f8563239848aabd3a655c2bc185a7d7f47dcf59228353a6713eec036269": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm"
+          },
+          "sha256:608b7df709cddea3a9733e93502f1f1c052d3cd6044f2b00af6116b4cedd10bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/deltarpm-3.6.3-4.fc37.aarch64.rpm"
+          },
+          "sha256:60cdfaff2b8bd8de04414164dcdbb106e2fdb6846f2b6cb2540bf51eb9a80510": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libqrtr-glib-1.0.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:640116bfdde14e93341912ea1624c7a54944ed5335f79669c8da3c865ef4f900": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:651e597e44eb44b6ebcd6d1c834a71d76cb2826c03328e42b0da4d2fc1c4c9e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-libs-1.14.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:652651d53baca4887a163eda001cd887b32c72a6eeb999089037353ea550de2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/NetworkManager-libnm-1.41.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:659e775e54fc94630a050d8ad717ab4bf60ec1ce5771936233b01764456d8573": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm"
+          },
+          "sha256:65f0e543799ac1d7b993d4eb44e76e0562f180d0cd108d0bab6574240fca6ea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libidn2-2.3.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:6605dc2f943b0b947a19c97fae4bca7608b59f1483c97882686c7ca05c4af7ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-libs-0.21.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:665af0acb1360c5efc0ff4e7c5d5b4864bbf77ee94bdc0cb78ba85088de13d45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsss_sudo-2.8.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:679728f60d6d1a342c06aebe3830dad314a5e46ef4295ae8a0494c04f34fca08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.aarch64.rpm"
+          },
+          "sha256:6835ca1b00813eff887ef180d9a41f561f9f096a39a6446e5b25dc9da283f8e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm"
+          },
+          "sha256:686fab2c75a3ecdc1573396c9dd97e7cdfc86da250bb0c01345ae0f0bb3831e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm"
+          },
+          "sha256:6902ed20a768a81df117a0ceeb0b0494c17966ebec2a2a4fbcb426aa4de60357": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/util-linux-core-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:6b5692cf64e00e2aca0b3a13ba133bce77c630c4ee79d34d4d1ca7b585d6fa3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fwupd-plugin-flashrom-1.8.6-1.fc38.aarch64.rpm"
+          },
+          "sha256:6ccad2fb8b08b10aff2cd6c5bee0d3bbaf839d28872090a616972f1161f1adbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc38.aarch64.rpm"
+          },
+          "sha256:6d5f46eddc547cddf4a2d33b952322d7cca7d32cb44891490f9de31c75b12652": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/groff-base-1.22.4-10.fc37.aarch64.rpm"
+          },
+          "sha256:6dc8ec1d8f370cfb509220b23a418938f44280f4d7d4a92458a78a5980281062": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-libs-0.187-8.fc38.aarch64.rpm"
+          },
+          "sha256:6f5b6b7d0c17fb19292cd8fbb5fd4def006eb8ad7b24d8117c1e975322d05891": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/coreutils-common-9.1-8.fc38.aarch64.rpm"
+          },
+          "sha256:700764e38ea8bc1c019d0aec39542b1af5f0c00f169a2210ff8d80504d0ce2ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/shim-aa64-15.6-2.aarch64.rpm"
+          },
+          "sha256:7011f454ba6e5d9f934fb2ad7c47e5c13e56ce7e9e1ac67f0c81cbca943b2792": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/linux-firmware-20221012-142.fc38.noarch.rpm"
+          },
+          "sha256:7191d8248bdd79d99bd96734ccdff48f8396cb8ed2d6e3685e1b26e08574c40d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dnf-data-4.14.0-1.fc38.noarch.rpm"
+          },
+          "sha256:72859b9721f0c6e7d2a2fdb5c2e928eec80becbf1761dd723c8ee912dd5e4de9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libdhash-0.5.0-52.fc37.aarch64.rpm"
+          },
+          "sha256:72e04c6d932e87f097a4bc344d67c2fdb383f5f5a7a532a236321f6a4dcfbb66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/v/volume_key-libs-0.3.12-17.fc37.aarch64.rpm"
+          },
+          "sha256:7347986518175c4c649d2cdab6378d55a565fdedc1cd6519fc5e8140e06f8ca4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:735bcb34d97de94e5515acf7b70bf6680e5f7a7235fe653bae666e9e664d41cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sudo-1.9.11-4.p3.fc37.aarch64.rpm"
+          },
+          "sha256:73793bf267725e2ebbf2fa5d32aff363a614d1cbc98624258ac8df564d158e4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/c-ares-1.17.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:73d3c84d2bd0f897c46f04fd4d3e816b0a77c5e1a5cb3e8b5a5ff22b86065351": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:73e74e9775bebc30a03b4407bb2b20061c09ee6b354ccac53dfed96205fc092a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ntfsprogs-2022.5.17-2.fc37.aarch64.rpm"
+          },
+          "sha256:74fc5e5601d6b7f798261c52490dd4283c06fd0a92ed91aefb145cae4dcbbfd8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-rpm-4.18.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:7520ccf6e89c32dabf2d57bfaeef54a560bd751c521a045baeb93572489f062b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/inih-56-2.fc37.aarch64.rpm"
+          },
+          "sha256:7577f8eaa1171a15629ec06c438266b6ce586b59fdf65f8bce8f449a16faea7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm"
+          },
+          "sha256:75b30fb7fe0a3e842a62dce2a34eb5d3ff740bc8e55cb9cb8e1b479d13fe9121": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kernel-modules-6.1.0-0.rc2.21.fc38.aarch64.rpm"
+          },
+          "sha256:76382f66152a11217bfc5fa63aa8cc51ee0444bddab95f4810694eb83af21518": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:786cec3721ba9907a4c69620cee6bc3952de8f27dec33f57d9939619b8514f87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:7afa5da1ec37dad4230b57f2df4d6c07f404b31248fcd171d330d2f8b7ad148c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libibverbs-41.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:7bc94cac34223cdd536ed08b4fe8cdcc3b30fd831995075010cf1499dda82012": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-unbound-1.16.3-3.fc38.aarch64.rpm"
+          },
+          "sha256:7c4743682019a693624ede5af59d0eb4b112c3c493f91f0c59ffa7d3e171b301": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gnutls-3.7.8-8.fc38.aarch64.rpm"
+          },
+          "sha256:7c508a709e816951b3650e600925e691f180f25f92b68f2b0433ef3d787137f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm"
+          },
+          "sha256:7c7b74094a5e268849ad2d86fbeb78b67b52c8aed96a88c855ac8fc7a274a569": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm"
+          },
+          "sha256:7c87edabffda243c7ca7a95e9efc1f389096f2387b493a9f2af14bd3385eaeae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bluez-5.65-3.fc38.aarch64.rpm"
+          },
+          "sha256:7d101e3624bb04eee8fedae8425964f6276d2b50badb75b6885ac255ad2101ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/polkit-libs-121-4.fc38.aarch64.rpm"
+          },
+          "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-misc-2.5.1-3.fc38.noarch.rpm"
+          },
+          "sha256:7e6b74f7398bf2d4b7aa9bbdcd098c128ed93a961b8c1de18c84f641f3edee1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-part-2.28-2.fc38.aarch64.rpm"
+          },
+          "sha256:7f406e777df209456ce8ddf6a1e091ed20f46d536869345997d692c5aca9b575": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nss-softokn-3.83.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:80947c794b006db9f11bc4b5eade078fb29fcd0f4c44819683b232936fa830bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openldap-2.6.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:818131ccd1235feeeb708903406eba00731ab0028b2272004b06235c75a121b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/parted-3.5-6.fc38.aarch64.rpm"
+          },
+          "sha256:81982f4c377e24e62cc250654706f2236d8c714d3381c48704ba5ea5ebf2a139": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/procps-ng-3.3.17-8.fc38.aarch64.rpm"
+          },
+          "sha256:821d92639d372d0a91b18587c5b9c698ab93aa47260f100531ee57cf2d0eb13c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:83d32dc63c203187bce8ff7534440260235d51e0e9f1b0101d3f01c8adf59a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libatomic-12.2.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:83dd30b8a1e0122006e6c7c0d37a96d35084141070e16e32f19da807793a4635": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dracut-config-rescue-057-4.fc38.aarch64.rpm"
+          },
+          "sha256:84d0d30b0bc33e35a1ba0d0b8d7421b7b66242d8a7dee7c0728633201eb8a441": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcurl-7.85.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:85a45ca1842eef2537163421043df629daf951705453a8a6ce4c6b4d80c45a31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:8753e26208dc659797cafc163c8fa06c3924d2dc9fdf6ccee94647ff4edde735": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm"
+          },
+          "sha256:875e1ad123d2c83aea326805a53f4140296c2a6afad6c45882e1cae2c8d7ca8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpipeline-1.5.6-2.fc37.aarch64.rpm"
+          },
+          "sha256:87e6f4a0c2348bece410abe32fd7043a92631a2125913a1027835144844037e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/NetworkManager-1.41.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:89013dbf6d1eda9b50402fbe4691d2d911d7f9a1cf69657cd88e9a3232fa0ab5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.aarch64.rpm"
+          },
+          "sha256:89a5adf72e69d09062679b566dfb59b93d67d53944b395e4379b4e4d31ff9f0e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgusb-0.4.2-1.fc38.aarch64.rpm"
+          },
+          "sha256:89ef8e879fd7ae5dd9e54405accaf1b558bb98edb423eaf27cd44a45c7c443bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-gpg-keys-38-0.3.noarch.rpm"
+          },
+          "sha256:89fdf49c17b8e2ddc9b8860ccd6ffddda6656589faa7adf9b0bd701ee89b0e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm"
+          },
+          "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm"
+          },
+          "sha256:8b21c89fe2abd9e577631d2541cd7cfb1af5e11e9493c90b354dc772bef35aa1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:8bdab2683f713bfec8afa396ce5bfd4e6ec9e87adcb5bbd01ca343626c97c726": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-utils-2.28-2.fc38.aarch64.rpm"
+          },
+          "sha256:8c0d4a908b2cf6051da6d5ce3171f65cf193acc1b10968a376424f11ad7dc60d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/shared-mime-info-2.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:8ce087df2a91fd49e8e796e215d04125eaae9a334d3c55fead4f4eac7142a91e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnghttp2-1.50.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:8ce21c95f1561f61e01d074200a4f1d5ac96c95e00e2ccecfe12d360a18d804d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libedit-3.1-43.20221009cvs.fc38.aarch64.rpm"
+          },
+          "sha256:8cf395ef797a9aac4df6b7a02ce18a0032c76092bc9c4afa1471540c263e79ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbasicobjects-0.1.1-52.fc37.aarch64.rpm"
+          },
+          "sha256:8d212a47eb8c87e62775a24fe1d14073f594897b5191db50efe31ce678f4dab1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-build-libs-4.18.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:8dd6e8a9176e9902effd883bf722f9e66cc931df831bd0ac070faf6c51ea9531": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dnf-plugins-core-4.3.1-1.fc38.noarch.rpm"
+          },
+          "sha256:8ecb612b9f4babce896a84ec90ef21ea7dd1ad6f3320d2c54fc1bb2eac4170e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libuser-0.63-13.fc38.aarch64.rpm"
+          },
+          "sha256:90c932fe01f11a1ac5bfeb956aa4bf45570101e0b899e00c9a452e2c5666bea4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libuuid-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:92b25b91d7e69e1c9ee6dff32948d244776a1ff75cd2eee87c3665cb427a33b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gnupg2-2.3.8-1.fc38.aarch64.rpm"
+          },
+          "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-legacy-2.5.1-3.fc38.noarch.rpm"
+          },
+          "sha256:962c21812673023f39908e6872018f254fea94c46312a1d50a5efb0a553ffa25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dhcp-common-4.4.3-4.P1.fc38.noarch.rpm"
+          },
+          "sha256:96f465090b634df32e8d5c1e95e915b82da5537f38c46f9eec88484b719786c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/setup-2.14.2-1.fc38.noarch.rpm"
+          },
+          "sha256:978de409a64943493b270e96c146b501414df01a880ce29306ef3b48d6346f68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-firewall-1.2.1-1.fc38.noarch.rpm"
+          },
+          "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-identity-basic-38-0.4.noarch.rpm"
+          },
+          "sha256:98204d9f002323eb100429184488ca9130659290c4446c974a9346a6e93df889": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-common-2.36.9000-10.fc38.aarch64.rpm"
+          },
+          "sha256:9a2b564a7855fd993a70efa5e5b2e8fdc1c5ae8635ab8314eb3a2df544764d60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm"
+          },
+          "sha256:9cecd9c301c808e795c6d33b1440bbd552e71ad20a2bd3e523cdd8459210e62a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/linux-firmware-whence-20221012-142.fc38.noarch.rpm"
+          },
+          "sha256:9cf98847c92321215a42aa1061e143f35d10ac3e738943ce0ce00dafe1df9471": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/device-mapper-1.02.185-1.fc38.aarch64.rpm"
+          },
+          "sha256:9d044d167ba9209a4dfe0314501e0f0cc1a589b45a40a65775bf7e433e71cbae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnfnetlink-1.0.1-22.fc37.aarch64.rpm"
+          },
+          "sha256:9de5d871550544523eb64203df597c0eb2e3b4d4471d0f118eaeadae72055fc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libndp-1.8-4.fc37.aarch64.rpm"
+          },
+          "sha256:9e2717a19a4f68657b5b82fccfc85e9bbb6dc3a29d87496b9f96edd3023c029f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-efi-aa64-2.06-60.fc38.aarch64.rpm"
+          },
+          "sha256:9e33a4dbe7d2fd2760c6912b6a5b8efc055d6ad93c9936689a940f3204aee55b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/udisks2-2.9.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:9f7e876d7352b9857ca1421b5503d329f4198d287c2cb21d45e77e639f77ccd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libssh-0.10.4-2.fc38.aarch64.rpm"
+          },
+          "sha256:a0527ff7d382107084ff5a8d5a5c9c95e4f2b526fbff98dfb251c947f4003efa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/w/whois-nls-5.5.14-1.fc38.noarch.rpm"
+          },
+          "sha256:a09e3668ccadb40503e28e2efd8ed3d0dec2946fc551856b25c845d8c6d08794": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:a13de4ba06fb2dd33107779691c4d4e04b44af5d6cb8c24ec7ff37c5ad267eb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-dbus-1.3.2-1.fc38.aarch64.rpm"
+          },
+          "sha256:a17d3ec2925c94030cf456e706bc96b7f4cccfc4119d5b1f5a89aa302da12ea5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nettle-3.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:a1eeea74b3fe8500ee50fb3ad828ee4b980d41f568ad31c441df42b2daeff71c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:a1fb07220d23a99fd4122fe207749d09122b7781719da301a6f43d5bb9f14ca7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kmod-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:a21e3d9871e35bffbb194952de4bac40bfd2cc4481225c5da610db824d83e3d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/ModemManager-glib-1.18.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:a3124d8a892116345eab8f50b79835214599ea061cf66665397e9a1cf0f05ba5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm"
+          },
+          "sha256:a317432b034404123e89b883bef600c1771247fe09f463fc1b39313bfc2e80bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgcab1-1.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:a3ebf0ae35c1fc16342a8778cc9212b5254c9ee5162cf439dfe66eedfda5c39a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libudisks2-2.9.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:a42215e87f56483854177094f00a56dec2355e2cc0346091c0d131696114bd81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-libcomps-0.1.18-4.fc37.aarch64.rpm"
+          },
+          "sha256:a452e760f5b524cd86b3c2f252816d07bb62e1d59fdda8883148dfd6bbfcb973": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/intel-gpu-firmware-20221012-142.fc38.noarch.rpm"
+          },
+          "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm"
+          },
+          "sha256:a685678a81eadc35331a74023672a94d7e8a71ebb15aa19ee3e0c2b79d4c625e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:a6a4f4f771635485035a2f16b8a152f29aff11dc1f975e78557c7241f0c6722c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dhcp-client-4.4.3-4.P1.fc38.aarch64.rpm"
+          },
+          "sha256:a6c2d07340d47de477613c6c3ef2f643f26b00d6b47dea2fa6078a076268004d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/firewalld-filesystem-1.2.1-1.fc38.noarch.rpm"
+          },
+          "sha256:a7177fc17d2c1a947b971d5cc8528e477a19cca68000c30552f14f0a8e96b4ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/popt-1.19-1.fc38.aarch64.rpm"
+          },
+          "sha256:a73dbf0bb7b043b8469fab0128420673cab87911f9af0befbb12c32123f0374f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libstdc++-12.2.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:a77017d08f6b0be4bcf52fbb6b471465a7cf6c6361195167b07e81feaacdb10b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/h/hostname-3.23-7.fc37.aarch64.rpm"
+          },
+          "sha256:a7bfc2e27dc453726495f11d21f2f4e79716be924d744a92d0a4e4fcb96acca8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:a8129f094fe65cead350dabb4078b7c5f108a8108b24be0cb28f5d4ef874748f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libjcat-0.1.12-1.fc38.aarch64.rpm"
+          },
+          "sha256:a9b3c5a71bd562a3c71f6510b8562ae093a683db22448f03fdf91814123dedf8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:a9eec50a5268e65f02c40bd2fad7849deb6c895b835094d8f4c996824e3fa923": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gdisk-1.0.9-4.fc38.aarch64.rpm"
+          },
+          "sha256:aa71f4f1c3cc79edc9343ea0fcf558bdfed408a094ddda0bbc7582a0c647fc7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tzdata-2022e-1.fc38.noarch.rpm"
+          },
+          "sha256:abfd9ef518fca89f4db8d12165229e5abb5155e187af197617f690512e3af302": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/initscripts-service-10.17-1.fc38.noarch.rpm"
+          },
+          "sha256:aca40dd03fc1eb93703ea43d9a96a70ad87792e1d675f7a9a762be71d8908c33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc38.noarch.rpm"
+          },
+          "sha256:ad059e8b67b65d9a0c87f6dab6c27e710c1e232b880475538d7f300cf763855e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm"
+          },
+          "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm"
+          },
+          "sha256:ad7e1f3c7eac701c59cdc1251d90c68338d4c4770f7fc1ded5f82286e5ce6da0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/plymouth-core-libs-22.02.122-3.fc38.aarch64.rpm"
+          },
+          "sha256:add4f6ec969242fe36a7c88306688551123f93fcc74864671956683aa1d86339": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcollection-0.7.0-52.fc37.aarch64.rpm"
+          },
+          "sha256:ade9a1cbf3063e2284c79fb80282dbb176de4578e9de53f96e45bef1a50a6c19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnl3-3.7.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:ae6ef1c1cfb61f9940bb23f79d271e8b6e4ca7cec9825dfe992cb8ef7a2b1aa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm"
+          },
+          "sha256:ae88ef5dda0d2d000080a445ad51747a55df4fa94594fc11b1636639768e87be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-envsubst-0.21.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:aec24794b31ece49a4cc72a2e038cbf4f58cbe5606a28bf40d231b53e0832542": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/iptables-nft-1.8.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:b11aea62a9e6e4295e33c6856c1a32b8f50af5ae98750836d1f97163a8a17bdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/efivar-libs-38-5.fc37.aarch64.rpm"
+          },
+          "sha256:b135f59b5f3c6935955ffc36cffd28c59e9678c3551297f689edd708e3910826": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sssd-client-2.8.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:b25ce7686cc5c1cf3d59e8a9ac89156e9f4bb846de8a6fb44ad33c1a19179067": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dracut-057-4.fc38.aarch64.rpm"
+          },
+          "sha256:b2a8f241adc3298633c436f1ca4433a7cd7e9bbcf019865dab9d7e1c1c1094da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-gconv-extra-2.36.9000-10.fc38.aarch64.rpm"
+          },
+          "sha256:b2c4f6d1944d3eee2fe5bbd79c89865cc89bde742fdb9538093048cc95ca6d71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sed-4.8-11.fc37.aarch64.rpm"
+          },
+          "sha256:b2d2472284b2f589e360c7c49705812112322e53110b98faee4088f94933e9ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm"
+          },
+          "sha256:b312bd8a2bc1234dd63a701f35bc65bf4fcd8ec290a45debf3515b7f38e95d66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kernel-6.1.0-0.rc2.21.fc38.aarch64.rpm"
+          },
+          "sha256:b3c1e63f22367cf75cc0ddb8555ac07ed638d17e89a774cdd8feb65d00c7fc9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsss_idmap-2.8.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:b3f83992a7dd875f0ab4cdc421e2f96f36ebcdd06077dcf3c685b349fa25a553": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libkcapi-1.4.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:b489d449fd57dd801e6f57fd3f774c0b087c9bf136d5a920084af524ddca588e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/audit-3.0.9-1.fc38.aarch64.rpm"
+          },
+          "sha256:b4ca03301fe8f6074211c3be890a2ff44d14c8d067c469f92b111d7d841da3fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcomps-0.1.18-4.fc37.aarch64.rpm"
+          },
+          "sha256:b5319b25ee50ebf4c3e1f0e20a627110459179858455dfe4e5ea9ef98ac3a0f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm"
+          },
+          "sha256:b5c2231369227e12b0c9e380a8ea0b6459a34eb73469b8e424a7467d11bc125c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:b6339453924f503b9d3cb4dde921f7b705528e2cb7f562243444121e7dbf19b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libfsverity-1.4-8.fc37.aarch64.rpm"
+          },
+          "sha256:b763867cad65628e83ce7bad924692eb5e597bbbea3ad03167c51698f0b15239": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/amd-gpu-firmware-20221012-142.fc38.noarch.rpm"
+          },
+          "sha256:b81eff17b72f9d25482a25eee089dea76ee1c2f853deae9b65e0fcad01bb8b66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:b850dec7cc93073fd5c1dd6a86fcd4c300d046acb29c81d0cf1c0324a84a13ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/j/json-c-0.16-2.fc37.aarch64.rpm"
+          },
+          "sha256:b8b26543b81a634855287185000dcefe6c0e09f35bd77347e8215969aeda5959": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm"
+          },
+          "sha256:b9618eabe91acefaa7406a01e8ea2033cf3cf5111ab9e1738b80212b6375d78c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgomp-12.2.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:b9e3aa8ab64ac34d90ce78c5911d91d7574de4c42bacd5ae9563b6d945147bf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/passwd-0.80-13.fc37.aarch64.rpm"
+          },
+          "sha256:ba72fbb32b033ac001d8a410f864e6e2e456dbcb2fba09a4849efc1205e6d0ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/alternatives-1.21-1.fc38.aarch64.rpm"
+          },
+          "sha256:bad9043c625b8d266cf0c817453af694b04d41e204270ce91b02013320e6a66d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:bb473c20d69060ea166d4e111ac457230d35e8e5a440ed1fae3db4b6da5dc4b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:bbfa023e35aa0c917ca8b0f451b24af4582c769c65571e4c0d90c7dbbef92615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm"
+          },
+          "sha256:bd568ab6d1fcc43bf18bc353cbea23fe884c52f54079ee6ad5dfbc921cb72106": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-runtime-0.21.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:bdd1cffeb7fd0ce84ee0223c0fb1325505d96803a781c399181ee8f86a0bac8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm"
+          },
+          "sha256:bdecabcb7a7e24b2c2d52220d2e958b42466e868416553a079a7f01c0d5ff0fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:be3ef20dae96e3eab2f93cb740ede2268ea3cb3f28719666040ba4394c1aa56d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-swap-2.28-2.fc38.aarch64.rpm"
+          },
+          "sha256:bf2e33036db5d364e097118c03b577f7296786cee248f1ff76a4228db48227c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libusb1-1.0.26-1.fc38.aarch64.rpm"
+          },
+          "sha256:c05e5fa84c9bc32032d400b31adc4e6e291ff18029f44d436c3c4c115c5d70af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssh-clients-9.0p1-8.fc38.aarch64.rpm"
+          },
+          "sha256:c09b8285b4fa856c472ff33e8220186fb35220161fcdd2b6054dc27574cf5066": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/crypto-policies-20221003-1.gitcb1ad32.fc38.noarch.rpm"
+          },
+          "sha256:c208a19538792b5664edf16eb9e1fa4e41a362a07879ef452f103eed5e3d9447": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/ipcalc-1.0.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:c2fb53692b291acfb5641ac4128fbf5f34703f04dede9c51994fc247d13739c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ncurses-6.3-3.20220501.fc37.aarch64.rpm"
+          },
+          "sha256:c568a007b9dae0d471d6badf723161e565f921c2b1eb04e19aee5fbf7dc6e61b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:c6871fd28de18a80a42d8b5a1088210c32e9dbff12c5395d25c76cf8b4e65612": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:c6a8703569b259662eda94a475f0c652482613e1449db7bfa5a18c62f89bfe7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cracklib-dicts-2.9.7-30.fc38.aarch64.rpm"
+          },
+          "sha256:c6bcc3e1b3b6515466f3f771069003d1a7c28be3adaeecf7afa6318ad0f679fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fwupd-efi-1.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:c6be0a645980cad59105282dfced45f7b3972525fa0a3fd8939c8057ad0e698d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.6-1.fc38.aarch64.rpm"
+          },
+          "sha256:c6c268d36a199f6173e6ecc5cdbbc38b0e203d034ecb91ab09cb87d2107f0534": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/npth-1.6-10.fc38.aarch64.rpm"
+          },
+          "sha256:c944c353ce1d26e0cafbe1a171d2bd8002d9588e6d217c811e8862ff12aad4dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-gpg-1.17.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:c9c6ccb93cbf9b7a962b10432d64d88f0a91fe856ab104eb04adc31d75dff2f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-dnf-4.14.0-1.fc38.noarch.rpm"
+          },
+          "sha256:ca5a06cd3eaa5701c9be12d3fabda97454e9a9e6aca9ffc586b9e14eb3952520": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:cae55e7380b67c572cd4f793412c604707f77b2ae5e1bbb77133b17f35ab5e92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm"
+          },
+          "sha256:cbe6fe8f74c609ee672cfb35b75497ace1cdf17501a41f205bef49a806097e67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm"
+          },
+          "sha256:cc2566ef3de1b9983323341861fc4658422161e167eb29419deb2f438dd907e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsmartcols-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:cc386271543d38280f8c4a28d701b292c8f5722c969e2a46e4fdc8b6f840be62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmnl-1.0.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:cc4c3c8d3d86e86b9666d819723fa9d0b1bae74a5c517ddb80e57589a57ea690": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssh-server-9.0p1-8.fc38.aarch64.rpm"
+          },
+          "sha256:ccbd03bfb04069ba7c0400dd1b6ccd54a8dd83b5cd8881d0c75ed7d8468da1f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/shadow-utils-4.12.3-3.fc38.aarch64.rpm"
+          },
+          "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm"
+          },
+          "sha256:cd85247a2b661c62ae903219fa25cff5f583fc2c6b193e02d201dae26f1ce84d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtdb-1.4.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:ce92079aa9854b25e8b0179e884c7fac36787f1227f087caddcce1cbc3f42568": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-nftables-1.0.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:cef75ed0e5383138263d81e2cf31d65c1bfb2416f3fa33d91dd56f772a1aa8fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nftables-1.0.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:d1e2e146ad4254ab7bad7ea61acbc7318a9a3bcd254f8c5d06f15a2fa97c5c1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-tools-2.06-60.fc38.aarch64.rpm"
+          },
+          "sha256:d3b7939b663a7c169c436d40adcbf78b20386928ffb620e951703ef5e20b3ed8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm"
+          },
+          "sha256:d42939c39dc1e978f4fa9530f3253d521cace197a18dc566454b0143c48bb0d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libftdi-1.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:d48d0bcb1de7ca243014616e40871ae85fd905923636d46917467f947deef1c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/iputils-20211215-3.fc37.aarch64.rpm"
+          },
+          "sha256:d5bdb1c4df2bf524e5800bb8f530181e31842bff8976a14d7c77360352a646f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgudev-237-3.fc37.aarch64.rpm"
+          },
+          "sha256:d63275a7fba7a2bf7a30df0e4a32f9955eb932bd32d80ccdf70b0ca45f138b90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:d65784b3cf614b9393ebe68e270b1b2e689dc258daaabaf173ec4934796899bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-fs-2.28-2.fc38.aarch64.rpm"
+          },
+          "sha256:d6a0316b7b4713c22e093abc05a5bf01541c77ed24578fe1f57fe437a4208a25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/psmisc-23.4-4.fc37.aarch64.rpm"
+          },
+          "sha256:d9572a1494fa167b5073b7a8633eb278b40d85d9d57426e2fec190cef713551b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm"
+          },
+          "sha256:d9828e6e75cd847a6cf4aa0d27d0f4884df5779546ff6b194a759a84e1894e85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc38.aarch64.rpm"
+          },
+          "sha256:dbdaa37cc9bf25cabe9cb48e86720efe609bbc2d6244c115d601d932bac0edd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtalloc-2.3.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:dc7f1b56cadb7d7c1f4b1dba4bca9a87b22071d592f1e06e25d0be7106dd418f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/selinux-policy-37.13-1.fc38.noarch.rpm"
+          },
+          "sha256:dcc4bd4d5fb72f38b7c23f32047cb820ec2dc2242f08ec69619e62582b909f73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libref_array-0.1.5-52.fc37.aarch64.rpm"
+          },
+          "sha256:dccb33ffe4778bee0967443755e55e7ae96fdda9e827bc61ea6287d11bda1a19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/lmdb-libs-0.9.29-4.fc37.aarch64.rpm"
+          },
+          "sha256:de090ad42c7e36fa7bb2e4408a6bab45e216c0420ae055b9ba1f96c20f804463": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-1.14.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:decf31a52963be8f8735646a1b51a5e574a2123486ec6813f5ba6e728f5b00c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-pam-252~rc2-612.fc38.aarch64.rpm"
+          },
+          "sha256:df039113134ebe1450875b29e86003ba6d70fd29ad154d861c7df212e821007c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblkid-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:df36f338c43b86547adf17d9bfdadcad07f1ac7d6456bc416c29d3373e6287c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/crypto-policies-scripts-20221003-1.gitcb1ad32.fc38.noarch.rpm"
+          },
+          "sha256:df7f7e1774a64e458e4836972fc09673080e56490ec11b08327cb6137f1b9bd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc38.aarch64.rpm"
+          },
+          "sha256:dff1f45a48b30cbe5b38a98dc4eb38da373f1248dc35f2256d245eb1fa9cfaa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssl-libs-3.0.5-5.fc38.aarch64.rpm"
+          },
+          "sha256:e1a639fc3080b7266b470b39ddb038e711b1c758e522b5cda2618fa3cc22c433": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm"
+          },
+          "sha256:e1e11cf874a9ce02555a090a5bb783562854fbd037216e4c23cfbd1fa7f11ce0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-libs-4.18.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:e2038e0d7d9f572dc7cf4316a026580021b45374e189cf155849f292558e799b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/audit-libs-3.0.9-1.fc38.aarch64.rpm"
+          },
+          "sha256:e204891e00573ee6e4d11ff11f373d345f1694ca657af48d2d3aabf7767ef7ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dnf-4.14.0-1.fc38.noarch.rpm"
+          },
+          "sha256:e59f2bf60be15a82c13bf6532a12b19ea2951c6b81f0f07dd110bd9747175c84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/j/jansson-2.13.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:e5f8a73efcea92b3d5df1e23cbbbf19dc32382bc367632850c3bdb717566beb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:e5fa3bc538b9b2cd12fc597400a656a60772c2874637d4932ae8db60082291d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-networkd-252~rc2-612.fc38.aarch64.rpm"
+          },
+          "sha256:e6164c42552319cacc4226dbb680be091ac0e0853a91b63c496822daff175b68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:e6230082f2c0be95a69f4d23d0722705cfe8f4c5681573107818c0f4dda626d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-hawkey-0.68.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:e7a61dd5759669ca441ff0023eabd9af78d1455d4931ab0a31db0107a54b3fc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cracklib-2.9.7-30.fc38.aarch64.rpm"
+          },
+          "sha256:e8881afbc4b5e0c6db4a7ac69626cb89f7e619eb7af09e8381f8b8ca90033b33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/unbound-libs-1.16.3-3.fc38.aarch64.rpm"
+          },
+          "sha256:e915e3507eb1e877251ac175df26c3be8022b31daedc39fcfa2e05c1ef190911": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-setuptools-wheel-65.3.0-1.fc38.noarch.rpm"
+          },
+          "sha256:e9e8fb55571c6d0431301a842757222f16960a3cbecff50d09a9b1dbd9aee16b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sssd-common-2.8.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:ea22a10ee200ce742b5eb4924e78edbcfb16848853ba4944129a2fe8758e5fb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-distro-1.8.0-1.fc38.noarch.rpm"
+          },
+          "sha256:ea6f9c67d170d681d049b1eddafed05dbdb3915160c2b9e7a914863b9f512948": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmaxminddb-1.7.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:eaae6a0af3ac091fc1a5a85f2a0747f4b0f915eada8396cc02229a28b9cf010a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/ipset-7.15-5.fc38.aarch64.rpm"
+          },
+          "sha256:eb1ace6f27ff1c53520c2004f93389bae355517ff3b0db39d88d26fee2dedc03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsss_certmap-2.8.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:eb62b4c7c08929750ed58268b2552105c360e8c0e8adfc4e1a53bb398e69333c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:eb820f40785631e37e1a023f8494c75feb743e4a172a503ff3feccad1d24f391": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glib2-2.74.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:ec60544d1423d5ea064e6edbd7beb3cf98e78fe5de2980cc9200428aa3452516": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm"
+          },
+          "sha256:ee8965bd1645c1bd864b673ef0e2f869b4a7fce877abb2d4bb515c76d568cf82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kernel-core-6.1.0-0.rc2.21.fc38.aarch64.rpm"
+          },
+          "sha256:eee8b86ba5a4df490b10f313eff21514290074ba7e7582ae9782a2cac7ed73ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nss-softokn-freebl-3.83.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:f08914dbfdc4e8ca31930627a34f2c8f8d10878e4c0531638e540620f6da3918": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/unbound-anchor-1.16.3-3.fc38.aarch64.rpm"
+          },
+          "sha256:f11d4ef320502bcd0fe26ccbe1850a8969bf04cd28f04efe5b9e913054841fa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbytesize-2.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:f295d316d8aaa426972fd9fff029497b28f9a7572da5faf7e1b121fc0868bd23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-38-0.3.noarch.rpm"
+          },
+          "sha256:f35d38bf1a573e6dec25fab79a39f29dce274b3e617f5628999a3a6ff0bea009": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxcrypt-4.4.28-3.fc38.aarch64.rpm"
+          },
+          "sha256:f3baa568b572643be26056e5f5bebdbb061d726c635c78fc2a8970335c724064": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-libelf-0.187-8.fc38.aarch64.rpm"
+          },
+          "sha256:f4212481acdda13660bb660a7169e44d46c9a8ec95c4f545fad6813553f13a9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/plymouth-scripts-22.02.122-3.fc38.aarch64.rpm"
+          },
+          "sha256:f45f46be9bfa2ed73829988839fd2ceca36600e3597605205841255b4556371c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-2.5.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:f4cfae4f2e8ebb6772c7c5d6ca6212f776c36e5da5c47bb0ef51f444e4a68d3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc38.noarch.rpm"
+          },
+          "sha256:f54c232b4713ac362a343800003ff7deff1c5e7c75710235b9cab5df55ef94a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm"
+          },
+          "sha256:f811cc8fc811d631471eb6adabcc1014ea329258cf37c2a5f7b936830e3b2e57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm"
+          },
+          "sha256:f8429326af23a76cb51e2944b846a141b9d3d121a3cc455b4a83e319bd2a1d6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/iptables-libs-1.8.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:f8ee4c26b98c6d2c1cbd59aa001871b1e8387e71983c5935ed680767678fd263": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxmlb-0.3.10-1.fc38.aarch64.rpm"
+          },
+          "sha256:f9585589b8e7587ceb1ae2dfa8f2ef019ee27d4a3f73cfc382edf099934b3e26": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-loop-2.28-2.fc38.aarch64.rpm"
+          },
+          "sha256:f99af7003a71fc0afacf96968a740ea2892b2fc8c6b45ed8321fe7fe0260c4b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xfsprogs-5.19.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:f9b91a1c6f4e194acd077ece95b995b3c0987734d75dfc3a0f2abdcdeedf1be1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmbim-1.26.4-2.fc37.aarch64.rpm"
+          },
+          "sha256:fa38c933e194c67185d9982e700bd67f65b9c8fbe23f0146a3a96987516eb668": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zlib-1.2.12-5.fc38.aarch64.rpm"
+          },
+          "sha256:fc3310c7d92abc3e42e89af3afd7b9b050000878db63cf08167d331bf4cc3b76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libqmi-1.30.6-2.fc37.aarch64.rpm"
+          },
+          "sha256:fd15bba53fc3e0c82c546a080c6f5441bed7d87587195843516949e230faf66a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:fdc0d4aeb8f58c2ff8afdd4e4716145c0f6dcf1d71ccc44e3e0c4986e0054913": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:fe3273344f14113724d991eadf8ccfbc945ce7be74c80bfe667d33c0741f5eb3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-resolved-252~rc2-612.fc38.aarch64.rpm"
+          },
+          "sha256:fe44f2c8c66aa23acee69b313fae5e001b28d139319677ea4aa6a4d3dc2f134d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kpartx-0.9.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:fe92321ab2497d6cc37cede52b83fbea4b2ffb16650e88e33bee2d2371bf37cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/iproute-6.0.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:ff017b16ca598f61547ca1f70a677c8e8bc87794b646686acdd55a70ac12cc48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nvidia-gpu-firmware-20221012-142.fc38.noarch.rpm"
+          },
+          "sha256:ff128f537a012f30dfec9fec00d38f9f50268198a124783e2c2c1dbc54a79873": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ntfs-3g-2022.5.17-2.fc37.aarch64.rpm"
+          },
+          "sha256:ff3cb745172d9bd639d22e13dc66e94b2df4dae847cbc55d63ae6a6c1b69bf49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm"
+          },
+          "sha256:ffa79d41f91cf48696bb9845b87eb8888efad8e52d914087d94de139363012a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxml2-2.10.3-1.fc38.aarch64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/alternatives-1.21-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ba72fbb32b033ac001d8a410f864e6e2e456dbcb2fba09a4849efc1205e6d0ab",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/audit-libs-3.0.9-1.fc38.aarch64.rpm",
+        "checksum": "sha256:e2038e0d7d9f572dc7cf4316a026580021b45374e189cf155849f292558e799b",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:fd15bba53fc3e0c82c546a080c6f5441bed7d87587195843516949e230faf66a",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:7347986518175c4c649d2cdab6378d55a565fdedc1cd6519fc5e8140e06f8ca4",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bash-5.2.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:48897ef50d1d7fceced43f3fb3a8159e4aa4eacf87d4ed2a13880a9f6dcec6bc",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm",
+        "checksum": "sha256:bbfa023e35aa0c917ca8b0f451b24af4582c769c65571e4c0d90c7dbbef92615",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/coreutils-9.1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:24ef51235db87f815528627f58d9b7a1720e3984ecc382ec5d5833d2852d5c60",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/coreutils-common-9.1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:6f5b6b7d0c17fb19292cd8fbb5fd4def006eb8ad7b24d8117c1e975322d05891",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cpio-2.13-13.fc38.aarch64.rpm",
+        "checksum": "sha256:13a5171648e217e0d3b3f7021dff491e736a39b5f7162a1c2bd3779bd3bcbd17",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cracklib-2.9.7-30.fc38.aarch64.rpm",
+        "checksum": "sha256:e7a61dd5759669ca441ff0023eabd9af78d1455d4931ab0a31db0107a54b3fc7",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20221003",
+        "release": "1.gitcb1ad32.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/crypto-policies-20221003-1.gitcb1ad32.fc38.noarch.rpm",
+        "checksum": "sha256:c09b8285b4fa856c472ff33e8220186fb35220161fcdd2b6054dc27574cf5066",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20221003",
+        "release": "1.gitcb1ad32.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/crypto-policies-scripts-20221003-1.gitcb1ad32.fc38.noarch.rpm",
+        "checksum": "sha256:df36f338c43b86547adf17d9bfdadcad07f1ac7d6456bc416c29d3373e6287c6",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ca5a06cd3eaa5701c9be12d3fabda97454e9a9e6aca9ffc586b9e14eb3952520",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/curl-7.85.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:1a4d8cc770e436919ebad73a32168e2cd4da3cad8781d3cce6c9d654a5d3fe59",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc38.aarch64.rpm",
+        "checksum": "sha256:d9828e6e75cd847a6cf4aa0d27d0f4884df5779546ff6b194a759a84e1894e85",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-1.14.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:de090ad42c7e36fa7bb2e4408a6bab45e216c0420ae055b9ba1f96c20f804463",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a3124d8a892116345eab8f50b79835214599ea061cf66665397e9a1cf0f05ba5",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-common-1.14.4-1.fc38.noarch.rpm",
+        "checksum": "sha256:313910bb3c90cc31b7c82212fa71121c54b311f1d9af4eb78e50c7d39446ac86",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.185",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/device-mapper-1.02.185-1.fc38.aarch64.rpm",
+        "checksum": "sha256:9cf98847c92321215a42aa1061e143f35d10ac3e738943ce0ce00dafe1df9471",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.185",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/device-mapper-libs-1.02.185-1.fc38.aarch64.rpm",
+        "checksum": "sha256:04296a5d261f241802a92a70c9b000d98e11c0389d689af0bd19bb55abf75bbd",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:786cec3721ba9907a4c69620cee6bc3952de8f27dec33f57d9939619b8514f87",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:38e6676864f276c4364b6324b787b6e19ad4d160107e9867a57fbbf84530a7ef",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dracut-057-4.fc38.aarch64.rpm",
+        "checksum": "sha256:b25ce7686cc5c1cf3d59e8a9ac89156e9f4bb846de8a6fb44ad33c1a19179067",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:34eaff2e19c7ecf3be38670103a4ca8655c5670f42a3c32d4d1fd13de76be842",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:bdecabcb7a7e24b2c2d52220d2e958b42466e868416553a079a7f01c0d5ff0fa",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc38.aarch64.rpm",
+        "checksum": "sha256:df7f7e1774a64e458e4836972fc09673080e56490ec11b08327cb6137f1b9bd3",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc38.noarch.rpm",
+        "checksum": "sha256:f4cfae4f2e8ebb6772c7c5d6ca6212f776c36e5da5c47bb0ef51f444e4a68d3f",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-libelf-0.187-8.fc38.aarch64.rpm",
+        "checksum": "sha256:f3baa568b572643be26056e5f5bebdbb061d726c635c78fc2a8970335c724064",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-libs-0.187-8.fc38.aarch64.rpm",
+        "checksum": "sha256:6dc8ec1d8f370cfb509220b23a418938f44280f4d7d4a92458a78a5980281062",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:503b9b7f3b947c4d1a50dfe8dac8064b726a09beade31f116c0e3fd5df5ad78a",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-gpg-keys-38-0.3.noarch.rpm",
+        "checksum": "sha256:89ef8e879fd7ae5dd9e54405accaf1b558bb98edb423eaf27cd44a45c7c443bf",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-38-0.4.noarch.rpm",
+        "checksum": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-common-38-0.4.noarch.rpm",
+        "checksum": "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-identity-basic-38-0.4.noarch.rpm",
+        "checksum": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-38-0.3.noarch.rpm",
+        "checksum": "sha256:f295d316d8aaa426972fd9fff029497b28f9a7572da5faf7e1b121fc0868bd23",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-rawhide-38-0.3.noarch.rpm",
+        "checksum": "sha256:2be19d631bc2c3399af9c4a02a73c882cfc79a0296e3101304f5f41bdd5587a3",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/file-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3d7d9e4cc7520cba86f679322b635238761b4a8ffb443cb3b2e8228d88a5bdaa",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3a4df46e9482e6dd68f6ff70603e36aaf846d4767ecb69b034900813566f705d",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0ccaefa2ac125fc90c752808872eef3f72d0e159e4497a58a2b65ce0ca863ca0",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:bad9043c625b8d266cf0c817453af694b04d41e204270ce91b02013320e6a66d",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:7c7b74094a5e268849ad2d86fbeb78b67b52c8aed96a88c855ac8fc7a274a569",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1b162d37fea25914e42e63e6483127b4ac8889e5587f461989e6be6769e5f694",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1520d5466cbb6f853828e3d8454a0a2a255247a2eb08315b35f5e8e147e6504d",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm",
+        "checksum": "sha256:7577f8eaa1171a15629ec06c438266b6ce586b59fdf65f8bce8f449a16faea7d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-envsubst-0.21.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ae88ef5dda0d2d000080a445ad51747a55df4fa94594fc11b1636639768e87be",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-libs-0.21.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:6605dc2f943b0b947a19c97fae4bca7608b59f1483c97882686c7ca05c4af7ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-runtime-0.21.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:bd568ab6d1fcc43bf18bc353cbea23fe884c52f54079ee6ad5dfbc921cb72106",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-2.36.9000-10.fc38.aarch64.rpm",
+        "checksum": "sha256:0107618d15c26f2cd52d1c52825e02bb2fdead1fd6449bd670427f5cf880757a",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-common-2.36.9000-10.fc38.aarch64.rpm",
+        "checksum": "sha256:98204d9f002323eb100429184488ca9130659290c4446c974a9346a6e93df889",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-gconv-extra-2.36.9000-10.fc38.aarch64.rpm",
+        "checksum": "sha256:b2a8f241adc3298633c436f1ca4433a7cd7e9bbcf019865dab9d7e1c1c1094da",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-minimal-langpack-2.36.9000-10.fc38.aarch64.rpm",
+        "checksum": "sha256:07c102c24aaa0e06cccf2968b5da223961571b1a22931834db21295711f94de1",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:25a8c9a2d2b341f6aea2cac2dae0d1cdd01266fbd7cbbf4bc9a044039944f380",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grep-3.8-1.fc38.aarch64.rpm",
+        "checksum": "sha256:2d24979d1cf80f3906eab72efcac23bbbea35ef6eb10475631b5ffc32370621e",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-common-2.06-60.fc38.noarch.rpm",
+        "checksum": "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-tools-2.06-60.fc38.aarch64.rpm",
+        "checksum": "sha256:d1e2e146ad4254ab7bad7ea61acbc7318a9a3bcd254f8c5d06f15a2fa97c5c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-tools-minimal-2.06-60.fc38.aarch64.rpm",
+        "checksum": "sha256:114871e86a9e186ae8ff94ea02235f4d1eb98f7ef22a6945435beb0044f35d7a",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "67.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grubby-8.40-67.fc38.aarch64.rpm",
+        "checksum": "sha256:08fe4ae654a7c12bf80888ad0f52dc8d28ad7cd79c74c2466fcc98ef9b229908",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gzip-1.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2b817b5ef5565a9190d29d77513dfbae65222fb156f80c4f64a03a12f0b8df52",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/j/json-c-0.16-2.fc37.aarch64.rpm",
+        "checksum": "sha256:b850dec7cc93073fd5c1dd6a86fcd4c300d046acb29c81d0cf1c0324a84a13ca",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-2.5.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f45f46be9bfa2ed73829988839fd2ceca36600e3597605205841255b4556371c",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-legacy-2.5.1-3.fc38.noarch.rpm",
+        "checksum": "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-misc-2.5.1-3.fc38.noarch.rpm",
+        "checksum": "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:73d3c84d2bd0f897c46f04fd4d3e816b0a77c5e1a5cb3e8b5a5ff22b86065351",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kmod-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a1fb07220d23a99fd4122fe207749d09122b7781719da301a6f43d5bb9f14ca7",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:821d92639d372d0a91b18587c5b9c698ab93aa47260f100531ee57cf2d0eb13c",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kpartx-0.9.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:fe44f2c8c66aa23acee69b313fae5e001b28d139319677ea4aa6a4d3dc2f134d",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm",
+        "checksum": "sha256:48ff03b4055e7d41b519fb552410334f9702a955981b06ef9bedfb7ddcf8181b",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:fdc0d4aeb8f58c2ff8afdd4e4716145c0f6dcf1d71ccc44e3e0c4986e0054913",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:07041e5bfeb6f98229333d7a77210942f67a5e6bc82bec5af0f7a51d401a68be",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ad059e8b67b65d9a0c87f6dab6c27e710c1e232b880475538d7f300cf763855e",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b5c2231369227e12b0c9e380a8ea0b6459a34eb73469b8e424a7467d11bc125c",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:33445abbe9ea176b4a1f40a3ad3bdc7aa3efb8398a627cbdc25dacaf5f95a74f",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblkid-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:df039113134ebe1450875b29e86003ba6d70fd29ad154d861c7df212e821007c",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:85a45ca1842eef2537163421043df629daf951705453a8a6ce4c6b4d80c45a31",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm",
+        "checksum": "sha256:b5319b25ee50ebf4c3e1f0e20a627110459179858455dfe4e5ea9ef98ac3a0f5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcap-2.48-5.fc37.aarch64.rpm",
+        "checksum": "sha256:35d5d6f894585c851435e1eba94c6fc5e9c7cea6eb689f40b560b98d2542ae20",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:640116bfdde14e93341912ea1624c7a54944ed5335f79669c8da3c865ef4f900",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm",
+        "checksum": "sha256:bdd1cffeb7fd0ce84ee0223c0fb1325505d96803a781c399181ee8f86a0bac8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1fa19567790fa568c37734961a36d3055308b0b640e67f58a5a25c0dd4c8e791",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcurl-7.85.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:84d0d30b0bc33e35a1ba0d0b8d7421b7b66242d8a7dee7c0728633201eb8a441",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm",
+        "checksum": "sha256:659e775e54fc94630a050d8ad717ab4bf60ec1ce5771936233b01764456d8573",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:5d678daeae88dedc53e06a79694ac5917341c30f2500e5e09928d0ed74c08a59",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm",
+        "checksum": "sha256:0dc74a66395954759fab10903160f3643a43d6b26497c68c36588726e2a83e5a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libfdisk-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:53c7deb95ab9e9672f896a86ac4264d45a5ae6618f8aaa121d29acbca4aec9cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:0a38680aa5eb19d5f694ba4a6c15ba55a2439c29d2003ff7586f2268cb01f14a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.12.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libfido2-1.12.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:1f186cac7f4199f6927059b8adb3122c6c15e4f5ab92929aa25456164912c9ba",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgcc-12.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:23a74944220bbfc19d5d26ed1ecc24f6f0f3871a33c71569a15aa8d17101885b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgomp-12.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:b9618eabe91acefaa7406a01e8ea2033cf3cf5111ab9e1738b80212b6375d78c",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libidn2-2.3.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:65f0e543799ac1d7b993d4eb44e76e0562f180d0cd108d0bab6574240fca6ea9",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libkcapi-1.4.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:b3f83992a7dd875f0ab4cdc421e2f96f36ebcdd06077dcf3c685b349fa25a553",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:2396e128877a15edb4d75caa013a3bedd1bdc4f923aee8a967c687a702d72892",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmount-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:329683a63e8ac4bbc810e06338f0257db0b231f90eb86b19e864d4036b3a7ae3",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.50.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnghttp2-1.50.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:8ce087df2a91fd49e8e796e215d04125eaae9a334d3c55fead4f4eac7142a91e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:2f04577c4ac4fa114df989e3ff36c69d10cb2e4fdbf75691ac1498c770bc28a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:a09e3668ccadb40503e28e2efd8ed3d0dec2946fc551856b25c845d8c6d08794",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm",
+        "checksum": "sha256:cbe6fe8f74c609ee672cfb35b75497ace1cdf17501a41f205bef49a806097e67",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:a685678a81eadc35331a74023672a94d7e8a71ebb15aa19ee3e0c2b79d4c625e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:2abcc292c06a17a25e60f0e8151c66943da7559c357e025f6acf0ece1cc1fea9",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:59035fd7df5f840f60fb189f96c5d12c2f0be34db6d91ba768358f797263d210",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a9b3c5a71bd562a3c71f6510b8562ae093a683db22448f03fdf91814123dedf8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:c6871fd28de18a80a42d8b5a1088210c32e9dbff12c5395d25c76cf8b4e65612",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:044b32d2bb74e2ad1bde221b87c476c83c8274fbf6f30e928c7ef721f59c518a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsmartcols-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:cc2566ef3de1b9983323341861fc4658422161e167eb29419deb2f438dd907e4",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:76382f66152a11217bfc5fa63aa8cc51ee0444bddab95f4810694eb83af21518",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libssh-0.10.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:9f7e876d7352b9857ca1421b5503d329f4198d287c2cb21d45e77e639f77ccd2",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libssh-config-0.10.4-2.fc38.noarch.rpm",
+        "checksum": "sha256:0f658f37cc911a0ed122c445ee07555c27d8f98ddf30424bdaa528cdf0cfe166",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libstdc++-12.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:a73dbf0bb7b043b8469fab0128420673cab87911f9af0befbb12c32123f0374f",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d63275a7fba7a2bf7a30df0e4a32f9955eb932bd32d80ccdf70b0ca45f138b90",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm",
+        "checksum": "sha256:89fdf49c17b8e2ddc9b8860ccd6ffddda6656589faa7adf9b0bd701ee89b0e04",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:8b21c89fe2abd9e577631d2541cd7cfb1af5e11e9493c90b354dc772bef35aa1",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:b81eff17b72f9d25482a25eee089dea76ee1c2f853deae9b65e0fcad01bb8b66",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libuuid-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:90c932fe01f11a1ac5bfeb956aa4bf45570101e0b899e00c9a452e2c5666bea4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxcrypt-4.4.28-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f35d38bf1a573e6dec25fab79a39f29dce274b3e617f5628999a3a6ff0bea009",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:56ec328ba2bc798113071cb36196e69fff2e5bc3abb48be4cf263bfa101c827c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxml2-2.10.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ffa79d41f91cf48696bb9845b87eb8888efad8e52d914087d94de139363012a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e5f8a73efcea92b3d5df1e23cbbbf19dc32382bc367632850c3bdb717566beb7",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/lua-libs-5.4.4-6.fc38.aarch64.rpm",
+        "checksum": "sha256:368d069f5630080a91013f51d3a4ecff6dbd4ffe29f667f6b73cfef681780190",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b8b26543b81a634855287185000dcefe6c0e09f35bd77347e8215969aeda5959",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:09f8de1e0c90ea397c7677df9e550a1296668a3e018bd58eb1f704b77d7e815c",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.14",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mkpasswd-5.5.14-1.fc38.aarch64.rpm",
+        "checksum": "sha256:25a5c9e303d5586812b4bd3ca7bc1b1af1e1fe80a1764dabd84409468c1acacd",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a7bfc2e27dc453726495f11d21f2f4e79716be924d744a92d0a4e4fcb96acca8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:8753e26208dc659797cafc163c8fa06c3924d2dc9fdf6ccee94647ff4edde735",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:d3b7939b663a7c169c436d40adcbf78b20386928ffb620e951703ef5e20b3ed8",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openldap-2.6.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:80947c794b006db9f11bc4b5eade078fb29fcd0f4c44819683b232936fa830bf",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssl-libs-3.0.5-5.fc38.aarch64.rpm",
+        "checksum": "sha256:dff1f45a48b30cbe5b38a98dc4eb38da373f1248dc35f2256d245eb1fa9cfaa5",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:cae55e7380b67c572cd4f793412c604707f77b2ae5e1bbb77133b17f35ab5e92",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f811cc8fc811d631471eb6adabcc1014ea329258cf37c2a5f7b936830e3b2e57",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:c568a007b9dae0d471d6badf723161e565f921c2b1eb04e19aee5fbf7dc6e61b",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f54c232b4713ac362a343800003ff7deff1c5e7c75710235b9cab5df55ef94a9",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:7c508a709e816951b3650e600925e691f180f25f92b68f2b0433ef3d787137f3",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:ff3cb745172d9bd639d22e13dc66e94b2df4dae847cbc55d63ae6a6c1b69bf49",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm",
+        "checksum": "sha256:6835ca1b00813eff887ef180d9a41f561f9f096a39a6446e5b25dc9da283f8e6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pigz-2.7-2.fc37.aarch64.rpm",
+        "checksum": "sha256:40ee09498cf64c1474ab90c473c9f363bf51611b18d2a929bb57cb8b6be505f4",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:315ad79fbc53c6098168be87264263dd332e9b8df9fbc29a64b6fc44da182344",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/popt-1.19-1.fc38.aarch64.rpm",
+        "checksum": "sha256:a7177fc17d2c1a947b971d5cc8528e477a19cca68000c30552f14f0a8e96b4ab",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/procps-ng-3.3.17-8.fc38.aarch64.rpm",
+        "checksum": "sha256:81982f4c377e24e62cc250654706f2236d8c714d3381c48704ba5ea5ebf2a139",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2.2",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc38.noarch.rpm",
+        "checksum": "sha256:aca40dd03fc1eb93703ea43d9a96a70ad87792e1d675f7a9a762be71d8908c33",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "65.3.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-setuptools-wheel-65.3.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:e915e3507eb1e877251ac175df26c3be8022b31daedc39fcfa2e05c1ef190911",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc38.noarch.rpm",
+        "checksum": "sha256:310078572de43cf8be4ae7dd9041028fcdf4b4cba315ed3c97a53cf2049d6793",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-3.11.0~rc2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:0749ca93d398834c7e4f2c252100b1fc104a2f4461640ebe18928f2315ee0013",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3ae21d35720ece7b6a01da963444603844d323a7d498b7bbcab2aa26aed1117a",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4a9ff34d2b8abc163eff8534a8798e95e077d77936838930240b6da876cf4c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/readline-8.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:29f0368744406e96a46faa1601aab4aa62107e232cb19ca72bca5116249acc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-4.18.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:2670a90b97a51893703b9617dc0368b4ec2aee9136f6351b3d06841dff284947",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-libs-4.18.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:e1e11cf874a9ce02555a090a5bb783562854fbd037216e4c23cfbd1fa7f11ce0",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-plugin-selinux-4.18.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:4f759215cd4075a109ac771993890b0e42dbdeacd14ffdbd8c81dce12e39dafa",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sed-4.8-11.fc37.aarch64.rpm",
+        "checksum": "sha256:b2c4f6d1944d3eee2fe5bbd79c89865cc89bde742fdb9538093048cc95ca6d71",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.13",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/selinux-policy-37.13-1.fc38.noarch.rpm",
+        "checksum": "sha256:dc7f1b56cadb7d7c1f4b1dba4bca9a87b22071d592f1e06e25d0be7106dd418f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.13",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/selinux-policy-targeted-37.13-1.fc38.noarch.rpm",
+        "checksum": "sha256:36e6835f02c897ea7d1929163cf0dba9317a9fe38637bfa349ecd291ba4b36ae",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.2",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/setup-2.14.2-1.fc38.noarch.rpm",
+        "checksum": "sha256:96f465090b634df32e8d5c1e95e915b82da5537f38c46f9eec88484b719786c8",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.12.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/shadow-utils-4.12.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:ccbd03bfb04069ba7c0400dd1b6ccd54a8dd83b5cd8881d0c75ed7d8468da1f6",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sqlite-libs-3.39.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3cc37b098b36f89cdf93fc6eaf16bd650ab0b5e7040e789b567c42a934c5f03f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:0ffc6ebe5127bbc38080006a4fdeace052e8ca2765f41a8dd1190eee720b904d",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-libs-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:40ea98773d45bd6bd6a1e756afd183711ba5b4d4c1e56777551e9af16c4979b5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-networkd-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:e5fa3bc538b9b2cd12fc597400a656a60772c2874637d4932ae8db60082291d1",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-pam-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:decf31a52963be8f8735646a1b51a5e574a2123486ec6813f5ba6e728f5b00c2",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-resolved-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:fe3273344f14113724d991eadf8ccfbc945ce7be74c80bfe667d33c0741f5eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-udev-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:430204db219fd88d828a7b1e4ab0f716034128d10226266aa2ec3517ff48c0da",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tpm2-tools-5.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3a7e6b04e4e03810cb47b3a028c089de84917b63c03bd8f1bc82322afa59c78f",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:eb62b4c7c08929750ed58268b2552105c360e8c0e8adfc4e1a53bb398e69333c",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022e",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tzdata-2022e-1.fc38.noarch.rpm",
+        "checksum": "sha256:aa71f4f1c3cc79edc9343ea0fcf558bdfed408a094ddda0bbc7582a0c647fc7e",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/util-linux-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:30d5904ee6c1e49e2b78fd85c35202658945614fbd4f14b8e12dba342abaaf46",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/util-linux-core-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:6902ed20a768a81df117a0ceeb0b0494c17966ebec2a2a4fbcb426aa4de60357",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.14",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/w/whois-nls-5.5.14-1.fc38.noarch.rpm",
+        "checksum": "sha256:a0527ff7d382107084ff5a8d5a5c9c95e4f2b526fbff98dfb251c947f4003efa",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.7",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xz-5.2.7-1.fc38.aarch64.rpm",
+        "checksum": "sha256:1257255c6b7842e0a8901cfc767dae55e22d642b920ef8250e6ded36a2b53615",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.7",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xz-libs-5.2.7-1.fc38.aarch64.rpm",
+        "checksum": "sha256:109073906a2f705f857104e3505315c122e4faa14142ad90d0bbdabcba257bc9",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zlib-1.2.12-5.fc38.aarch64.rpm",
+        "checksum": "sha256:fa38c933e194c67185d9982e700bd67f65b9c8fbe23f0146a3a96987516eb668",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/ModemManager-glib-1.18.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a21e3d9871e35bffbb194952de4bac40bfd2cc4481225c5da610db824d83e3d8",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.41.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/NetworkManager-1.41.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:87e6f4a0c2348bece410abe32fd7043a92631a2125913a1027835144844037e2",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.41.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/NetworkManager-libnm-1.41.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:652651d53baca4887a163eda001cd887b32c72a6eeb999089037353ea550de2b",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/alternatives-1.21-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ba72fbb32b033ac001d8a410f864e6e2e456dbcb2fba09a4849efc1205e6d0ab",
+        "check_gpg": true
+      },
+      {
+        "name": "amd-gpu-firmware",
+        "epoch": 0,
+        "version": "20221012",
+        "release": "142.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/amd-gpu-firmware-20221012-142.fc38.noarch.rpm",
+        "checksum": "sha256:b763867cad65628e83ce7bad924692eb5e597bbbea3ad03167c51698f0b15239",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/audit-3.0.9-1.fc38.aarch64.rpm",
+        "checksum": "sha256:b489d449fd57dd801e6f57fd3f774c0b087c9bf136d5a920084af524ddca588e",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/audit-libs-3.0.9-1.fc38.aarch64.rpm",
+        "checksum": "sha256:e2038e0d7d9f572dc7cf4316a026580021b45374e189cf155849f292558e799b",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:fd15bba53fc3e0c82c546a080c6f5441bed7d87587195843516949e230faf66a",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:7347986518175c4c649d2cdab6378d55a565fdedc1cd6519fc5e8140e06f8ca4",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bash-5.2.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:48897ef50d1d7fceced43f3fb3a8159e4aa4eacf87d4ed2a13880a9f6dcec6bc",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.65",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bluez-5.65-3.fc38.aarch64.rpm",
+        "checksum": "sha256:7c87edabffda243c7ca7a95e9efc1f389096f2387b493a9f2af14bd3385eaeae",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm",
+        "checksum": "sha256:bbfa023e35aa0c917ca8b0f451b24af4582c769c65571e4c0d90c7dbbef92615",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/c-ares-1.17.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:73793bf267725e2ebbf2fa5d32aff363a614d1cbc98624258ac8df564d158e4b",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/coreutils-9.1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:24ef51235db87f815528627f58d9b7a1720e3984ecc382ec5d5833d2852d5c60",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/coreutils-common-9.1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:6f5b6b7d0c17fb19292cd8fbb5fd4def006eb8ad7b24d8117c1e975322d05891",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cpio-2.13-13.fc38.aarch64.rpm",
+        "checksum": "sha256:13a5171648e217e0d3b3f7021dff491e736a39b5f7162a1c2bd3779bd3bcbd17",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cracklib-2.9.7-30.fc38.aarch64.rpm",
+        "checksum": "sha256:e7a61dd5759669ca441ff0023eabd9af78d1455d4931ab0a31db0107a54b3fc7",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cracklib-dicts-2.9.7-30.fc38.aarch64.rpm",
+        "checksum": "sha256:c6a8703569b259662eda94a475f0c652482613e1449db7bfa5a18c62f89bfe7e",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20221003",
+        "release": "1.gitcb1ad32.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/crypto-policies-20221003-1.gitcb1ad32.fc38.noarch.rpm",
+        "checksum": "sha256:c09b8285b4fa856c472ff33e8220186fb35220161fcdd2b6054dc27574cf5066",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20221003",
+        "release": "1.gitcb1ad32.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/crypto-policies-scripts-20221003-1.gitcb1ad32.fc38.noarch.rpm",
+        "checksum": "sha256:df36f338c43b86547adf17d9bfdadcad07f1ac7d6456bc416c29d3373e6287c6",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ca5a06cd3eaa5701c9be12d3fabda97454e9a9e6aca9ffc586b9e14eb3952520",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/curl-7.85.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:1a4d8cc770e436919ebad73a32168e2cd4da3cad8781d3cce6c9d654a5d3fe59",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc38.aarch64.rpm",
+        "checksum": "sha256:d9828e6e75cd847a6cf4aa0d27d0f4884df5779546ff6b194a759a84e1894e85",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-1.14.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:de090ad42c7e36fa7bb2e4408a6bab45e216c0420ae055b9ba1f96c20f804463",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a3124d8a892116345eab8f50b79835214599ea061cf66665397e9a1cf0f05ba5",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-common-1.14.4-1.fc38.noarch.rpm",
+        "checksum": "sha256:313910bb3c90cc31b7c82212fa71121c54b311f1d9af4eb78e50c7d39446ac86",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-libs-1.14.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:651e597e44eb44b6ebcd6d1c834a71d76cb2826c03328e42b0da4d2fc1c4c9e9",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.3",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/deltarpm-3.6.3-4.fc37.aarch64.rpm",
+        "checksum": "sha256:608b7df709cddea3a9733e93502f1f1c052d3cd6044f2b00af6116b4cedd10bc",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.185",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/device-mapper-1.02.185-1.fc38.aarch64.rpm",
+        "checksum": "sha256:9cf98847c92321215a42aa1061e143f35d10ac3e738943ce0ce00dafe1df9471",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.185",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/device-mapper-libs-1.02.185-1.fc38.aarch64.rpm",
+        "checksum": "sha256:04296a5d261f241802a92a70c9b000d98e11c0389d689af0bd19bb55abf75bbd",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "4.P1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dhcp-client-4.4.3-4.P1.fc38.aarch64.rpm",
+        "checksum": "sha256:a6a4f4f771635485035a2f16b8a152f29aff11dc1f975e78557c7241f0c6722c",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "4.P1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dhcp-common-4.4.3-4.P1.fc38.noarch.rpm",
+        "checksum": "sha256:962c21812673023f39908e6872018f254fea94c46312a1d50a5efb0a553ffa25",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:786cec3721ba9907a4c69620cee6bc3952de8f27dec33f57d9939619b8514f87",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.4",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dmidecode-3.4-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2d2bf7377a0181175b289acae55b3afad0dfb850ad9f65695818ec80481abccd",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dnf-4.14.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:e204891e00573ee6e4d11ff11f373d345f1694ca657af48d2d3aabf7767ef7ba",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dnf-data-4.14.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:7191d8248bdd79d99bd96734ccdff48f8396cb8ed2d6e3685e1b26e08574c40d",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dnf-plugins-core-4.3.1-1.fc38.noarch.rpm",
+        "checksum": "sha256:8dd6e8a9176e9902effd883bf722f9e66cc931df831bd0ac070faf6c51ea9531",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:38e6676864f276c4364b6324b787b6e19ad4d160107e9867a57fbbf84530a7ef",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dracut-057-4.fc38.aarch64.rpm",
+        "checksum": "sha256:b25ce7686cc5c1cf3d59e8a9ac89156e9f4bb846de8a6fb44ad33c1a19179067",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "057",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dracut-config-generic-057-4.fc38.aarch64.rpm",
+        "checksum": "sha256:15a878661b48b5b4613601eacfc195b812e069a839324dd7d963c7a43d03f1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "057",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dracut-config-rescue-057-4.fc38.aarch64.rpm",
+        "checksum": "sha256:83dd30b8a1e0122006e6c7c0d37a96d35084141070e16e32f19da807793a4635",
+        "check_gpg": true
+      },
+      {
+        "name": "duktape",
+        "epoch": 0,
+        "version": "2.6.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/duktape-2.6.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:015477e0760f1cc1f080ca43716bcf05c9e40ff7394c26f25e5a4e5512f4074a",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:34eaff2e19c7ecf3be38670103a4ca8655c5670f42a3c32d4d1fd13de76be842",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:bdecabcb7a7e24b2c2d52220d2e958b42466e868416553a079a7f01c0d5ff0fa",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm",
+        "checksum": "sha256:433b6f621d595b607c4a9f73201e4be9b2a54535191b214b5905278e064c32cf",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:19a1bf0b6a02842ec4d86d9a26a0fafb3864b8a18a05eec266d52bb58f3d1feb",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/efivar-libs-38-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b11aea62a9e6e4295e33c6856c1a32b8f50af5ae98750836d1f97163a8a17bdf",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc38.aarch64.rpm",
+        "checksum": "sha256:df7f7e1774a64e458e4836972fc09673080e56490ec11b08327cb6137f1b9bd3",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc38.noarch.rpm",
+        "checksum": "sha256:f4cfae4f2e8ebb6772c7c5d6ca6212f776c36e5da5c47bb0ef51f444e4a68d3f",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-libelf-0.187-8.fc38.aarch64.rpm",
+        "checksum": "sha256:f3baa568b572643be26056e5f5bebdbb061d726c635c78fc2a8970335c724064",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-libs-0.187-8.fc38.aarch64.rpm",
+        "checksum": "sha256:6dc8ec1d8f370cfb509220b23a418938f44280f4d7d4a92458a78a5980281062",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:503b9b7f3b947c4d1a50dfe8dac8064b726a09beade31f116c0e3fd5df5ad78a",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-gpg-keys-38-0.3.noarch.rpm",
+        "checksum": "sha256:89ef8e879fd7ae5dd9e54405accaf1b558bb98edb423eaf27cd44a45c7c443bf",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-38-0.4.noarch.rpm",
+        "checksum": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-common-38-0.4.noarch.rpm",
+        "checksum": "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-identity-basic-38-0.4.noarch.rpm",
+        "checksum": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-38-0.3.noarch.rpm",
+        "checksum": "sha256:f295d316d8aaa426972fd9fff029497b28f9a7572da5faf7e1b121fc0868bd23",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-modular-38-0.3.noarch.rpm",
+        "checksum": "sha256:39b66e5e65abdb4c25ea38a0c70083fbe94a77907388fd521bfcc799494a8d98",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-rawhide-38-0.3.noarch.rpm",
+        "checksum": "sha256:2be19d631bc2c3399af9c4a02a73c882cfc79a0296e3101304f5f41bdd5587a3",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide-modular",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-rawhide-modular-38-0.3.noarch.rpm",
+        "checksum": "sha256:2af1c9ecfcad5bba54169861492eaa97ed3ecd54c295abdc373c226e7879158a",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/file-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3d7d9e4cc7520cba86f679322b635238761b4a8ffb443cb3b2e8228d88a5bdaa",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3a4df46e9482e6dd68f6ff70603e36aaf846d4767ecb69b034900813566f705d",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0ccaefa2ac125fc90c752808872eef3f72d0e159e4497a58a2b65ce0ca863ca0",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:bad9043c625b8d266cf0c817453af694b04d41e204270ce91b02013320e6a66d",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/firewalld-1.2.1-1.fc38.noarch.rpm",
+        "checksum": "sha256:0654cefcc22d52fcdbf7b3d0a7077babb6491a7d812a7c6caa68652da617672f",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/firewalld-filesystem-1.2.1-1.fc38.noarch.rpm",
+        "checksum": "sha256:a6c2d07340d47de477613c6c3ef2f643f26b00d6b47dea2fa6078a076268004d",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/flashrom-1.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:1b4d3978ec7272aedd39b654ca1e360d1d433da76cafc74e5cc0a4271b4f63dc",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:7c7b74094a5e268849ad2d86fbeb78b67b52c8aed96a88c855ac8fc7a274a569",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.6",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fwupd-1.8.6-1.fc38.aarch64.rpm",
+        "checksum": "sha256:12f94a958b034ff0c24f4ccfb2d5f13d42f47702bf61e151fb488323bbe2dd5e",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fwupd-efi-1.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:c6bcc3e1b3b6515466f3f771069003d1a7c28be3adaeecf7afa6318ad0f679fe",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.6",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fwupd-plugin-flashrom-1.8.6-1.fc38.aarch64.rpm",
+        "checksum": "sha256:6b5692cf64e00e2aca0b3a13ba133bce77c630c4ee79d34d4d1ca7b585d6fa3c",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.6",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fwupd-plugin-modem-manager-1.8.6-1.fc38.aarch64.rpm",
+        "checksum": "sha256:0ed3d542c929b09db89bbf79e90929c2069c2bcef6fbf58fea8076d2a69ae9c9",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.6",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.6-1.fc38.aarch64.rpm",
+        "checksum": "sha256:c6be0a645980cad59105282dfced45f7b3972525fa0a3fd8939c8057ad0e698d",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1b162d37fea25914e42e63e6483127b4ac8889e5587f461989e6be6769e5f694",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1520d5466cbb6f853828e3d8454a0a2a255247a2eb08315b35f5e8e147e6504d",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm",
+        "checksum": "sha256:7577f8eaa1171a15629ec06c438266b6ce586b59fdf65f8bce8f449a16faea7d",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gdisk-1.0.9-4.fc38.aarch64.rpm",
+        "checksum": "sha256:a9eec50a5268e65f02c40bd2fad7849deb6c895b835094d8f4c996824e3fa923",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:00054d4310ddebcfd966ebcbd42c072bfb69d0709f6165e2c0bc0ee1337efba2",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:4cfd593ae556df6f8e3ace44379261ab2d44044a2ab25c2fd4a4323b73cd17d8",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-envsubst-0.21.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ae88ef5dda0d2d000080a445ad51747a55df4fa94594fc11b1636639768e87be",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-libs-0.21.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:6605dc2f943b0b947a19c97fae4bca7608b59f1483c97882686c7ca05c4af7ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-runtime-0.21.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:bd568ab6d1fcc43bf18bc353cbea23fe884c52f54079ee6ad5dfbc921cb72106",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.74.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glib2-2.74.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:eb820f40785631e37e1a023f8494c75feb743e4a172a503ff3feccad1d24f391",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-2.36.9000-10.fc38.aarch64.rpm",
+        "checksum": "sha256:0107618d15c26f2cd52d1c52825e02bb2fdead1fd6449bd670427f5cf880757a",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-common-2.36.9000-10.fc38.aarch64.rpm",
+        "checksum": "sha256:98204d9f002323eb100429184488ca9130659290c4446c974a9346a6e93df889",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-gconv-extra-2.36.9000-10.fc38.aarch64.rpm",
+        "checksum": "sha256:b2a8f241adc3298633c436f1ca4433a7cd7e9bbcf019865dab9d7e1c1c1094da",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-minimal-langpack-2.36.9000-10.fc38.aarch64.rpm",
+        "checksum": "sha256:07c102c24aaa0e06cccf2968b5da223961571b1a22931834db21295711f94de1",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:25a8c9a2d2b341f6aea2cac2dae0d1cdd01266fbd7cbbf4bc9a044039944f380",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.8",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gnupg2-2.3.8-1.fc38.aarch64.rpm",
+        "checksum": "sha256:92b25b91d7e69e1c9ee6dff32948d244776a1ff75cd2eee87c3665cb427a33b1",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.8",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gnupg2-smime-2.3.8-1.fc38.aarch64.rpm",
+        "checksum": "sha256:22672c886e6d1f1b49f962ff7258c12ac43b4b65cf60aa44651982ba36b0c973",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.8",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gnutls-3.7.8-8.fc38.aarch64.rpm",
+        "checksum": "sha256:7c4743682019a693624ede5af59d0eb4b112c3c493f91f0c59ffa7d3e171b301",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.74.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gobject-introspection-1.74.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:0475dd0163729558a14e371351daec7d7bf5fa5fc70436f47c00d0acee7ead8a",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:12b45030df4dad11f26ed6e6d0c1c749941fcf96dffd72bbd4c122293f85994b",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grep-3.8-1.fc38.aarch64.rpm",
+        "checksum": "sha256:2d24979d1cf80f3906eab72efcac23bbbea35ef6eb10475631b5ffc32370621e",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/groff-base-1.22.4-10.fc37.aarch64.rpm",
+        "checksum": "sha256:6d5f46eddc547cddf4a2d33b952322d7cca7d32cb44891490f9de31c75b12652",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-common-2.06-60.fc38.noarch.rpm",
+        "checksum": "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-efi-aa64-2.06-60.fc38.aarch64.rpm",
+        "checksum": "sha256:9e2717a19a4f68657b5b82fccfc85e9bbb6dc3a29d87496b9f96edd3023c029f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-tools-2.06-60.fc38.aarch64.rpm",
+        "checksum": "sha256:d1e2e146ad4254ab7bad7ea61acbc7318a9a3bcd254f8c5d06f15a2fa97c5c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-tools-minimal-2.06-60.fc38.aarch64.rpm",
+        "checksum": "sha256:114871e86a9e186ae8ff94ea02235f4d1eb98f7ef22a6945435beb0044f35d7a",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "67.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grubby-8.40-67.fc38.aarch64.rpm",
+        "checksum": "sha256:08fe4ae654a7c12bf80888ad0f52dc8d28ad7cd79c74c2466fcc98ef9b229908",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gzip-1.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2b817b5ef5565a9190d29d77513dfbae65222fb156f80c4f64a03a12f0b8df52",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/h/hostname-3.23-7.fc37.aarch64.rpm",
+        "checksum": "sha256:a77017d08f6b0be4bcf52fbb6b471465a7cf6c6361195167b07e81feaacdb10b",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/ima-evm-utils-1.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:27c7f18e0360f10badc8bd3156fcf255dcfd0500ac86c7793a5edfef02a3647c",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "56",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/inih-56-2.fc37.aarch64.rpm",
+        "checksum": "sha256:7520ccf6e89c32dabf2d57bfaeef54a560bd751c521a045baeb93572489f062b",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.17",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/initscripts-service-10.17-1.fc38.noarch.rpm",
+        "checksum": "sha256:abfd9ef518fca89f4db8d12165229e5abb5155e187af197617f690512e3af302",
+        "check_gpg": true
+      },
+      {
+        "name": "intel-gpu-firmware",
+        "epoch": 0,
+        "version": "20221012",
+        "release": "142.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/intel-gpu-firmware-20221012-142.fc38.noarch.rpm",
+        "checksum": "sha256:a452e760f5b524cd86b3c2f252816d07bb62e1d59fdda8883148dfd6bbfcb973",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/ipcalc-1.0.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:c208a19538792b5664edf16eb9e1fa4e41a362a07879ef452f103eed5e3d9447",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "6.0.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/iproute-6.0.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:fe92321ab2497d6cc37cede52b83fbea4b2ffb16650e88e33bee2d2371bf37cc",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/ipset-7.15-5.fc38.aarch64.rpm",
+        "checksum": "sha256:eaae6a0af3ac091fc1a5a85f2a0747f4b0f915eada8396cc02229a28b9cf010a",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/ipset-libs-7.15-5.fc38.aarch64.rpm",
+        "checksum": "sha256:3cfd596aafe85ab76ba6cade515c90be03a63652a09521bd12bf2402cc18e755",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/iptables-libs-1.8.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f8429326af23a76cb51e2944b846a141b9d3d121a3cc455b4a83e319bd2a1d6c",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/iptables-nft-1.8.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:aec24794b31ece49a4cc72a2e038cbf4f58cbe5606a28bf40d231b53e0832542",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/i/iputils-20211215-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d48d0bcb1de7ca243014616e40871ae85fd905923636d46917467f947deef1c7",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/j/jansson-2.13.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:e59f2bf60be15a82c13bf6532a12b19ea2951c6b81f0f07dd110bd9747175c84",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/j/jq-1.6-14.fc37.aarch64.rpm",
+        "checksum": "sha256:36cbb69f70b77ab95176533a4b35ee1cc44755804d958038524222d50edb9238",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/j/json-c-0.16-2.fc37.aarch64.rpm",
+        "checksum": "sha256:b850dec7cc93073fd5c1dd6a86fcd4c300d046acb29c81d0cf1c0324a84a13ca",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm",
+        "checksum": "sha256:686fab2c75a3ecdc1573396c9dd97e7cdfc86da250bb0c01345ae0f0bb3831e7",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-2.5.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f45f46be9bfa2ed73829988839fd2ceca36600e3597605205841255b4556371c",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-legacy-2.5.1-3.fc38.noarch.rpm",
+        "checksum": "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-misc-2.5.1-3.fc38.noarch.rpm",
+        "checksum": "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "6.1.0",
+        "release": "0.rc2.21.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kernel-6.1.0-0.rc2.21.fc38.aarch64.rpm",
+        "checksum": "sha256:b312bd8a2bc1234dd63a701f35bc65bf4fcd8ec290a45debf3515b7f38e95d66",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "6.1.0",
+        "release": "0.rc2.21.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kernel-core-6.1.0-0.rc2.21.fc38.aarch64.rpm",
+        "checksum": "sha256:ee8965bd1645c1bd864b673ef0e2f869b4a7fce877abb2d4bb515c76d568cf82",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "6.1.0",
+        "release": "0.rc2.21.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kernel-modules-6.1.0-0.rc2.21.fc38.aarch64.rpm",
+        "checksum": "sha256:75b30fb7fe0a3e842a62dce2a34eb5d3ff740bc8e55cb9cb8e1b479d13fe9121",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:73d3c84d2bd0f897c46f04fd4d3e816b0a77c5e1a5cb3e8b5a5ff22b86065351",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kmod-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a1fb07220d23a99fd4122fe207749d09122b7781719da301a6f43d5bb9f14ca7",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:821d92639d372d0a91b18587c5b9c698ab93aa47260f100531ee57cf2d0eb13c",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kpartx-0.9.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:fe44f2c8c66aa23acee69b313fae5e001b28d139319677ea4aa6a4d3dc2f134d",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm",
+        "checksum": "sha256:48ff03b4055e7d41b519fb552410334f9702a955981b06ef9bedfb7ddcf8181b",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/less-590-5.fc37.aarch64.rpm",
+        "checksum": "sha256:4623dd1d17576dc75dc5e017429ddad453ae03b424c27b1f119628fa8f7b2c05",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:fdc0d4aeb8f58c2ff8afdd4e4716145c0f6dcf1d71ccc44e3e0c4986e0054913",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:07041e5bfeb6f98229333d7a77210942f67a5e6bc82bec5af0f7a51d401a68be",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ad059e8b67b65d9a0c87f6dab6c27e710c1e232b880475538d7f300cf763855e",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:2cef5121f03115ec8c49b55f61ed2a990861b9cde76f89645df461e34478c1f2",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "23.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libatasmart-0.19-23.fc37.aarch64.rpm",
+        "checksum": "sha256:44ee380afc6f438f608704b108853ff0d501b700c4a8196fa16a824ac31e777d",
+        "check_gpg": true
+      },
+      {
+        "name": "libatomic",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libatomic-12.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:83d32dc63c203187bce8ff7534440260235d51e0e9f1b0101d3f01c8adf59a20",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b5c2231369227e12b0c9e380a8ea0b6459a34eb73469b8e424a7467d11bc125c",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:33445abbe9ea176b4a1f40a3ad3bdc7aa3efb8398a627cbdc25dacaf5f95a74f",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbasicobjects-0.1.1-52.fc37.aarch64.rpm",
+        "checksum": "sha256:8cf395ef797a9aac4df6b7a02ce18a0032c76092bc9c4afa1471540c263e79ce",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblkid-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:df039113134ebe1450875b29e86003ba6d70fd29ad154d861c7df212e821007c",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-2.28-2.fc38.aarch64.rpm",
+        "checksum": "sha256:58a931d2c06f53b60f7ec8f8f02e475582b763985a41c74d81a62fc28d98e862",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-crypto-2.28-2.fc38.aarch64.rpm",
+        "checksum": "sha256:5113ea9d9576c9c8a7a47a815be9477cec5bdedecb717f4ce778d6fce2f89271",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-fs-2.28-2.fc38.aarch64.rpm",
+        "checksum": "sha256:d65784b3cf614b9393ebe68e270b1b2e689dc258daaabaf173ec4934796899bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-loop-2.28-2.fc38.aarch64.rpm",
+        "checksum": "sha256:f9585589b8e7587ceb1ae2dfa8f2ef019ee27d4a3f73cfc382edf099934b3e26",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-mdraid-2.28-2.fc38.aarch64.rpm",
+        "checksum": "sha256:449392dec0fc36be3820157dc7c90a1ea110644ed580483bf6fbf97667cc4dd8",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-part-2.28-2.fc38.aarch64.rpm",
+        "checksum": "sha256:7e6b74f7398bf2d4b7aa9bbdcd098c128ed93a961b8c1de18c84f641f3edee1a",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-swap-2.28-2.fc38.aarch64.rpm",
+        "checksum": "sha256:be3ef20dae96e3eab2f93cb740ede2268ea3cb3f28719666040ba4394c1aa56d",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblockdev-utils-2.28-2.fc38.aarch64.rpm",
+        "checksum": "sha256:8bdab2683f713bfec8afa396ce5bfd4e6ec9e87adcb5bbd01ca343626c97c726",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:85a45ca1842eef2537163421043df629daf951705453a8a6ce4c6b4d80c45a31",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm",
+        "checksum": "sha256:b5319b25ee50ebf4c3e1f0e20a627110459179858455dfe4e5ea9ef98ac3a0f5",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbytesize-2.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f11d4ef320502bcd0fe26ccbe1850a8969bf04cd28f04efe5b9e913054841fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcap-2.48-5.fc37.aarch64.rpm",
+        "checksum": "sha256:35d5d6f894585c851435e1eba94c6fc5e9c7cea6eb689f40b560b98d2542ae20",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:640116bfdde14e93341912ea1624c7a54944ed5335f79669c8da3c865ef4f900",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcap-ng-python3-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:331103386328c4cf8d8620885a847703b5844b568ed842383d4ec454ab8e1846",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm",
+        "checksum": "sha256:bdd1cffeb7fd0ce84ee0223c0fb1325505d96803a781c399181ee8f86a0bac8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcollection-0.7.0-52.fc37.aarch64.rpm",
+        "checksum": "sha256:add4f6ec969242fe36a7c88306688551123f93fcc74864671956683aa1d86339",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1fa19567790fa568c37734961a36d3055308b0b640e67f58a5a25c0dd4c8e791",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcomps-0.1.18-4.fc37.aarch64.rpm",
+        "checksum": "sha256:b4ca03301fe8f6074211c3be890a2ff44d14c8d067c469f92b111d7d841da3fa",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcurl-7.85.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:84d0d30b0bc33e35a1ba0d0b8d7421b7b66242d8a7dee7c0728633201eb8a441",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm",
+        "checksum": "sha256:659e775e54fc94630a050d8ad717ab4bf60ec1ce5771936233b01764456d8573",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libdhash-0.5.0-52.fc37.aarch64.rpm",
+        "checksum": "sha256:72859b9721f0c6e7d2a2fdb5c2e928eec80becbf1761dd723c8ee912dd5e4de9",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libdnf-0.68.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3794a7c4841e78c4fbd6003a9fae15ea6912cfcb9ba582684e9e606bcf60dd6d",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:5d678daeae88dedc53e06a79694ac5917341c30f2500e5e09928d0ed74c08a59",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "43.20221009cvs.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libedit-3.1-43.20221009cvs.fc38.aarch64.rpm",
+        "checksum": "sha256:8ce21c95f1561f61e01d074200a4f1d5ac96c95e00e2ccecfe12d360a18d804d",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm",
+        "checksum": "sha256:0dc74a66395954759fab10903160f3643a43d6b26497c68c36588726e2a83e5a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libfdisk-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:53c7deb95ab9e9672f896a86ac4264d45a5ae6618f8aaa121d29acbca4aec9cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:0a38680aa5eb19d5f694ba4a6c15ba55a2439c29d2003ff7586f2268cb01f14a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.12.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libfido2-1.12.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:1f186cac7f4199f6927059b8adb3122c6c15e4f5ab92929aa25456164912c9ba",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libfsverity-1.4-8.fc37.aarch64.rpm",
+        "checksum": "sha256:b6339453924f503b9d3cb4dde921f7b705528e2cb7f562243444121e7dbf19b3",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libftdi-1.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:d42939c39dc1e978f4fa9530f3253d521cace197a18dc566454b0143c48bb0d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgcab1-1.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a317432b034404123e89b883bef600c1771247fe09f463fc1b39313bfc2e80bf",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgcc-12.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:23a74944220bbfc19d5d26ed1ecc24f6f0f3871a33c71569a15aa8d17101885b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a1eeea74b3fe8500ee50fb3ad828ee4b980d41f568ad31c441df42b2daeff71c",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgomp-12.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:b9618eabe91acefaa7406a01e8ea2033cf3cf5111ab9e1738b80212b6375d78c",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.46",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgpg-error-1.46-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3dc4c94526a92526b1af09a991f588ec4b4143aeadc79866fbd7e1dd021107f1",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgudev-237-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d5bdb1c4df2bf524e5800bb8f530181e31842bff8976a14d7c77360352a646f7",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.4.2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgusb-0.4.2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:89a5adf72e69d09062679b566dfb59b93d67d53944b395e4379b4e4d31ff9f0e",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "41.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libibverbs-41.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7afa5da1ec37dad4230b57f2df4d6c07f404b31248fcd171d330d2f8b7ad148c",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libidn2-2.3.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:65f0e543799ac1d7b993d4eb44e76e0562f180d0cd108d0bab6574240fca6ea9",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libini_config-1.3.1-52.fc37.aarch64.rpm",
+        "checksum": "sha256:3db76609448c443df02b8277429507b64f3ac814616778b80a7c5a2a0409cf96",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.12",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libjcat-0.1.12-1.fc38.aarch64.rpm",
+        "checksum": "sha256:a8129f094fe65cead350dabb4078b7c5f108a8108b24be0cb28f5d4ef874748f",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libkcapi-1.4.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:b3f83992a7dd875f0ab4cdc421e2f96f36ebcdd06077dcf3c685b349fa25a553",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:2396e128877a15edb4d75caa013a3bedd1bdc4f923aee8a967c687a702d72892",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libksba-1.6.2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:228736bb7c085e000a1c3b104bf5fb38ae2f60be99fe6a62ee67b44e9e571629",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libldb-2.6.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:3c156e8db644666cd02c17335383f1e33513f71ad05aa279fb47d7746b8ea595",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmaxminddb-1.7.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ea6f9c67d170d681d049b1eddafed05dbdb3915160c2b9e7a914863b9f512948",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmbim-1.26.4-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f9b91a1c6f4e194acd077ece95b995b3c0987734d75dfc3a0f2abdcdeedf1be1",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmnl-1.0.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:cc386271543d38280f8c4a28d701b292c8f5722c969e2a46e4fdc8b6f840be62",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:bb473c20d69060ea166d4e111ac457230d35e8e5a440ed1fae3db4b6da5dc4b7",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmount-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:329683a63e8ac4bbc810e06338f0257db0b231f90eb86b19e864d4036b3a7ae3",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libndp-1.8-4.fc37.aarch64.rpm",
+        "checksum": "sha256:9de5d871550544523eb64203df597c0eb2e3b4d4471d0f118eaeadae72055fc5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.aarch64.rpm",
+        "checksum": "sha256:051a659d539bcbbeb00f6c4f76a927fcf2939cc351302ccec6960d4d92305ea9",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "22.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnfnetlink-1.0.1-22.fc37.aarch64.rpm",
+        "checksum": "sha256:9d044d167ba9209a4dfe0314501e0f0cc1a589b45a40a65775bf7e433e71cbae",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnftnl-1.2.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:378bd2a9d051665b960728fd8a562c5b776ede0f8cc4821b5ceb92b470153503",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.50.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnghttp2-1.50.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:8ce087df2a91fd49e8e796e215d04125eaae9a334d3c55fead4f4eac7142a91e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnl3-3.7.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ade9a1cbf3063e2284c79fb80282dbb176de4578e9de53f96e45bef1a50a6c19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:2f04577c4ac4fa114df989e3ff36c69d10cb2e4fdbf75691ac1498c770bc28a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpath_utils-0.2.1-52.fc37.aarch64.rpm",
+        "checksum": "sha256:0b694b01bb2873bcc3585bb65ace24e92948af31e1f1f2a8211dabbea1424188",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpcap-1.10.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1db6355fdeda942720b166dec938b0e7a081cb87de80e72f23d30f5896f3bc97",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.6",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpipeline-1.5.6-2.fc37.aarch64.rpm",
+        "checksum": "sha256:875e1ad123d2c83aea326805a53f4140296c2a6afad6c45882e1cae2c8d7ca8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:a09e3668ccadb40503e28e2efd8ed3d0dec2946fc551856b25c845d8c6d08794",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm",
+        "checksum": "sha256:cbe6fe8f74c609ee672cfb35b75497ace1cdf17501a41f205bef49a806097e67",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libqmi-1.30.6-2.fc37.aarch64.rpm",
+        "checksum": "sha256:fc3310c7d92abc3e42e89af3afd7b9b050000878db63cf08167d331bf4cc3b76",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libqrtr-glib-1.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:60cdfaff2b8bd8de04414164dcdbb106e2fdb6846f2b6cb2540bf51eb9a80510",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libref_array-0.1.5-52.fc37.aarch64.rpm",
+        "checksum": "sha256:dcc4bd4d5fb72f38b7c23f32047cb820ec2dc2242f08ec69619e62582b909f73",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/librepo-1.14.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:19ba66f8a1b897f620e4bfd5d66bd7e190460f5bc68288d4fda15f9a23063363",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.5",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libreport-filesystem-2.17.5-2.fc38.noarch.rpm",
+        "checksum": "sha256:17f2d670442cfb22138f3eaf331e045c2b0526d0d9ec4c68f3b215db15168cd7",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:a685678a81eadc35331a74023672a94d7e8a71ebb15aa19ee3e0c2b79d4c625e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:01b4d4c566896c87ea8736a1a0406eb3480e5e9dec581a49c973ea30774cff52",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:2abcc292c06a17a25e60f0e8151c66943da7559c357e025f6acf0ece1cc1fea9",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:59035fd7df5f840f60fb189f96c5d12c2f0be34db6d91ba768358f797263d210",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a9b3c5a71bd562a3c71f6510b8562ae093a683db22448f03fdf91814123dedf8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:c6871fd28de18a80a42d8b5a1088210c32e9dbff12c5395d25c76cf8b4e65612",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:044b32d2bb74e2ad1bde221b87c476c83c8274fbf6f30e928c7ef721f59c518a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsmartcols-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:cc2566ef3de1b9983323341861fc4658422161e167eb29419deb2f438dd907e4",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ec60544d1423d5ea064e6edbd7beb3cf98e78fe5de2980cc9200428aa3452516",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:76382f66152a11217bfc5fa63aa8cc51ee0444bddab95f4810694eb83af21518",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libssh-0.10.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:9f7e876d7352b9857ca1421b5503d329f4198d287c2cb21d45e77e639f77ccd2",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libssh-config-0.10.4-2.fc38.noarch.rpm",
+        "checksum": "sha256:0f658f37cc911a0ed122c445ee07555c27d8f98ddf30424bdaa528cdf0cfe166",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsss_certmap-2.8.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:eb1ace6f27ff1c53520c2004f93389bae355517ff3b0db39d88d26fee2dedc03",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsss_idmap-2.8.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:b3c1e63f22367cf75cc0ddb8555ac07ed638d17e89a774cdd8feb65d00c7fc9f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsss_nss_idmap-2.8.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:1bc9eb309534f402f392c562fab856e209ce615228cc8c2d8f3b25384cd0542b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsss_sudo-2.8.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:665af0acb1360c5efc0ff4e7c5d5b4864bbf77ee94bdc0cb78ba85088de13d45",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libstdc++-12.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:a73dbf0bb7b043b8469fab0128420673cab87911f9af0befbb12c32123f0374f",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtalloc-2.3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:dbdaa37cc9bf25cabe9cb48e86720efe609bbc2d6244c115d601d932bac0edd3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d63275a7fba7a2bf7a30df0e4a32f9955eb932bd32d80ccdf70b0ca45f138b90",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtdb-1.4.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:cd85247a2b661c62ae903219fa25cff5f583fc2c6b193e02d201dae26f1ce84d",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtevent-0.13.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:4c6c0d8654f12e0f6b2fbb06d8ef55081e97f530a48562d4c844127d1fcf6b7c",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm",
+        "checksum": "sha256:89fdf49c17b8e2ddc9b8860ccd6ffddda6656589faa7adf9b0bd701ee89b0e04",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libudisks2-2.9.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a3ebf0ae35c1fc16342a8778cc9212b5254c9ee5162cf439dfe66eedfda5c39a",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:8b21c89fe2abd9e577631d2541cd7cfb1af5e11e9493c90b354dc772bef35aa1",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.26",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libusb1-1.0.26-1.fc38.aarch64.rpm",
+        "checksum": "sha256:bf2e33036db5d364e097118c03b577f7296786cee248f1ff76a4228db48227c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "13.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libuser-0.63-13.fc38.aarch64.rpm",
+        "checksum": "sha256:8ecb612b9f4babce896a84ec90ef21ea7dd1ad6f3320d2c54fc1bb2eac4170e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:b81eff17b72f9d25482a25eee089dea76ee1c2f853deae9b65e0fcad01bb8b66",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libuuid-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:90c932fe01f11a1ac5bfeb956aa4bf45570101e0b899e00c9a452e2c5666bea4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxcrypt-4.4.28-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f35d38bf1a573e6dec25fab79a39f29dce274b3e617f5628999a3a6ff0bea009",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:56ec328ba2bc798113071cb36196e69fff2e5bc3abb48be4cf263bfa101c827c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxml2-2.10.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ffa79d41f91cf48696bb9845b87eb8888efad8e52d914087d94de139363012a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxmlb-0.3.10-1.fc38.aarch64.rpm",
+        "checksum": "sha256:f8ee4c26b98c6d2c1cbd59aa001871b1e8387e71983c5935ed680767678fd263",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm",
+        "checksum": "sha256:9a2b564a7855fd993a70efa5e5b2e8fdc1c5ae8635ab8314eb3a2df544764d60",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e5f8a73efcea92b3d5df1e23cbbbf19dc32382bc367632850c3bdb717566beb7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20221012",
+        "release": "142.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/linux-firmware-20221012-142.fc38.noarch.rpm",
+        "checksum": "sha256:7011f454ba6e5d9f934fb2ad7c47e5c13e56ce7e9e1ac67f0c81cbca943b2792",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20221012",
+        "release": "142.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/linux-firmware-whence-20221012-142.fc38.noarch.rpm",
+        "checksum": "sha256:9cecd9c301c808e795c6d33b1440bbd552e71ad20a2bd3e523cdd8459210e62a",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/lmdb-libs-0.9.29-4.fc37.aarch64.rpm",
+        "checksum": "sha256:dccb33ffe4778bee0967443755e55e7ae96fdda9e827bc61ea6287d11bda1a19",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/lua-libs-5.4.4-6.fc38.aarch64.rpm",
+        "checksum": "sha256:368d069f5630080a91013f51d3a4ecff6dbd4ffe29f667f6b73cfef681780190",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b8b26543b81a634855287185000dcefe6c0e09f35bd77347e8215969aeda5959",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.11.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/man-db-2.11.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:0288a3b93e62a46e4f86ad136efffcbb40ca8ed299aca0e719dadd3630b84b6f",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mdadm-4.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:03ff91894dcba5710060a913dee3387294d5d918b4d92dab96205afd50459ae0",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:09f8de1e0c90ea397c7677df9e550a1296668a3e018bd58eb1f704b77d7e815c",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.14",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mkpasswd-5.5.14-1.fc38.aarch64.rpm",
+        "checksum": "sha256:25a5c9e303d5586812b4bd3ca7bc1b1af1e1fe80a1764dabd84409468c1acacd",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:e6164c42552319cacc4226dbb680be091ac0e0853a91b63c496822daff175b68",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a7bfc2e27dc453726495f11d21f2f4e79716be924d744a92d0a4e4fcb96acca8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:8753e26208dc659797cafc163c8fa06c3924d2dc9fdf6ccee94647ff4edde735",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nano-6.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:3c55024a1b2106ffdf399590f6ed7ea33f5ae534b601d7eb726a02ac02b687bb",
+        "check_gpg": true
+      },
+      {
+        "name": "nano-default-editor",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:60040f8563239848aabd3a655c2bc185a7d7f47dcf59228353a6713eec036269",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ncurses-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:c2fb53692b291acfb5641ac4128fbf5f34703f04dede9c51994fc247d13739c0",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:d3b7939b663a7c169c436d40adcbf78b20386928ffb620e951703ef5e20b3ed8",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nettle-3.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a17d3ec2925c94030cf456e706bc96b7f4cccfc4119d5b1f5a89aa302da12ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nftables-1.0.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:cef75ed0e5383138263d81e2cf31d65c1bfb2416f3fa33d91dd56f772a1aa8fa",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/npth-1.6-10.fc38.aarch64.rpm",
+        "checksum": "sha256:c6c268d36a199f6173e6ecc5cdbbc38b0e203d034ecb91ab09cb87d2107f0534",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.35.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nspr-4.35.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:02c8b71d500f26cf0c1ed100be369307fb8872cec16ccbb413199b7ee6c26f43",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nss-3.83.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:4b0701e9c84e575d8902a3a9b67e036fffe8c06620bc26eba52c6a9810edde7e",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nss-softokn-3.83.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:7f406e777df209456ce8ddf6a1e091ed20f46d536869345997d692c5aca9b575",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nss-softokn-freebl-3.83.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:eee8b86ba5a4df490b10f313eff21514290074ba7e7582ae9782a2cac7ed73ad",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nss-sysinit-3.83.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3eb44c8a2d21d2de989c939cf6f25c881d2ddba8c25c81aca4b78f6a0fcbcaa5",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nss-util-3.83.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:078b851568a516e84458ad0631655de6f8e136de0ccd35330b3bc02599887d58",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ntfs-3g-2022.5.17-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ff128f537a012f30dfec9fec00d38f9f50268198a124783e2c2c1dbc54a79873",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.aarch64.rpm",
+        "checksum": "sha256:89013dbf6d1eda9b50402fbe4691d2d911d7f9a1cf69657cd88e9a3232fa0ab5",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:03e753dd69715f7b1b4bb994eb3d9a0c9b26fa611603492f6b5554999f8e2114",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ntfsprogs-2022.5.17-2.fc37.aarch64.rpm",
+        "checksum": "sha256:73e74e9775bebc30a03b4407bb2b20061c09ee6b354ccac53dfed96205fc092a",
+        "check_gpg": true
+      },
+      {
+        "name": "nvidia-gpu-firmware",
+        "epoch": 0,
+        "version": "20221012",
+        "release": "142.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nvidia-gpu-firmware-20221012-142.fc38.noarch.rpm",
+        "checksum": "sha256:ff017b16ca598f61547ca1f70a677c8e8bc87794b646686acdd55a70ac12cc48",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "2.D20220919gitb041f6d.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/oniguruma-6.9.8-2.D20220919gitb041f6d.fc38.aarch64.rpm",
+        "checksum": "sha256:282462c376b6ee60c41d6d3d92369cc99c478bdb88d5b0683acd7188743ac323",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openldap-2.6.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:80947c794b006db9f11bc4b5eade078fb29fcd0f4c44819683b232936fa830bf",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "9.0p1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssh-9.0p1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:11f41a9c33efe9791f6fb47b8fab84c3dcaffa5bbb9811d96cceed1e03d42470",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "9.0p1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssh-clients-9.0p1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:c05e5fa84c9bc32032d400b31adc4e6e291ff18029f44d436c3c4c115c5d70af",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "9.0p1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssh-server-9.0p1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:cc4c3c8d3d86e86b9666d819723fa9d0b1bae74a5c517ddb80e57589a57ea690",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssl-libs-3.0.5-5.fc38.aarch64.rpm",
+        "checksum": "sha256:dff1f45a48b30cbe5b38a98dc4eb38da373f1248dc35f2256d245eb1fa9cfaa5",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:cae55e7380b67c572cd4f793412c604707f77b2ae5e1bbb77133b17f35ab5e92",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f811cc8fc811d631471eb6adabcc1014ea329258cf37c2a5f7b936830e3b2e57",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:c568a007b9dae0d471d6badf723161e565f921c2b1eb04e19aee5fbf7dc6e61b",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f54c232b4713ac362a343800003ff7deff1c5e7c75710235b9cab5df55ef94a9",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:7c508a709e816951b3650e600925e691f180f25f92b68f2b0433ef3d787137f3",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:ff3cb745172d9bd639d22e13dc66e94b2df4dae847cbc55d63ae6a6c1b69bf49",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/parted-3.5-6.fc38.aarch64.rpm",
+        "checksum": "sha256:818131ccd1235feeeb708903406eba00731ab0028b2272004b06235c75a121b3",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/passwd-0.80-13.fc37.aarch64.rpm",
+        "checksum": "sha256:b9e3aa8ab64ac34d90ce78c5911d91d7574de4c42bacd5ae9563b6d945147bf9",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm",
+        "checksum": "sha256:6835ca1b00813eff887ef180d9a41f561f9f096a39a6446e5b25dc9da283f8e6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcsc-lite-1.9.9-1.fc38.aarch64.rpm",
+        "checksum": "sha256:11c6ef78372b52968cdea9fd2062bec3fd0cdd77209d5bff8c58da2dbb3f61ce",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:25930a2fdaa748fc28850dc1afd3e02a497b0e4aac518d36be8c80a9fee91a24",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc38.aarch64.rpm",
+        "checksum": "sha256:6ccad2fb8b08b10aff2cd6c5bee0d3bbaf839d28872090a616972f1161f1adbc",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pigz-2.7-2.fc37.aarch64.rpm",
+        "checksum": "sha256:40ee09498cf64c1474ab90c473c9f363bf51611b18d2a929bb57cb8b6be505f4",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pinentry-1.2.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:315097bc4f6f543ef241fe82935e9e89ea9e3e35fdea84a9eeee6dcea75aad70",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/plymouth-22.02.122-3.fc38.aarch64.rpm",
+        "checksum": "sha256:576353a8452a5283209f9e63fbb70a3743369580156ddb57f726b00c460b58d1",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/plymouth-core-libs-22.02.122-3.fc38.aarch64.rpm",
+        "checksum": "sha256:ad7e1f3c7eac701c59cdc1251d90c68338d4c4770f7fc1ded5f82286e5ce6da0",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/plymouth-scripts-22.02.122-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f4212481acdda13660bb660a7169e44d46c9a8ec95c4f545fad6813553f13a9c",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:315ad79fbc53c6098168be87264263dd332e9b8df9fbc29a64b6fc44da182344",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/polkit-121-4.fc38.aarch64.rpm",
+        "checksum": "sha256:283b9a24381d643403c7957c5df4cb389890564082f1f16f9696ca8b35322930",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/polkit-libs-121-4.fc38.aarch64.rpm",
+        "checksum": "sha256:7d101e3624bb04eee8fedae8425964f6276d2b50badb75b6885ac255ad2101ee",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "22.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm",
+        "checksum": "sha256:e1a639fc3080b7266b470b39ddb038e711b1c758e522b5cda2618fa3cc22c433",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/popt-1.19-1.fc38.aarch64.rpm",
+        "checksum": "sha256:a7177fc17d2c1a947b971d5cc8528e477a19cca68000c30552f14f0a8e96b4ab",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/procps-ng-3.3.17-8.fc38.aarch64.rpm",
+        "checksum": "sha256:81982f4c377e24e62cc250654706f2236d8c714d3381c48704ba5ea5ebf2a139",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/protobuf-c-1.4.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:16a2f7b9a34ce32540c6e8a4ab87b68d5cbdc3ae75beae42fc8b83b41711fc8d",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/psmisc-23.4-4.fc37.aarch64.rpm",
+        "checksum": "sha256:d6a0316b7b4713c22e093abc05a5bf01541c77ed24578fe1f57fe437a4208a25",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2.2",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc38.noarch.rpm",
+        "checksum": "sha256:aca40dd03fc1eb93703ea43d9a96a70ad87792e1d675f7a9a762be71d8908c33",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "65.3.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-setuptools-wheel-65.3.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:e915e3507eb1e877251ac175df26c3be8022b31daedc39fcfa2e05c1ef190911",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc38.noarch.rpm",
+        "checksum": "sha256:310078572de43cf8be4ae7dd9041028fcdf4b4cba315ed3c97a53cf2049d6793",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-3.11.0~rc2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:0749ca93d398834c7e4f2c252100b1fc104a2f4461640ebe18928f2315ee0013",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.2",
+        "release": "4.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm",
+        "checksum": "sha256:d9572a1494fa167b5073b7a8633eb278b40d85d9d57426e2fec190cef713551b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-dbus-1.3.2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:a13de4ba06fb2dd33107779691c4d4e04b44af5d6cb8c24ec7ff37c5ad267eb2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-distro-1.8.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:ea22a10ee200ce742b5eb4924e78edbcfb16848853ba4944129a2fe8758e5fb2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-dnf-4.14.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:c9c6ccb93cbf9b7a962b10432d64d88f0a91fe856ab104eb04adc31d75dff2f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-dnf-plugins-core-4.3.1-1.fc38.noarch.rpm",
+        "checksum": "sha256:4d59c2e3c373b76eeecff57b35f8839c4b4c9c0eb877de739f582d56ac38a00b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-firewall-1.2.1-1.fc38.noarch.rpm",
+        "checksum": "sha256:978de409a64943493b270e96c146b501414df01a880ce29306ef3b48d6346f68",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-gobject-base-3.42.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:44eb78b7f830a5cddf847c541080f8d2f54aed8ffbbf9e9e0a82f148893dbe5b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:358de9892f2947ad5ae159ae918e9a568e1ae5f8e8ee56d875e21bc758230914",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-gpg-1.17.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:c944c353ce1d26e0cafbe1a171d2bd8002d9588e6d217c811e8862ff12aad4dc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-hawkey-0.68.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:e6230082f2c0be95a69f4d23d0722705cfe8f4c5681573107818c0f4dda626d4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-libcomps-0.1.18-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a42215e87f56483854177094f00a56dec2355e2cc0346091c0d131696114bd81",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-libdnf-0.68.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:5c5fa9bae071ce79c28fffdaf6d1377a5a8bc423cdb18ff83a8aeda51dec5c61",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3ae21d35720ece7b6a01da963444603844d323a7d498b7bbcab2aa26aed1117a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-nftables-1.0.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ce92079aa9854b25e8b0179e884c7fac36787f1227f087caddcce1cbc3f42568",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-rpm-4.18.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:74fc5e5601d6b7f798261c52490dd4283c06fd0a92ed91aefb145cae4dcbbfd8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm",
+        "checksum": "sha256:47a875f1e20f6981847217e875699f645665dc968dd77149289ddff4de1fd76a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-unbound-1.16.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:7bc94cac34223cdd536ed08b4fe8cdcc3b30fd831995075010cf1499dda82012",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4a9ff34d2b8abc163eff8534a8798e95e077d77936838930240b6da876cf4c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/readline-8.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:29f0368744406e96a46faa1601aab4aa62107e232cb19ca72bca5116249acc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "32.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm",
+        "checksum": "sha256:b2d2472284b2f589e360c7c49705812112322e53110b98faee4088f94933e9ad",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-4.18.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:2670a90b97a51893703b9617dc0368b4ec2aee9136f6351b3d06841dff284947",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-build-libs-4.18.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:8d212a47eb8c87e62775a24fe1d14073f594897b5191db50efe31ce678f4dab1",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-libs-4.18.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:e1e11cf874a9ce02555a090a5bb783562854fbd037216e4c23cfbd1fa7f11ce0",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-plugin-selinux-4.18.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:4f759215cd4075a109ac771993890b0e42dbdeacd14ffdbd8c81dce12e39dafa",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:554f968141a39d70387a507df696d17c013c5fb496911de82fdaa37e5f269961",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-sign-libs-4.18.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:47219173bbe39015751d8b33d5f524da87cd0696a307f58fca1e8358c99e1e74",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sed-4.8-11.fc37.aarch64.rpm",
+        "checksum": "sha256:b2c4f6d1944d3eee2fe5bbd79c89865cc89bde742fdb9538093048cc95ca6d71",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.13",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/selinux-policy-37.13-1.fc38.noarch.rpm",
+        "checksum": "sha256:dc7f1b56cadb7d7c1f4b1dba4bca9a87b22071d592f1e06e25d0be7106dd418f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.13",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/selinux-policy-targeted-37.13-1.fc38.noarch.rpm",
+        "checksum": "sha256:36e6835f02c897ea7d1929163cf0dba9317a9fe38637bfa349ecd291ba4b36ae",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.2",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/setup-2.14.2-1.fc38.noarch.rpm",
+        "checksum": "sha256:96f465090b634df32e8d5c1e95e915b82da5537f38c46f9eec88484b719786c8",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.12.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/shadow-utils-4.12.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:ccbd03bfb04069ba7c0400dd1b6ccd54a8dd83b5cd8881d0c75ed7d8468da1f6",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/shared-mime-info-2.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:8c0d4a908b2cf6051da6d5ce3171f65cf193acc1b10968a376424f11ad7dc60d",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/shim-aa64-15.6-2.aarch64.rpm",
+        "checksum": "sha256:700764e38ea8bc1c019d0aec39542b1af5f0c00f169a2210ff8d80504d0ce2ee",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sqlite-libs-3.39.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3cc37b098b36f89cdf93fc6eaf16bd650ab0b5e7040e789b567c42a934c5f03f",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sssd-client-2.8.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:b135f59b5f3c6935955ffc36cffd28c59e9678c3551297f689edd708e3910826",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sssd-common-2.8.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:e9e8fb55571c6d0431301a842757222f16960a3cbecff50d09a9b1dbd9aee16b",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sssd-kcm-2.8.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:2a033496e4f4bea32d9cdced89189040ebf0ab6dbf2fc6f7006b9c56eb2d1530",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sudo-1.9.11-4.p3.fc37.aarch64.rpm",
+        "checksum": "sha256:735bcb34d97de94e5515acf7b70bf6680e5f7a7235fe653bae666e9e664d41cd",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.aarch64.rpm",
+        "checksum": "sha256:679728f60d6d1a342c06aebe3830dad314a5e46ef4295ae8a0494c04f34fca08",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:0ffc6ebe5127bbc38080006a4fdeace052e8ca2765f41a8dd1190eee720b904d",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-libs-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:40ea98773d45bd6bd6a1e756afd183711ba5b4d4c1e56777551e9af16c4979b5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-networkd-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:e5fa3bc538b9b2cd12fc597400a656a60772c2874637d4932ae8db60082291d1",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-pam-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:decf31a52963be8f8735646a1b51a5e574a2123486ec6813f5ba6e728f5b00c2",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-resolved-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:fe3273344f14113724d991eadf8ccfbc945ce7be74c80bfe667d33c0741f5eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-udev-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:430204db219fd88d828a7b1e4ab0f716034128d10226266aa2ec3517ff48c0da",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tpm2-tools-5.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3a7e6b04e4e03810cb47b3a028c089de84917b63c03bd8f1bc82322afa59c78f",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:eb62b4c7c08929750ed58268b2552105c360e8c0e8adfc4e1a53bb398e69333c",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022e",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tzdata-2022e-1.fc38.noarch.rpm",
+        "checksum": "sha256:aa71f4f1c3cc79edc9343ea0fcf558bdfed408a094ddda0bbc7582a0c647fc7e",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/udisks2-2.9.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:9e33a4dbe7d2fd2760c6912b6a5b8efc055d6ad93c9936689a940f3204aee55b",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-anchor",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/unbound-anchor-1.16.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f08914dbfdc4e8ca31930627a34f2c8f8d10878e4c0531638e540620f6da3918",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/unbound-libs-1.16.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:e8881afbc4b5e0c6db4a7ac69626cb89f7e619eb7af09e8381f8b8ca90033b33",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/userspace-rcu-0.13.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:5f0f886c8994e9def478076bbc14120da42450dd342b085a99b9ef8084af9aab",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/util-linux-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:30d5904ee6c1e49e2b78fd85c35202658945614fbd4f14b8e12dba342abaaf46",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/util-linux-core-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:6902ed20a768a81df117a0ceeb0b0494c17966ebec2a2a4fbcb426aa4de60357",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "9.0.803",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/v/vim-data-9.0.803-1.fc38.noarch.rpm",
+        "checksum": "sha256:59f140bbc5ba53d4b5c7aac0012bfc4c6d638047e3c335f46cb532bb884b46ff",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "9.0.803",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/v/vim-minimal-9.0.803-1.fc38.aarch64.rpm",
+        "checksum": "sha256:4fd1e29103ddcd00cffceb8044353a62236466327c6cdbf737cb44fd1cf2faa8",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "17.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/v/volume_key-libs-0.3.12-17.fc37.aarch64.rpm",
+        "checksum": "sha256:72e04c6d932e87f097a4bc344d67c2fdb383f5f5a7a532a236321f6a4dcfbb66",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.14",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/w/whois-nls-5.5.14-1.fc38.noarch.rpm",
+        "checksum": "sha256:a0527ff7d382107084ff5a8d5a5c9c95e4f2b526fbff98dfb251c947f4003efa",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.19.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xfsprogs-5.19.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:f99af7003a71fc0afacf96968a740ea2892b2fc8c6b45ed8321fe7fe0260c4b4",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.7",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xz-5.2.7-1.fc38.aarch64.rpm",
+        "checksum": "sha256:1257255c6b7842e0a8901cfc767dae55e22d642b920ef8250e6ded36a2b53615",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.7",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xz-libs-5.2.7-1.fc38.aarch64.rpm",
+        "checksum": "sha256:109073906a2f705f857104e3505315c122e4faa14142ad90d0bbdabcba257bc9",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/y/yum-4.14.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:28dae95fc01ad9a74e93e6c4a76ba4807cc2d920aaf99c2124133a2fc5a4e54d",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zchunk-libs-1.2.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:2b990ceb0f22e2147777ceace7f486a6021e9373a5ece97feee463bbc9793cb2",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zlib-1.2.12-5.fc38.aarch64.rpm",
+        "checksum": "sha256:fa38c933e194c67185d9982e700bd67f65b9c8fbe23f0146a3a96987516eb668",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zram-generator-1.1.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:37596c9b03d1beac82964c6cf5b1e5abe75c4a6975d82973ab2d4dda90a2faef",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:ae6ef1c1cfb61f9940bb23f79d271e8b6e4ca7cec9825dfe992cb8ef7a2b1aa5",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_38-x86_64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-minimal_raw-boot.json
@@ -1,0 +1,11501 @@
+{
+  "compose-request": {
+    "distro": "fedora-38",
+    "arch": "x86_64",
+    "image-type": "minimal-raw",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-modular-20221025/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "raw.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora38",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:70592f23f23dd66ea9dc8014026eb63d87db185dd5350fa646710f70c6754631",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f14c5249a75f2813499b6b49b59929c8c4c390237a909aad8cc4c902b8e60d62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b02ca8808bb8cd14dfc9da4fac4d1a0e90a5cd9a41c801686c2c4b61dcc3de48",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c420528bee4010117e5e5c5dedf1a30811136175e4d165f19162295066d224b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a275005b6cd03f94919a8db25ba6615e017d82d659edc9deab146202cbddeed8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1379517e611bd4235f3fea36107cd095392d05bc7d5c6d9cb5aacf0a87946f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28d665711b8c7b76a067b53a55127d06d361e911e33179b14d203bd06888e07a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:559efa0bdbec897dbfb2011b498b075b4491502aba95b913ddc2fff84df614cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da0bfef07d054d11e12db8c5026302f80895d45f5cabfec3fd4f340ed7935a95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75f5ed61039c566fff9e769f3bd632c194d9f112128e71a7c4494bc85a6d57e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c09b8285b4fa856c472ff33e8220186fb35220161fcdd2b6054dc27574cf5066",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df36f338c43b86547adf17d9bfdadcad07f1ac7d6456bc416c29d3373e6287c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ade1098a8b124d57f0f5154e6918819e2a6f63206a55e84326a5a79498c9f817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf584be55e7774395bea83a383c28d148fee267ef396d5a6b3b520cf1e724db4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:997a1f939ff6c65d45f48e4f7496ec97aa091f4274084a9cac776ec94c6127c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e35838c07a6255862edc0a3b020a294626c2f2c1c966c65b79734aea54dbd4f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a069111178e08a8e414eb9a738f927cadbba2817b343142489f63e8c3e592100",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:313910bb3c90cc31b7c82212fa71121c54b311f1d9af4eb78e50c7d39446ac86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acf915225bc2597876fb3cc3241edab02490c2679f8429933328084ea0a04b2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a77dccadd29c0f522090b7bb5720fc3bbeb6cec5ae32eb044c8bb2d1f4b8768",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22cceb6527dbd46ee35cf2d461003df43bc2637b48b86dd8a677ad50bb7e3f84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74026fb802867ad2d70544e1ebee0d6d699dfa01890a4044b385ba435803760f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:781a96f533f2338c4732f93fa48a5ff2690f544a38c506fdfa4100292c882933",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be840ed4c79ce5eb22c1870864120d1280d723731b88504d175337506cb4d680",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f02595d2c580ab3f0cd4048137140898e09f2b7092d3c26b8d7e7a234498d091",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffefe533dcad6a1b8688fd24d675b7eb00bc5763913aa584be5f0a02762a66fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4cfae4f2e8ebb6772c7c5d6ca6212f776c36e5da5c47bb0ef51f444e4a68d3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e576e370fe923be6cbe8f23a72687eea55b259d0b846c638e11bce7b894413cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64deb61911d55fc1c9ba0d9e1e7eb10b77b6a1963e67266a9bea17dbd6f74238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0c055b565c6514d2f8d7be063202e550357c6146b2c92cc17bac6cad59aab2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89ef8e879fd7ae5dd9e54405accaf1b558bb98edb423eaf27cd44a45c7c443bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f295d316d8aaa426972fd9fff029497b28f9a7572da5faf7e1b121fc0868bd23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2be19d631bc2c3399af9c4a02a73c882cfc79a0296e3101304f5f41bdd5587a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c91dbcccb9f11de00029b63890d10d496f58e51731b5f4afb6700685a4bfa264",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bb7bb8b78456dbd0b94511b26becb472ada8a5482871ebe7e2f8a8a044fae3a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3598c5f780a4a3af6ec93a80183361d0339f7b94da25a09e6356d260fee96fdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a0b7208d4fa48eff55578ad2e99d8d4a53888ede87df804c6bb89d125417c46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb8340f6d2151b97e54df3fe09c063ac8f820bfe096753cfe395e2516030c70c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:336b5d44b186dbfa29e8c4a2c387a6225671787812395bd49c05249d969008d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:408b6c8214a6fbdc2b921d3d1acb056b3a8fba0e7d5f51ca7817b5e55c59270b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58a55546644acbbf49ac082cd4855f475192caadc835722c38dd86ef9d285057",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:898b382eabfaa94f782cafb61fdbc1bef82d69e3f616bb9f00e1ab080f41ccb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7da4199722fa5db76e95dc503f62cb954c90b588d0db49d096565fa8a74bdbe0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fd7c1aa26f19b023a252e7edc5bf42372bece3b15de889c882ff276f8445f2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a35bd31f378f8c866577017f750248571fdf2d9b4f8f1c1d58c67c847ec1fb6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:238e13f764c6efc503e17f5a8c98dba1c1a01cb2d5ef8a7d037df4a6f3741f1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f93547eeb6911beb0ed3c4082d2b81fd9fc3c80b77557568133eb80c9744af82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:82909f3b2c48da81c37425947ca7b331bdd49ecaa404aba1443bf0885622ea6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:718b9103f02d5aebee50918c1d324cda6e3c5aec8e63ed8daaed3b1b104acd7c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:154c20ac5d2a2a1286018dfce619fd883c520307322ca3a3513aaeca755130fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:623394bbabadd7595dd001d9909de43fa4ac339be2b2cce66d94f4e3418c3ccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbe8a6710d8146771ce0c68a9f91c6515ec2d58f1ef3737aa08992abfbe29fc6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0bfa7c7b3371a5fe0130d4f26aab83270fce96f819ccf45d1def09c39ac1b0fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38b7d5c5f8aae3b697e3a9d21ca78465f66980acd0cfd8bcccf100c2cc6400f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd577dc1b6787341ec0d89a688a9e5c5450badbebe8abdc1049aca4f8553c3b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6bc9869c8ba8704f16fcec7543d4b029dd51213ff171fee7cb8e0a3da167b77a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fcbd5077df15f8c8d3f3df2139087238868ef26ecdd68669364b4fb3e355c7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a847f339173fd09197887df7f84218b2cba1020e80b78399fca3e084751b77df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3b4d41f2e0c05622a18888d356210282cc3309fb132a0e967edd8aa0fafc58c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6722c48276ab3dc0ba58692892d06056097e973f44e416b94bd26a5a975f2b40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9fb93562eb8a553196dd8133a422161c0c54f396338e2467a6830cf79db37f38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34fb99840e8800b5f105b18aed42c33371421e1cd6c4092727cd9a01587a072e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc8a30844c2e5a519e69bc35e9a12571698a99c89dbe4e6e4febaaac623636d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36ce047183f8e73f9dc2e675f800001e9656dc31641360224c04a47a8f1437c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b52d63173a94b61eead79ec9146111a5877b2e9f5a21c947e385fdef8304969c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25cd4bedd47325a47e47a27062fa6c139ee56a92ed119fe88eefd6263a2e09df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a9f3b0a766c4436de5242a0a6f1f52c94f3d009b963ef3c2385472d12ecc88d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d012a020c6e80fb827881e026d572022730cc86c16d0b6b3d3935c2860e49d10",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa9327946e86d20192948513e27b5314e565bd533f4e801215cf62190314056e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cde5a2b8b2b57ca5986327f5aea5eda780e3fce2a38de4bc93d1098c94781d50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66797ffb041aa8f8df7259c33063a328c641ca6a9b2c01b226877d7369d0ac91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a51a769a3a49965980b3ddf74cc8dd8380265a14bb76fc3a78645dee87bc828e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d77164c603273f980bf9152290c2b507df0c6ea6b907c93f1de73c50eb489f76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0719f5a4f1e14196f2ef1cca8107ca91585a1b4fe8b382e84e306c3bcab4f2a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3201b65c3a8178d52164089dfe5800314b803d1a88367fbe12c8906f1c05da02",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff1cb7ddb5c0ebf0b4dbd9e307591dad5de749f9a8226ad5fe38ce1dd6fc9b39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a66d6e4a4d83cb48ab7ca731da9c63c3e40d3f8fa2e9c1d4ea41cf3924c0415",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc809c6aedb53823e5ec114794e529db7adb287ed66b4773620c4a1c2f2b3001",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f216369a72a6f3cd932463e7d236c853b1bf2f63526b1637d0aa1269ac35ce57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f6ce4010c06399729060921fbea0e39c25f87b0dd7820143cceedc9e858441f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6114461c8756323c5470f2be5ab45e7405bcb9e1f54b01f6c82c80c1595af34b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b38f041914297b8dbd7e4f04571eda70ddb58c39babc276af8352c2552dfd60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9021392d34a59f5c717cc4523d38574a4e110fd24ff554b771e5c17f42369df0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:348b04d1e81b64dc688fff396798a364212e27cada55e87ed1eed7336782fccb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aafc48fc095f171d20fd31e1a4a88784ca8017a75d167bf794dae3394661517",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc47bfd4eef2547fcd6980a6b0a4f19ba84d9dab159bed6bbbf7a5dd43fee25b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5394d42b3f062b40e98b594f338122b3cbd4d8dd4e3469ee8d02908148a27122",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dbcefd797e17c3e6b73bb43351003f8fdb5236bdd6f4e288301119b663a0c7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20925047133a5303a51f4e376b537c3d14c2a4ab0c239c5b480327a948b948ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:093d967abc65b0810e20724e9f8e446d4a3901ef0bbd0aed7756e7a1535644d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa1981728f4d99093e379a6cdf6815257afd48a940b3fcedeea53799234e662b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4d348f2385b36bdc1a818b36511e491ccff83cbb24040472303e8bc02a1ca7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c96af87a1d3aad0cb63953fb402ae37d14823288dd74e910686d0322172140d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83518b7a45109407fcac3427dad51a9f7f7d3668e0a0942ad2158da82b869476",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aad543b786b8f870cd0a7a1d472199b5ac3f10a87e58133146470c3183d6862a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5f0521c7a9e1cd8fbd0e1fe82f3f91de9ed38b4680bf2eb929cd592522c6652",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b480e6b6364e9e1b048f2b17eb5c2e628e97956b5c448c8753998e5a253ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d8cedf110833c4652b589953178498f3d6ec9218b3419f3e25da8f89fbd379c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78636eaf09ba4e85ef46c9f53cf8832a5458817ee3c948683eeff253e0013716",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f658f37cc911a0ed122c445ee07555c27d8f98ddf30424bdaa528cdf0cfe166",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6269bc8372cbde95f4b6fd1189030903a5dbf0310fabbe5fece6cf60de79dd37",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6206e39671991eb0ee840e2daf92cd84ff72aa04b8d089e7dfe7ab29602c088b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:beb040c019a273d6f8b189dbe5898fbcce953fc8ed82a44b038177b2d5e50e60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39f7b9690b91d195a45782d7aaf37e407eb553027bbed89e9a9a2abaca6c461e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12a585c3a3636f88abcc9afb60d2a691006dc5b40879a8abd5e903a7a78a6a62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a3cfdfce26f9b7d7f3d3626e464f47e465308765d58366feff06371eccd1fec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f7f29a0e81b5049ae1882f1e6656133818b46d3923be2fcea41ff5e0ef10c622",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76bbb5d3dacb6b5d086d4c425ca05a2b63b8ef6f17e905d523acf4659b71c865",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98da69aa484ccd357cc76312774d53a64f552b21b594d74a2fd01be5e21f300b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7552ec8b34844ba0cdc2f8c19dbac36b898e3d303e778888ff30193333d0a859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf8017c6cb5e00fc35157fe47d6d13ed86079d9fe793c225ecaddac105834c96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f0e83dae6f1df1074aed8bd8a072edb2fed894f734ab55f07f31dd214e6db25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd981fc525ac4e032e36d2e8519288304936d3f5e89c866f22878491f46df8be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:695c89729d68929af4096102abc3b40ae12ce8cf18f0a6c85703474ffaca5bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7eae9fb9787d66887be6131718a6769fa6b963a6c3df9f9248ac0296aa7a6538",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e0812486718e1af122081b977142ec70c1b5046416db99c8c00901003520c2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0679744c52934c2f7285aa54209e7a3bc6db713f9570652894b8ebbc4a4b6fe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e0e9ba133c66e1858baa05017c196c75c59fe4c9df6d7b3476470164a8f17f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae3f201e386217e734ab85b1744505ed5346cb70c049ca8ee7f122b2550de38c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b4358d599ab4a52ee8509d33635a8cdd5da34487a7225a24b3fc72696adadfb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0aba1be1f5587c603583c56572bd40e54cee9789e2bc58ae7c0d4ab3a84848d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c416cd702ce78583b177eb152e87424e4e65a706cad8966904d10f3b413ddc54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79426b7b91b26682579cab6943516b32797f6c3028008e9c52d3299fb8299f1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d238b2e8d817b89bc0d1d22d716c3695185a96bf939b548e1143ff76c4d5def8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05172ef8afc62632b5e7c395dc9ed2f801e84ace131d36b1df777109df138797",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cb235881ac5c89085fe28e6fde153920cde9f4bdcebc17fca86723f3cc19310",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:043bbdc6ac7341dd00c1857c68d50f8fc91e2d589e1020c5c4678ef6327fd03c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d2bb2cef78697952123b3a7a6a21dcd244d3fbfea20f577f75fd09b9d52fd74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b03af8ac2ea38b815d942ec3acd99ecc6628c2047395f5c9667c044972fa114",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05b63669a849d7cfac20c627dc0bfaaab33ed479f7be9623154adaccceb68476",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4512d87241a25cc9e36731cc02119a5dff8fc576fb6526fa69732028b728d1f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2e124d9f28bc74b9987ea9414e1a5d2cac1dafa437085f5f93a6b00bd328ced",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca40dd03fc1eb93703ea43d9a96a70ad87792e1d675f7a9a762be71d8908c33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e915e3507eb1e877251ac175df26c3be8022b31daedc39fcfa2e05c1ef190911",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:310078572de43cf8be4ae7dd9041028fcdf4b4cba315ed3c97a53cf2049d6793",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95897c4f7822c7a154b19754b820171f06558c58487476755ec3e2e43f4656c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74a9c81894135aa917bcc1e202a05b1825d17eefeda9f4cd0be5dcb51cbfb402",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:216fed7a0ac19abeb145eea54e4d9accfa066aea30e68b7886467f7e4bb5fad7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7965785a37ec727d85958b6130c2270ed3bd0dc9b2acd2fb3f1b8ea833dad27a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58dfffe5230e210f2b0ea5256e826d4ad14934c96e6671aa4d5cdef9c50fdb37",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30802b6ca4d505cc587b2ddb566450526262753d8d3640dd7000098808be9e24",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8cd7312e2810f706aeec6985c277f1500be87f0e58f4311f1fd2d9ee00f5eb3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc7f1b56cadb7d7c1f4b1dba4bca9a87b22071d592f1e06e25d0be7106dd418f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36e6835f02c897ea7d1929163cf0dba9317a9fe38637bfa349ecd291ba4b36ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96f465090b634df32e8d5c1e95e915b82da5537f38c46f9eec88484b719786c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f491ed8c89370dd6b50559848f3a6f1da15dca574fb8f223522f7eab6709434c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a337038500fb016e11c6d3b507c166cc3d3c3f82b5d4d288deb7322485c7522",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a518008b5801ccdf9b233818e47b6533d7b7be9729065475836c7fbb1fdac0e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35b99038400405fdf56e8562ece4b2efb82148f0b51d4a4bf71f565839842d7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dabc9574f3b57343367de49c90ee35d83c9429c27d756f5a2cf52ee1788c9247",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c7caf66231bf06e65b6ef30f97d923da9705d1923d5765d4b726558ab116a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f202dbd3bbaf0710ead0a34ec18563d0835cbf169854afee778f2a07919c6e9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcb77480c5ed23e8b582a83b43661ce8ef6fc091f187d66794f315c41bc7db7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c614e41af121bf40bf33a48eb0886d99a9cc17665ea3120b063e1013c821d61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d52620cf80bde19169fca7ce66fa7cff416b04b7a0cf2bd7dae8446578dc999b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa71f4f1c3cc79edc9343ea0fcf558bdfed408a094ddda0bbc7582a0c647fc7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:747b441efd11d03e0170939848dd6d7dde39ae798f8d934777fbaf80cb622510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:798fb2747499e270c152059a31d15456dc426c8e9dc3448bc200bff78457cc91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0527ff7d382107084ff5a8d5a5c9c95e4f2b526fbff98dfb251c947f4003efa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e74ae013ee0e8f2294b9c4947d1a729005755528cac4a577f8a0d7f2e89a039",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d927c7a593e01c56c79d90e8be3a5d3de10a8efc8a5206e78081967881b96da8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b4b1667e8dad494e6437505e2caf52501ef6eb8ad7668fab2c2c591397812b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:777f6e31853070aba2797e9332ef135032be2a40291da87e40795dfd0b7c6e07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84b793fda6304051e2bbb6358e4c4f42a83ec68dc2a9a6b15884eb8ec401ca6e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34c9b59f820d71dd7d5b46a39f5b0377adc8f272ee5bee136734464bc17b268e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70592f23f23dd66ea9dc8014026eb63d87db185dd5350fa646710f70c6754631",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b763867cad65628e83ce7bad924692eb5e597bbbea3ad03167c51698f0b15239",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f27c5c6787f59696ceee324176b0b9ba64c4b1709ddd30fa0fc5cd2dc4c83f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f14c5249a75f2813499b6b49b59929c8c4c390237a909aad8cc4c902b8e60d62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b02ca8808bb8cd14dfc9da4fac4d1a0e90a5cd9a41c801686c2c4b61dcc3de48",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c420528bee4010117e5e5c5dedf1a30811136175e4d165f19162295066d224b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a275005b6cd03f94919a8db25ba6615e017d82d659edc9deab146202cbddeed8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cfbbd0a959d3acba32a3af8be1095733a00814417390c6e7b5e9f43048e79fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1379517e611bd4235f3fea36107cd095392d05bc7d5c6d9cb5aacf0a87946f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:627a4f6c12cfe958371ed4829de0eda73ab4fca3e696167f5780586d0dfef5c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28d665711b8c7b76a067b53a55127d06d361e911e33179b14d203bd06888e07a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:559efa0bdbec897dbfb2011b498b075b4491502aba95b913ddc2fff84df614cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da0bfef07d054d11e12db8c5026302f80895d45f5cabfec3fd4f340ed7935a95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75f5ed61039c566fff9e769f3bd632c194d9f112128e71a7c4494bc85a6d57e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:794645f5d6035cd473486ba62cd7ccd96b755a5c51244ddbc406350f20410fd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c09b8285b4fa856c472ff33e8220186fb35220161fcdd2b6054dc27574cf5066",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df36f338c43b86547adf17d9bfdadcad07f1ac7d6456bc416c29d3373e6287c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ade1098a8b124d57f0f5154e6918819e2a6f63206a55e84326a5a79498c9f817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf584be55e7774395bea83a383c28d148fee267ef396d5a6b3b520cf1e724db4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:997a1f939ff6c65d45f48e4f7496ec97aa091f4274084a9cac776ec94c6127c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e35838c07a6255862edc0a3b020a294626c2f2c1c966c65b79734aea54dbd4f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a069111178e08a8e414eb9a738f927cadbba2817b343142489f63e8c3e592100",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:313910bb3c90cc31b7c82212fa71121c54b311f1d9af4eb78e50c7d39446ac86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:361151172e791126195e46c380cd04cdc62c9729c64a88a479e774ddf11a9bb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39b86b1de69f52c26e72945d84c5767248a6ef3280289dc7c3fd5d55d251b504",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acf915225bc2597876fb3cc3241edab02490c2679f8429933328084ea0a04b2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a77dccadd29c0f522090b7bb5720fc3bbeb6cec5ae32eb044c8bb2d1f4b8768",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:680ab3372d3e91f57f0a8852c3f18c1416a7208ab6d48233e4dcc1543a39d8a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:962c21812673023f39908e6872018f254fea94c46312a1d50a5efb0a553ffa25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22cceb6527dbd46ee35cf2d461003df43bc2637b48b86dd8a677ad50bb7e3f84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d96a131abbdbea273866174699f0c7c563fa35481fc8ea198064ad1857d5e979",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e204891e00573ee6e4d11ff11f373d345f1694ca657af48d2d3aabf7767ef7ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7191d8248bdd79d99bd96734ccdff48f8396cb8ed2d6e3685e1b26e08574c40d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8dd6e8a9176e9902effd883bf722f9e66cc931df831bd0ac070faf6c51ea9531",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74026fb802867ad2d70544e1ebee0d6d699dfa01890a4044b385ba435803760f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:781a96f533f2338c4732f93fa48a5ff2690f544a38c506fdfa4100292c882933",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0ac75db74de456c8d7b94cde11ab5501b7575ec6bb63af3fa50a83b26dc281d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c42abbb29dd2811fb9ecf7ddac81e844fee21a27674f32543a31de51f67c69a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6e1018e5327403c955cb766feaa112687b3210f06afc7702abae185de061506",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be840ed4c79ce5eb22c1870864120d1280d723731b88504d175337506cb4d680",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f02595d2c580ab3f0cd4048137140898e09f2b7092d3c26b8d7e7a234498d091",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:433b6f621d595b607c4a9f73201e4be9b2a54535191b214b5905278e064c32cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a0c31c6ec6c1bee4c9f4f5004a1090447b823cabc97636846ff080b5bec411a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0c0c018d4123a23c789a078f73a0bc4e026b74281e5dbfe049c5f2b8266937f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffefe533dcad6a1b8688fd24d675b7eb00bc5763913aa584be5f0a02762a66fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4cfae4f2e8ebb6772c7c5d6ca6212f776c36e5da5c47bb0ef51f444e4a68d3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e576e370fe923be6cbe8f23a72687eea55b259d0b846c638e11bce7b894413cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64deb61911d55fc1c9ba0d9e1e7eb10b77b6a1963e67266a9bea17dbd6f74238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0c055b565c6514d2f8d7be063202e550357c6146b2c92cc17bac6cad59aab2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89ef8e879fd7ae5dd9e54405accaf1b558bb98edb423eaf27cd44a45c7c443bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f295d316d8aaa426972fd9fff029497b28f9a7572da5faf7e1b121fc0868bd23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39b66e5e65abdb4c25ea38a0c70083fbe94a77907388fd521bfcc799494a8d98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2be19d631bc2c3399af9c4a02a73c882cfc79a0296e3101304f5f41bdd5587a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2af1c9ecfcad5bba54169861492eaa97ed3ecd54c295abdc373c226e7879158a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c91dbcccb9f11de00029b63890d10d496f58e51731b5f4afb6700685a4bfa264",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bb7bb8b78456dbd0b94511b26becb472ada8a5482871ebe7e2f8a8a044fae3a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3598c5f780a4a3af6ec93a80183361d0339f7b94da25a09e6356d260fee96fdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a0b7208d4fa48eff55578ad2e99d8d4a53888ede87df804c6bb89d125417c46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0654cefcc22d52fcdbf7b3d0a7077babb6491a7d812a7c6caa68652da617672f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6c2d07340d47de477613c6c3ef2f643f26b00d6b47dea2fa6078a076268004d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2af369b0f500f875bf394b437524ba072cc317b0841cd62815691bc36d487ff1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb8340f6d2151b97e54df3fe09c063ac8f820bfe096753cfe395e2516030c70c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:709f71501e54efff438b6b418d8e69cc85887c6ff8b7a21dd8835d435f1668d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd8987f528bf3bd926c809d492f64374dcbf4a95252b569fd9cbf804848c319f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2f0e9e62e8309396833c485f185a928bcf9617db1f7e79ff24109857f217632",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:efb40dbd73db04020f2212ae13e8f781424bc0463c4e0ed30875e46737c1ee60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:583f171c10924f83bf4916eb98bb64a4d8d5c1d8522a721d3c2bee8c48e753ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:336b5d44b186dbfa29e8c4a2c387a6225671787812395bd49c05249d969008d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:408b6c8214a6fbdc2b921d3d1acb056b3a8fba0e7d5f51ca7817b5e55c59270b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58a55546644acbbf49ac082cd4855f475192caadc835722c38dd86ef9d285057",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:382de44811c7f29aa781faf4c701f54304fae4b41dae49e73b113a165feed110",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00054d4310ddebcfd966ebcbd42c072bfb69d0709f6165e2c0bc0ee1337efba2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cfd593ae556df6f8e3ace44379261ab2d44044a2ab25c2fd4a4323b73cd17d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:898b382eabfaa94f782cafb61fdbc1bef82d69e3f616bb9f00e1ab080f41ccb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7da4199722fa5db76e95dc503f62cb954c90b588d0db49d096565fa8a74bdbe0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fd7c1aa26f19b023a252e7edc5bf42372bece3b15de889c882ff276f8445f2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e82a29caed678de72840ce2b5911d67a68bfaa9a69da576649becde2811b46c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a35bd31f378f8c866577017f750248571fdf2d9b4f8f1c1d58c67c847ec1fb6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:238e13f764c6efc503e17f5a8c98dba1c1a01cb2d5ef8a7d037df4a6f3741f1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f93547eeb6911beb0ed3c4082d2b81fd9fc3c80b77557568133eb80c9744af82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:82909f3b2c48da81c37425947ca7b331bdd49ecaa404aba1443bf0885622ea6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:718b9103f02d5aebee50918c1d324cda6e3c5aec8e63ed8daaed3b1b104acd7c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4c60148da66b03578e6593b7b498ccbef81464b2456be1ccd84918aa2ae8d84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e953af5a5b8f5d9d4d21779c1925af9f5ddf6e9f9ebb1ce8aac547de19ac742",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb37630c680e8b9ba2480e862c81cd42994147fad219b44006840e8642e144ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7b80b715ca72917a9662b48c040f07fdb4343f69fe5f1b628b3a759dbc4537c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:368fb99245a0a78c0c229a9a53791b7ec0c4aaaf22d64451f36637d652a4aa55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:154c20ac5d2a2a1286018dfce619fd883c520307322ca3a3513aaeca755130fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:648b73a8211d7b165c80bf366895cb39a3b86dbbf1d971258de653be0b6cb289",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d20c06c82e13eb08ce603b9a676bd16ce74f78bcfeec0f67d8140523ba84649",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:623394bbabadd7595dd001d9909de43fa4ac339be2b2cce66d94f4e3418c3ccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbe8a6710d8146771ce0c68a9f91c6515ec2d58f1ef3737aa08992abfbe29fc6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0bfa7c7b3371a5fe0130d4f26aab83270fce96f819ccf45d1def09c39ac1b0fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38b7d5c5f8aae3b697e3a9d21ca78465f66980acd0cfd8bcccf100c2cc6400f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cd7cb3a9dcb03e1a3322200060b02fea694400f5c58ca1143a78758c55b6304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18238fedd785dbfe55bed864c13635a9feee9f4b929ffbd258c58e61736e4236",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12cb09ac132e4945809adfa22d3edbdc7fb458361d37032d6300830c052490c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abfd9ef518fca89f4db8d12165229e5abb5155e187af197617f690512e3af302",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a452e760f5b524cd86b3c2f252816d07bb62e1d59fdda8883148dfd6bbfcb973",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7931f5dc4a593808c00346a9a452e24e79d5a70201da6ffbd3fc18d9a0e04a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d604c93f87f6115968da6415b286ce60ac7a423cbf174beed96bada597ff5dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c51e6fdb4353a2fce7758af9c1fcc97e6a54f7b7162464b7888ac2796aa3e442",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3eb234e9d0b498ca0c700d97ee48b0d107c8454d93e0d51704de4d9f5c6552d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d3f733c72e0a227747d0c3319f35c197126a84cea362b4c32f34ea253d0e3b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:089e516a282a6611d8ccb37ed05870860c71d0fe0a00fcc75dfdc70e082d49cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dbb1fc38e0bac0925353d24aa78aeb2030f5eed9ef4b2637ccf5811d37fc807",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0bc33ff5df85f2c9a1bf645a20c77b60a7c270b1dfd54305d5ae3b75e89f4a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b39adb12197f08a665204c5628eca9a8025b24f12a77d6c7b4e04a2e11532a03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd577dc1b6787341ec0d89a688a9e5c5450badbebe8abdc1049aca4f8553c3b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f74da1c044980e6bfcdfc8340fa91899f9a944800e3e6f71bd6e99e7693df5e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6bc9869c8ba8704f16fcec7543d4b029dd51213ff171fee7cb8e0a3da167b77a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de8607703bf0476f4d60389d03d15780450bf30d2b0ee138965261107a2ee937",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a09dc2a014eed705062f6ce9ad7520ec5f02b705d7fe515ed9fd17880c7ea330",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4380ca3d259f47ea47a80ae46fc397cb536ba9c2491c643bc20d61001983b47f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fcbd5077df15f8c8d3f3df2139087238868ef26ecdd68669364b4fb3e355c7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a847f339173fd09197887df7f84218b2cba1020e80b78399fca3e084751b77df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3b4d41f2e0c05622a18888d356210282cc3309fb132a0e967edd8aa0fafc58c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6722c48276ab3dc0ba58692892d06056097e973f44e416b94bd26a5a975f2b40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9fb93562eb8a553196dd8133a422161c0c54f396338e2467a6830cf79db37f38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3a4e9b6e68360f24bb2b92bf23068c47e96d6d705f546648b2e10dd88e44e84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34fb99840e8800b5f105b18aed42c33371421e1cd6c4092727cd9a01587a072e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc8a30844c2e5a519e69bc35e9a12571698a99c89dbe4e6e4febaaac623636d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36ce047183f8e73f9dc2e675f800001e9656dc31641360224c04a47a8f1437c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e66f6a75e909357289e07d9ce9801a0662527aebee680bc255637012b956e66c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b79e53815bf9ccfdced5dc732b9d20ef47ab8dd20a5777e136adfc1740bf570",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b52d63173a94b61eead79ec9146111a5877b2e9f5a21c947e385fdef8304969c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25cd4bedd47325a47e47a27062fa6c139ee56a92ed119fe88eefd6263a2e09df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:193f1fe42eef13e768d599bc89b07a2bfaab4223e66b35b1a6f89e3712fa73f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a9f3b0a766c4436de5242a0a6f1f52c94f3d009b963ef3c2385472d12ecc88d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb56399a89890eb0b198977815af29059ff1e10f3a4d350e597ce2948c428980",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5d52ea60f458ae82a7924187ada1a537407ec86186211c0a3bac2f0d1f7a654",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:372abc48a1a19e06e788e4d5e8b4f20b498585e99db9d9cbf1a19bae64d80c58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0c845989f397bc869c787b032f32f070aa7c64549c5bbc8de7ad8ab2fb997df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eff1051e94730b8b50fcd37a109b3eb9ba0e9fed80745eead6a180b9135dd16a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d460ef02a880ed345a255e6bdc6920ac30d40668edd43b233bf28f71e235088b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:418a3538d59143ef1fe383afd0438b9807d3e5ab7e8d5ca563cf1609d6d696f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2fd247fbf630e9ea2775669d319b5bdef6679740b80062e886923eb791b49a42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d012a020c6e80fb827881e026d572022730cc86c16d0b6b3d3935c2860e49d10",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa9327946e86d20192948513e27b5314e565bd533f4e801215cf62190314056e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9afc19fb507521ee32f35e2cad4b530d863b2cc3810cb9b8408eb61bbb50b6b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cde5a2b8b2b57ca5986327f5aea5eda780e3fce2a38de4bc93d1098c94781d50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66797ffb041aa8f8df7259c33063a328c641ca6a9b2c01b226877d7369d0ac91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:633d70b8df9fbd3a9a66ac186e5827525a1d01adeed448147e40a2b7c2a30ba4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a51a769a3a49965980b3ddf74cc8dd8380265a14bb76fc3a78645dee87bc828e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:115f36517e2b9c7cab9ee7b092f8bfff6c1d53b09d0d774969c3884ecec1b601",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d77164c603273f980bf9152290c2b507df0c6ea6b907c93f1de73c50eb489f76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a0f03d9442843a9df7468a5a926a43c76d4c6437405db90598faea2f35434d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0719f5a4f1e14196f2ef1cca8107ca91585a1b4fe8b382e84e306c3bcab4f2a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3201b65c3a8178d52164089dfe5800314b803d1a88367fbe12c8906f1c05da02",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:453eec881996f5c80bec7ac779f7973ba8c2244e83d01e87daf4c3381b88a1ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8a3d24889c2c77145c7ec6734290188651f84ac1cb7a3d283189b5010e326dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff1cb7ddb5c0ebf0b4dbd9e307591dad5de749f9a8226ad5fe38ce1dd6fc9b39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65874efe12ae8f0816cc2ce6aacf65383eb01bcff313284424f6a4bad23e7726",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a66d6e4a4d83cb48ab7ca731da9c63c3e40d3f8fa2e9c1d4ea41cf3924c0415",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc809c6aedb53823e5ec114794e529db7adb287ed66b4773620c4a1c2f2b3001",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f216369a72a6f3cd932463e7d236c853b1bf2f63526b1637d0aa1269ac35ce57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f6ce4010c06399729060921fbea0e39c25f87b0dd7820143cceedc9e858441f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48c3829c4b7616d6985737c5c8552d49ac9d80e41780af6daa34963b8d5b9225",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b79f85fa9266e4ed110f75e71125593d7de788a3f8242a69acfb4be56e92190",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6fdb21908848e96e58d0ea2b495701eedad190b01f9df44c16e35f760cacae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6114461c8756323c5470f2be5ab45e7405bcb9e1f54b01f6c82c80c1595af34b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d599d9a7ce446f0c7e2040422fec9a241f6c45dc0371372e9704abdaa8bd21d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b38f041914297b8dbd7e4f04571eda70ddb58c39babc276af8352c2552dfd60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a3dbe2cf5ac3caacb44785b6c5005b6d2e3792a7ff6a53c26dac66b2675681b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50a0828e3f1eba2ec053d15a3412b2ca62ae513c3899ac5a6e88e9d91a21041f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9de9a79d1dc9c8937b1df541dedce3cd01be557bfa1187c46ab7353a73edd19b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:922d0eab6721af3757cb60b4c0b79abd47e32897ece35bf02f08bc4951c2fc65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9021392d34a59f5c717cc4523d38574a4e110fd24ff554b771e5c17f42369df0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd5ceea29405a70d0751933a5c3d6178b671c80ff97e04aec2614caf6156d238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09fc65ab51d47ada940766c145b96f738bf592e0359bb2a42ba2a398fdc7f6cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb0e0ae250fb3fb0abf5fa3e958148a5a0ecccf59b41b23adf96ab3f34c3fce8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:348b04d1e81b64dc688fff396798a364212e27cada55e87ed1eed7336782fccb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aafc48fc095f171d20fd31e1a4a88784ca8017a75d167bf794dae3394661517",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3822e08a6fa781057ae121ff8fc105ca0e42ecc95f3789cebd18944c7cc79e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c74fd7795d471046edbd2ba1eb6a984025519aa076b2e856363ca8c2c4e26e6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1d7d815ca8cc5ce4e8df78f2ddfcffec6742e482861ba670a3f7db5d418bbd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65d61922e3a2b117b79e44ffd2945ee5c8ee53e6d3603dff792982c04eb13d9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2acc31ad50943cab96867bee157c29e08d1b56f384c804cf33db0cf49f6cd026",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15358af44d005789cfda790606bd60c162b673167bbfe7153a97a043e1083768",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc47bfd4eef2547fcd6980a6b0a4f19ba84d9dab159bed6bbbf7a5dd43fee25b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:092a0396068edc5fbc4e77aa49aa5c312184ef4b0b7435c604107a52f712a19e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:995659e1f0c39fb758160120c68ece8446d14ab3e3b0527aeadb90b0547e5a7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a056805ee78f023e3dcabda0c298c6dcc16515a86153459c01905ab2b43e9be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:324c6e6d4a55b3ac12198e8c6a528be517d57cb38d27e3dd961bc0efd487b292",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5394d42b3f062b40e98b594f338122b3cbd4d8dd4e3469ee8d02908148a27122",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:118b3e835f01f45feb29c6c1eea1a50925ada9d5ff2804d6d7de74453aba5fbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dbcefd797e17c3e6b73bb43351003f8fdb5236bdd6f4e288301119b663a0c7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd593e435ea68265fe742c4c6e3acc7240abaf9b9d75882205c4f434b727e1aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:149011e66fc747517ea929ff80d4f88e72961b10e352a324a7ea4ec3d20503bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca34df9ec9bc66a150d308568c53e462a6f35b48a07354982a1773eb9cd0abe3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20925047133a5303a51f4e376b537c3d14c2a4ab0c239c5b480327a948b948ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:093d967abc65b0810e20724e9f8e446d4a3901ef0bbd0aed7756e7a1535644d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7f3c8c057eb68b6b5838ff0738826b996c847f2452ee62fb5c1c344161f633e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0315d368bde2128992a58c09596af85d39ef7a37e097bfc94612f3dd7178dad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cfd13bf9a8723dc1d74d68155e59692e83707928c7f1366be13472da7612acb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:008045c0fbc85a1b9a077567294efbaa56f61c75ab4100e86fa30a569480a2a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17f2d670442cfb22138f3eaf331e045c2b0526d0d9ec4c68f3b215db15168cd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa1981728f4d99093e379a6cdf6815257afd48a940b3fcedeea53799234e662b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89fc69c405e600d7667df2cb98d4c7d62259c72545db6267f234b28761244224",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4d348f2385b36bdc1a818b36511e491ccff83cbb24040472303e8bc02a1ca7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c96af87a1d3aad0cb63953fb402ae37d14823288dd74e910686d0322172140d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83518b7a45109407fcac3427dad51a9f7f7d3668e0a0942ad2158da82b869476",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aad543b786b8f870cd0a7a1d472199b5ac3f10a87e58133146470c3183d6862a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5f0521c7a9e1cd8fbd0e1fe82f3f91de9ed38b4680bf2eb929cd592522c6652",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b480e6b6364e9e1b048f2b17eb5c2e628e97956b5c448c8753998e5a253ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95aac8f490ae408be49651cba31d9ae7805157013629317cd5f13eaf6ce4696d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:891ca4669541cb323a77e6d2224baeebccb8d0bb892670521f63ecf4a5d490d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d8cedf110833c4652b589953178498f3d6ec9218b3419f3e25da8f89fbd379c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78636eaf09ba4e85ef46c9f53cf8832a5458817ee3c948683eeff253e0013716",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f658f37cc911a0ed122c445ee07555c27d8f98ddf30424bdaa528cdf0cfe166",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:940a47c7c4ac5950d7c5b455077cff86629084d494be38eed3daf533d7eb5428",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01ac72679f09426833e1f1c205dd530edd10c1120918e603048add5c88f25ea0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42efbc1fcfb7f8d67b57d8a126aa3dc8cf7319e04fc5cf25b1d877abbd41fe6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b42966c07956a13614b5cdb76a6e06a22b1e875df9d7fab0ecfb11f6729581a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6269bc8372cbde95f4b6fd1189030903a5dbf0310fabbe5fece6cf60de79dd37",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f3e6504aef91fc641678229a4f9d8d5428dd7b837cc4b0fb57038583025cdbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6206e39671991eb0ee840e2daf92cd84ff72aa04b8d089e7dfe7ab29602c088b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4eb90ba78d6ebbc54758ec1787b3c1adf2608962d183a101da8de1013bcb7cef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0eaddcdfd370876db1241bf7251c8f87e0565dc818887d2bc95d7a211c77b3a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:beb040c019a273d6f8b189dbe5898fbcce953fc8ed82a44b038177b2d5e50e60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8afe733f094d886431d500e2c5aac11bf8bcef0a05314160a968684cb006d574",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39f7b9690b91d195a45782d7aaf37e407eb553027bbed89e9a9a2abaca6c461e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c18e137d6a407e789f0f97718977096ad976198de4b161df87ffebe270634e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55384f7ceb51716e0153951f3b1d9a43e9369738110aa92e2c92d1d8db6a700a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12a585c3a3636f88abcc9afb60d2a691006dc5b40879a8abd5e903a7a78a6a62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a3cfdfce26f9b7d7f3d3626e464f47e465308765d58366feff06371eccd1fec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f7f29a0e81b5049ae1882f1e6656133818b46d3923be2fcea41ff5e0ef10c622",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76bbb5d3dacb6b5d086d4c425ca05a2b63b8ef6f17e905d523acf4659b71c865",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98da69aa484ccd357cc76312774d53a64f552b21b594d74a2fd01be5e21f300b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7552ec8b34844ba0cdc2f8c19dbac36b898e3d303e778888ff30193333d0a859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf8017c6cb5e00fc35157fe47d6d13ed86079d9fe793c225ecaddac105834c96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af4bf71d9a3cb9f325925a951710e50b92a188f87edac5ca2384520520845d51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6183bae674287b17dd36e3f5c01f0abcb021875895959fa63fb5061f18ccc4b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f0e83dae6f1df1074aed8bd8a072edb2fed894f734ab55f07f31dd214e6db25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7011f454ba6e5d9f934fb2ad7c47e5c13e56ce7e9e1ac67f0c81cbca943b2792",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9cecd9c301c808e795c6d33b1440bbd552e71ad20a2bd3e523cdd8459210e62a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c28ce263b298c1f526718c1cb0f055bdbb455e1130a4bbcf7113fcc992b448e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd981fc525ac4e032e36d2e8519288304936d3f5e89c866f22878491f46df8be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:695c89729d68929af4096102abc3b40ae12ce8cf18f0a6c85703474ffaca5bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c835c03812834ed898e6b55802fe5a725cf4da1e2ac0ba44d41281184a6acb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2022bb0fe9c17df96734f4667357ddb956fd82004e9297504649ac60081b5464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7eae9fb9787d66887be6131718a6769fa6b963a6c3df9f9248ac0296aa7a6538",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e0812486718e1af122081b977142ec70c1b5046416db99c8c00901003520c2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcb97e83814f4229c89c00e82bcd25ab41c69aee5157582376adc4963abd142f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0679744c52934c2f7285aa54209e7a3bc6db713f9570652894b8ebbc4a4b6fe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e0e9ba133c66e1858baa05017c196c75c59fe4c9df6d7b3476470164a8f17f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:debc0be72012ae50ae10caa306ad14b7a4f61e6bc43161da7036e3091900297f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60040f8563239848aabd3a655c2bc185a7d7f47dcf59228353a6713eec036269",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81b81aee93d47f3a869b2582a53a0b59871b04f7e7c0b84d5e12207a271b0fb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae3f201e386217e734ab85b1744505ed5346cb70c049ca8ee7f122b2550de38c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7548d4dced9671ae77294541ce1c82c7db90e5e1634413bd49e0d4830452969",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80d01a8159d6c89b9e41b743a26a7148cb4ba043d2c8667c80738cf2e7efdd8f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfe6c6e0137845e5df00d636e6e68ebf690c0a4fdf1d8fcd645d94789cfd2c09",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:857b1e118da83981a1996af675ac5607f4267e1349ed1f05f90ad994404e0208",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e77404faa136326e63c2a943466b97ca43ef448feb7ce10ce50aac6c2f8fea9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:981c202e4e80078691f7aa5227305987d76b4614cb6a6fd0d4a2ff6c6e281077",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:234bda5eee845cc15508ef8fcd46651ed15da4e363a6d1bbf5453b7a22bd2e02",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12f08f59c8fce365914e1df0cbb2e0765c6fb7cbd55afbb138558c21ec78fe3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:388b23668bd8281624d23b3a78f42a5441e3775e08e541fb52f405b056170170",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39e14c4ed790fe4d47bd984afc47f291cac78bdfc9cae7d220979ca52c7301d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6fc5af931ae4e106fac29e38db61b4ac4e86331088ab085cb2e9ff0c33dc55bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c6819de5a54218e8d69921d7e9cab759b794c4d65c5b9199e0da3e05fc31ec1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0be81593c6a700d883ff95b06a92afef5790a5fbcdb8d35d6cbfc9c4e87e5a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff017b16ca598f61547ca1f70a677c8e8bc87794b646686acdd55a70ac12cc48",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8551d1552725100d8649b44cc51cbbe8c9e70b9c16c017a95001b701c2ff9b4b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b4358d599ab4a52ee8509d33635a8cdd5da34487a7225a24b3fc72696adadfb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c42725936f017feea8989faa8a90b966377185d42344ac3a3642cad14e0820e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4750930ebe4765c67d3c6065e0a92e6a1a4359d85fd819a18dcf6370b9ff4102",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:219f4432383b48bfacb028bdc7ef9afe372cf213e05c82a875afd5759216cde8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0aba1be1f5587c603583c56572bd40e54cee9789e2bc58ae7c0d4ab3a84848d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c416cd702ce78583b177eb152e87424e4e65a706cad8966904d10f3b413ddc54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79426b7b91b26682579cab6943516b32797f6c3028008e9c52d3299fb8299f1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d238b2e8d817b89bc0d1d22d716c3695185a96bf939b548e1143ff76c4d5def8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05172ef8afc62632b5e7c395dc9ed2f801e84ace131d36b1df777109df138797",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cb235881ac5c89085fe28e6fde153920cde9f4bdcebc17fca86723f3cc19310",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:043bbdc6ac7341dd00c1857c68d50f8fc91e2d589e1020c5c4678ef6327fd03c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:003ce0d20116e00e8b521e5b7451ea0606950387352596c066fa983d3b709d9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:873a81a4fe3a7364f2b93cfc72f6a0153e26051cf4937604fd9394e405600753",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b4e2edcab2b0876625a00d939f8e415e1ba52c70bc5e21d6ed0713fe7c44a8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d2bb2cef78697952123b3a7a6a21dcd244d3fbfea20f577f75fd09b9d52fd74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96bc81e214ddc10849313be4f9503366bd39d7d727222e9f3ba5119fbbd85a3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaad7eb1db33cd9a7d75dc22f93fedf00d5cb5e58c4b91da4efc08394b6a3465",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f23e684c367b3f1b3494d0b84dd98d33a60cc803f3670367c4e79b4ef57977f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b03af8ac2ea38b815d942ec3acd99ecc6628c2047395f5c9667c044972fa114",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4bba3f7ef03c6c0f17a9362291b39641d6777bac223b90168b6a18b9a7f8108f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c7cf01ca9153dbd45cc44987044797a628af29d97cdf7af8a4466363c758ca9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf3eba90b87e314919d683f8c934451cd1d0e9e64ab6d726c03fbc2dc2e984b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b657f57a69a3851254fd572330a6edc79c8b48661ead3c647834023031e14184",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05b63669a849d7cfac20c627dc0bfaaab33ed479f7be9623154adaccceb68476",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:151d21077d158b81f0b444fe3c819179f235db61e889245610f2474494781055",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84933208c4c2cd87bfdf08817f28fd8b2ea2f4920d63739cea1b937d63c5d0bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d655e5491ee4ced0bf5a9a374e5bd513ec0c82f1d606a534312824280c111fc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4512d87241a25cc9e36731cc02119a5dff8fc576fb6526fa69732028b728d1f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2e124d9f28bc74b9987ea9414e1a5d2cac1dafa437085f5f93a6b00bd328ced",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88d3170c87aa58df1b10b0f385302c7154375d1c06bc253462b2999989baac2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:692a5ce3d939ef1069eb54cdd3c67ca814f604199ae10dd40e1d1a6305d368d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca40dd03fc1eb93703ea43d9a96a70ad87792e1d675f7a9a762be71d8908c33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e915e3507eb1e877251ac175df26c3be8022b31daedc39fcfa2e05c1ef190911",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:310078572de43cf8be4ae7dd9041028fcdf4b4cba315ed3c97a53cf2049d6793",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95897c4f7822c7a154b19754b820171f06558c58487476755ec3e2e43f4656c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9572a1494fa167b5073b7a8633eb278b40d85d9d57426e2fec190cef713551b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f4574b0789a4724c8a80e83408443a94f78a79b28770f87e3ffed7a991c7edc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea22a10ee200ce742b5eb4924e78edbcfb16848853ba4944129a2fe8758e5fb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9c6ccb93cbf9b7a962b10432d64d88f0a91fe856ab104eb04adc31d75dff2f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d59c2e3c373b76eeecff57b35f8839c4b4c9c0eb877de739f582d56ac38a00b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:978de409a64943493b270e96c146b501414df01a880ce29306ef3b48d6346f68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23de5abc3a9620f7f8c5917cfd452892cfcab34fcae502de4d04f83964ca716f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:358de9892f2947ad5ae159ae918e9a568e1ae5f8e8ee56d875e21bc758230914",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ae53041ff5534b34434f74420fe2726ee16da7807058475993c1035c729d477",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ddfb8d7e3cc7379135eed9e730f5b14d248e6d603f53076688a0a1070ed1431",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e62e029027cfae50e42f483e2e275cf33f6e24e4bfd8dd0b88b9be7ed719ef6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b788ac65ce0f002c0ec43e639ecd7cd65db2ac42f8ca2619d00c29a9a473cec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74a9c81894135aa917bcc1e202a05b1825d17eefeda9f4cd0be5dcb51cbfb402",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:729c2e05903cc91e4bfa594265d346440e1dc72d52ae17b80edd998223660743",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a30ad509cd74be817eb4a3bfa648524f3908ea1eac8b08975bf785d76cbc209",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47a875f1e20f6981847217e875699f645665dc968dd77149289ddff4de1fd76a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85c8fd5be189f301742d731b537578fd181b2be52c158fb5840900fe25d61e08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:216fed7a0ac19abeb145eea54e4d9accfa066aea30e68b7886467f7e4bb5fad7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2d2472284b2f589e360c7c49705812112322e53110b98faee4088f94933e9ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7965785a37ec727d85958b6130c2270ed3bd0dc9b2acd2fb3f1b8ea833dad27a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfeb9c999a64412b461c9e9e4a94dbb0bc09bd40cab55fd0043173b893b92760",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58dfffe5230e210f2b0ea5256e826d4ad14934c96e6671aa4d5cdef9c50fdb37",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30802b6ca4d505cc587b2ddb566450526262753d8d3640dd7000098808be9e24",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1fa9e0323d3f21e5949b86c66a15b50b6b8d1c80e7514efa693f90ef3e2561a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e9c718fcce11ef6e3b46a0c99a29711f14292ffc14dfc7653378f32e1c5c295",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8cd7312e2810f706aeec6985c277f1500be87f0e58f4311f1fd2d9ee00f5eb3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc7f1b56cadb7d7c1f4b1dba4bca9a87b22071d592f1e06e25d0be7106dd418f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36e6835f02c897ea7d1929163cf0dba9317a9fe38637bfa349ecd291ba4b36ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96f465090b634df32e8d5c1e95e915b82da5537f38c46f9eec88484b719786c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f491ed8c89370dd6b50559848f3a6f1da15dca574fb8f223522f7eab6709434c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972aa39dadfa549706a4e5b1e021495060aad322663960d273f06ec093a1c009",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85bb1aa32f6345349c9cf09c35217caae441dca6b2be8f21619ea6808d3c5af6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a337038500fb016e11c6d3b507c166cc3d3c3f82b5d4d288deb7322485c7522",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:402d2da4ec5556004211e1e3e56fa57dc0d77d0f1aef9b34affb1ca3017fbf1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47553267529003e6657b8bbd288fc9918c81c798389ccf9e817b194f14a0715f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0b8633a4977c2307590bd9b629ad88e2b8c5e07961eb3ae5f6700b86ade4f0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59613aa4a26e2b338742edee7dc99d5fb1b2c7c81d500b5977a7a69a7174886e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b750d60543a4c45b5d663859d1372a041b2eb1c5d808c460cf536079e64ae02",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a518008b5801ccdf9b233818e47b6533d7b7be9729065475836c7fbb1fdac0e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35b99038400405fdf56e8562ece4b2efb82148f0b51d4a4bf71f565839842d7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dabc9574f3b57343367de49c90ee35d83c9429c27d756f5a2cf52ee1788c9247",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c7caf66231bf06e65b6ef30f97d923da9705d1923d5765d4b726558ab116a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f202dbd3bbaf0710ead0a34ec18563d0835cbf169854afee778f2a07919c6e9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcb77480c5ed23e8b582a83b43661ce8ef6fc091f187d66794f315c41bc7db7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c614e41af121bf40bf33a48eb0886d99a9cc17665ea3120b063e1013c821d61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d52620cf80bde19169fca7ce66fa7cff416b04b7a0cf2bd7dae8446578dc999b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa71f4f1c3cc79edc9343ea0fcf558bdfed408a094ddda0bbc7582a0c647fc7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86b85375ee031abc705f8cf1af528f761a5a5ef73418cb52ae58f44d1405f793",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c417bdcb698e2f835a0663ced24bde7003378000f5512015dc4f265dc58bb0bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b032f2edc13137e4d101bb58bb8c7da4c6e9bf06d489f7bc612c58a66797fad8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e674c68dc9d3b7b254b677696c12743e1fd79e31c9b315bc700d9f545d145fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:747b441efd11d03e0170939848dd6d7dde39ae798f8d934777fbaf80cb622510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:798fb2747499e270c152059a31d15456dc426c8e9dc3448bc200bff78457cc91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59f140bbc5ba53d4b5c7aac0012bfc4c6d638047e3c335f46cb532bb884b46ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca68536ce8790ceb00a99633e973da9a66da80d15b992801cd351976ff6baeaf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0088c48b167cc56fde621d2ced4addc70c1097f0ea57f91939ccba67a2b22f28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0527ff7d382107084ff5a8d5a5c9c95e4f2b526fbff98dfb251c947f4003efa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7998e07ae6dc75167fbb10dc3ee39e3cff89c129aa84166ee38449b01ac3e877",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e74ae013ee0e8f2294b9c4947d1a729005755528cac4a577f8a0d7f2e89a039",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d927c7a593e01c56c79d90e8be3a5d3de10a8efc8a5206e78081967881b96da8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28dae95fc01ad9a74e93e6c4a76ba4807cc2d920aaf99c2124133a2fc5a4e54d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a20d3aa298872db33035c6aa55473dc24001bb24bcfbb9052718a1c9a2371a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b4b1667e8dad494e6437505e2caf52501ef6eb8ad7668fab2c2c591397812b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26a3e46f75e0213db137674dbaadabb14e2164a6146236e1f8bc3f7a6b56780e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae6ef1c1cfb61f9940bb23f79d271e8b6e4ca7cec9825dfe992cb8ef7a2b1aa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
+              "saved_entry": "ffffffffffffffffffffffffffffffff-6.1.0-0.rc2.21.fc38.x86_64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "raw.img",
+              "size": "3958374400"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 2048,
+                  "start": 2048,
+                  "type": "21686148-6449-6E6F-744E-656564454649",
+                  "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+                },
+                {
+                  "size": 409600,
+                  "start": 4096,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 413696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1437696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 4096,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 413696,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 1437696,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 413696,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 4096,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "raw.img",
+                  "start": 1437696,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:00054d4310ddebcfd966ebcbd42c072bfb69d0709f6165e2c0bc0ee1337efba2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:003ce0d20116e00e8b521e5b7451ea0606950387352596c066fa983d3b709d9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/parted-3.5-6.fc38.x86_64.rpm"
+          },
+          "sha256:008045c0fbc85a1b9a077567294efbaa56f61c75ab4100e86fa30a569480a2a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/librepo-1.14.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:0088c48b167cc56fde621d2ced4addc70c1097f0ea57f91939ccba67a2b22f28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/v/volume_key-libs-0.3.12-17.fc37.x86_64.rpm"
+          },
+          "sha256:01ac72679f09426833e1f1c205dd530edd10c1120918e603048add5c88f25ea0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsss_idmap-2.8.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:043bbdc6ac7341dd00c1857c68d50f8fc91e2d589e1020c5c4678ef6327fd03c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm"
+          },
+          "sha256:05172ef8afc62632b5e7c395dc9ed2f801e84ace131d36b1df777109df138797": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:05b63669a849d7cfac20c627dc0bfaaab33ed479f7be9623154adaccceb68476": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm"
+          },
+          "sha256:0654cefcc22d52fcdbf7b3d0a7077babb6491a7d812a7c6caa68652da617672f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/firewalld-1.2.1-1.fc38.noarch.rpm"
+          },
+          "sha256:0679744c52934c2f7285aa54209e7a3bc6db713f9570652894b8ebbc4a4b6fe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:0719f5a4f1e14196f2ef1cca8107ca91585a1b4fe8b382e84e306c3bcab4f2a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcurl-7.85.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm"
+          },
+          "sha256:089e516a282a6611d8ccb37ed05870860c71d0fe0a00fcc75dfdc70e082d49cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/iptables-nft-1.8.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:092a0396068edc5fbc4e77aa49aa5c312184ef4b0b7435c604107a52f712a19e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libndp-1.8-4.fc37.x86_64.rpm"
+          },
+          "sha256:093d967abc65b0810e20724e9f8e446d4a3901ef0bbd0aed7756e7a1535644d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm"
+          },
+          "sha256:09fc65ab51d47ada940766c145b96f738bf592e0359bb2a42ba2a398fdc7f6cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libjaylink-0.3.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:0a3dbe2cf5ac3caacb44785b6c5005b6d2e3792a7ff6a53c26dac66b2675681b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgpg-error-1.46-1.fc38.x86_64.rpm"
+          },
+          "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grub2-common-2.06-60.fc38.noarch.rpm"
+          },
+          "sha256:0bfa7c7b3371a5fe0130d4f26aab83270fce96f819ccf45d1def09c39ac1b0fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grubby-8.40-67.fc38.x86_64.rpm"
+          },
+          "sha256:0c614e41af121bf40bf33a48eb0886d99a9cc17665ea3120b063e1013c821d61": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/t/tpm2-tools-5.3-1.fc38.x86_64.rpm"
+          },
+          "sha256:0cfbbd0a959d3acba32a3af8be1095733a00814417390c6e7b5e9f43048e79fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/b/bluez-5.65-3.fc38.x86_64.rpm"
+          },
+          "sha256:0d604c93f87f6115968da6415b286ce60ac7a423cbf174beed96bada597ff5dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/iproute-6.0.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:0eaddcdfd370876db1241bf7251c8f87e0565dc818887d2bc95d7a211c77b3a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libtevent-0.13.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-release-common-38-0.4.noarch.rpm"
+          },
+          "sha256:0f3e6504aef91fc641678229a4f9d8d5428dd7b837cc4b0fb57038583025cdbd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libtalloc-2.3.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:0f658f37cc911a0ed122c445ee07555c27d8f98ddf30424bdaa528cdf0cfe166": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libssh-config-0.10.4-2.fc38.noarch.rpm"
+          },
+          "sha256:115f36517e2b9c7cab9ee7b092f8bfff6c1d53b09d0d774969c3884ecec1b601": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcollection-0.7.0-52.fc37.x86_64.rpm"
+          },
+          "sha256:118b3e835f01f45feb29c6c1eea1a50925ada9d5ff2804d6d7de74453aba5fbd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnl3-3.7.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:12a585c3a3636f88abcc9afb60d2a691006dc5b40879a8abd5e903a7a78a6a62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:12cb09ac132e4945809adfa22d3edbdc7fb458361d37032d6300830c052490c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/inih-56-2.fc37.x86_64.rpm"
+          },
+          "sha256:12f08f59c8fce365914e1df0cbb2e0765c6fb7cbd55afbb138558c21ec78fe3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nss-sysinit-3.83.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:149011e66fc747517ea929ff80d4f88e72961b10e352a324a7ea4ec3d20503bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libpcap-1.10.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:151d21077d158b81f0b444fe3c819179f235db61e889245610f2474494781055": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/polkit-121-4.fc38.x86_64.rpm"
+          },
+          "sha256:15358af44d005789cfda790606bd60c162b673167bbfe7153a97a043e1083768": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:154c20ac5d2a2a1286018dfce619fd883c520307322ca3a3513aaeca755130fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grep-3.8-1.fc38.x86_64.rpm"
+          },
+          "sha256:17f2d670442cfb22138f3eaf331e045c2b0526d0d9ec4c68f3b215db15168cd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libreport-filesystem-2.17.5-2.fc38.noarch.rpm"
+          },
+          "sha256:18238fedd785dbfe55bed864c13635a9feee9f4b929ffbd258c58e61736e4236": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/ima-evm-utils-1.4-6.fc37.x86_64.rpm"
+          },
+          "sha256:193f1fe42eef13e768d599bc89b07a2bfaab4223e66b35b1a6f89e3712fa73f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libbasicobjects-0.1.1-52.fc37.x86_64.rpm"
+          },
+          "sha256:1a056805ee78f023e3dcabda0c298c6dcc16515a86153459c01905ab2b43e9be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnfnetlink-1.0.1-22.fc37.x86_64.rpm"
+          },
+          "sha256:1a9f3b0a766c4436de5242a0a6f1f52c94f3d009b963ef3c2385472d12ecc88d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblkid-2.38.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:1b38f041914297b8dbd7e4f04571eda70ddb58c39babc276af8352c2552dfd60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgomp-12.2.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:1cb235881ac5c89085fe28e6fde153920cde9f4bdcebc17fca86723f3cc19310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm"
+          },
+          "sha256:1cd7cb3a9dcb03e1a3322200060b02fea694400f5c58ca1143a78758c55b6304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/h/hostname-3.23-7.fc37.x86_64.rpm"
+          },
+          "sha256:1dbb1fc38e0bac0925353d24aa78aeb2030f5eed9ef4b2637ccf5811d37fc807": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/iputils-20211215-3.fc37.x86_64.rpm"
+          },
+          "sha256:1e9c718fcce11ef6e3b46a0c99a29711f14292ffc14dfc7653378f32e1c5c295": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-sign-libs-4.18.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:2022bb0fe9c17df96734f4667357ddb956fd82004e9297504649ac60081b5464": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/mdadm-4.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:20925047133a5303a51f4e376b537c3d14c2a4ab0c239c5b480327a948b948ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:216fed7a0ac19abeb145eea54e4d9accfa066aea30e68b7886467f7e4bb5fad7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/readline-8.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:219f4432383b48bfacb028bdc7ef9afe372cf213e05c82a875afd5759216cde8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openssh-server-9.0p1-8.fc38.x86_64.rpm"
+          },
+          "sha256:22cceb6527dbd46ee35cf2d461003df43bc2637b48b86dd8a677ad50bb7e3f84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:234bda5eee845cc15508ef8fcd46651ed15da4e363a6d1bbf5453b7a22bd2e02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nss-softokn-freebl-3.83.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:238e13f764c6efc503e17f5a8c98dba1c1a01cb2d5ef8a7d037df4a6f3741f1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glibc-common-2.36.9000-10.fc38.x86_64.rpm"
+          },
+          "sha256:23de5abc3a9620f7f8c5917cfd452892cfcab34fcae502de4d04f83964ca716f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-gobject-base-3.42.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:25cd4bedd47325a47e47a27062fa6c139ee56a92ed119fe88eefd6263a2e09df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:26a3e46f75e0213db137674dbaadabb14e2164a6146236e1f8bc3f7a6b56780e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/z/zram-generator-1.1.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:28d665711b8c7b76a067b53a55127d06d361e911e33179b14d203bd06888e07a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/coreutils-9.1-8.fc38.x86_64.rpm"
+          },
+          "sha256:28dae95fc01ad9a74e93e6c4a76ba4807cc2d920aaf99c2124133a2fc5a4e54d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/y/yum-4.14.0-1.fc38.noarch.rpm"
+          },
+          "sha256:2a30ad509cd74be817eb4a3bfa648524f3908ea1eac8b08975bf785d76cbc209": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-rpm-4.18.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:2a77dccadd29c0f522090b7bb5720fc3bbeb6cec5ae32eb044c8bb2d1f4b8768": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/device-mapper-libs-1.02.185-1.fc38.x86_64.rpm"
+          },
+          "sha256:2acc31ad50943cab96867bee157c29e08d1b56f384c804cf33db0cf49f6cd026": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libmnl-1.0.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:2af1c9ecfcad5bba54169861492eaa97ed3ecd54c295abdc373c226e7879158a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-repos-rawhide-modular-38-0.3.noarch.rpm"
+          },
+          "sha256:2af369b0f500f875bf394b437524ba072cc317b0841cd62815691bc36d487ff1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/flashrom-1.2-9.fc37.x86_64.rpm"
+          },
+          "sha256:2b750d60543a4c45b5d663859d1372a041b2eb1c5d808c460cf536079e64ae02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.x86_64.rpm"
+          },
+          "sha256:2be19d631bc2c3399af9c4a02a73c882cfc79a0296e3101304f5f41bdd5587a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-repos-rawhide-38-0.3.noarch.rpm"
+          },
+          "sha256:2c18e137d6a407e789f0f97718977096ad976198de4b161df87ffebe270634e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libusb1-1.0.26-1.fc38.x86_64.rpm"
+          },
+          "sha256:2c42abbb29dd2811fb9ecf7ddac81e844fee21a27674f32543a31de51f67c69a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dracut-config-rescue-057-4.fc38.x86_64.rpm"
+          },
+          "sha256:2d8cedf110833c4652b589953178498f3d6ec9218b3419f3e25da8f89fbd379c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:2dbcefd797e17c3e6b73bb43351003f8fdb5236bdd6f4e288301119b663a0c7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:2f6ce4010c06399729060921fbea0e39c25f87b0dd7820143cceedc9e858441f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libfido2-1.12.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:2fd247fbf630e9ea2775669d319b5bdef6679740b80062e886923eb791b49a42": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-utils-2.28-2.fc38.x86_64.rpm"
+          },
+          "sha256:30802b6ca4d505cc587b2ddb566450526262753d8d3640dd7000098808be9e24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-plugin-selinux-4.18.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:310078572de43cf8be4ae7dd9041028fcdf4b4cba315ed3c97a53cf2049d6793": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc38.noarch.rpm"
+          },
+          "sha256:313910bb3c90cc31b7c82212fa71121c54b311f1d9af4eb78e50c7d39446ac86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dbus-common-1.14.4-1.fc38.noarch.rpm"
+          },
+          "sha256:3201b65c3a8178d52164089dfe5800314b803d1a88367fbe12c8906f1c05da02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm"
+          },
+          "sha256:324c6e6d4a55b3ac12198e8c6a528be517d57cb38d27e3dd961bc0efd487b292": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnftnl-1.2.3-1.fc38.x86_64.rpm"
+          },
+          "sha256:336b5d44b186dbfa29e8c4a2c387a6225671787812395bd49c05249d969008d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:348b04d1e81b64dc688fff396798a364212e27cada55e87ed1eed7336782fccb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libkcapi-1.4.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:34c9b59f820d71dd7d5b46a39f5b0377adc8f272ee5bee136734464bc17b268e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/NetworkManager-libnm-1.41.3-1.fc38.x86_64.rpm"
+          },
+          "sha256:34fb99840e8800b5f105b18aed42c33371421e1cd6c4092727cd9a01587a072e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:358de9892f2947ad5ae159ae918e9a568e1ae5f8e8ee56d875e21bc758230914": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm"
+          },
+          "sha256:3598c5f780a4a3af6ec93a80183361d0339f7b94da25a09e6356d260fee96fdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm"
+          },
+          "sha256:35b99038400405fdf56e8562ece4b2efb82148f0b51d4a4bf71f565839842d7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-libs-252~rc2-612.fc38.x86_64.rpm"
+          },
+          "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-release-38-0.4.noarch.rpm"
+          },
+          "sha256:361151172e791126195e46c380cd04cdc62c9729c64a88a479e774ddf11a9bb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dbus-libs-1.14.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:368fb99245a0a78c0c229a9a53791b7ec0c4aaaf22d64451f36637d652a4aa55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gpgme-1.17.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:36ce047183f8e73f9dc2e675f800001e9656dc31641360224c04a47a8f1437c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm"
+          },
+          "sha256:36e6835f02c897ea7d1929163cf0dba9317a9fe38637bfa349ecd291ba4b36ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/selinux-policy-targeted-37.13-1.fc38.noarch.rpm"
+          },
+          "sha256:372abc48a1a19e06e788e4d5e8b4f20b498585e99db9d9cbf1a19bae64d80c58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-fs-2.28-2.fc38.x86_64.rpm"
+          },
+          "sha256:382de44811c7f29aa781faf4c701f54304fae4b41dae49e73b113a165feed110": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gdisk-1.0.9-4.fc38.x86_64.rpm"
+          },
+          "sha256:388b23668bd8281624d23b3a78f42a5441e3775e08e541fb52f405b056170170": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nss-util-3.83.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:38b7d5c5f8aae3b697e3a9d21ca78465f66980acd0cfd8bcccf100c2cc6400f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gzip-1.12-2.fc37.x86_64.rpm"
+          },
+          "sha256:39b66e5e65abdb4c25ea38a0c70083fbe94a77907388fd521bfcc799494a8d98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-repos-modular-38-0.3.noarch.rpm"
+          },
+          "sha256:39b86b1de69f52c26e72945d84c5767248a6ef3280289dc7c3fd5d55d251b504": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/deltarpm-3.6.3-4.fc37.x86_64.rpm"
+          },
+          "sha256:39e14c4ed790fe4d47bd984afc47f291cac78bdfc9cae7d220979ca52c7301d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ntfs-3g-2022.5.17-2.fc37.x86_64.rpm"
+          },
+          "sha256:39f7b9690b91d195a45782d7aaf37e407eb553027bbed89e9a9a2abaca6c461e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:3ae53041ff5534b34434f74420fe2726ee16da7807058475993c1035c729d477": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-gpg-1.17.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:3b4358d599ab4a52ee8509d33635a8cdd5da34487a7225a24b3fc72696adadfb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openldap-2.6.3-1.fc38.x86_64.rpm"
+          },
+          "sha256:3e0e9ba133c66e1858baa05017c196c75c59fe4c9df6d7b3476470164a8f17f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm"
+          },
+          "sha256:3e74ae013ee0e8f2294b9c4947d1a729005755528cac4a577f8a0d7f2e89a039": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/x/xz-5.2.7-1.fc38.x86_64.rpm"
+          },
+          "sha256:3e953af5a5b8f5d9d4d21779c1925af9f5ddf6e9f9ebb1ce8aac547de19ac742": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gnupg2-smime-2.3.8-1.fc38.x86_64.rpm"
+          },
+          "sha256:3eb234e9d0b498ca0c700d97ee48b0d107c8454d93e0d51704de4d9f5c6552d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/ipset-libs-7.15-5.fc38.x86_64.rpm"
+          },
+          "sha256:402d2da4ec5556004211e1e3e56fa57dc0d77d0f1aef9b34affb1ca3017fbf1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sssd-client-2.8.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:408b6c8214a6fbdc2b921d3d1acb056b3a8fba0e7d5f51ca7817b5e55c59270b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:418a3538d59143ef1fe383afd0438b9807d3e5ab7e8d5ca563cf1609d6d696f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-swap-2.28-2.fc38.x86_64.rpm"
+          },
+          "sha256:42efbc1fcfb7f8d67b57d8a126aa3dc8cf7319e04fc5cf25b1d877abbd41fe6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsss_nss_idmap-2.8.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:433b6f621d595b607c4a9f73201e4be9b2a54535191b214b5905278e064c32cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm"
+          },
+          "sha256:4380ca3d259f47ea47a80ae46fc397cb536ba9c2491c643bc20d61001983b47f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kernel-modules-6.1.0-0.rc2.21.fc38.x86_64.rpm"
+          },
+          "sha256:4512d87241a25cc9e36731cc02119a5dff8fc576fb6526fa69732028b728d1f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/popt-1.19-1.fc38.x86_64.rpm"
+          },
+          "sha256:453eec881996f5c80bec7ac779f7973ba8c2244e83d01e87daf4c3381b88a1ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libdhash-0.5.0-52.fc37.x86_64.rpm"
+          },
+          "sha256:4750930ebe4765c67d3c6065e0a92e6a1a4359d85fd819a18dcf6370b9ff4102": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openssh-clients-9.0p1-8.fc38.x86_64.rpm"
+          },
+          "sha256:47553267529003e6657b8bbd288fc9918c81c798389ccf9e817b194f14a0715f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sssd-common-2.8.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:47a875f1e20f6981847217e875699f645665dc968dd77149289ddff4de1fd76a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm"
+          },
+          "sha256:48c3829c4b7616d6985737c5c8552d49ac9d80e41780af6daa34963b8d5b9225": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libfsverity-1.4-8.fc37.x86_64.rpm"
+          },
+          "sha256:4aafc48fc095f171d20fd31e1a4a88784ca8017a75d167bf794dae3394661517": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:4b480e6b6364e9e1b048f2b17eb5c2e628e97956b5c448c8753998e5a253ed44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsmartcols-2.38.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:4bba3f7ef03c6c0f17a9362291b39641d6777bac223b90168b6a18b9a7f8108f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pinentry-1.2.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:4cfd593ae556df6f8e3ace44379261ab2d44044a2ab25c2fd4a4323b73cd17d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:4d59c2e3c373b76eeecff57b35f8839c4b4c9c0eb877de739f582d56ac38a00b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-dnf-plugins-core-4.3.1-1.fc38.noarch.rpm"
+          },
+          "sha256:4ddfb8d7e3cc7379135eed9e730f5b14d248e6d603f53076688a0a1070ed1431": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-hawkey-0.68.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:4e62e029027cfae50e42f483e2e275cf33f6e24e4bfd8dd0b88b9be7ed719ef6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-libcomps-0.1.18-4.fc37.x86_64.rpm"
+          },
+          "sha256:4eb90ba78d6ebbc54758ec1787b3c1adf2608962d183a101da8de1013bcb7cef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libtdb-1.4.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:4f0e83dae6f1df1074aed8bd8a072edb2fed894f734ab55f07f31dd214e6db25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:50a0828e3f1eba2ec053d15a3412b2ca62ae513c3899ac5a6e88e9d91a21041f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgudev-237-3.fc37.x86_64.rpm"
+          },
+          "sha256:5394d42b3f062b40e98b594f338122b3cbd4d8dd4e3469ee8d02908148a27122": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnghttp2-1.50.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:55384f7ceb51716e0153951f3b1d9a43e9369738110aa92e2c92d1d8db6a700a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libuser-0.63-13.fc38.x86_64.rpm"
+          },
+          "sha256:559efa0bdbec897dbfb2011b498b075b4491502aba95b913ddc2fff84df614cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/coreutils-common-9.1-8.fc38.x86_64.rpm"
+          },
+          "sha256:583f171c10924f83bf4916eb98bb64a4d8d5c1d8522a721d3c2bee8c48e753ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.6-1.fc38.x86_64.rpm"
+          },
+          "sha256:58a55546644acbbf49ac082cd4855f475192caadc835722c38dd86ef9d285057": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm"
+          },
+          "sha256:58dfffe5230e210f2b0ea5256e826d4ad14934c96e6671aa4d5cdef9c50fdb37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-libs-4.18.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:59613aa4a26e2b338742edee7dc99d5fb1b2c7c81d500b5977a7a69a7174886e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sudo-1.9.11-4.p3.fc37.x86_64.rpm"
+          },
+          "sha256:59f140bbc5ba53d4b5c7aac0012bfc4c6d638047e3c335f46cb532bb884b46ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/v/vim-data-9.0.803-1.fc38.noarch.rpm"
+          },
+          "sha256:5a20d3aa298872db33035c6aa55473dc24001bb24bcfbb9052718a1c9a2371a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/z/zchunk-libs-1.2.3-1.fc38.x86_64.rpm"
+          },
+          "sha256:5a3cfdfce26f9b7d7f3d3626e464f47e465308765d58366feff06371eccd1fec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libuuid-2.38.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:5b03af8ac2ea38b815d942ec3acd99ecc6628c2047395f5c9667c044972fa114": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pigz-2.7-2.fc37.x86_64.rpm"
+          },
+          "sha256:5c835c03812834ed898e6b55802fe5a725cf4da1e2ac0ba44d41281184a6acb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/man-db-2.11.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:5e0812486718e1af122081b977142ec70c1b5046416db99c8c00901003520c2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/mkpasswd-5.5.14-1.fc38.x86_64.rpm"
+          },
+          "sha256:5f27c5c6787f59696ceee324176b0b9ba64c4b1709ddd30fa0fc5cd2dc4c83f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/audit-3.0.9-1.fc38.x86_64.rpm"
+          },
+          "sha256:5f4574b0789a4724c8a80e83408443a94f78a79b28770f87e3ffed7a991c7edc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-dbus-1.3.2-1.fc38.x86_64.rpm"
+          },
+          "sha256:60040f8563239848aabd3a655c2bc185a7d7f47dcf59228353a6713eec036269": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm"
+          },
+          "sha256:6114461c8756323c5470f2be5ab45e7405bcb9e1f54b01f6c82c80c1595af34b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgcc-12.2.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:6183bae674287b17dd36e3f5c01f0abcb021875895959fa63fb5061f18ccc4b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libyaml-0.2.5-8.fc37.x86_64.rpm"
+          },
+          "sha256:6206e39671991eb0ee840e2daf92cd84ff72aa04b8d089e7dfe7ab29602c088b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:623394bbabadd7595dd001d9909de43fa4ac339be2b2cce66d94f4e3418c3ccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grub2-tools-2.06-60.fc38.x86_64.rpm"
+          },
+          "sha256:6269bc8372cbde95f4b6fd1189030903a5dbf0310fabbe5fece6cf60de79dd37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libstdc++-12.2.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:627a4f6c12cfe958371ed4829de0eda73ab4fca3e696167f5780586d0dfef5c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/c-ares-1.17.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:633d70b8df9fbd3a9a66ac186e5827525a1d01adeed448147e40a2b7c2a30ba4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcap-ng-python3-0.8.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:648b73a8211d7b165c80bf366895cb39a3b86dbbf1d971258de653be0b6cb289": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/groff-base-1.22.4-10.fc37.x86_64.rpm"
+          },
+          "sha256:64deb61911d55fc1c9ba0d9e1e7eb10b77b6a1963e67266a9bea17dbd6f74238": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/elfutils-libs-0.187-8.fc38.x86_64.rpm"
+          },
+          "sha256:65874efe12ae8f0816cc2ce6aacf65383eb01bcff313284424f6a4bad23e7726": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libedit-3.1-43.20221009cvs.fc38.x86_64.rpm"
+          },
+          "sha256:65d61922e3a2b117b79e44ffd2945ee5c8ee53e6d3603dff792982c04eb13d9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libmbim-1.26.4-2.fc37.x86_64.rpm"
+          },
+          "sha256:66797ffb041aa8f8df7259c33063a328c641ca6a9b2c01b226877d7369d0ac91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:6722c48276ab3dc0ba58692892d06056097e973f44e416b94bd26a5a975f2b40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kpartx-0.9.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:680ab3372d3e91f57f0a8852c3f18c1416a7208ab6d48233e4dcc1543a39d8a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dhcp-client-4.4.3-4.P1.fc38.x86_64.rpm"
+          },
+          "sha256:692a5ce3d939ef1069eb54cdd3c67ca814f604199ae10dd40e1d1a6305d368d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/psmisc-23.4-4.fc37.x86_64.rpm"
+          },
+          "sha256:695c89729d68929af4096102abc3b40ae12ce8cf18f0a6c85703474ffaca5bb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm"
+          },
+          "sha256:6a0f03d9442843a9df7468a5a926a43c76d4c6437405db90598faea2f35434d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcomps-0.1.18-4.fc37.x86_64.rpm"
+          },
+          "sha256:6b79e53815bf9ccfdced5dc732b9d20ef47ab8dd20a5777e136adfc1740bf570": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libatasmart-0.19-23.fc37.x86_64.rpm"
+          },
+          "sha256:6bc9869c8ba8704f16fcec7543d4b029dd51213ff171fee7cb8e0a3da167b77a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kbd-2.5.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:6d20c06c82e13eb08ce603b9a676bd16ce74f78bcfeec0f67d8140523ba84649": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grub2-efi-x64-2.06-60.fc38.x86_64.rpm"
+          },
+          "sha256:6d2bb2cef78697952123b3a7a6a21dcd244d3fbfea20f577f75fd09b9d52fd74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm"
+          },
+          "sha256:6d3f733c72e0a227747d0c3319f35c197126a84cea362b4c32f34ea253d0e3b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/iptables-libs-1.8.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:6fc5af931ae4e106fac29e38db61b4ac4e86331088ab085cb2e9ff0c33dc55bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.x86_64.rpm"
+          },
+          "sha256:7011f454ba6e5d9f934fb2ad7c47e5c13e56ce7e9e1ac67f0c81cbca943b2792": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/linux-firmware-20221012-142.fc38.noarch.rpm"
+          },
+          "sha256:70592f23f23dd66ea9dc8014026eb63d87db185dd5350fa646710f70c6754631": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/alternatives-1.21-1.fc38.x86_64.rpm"
+          },
+          "sha256:709f71501e54efff438b6b418d8e69cc85887c6ff8b7a21dd8835d435f1668d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fwupd-1.8.6-1.fc38.x86_64.rpm"
+          },
+          "sha256:718b9103f02d5aebee50918c1d324cda6e3c5aec8e63ed8daaed3b1b104acd7c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:7191d8248bdd79d99bd96734ccdff48f8396cb8ed2d6e3685e1b26e08574c40d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dnf-data-4.14.0-1.fc38.noarch.rpm"
+          },
+          "sha256:729c2e05903cc91e4bfa594265d346440e1dc72d52ae17b80edd998223660743": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-nftables-1.0.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:74026fb802867ad2d70544e1ebee0d6d699dfa01890a4044b385ba435803760f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm"
+          },
+          "sha256:747b441efd11d03e0170939848dd6d7dde39ae798f8d934777fbaf80cb622510": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/util-linux-2.38.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:74a9c81894135aa917bcc1e202a05b1825d17eefeda9f4cd0be5dcb51cbfb402": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc38.x86_64.rpm"
+          },
+          "sha256:7552ec8b34844ba0cdc2f8c19dbac36b898e3d303e778888ff30193333d0a859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:75f5ed61039c566fff9e769f3bd632c194d9f112128e71a7c4494bc85a6d57e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cracklib-2.9.7-30.fc38.x86_64.rpm"
+          },
+          "sha256:76bbb5d3dacb6b5d086d4c425ca05a2b63b8ef6f17e905d523acf4659b71c865": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxcrypt-4.4.28-3.fc38.x86_64.rpm"
+          },
+          "sha256:76c7caf66231bf06e65b6ef30f97d923da9705d1923d5765d4b726558ab116a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-pam-252~rc2-612.fc38.x86_64.rpm"
+          },
+          "sha256:777f6e31853070aba2797e9332ef135032be2a40291da87e40795dfd0b7c6e07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/ModemManager-glib-1.18.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:781a96f533f2338c4732f93fa48a5ff2690f544a38c506fdfa4100292c882933": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dracut-057-4.fc38.x86_64.rpm"
+          },
+          "sha256:78636eaf09ba4e85ef46c9f53cf8832a5458817ee3c948683eeff253e0013716": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libssh-0.10.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:79426b7b91b26682579cab6943516b32797f6c3028008e9c52d3299fb8299f1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm"
+          },
+          "sha256:794645f5d6035cd473486ba62cd7ccd96b755a5c51244ddbc406350f20410fd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cracklib-dicts-2.9.7-30.fc38.x86_64.rpm"
+          },
+          "sha256:7965785a37ec727d85958b6130c2270ed3bd0dc9b2acd2fb3f1b8ea833dad27a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-4.18.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:798fb2747499e270c152059a31d15456dc426c8e9dc3448bc200bff78457cc91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/util-linux-core-2.38.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:7998e07ae6dc75167fbb10dc3ee39e3cff89c129aa84166ee38449b01ac3e877": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/x/xfsprogs-5.19.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:7a0b7208d4fa48eff55578ad2e99d8d4a53888ede87df804c6bb89d125417c46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:7a0c31c6ec6c1bee4c9f4f5004a1090447b823cabc97636846ff080b5bec411a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/efibootmgr-18-2.fc37.x86_64.rpm"
+          },
+          "sha256:7c28ce263b298c1f526718c1cb0f055bdbb455e1130a4bbcf7113fcc992b448e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/lmdb-libs-0.9.29-4.fc37.x86_64.rpm"
+          },
+          "sha256:7c6819de5a54218e8d69921d7e9cab759b794c4d65c5b9199e0da3e05fc31ec1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.x86_64.rpm"
+          },
+          "sha256:7da4199722fa5db76e95dc503f62cb954c90b588d0db49d096565fa8a74bdbe0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gettext-libs-0.21.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kbd-misc-2.5.1-3.fc38.noarch.rpm"
+          },
+          "sha256:7e674c68dc9d3b7b254b677696c12743e1fd79e31c9b315bc700d9f545d145fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/userspace-rcu-0.13.0-5.fc37.x86_64.rpm"
+          },
+          "sha256:7eae9fb9787d66887be6131718a6769fa6b963a6c3df9f9248ac0296aa7a6538": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:80d01a8159d6c89b9e41b743a26a7148cb4ba043d2c8667c80738cf2e7efdd8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nftables-1.0.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:81b81aee93d47f3a869b2582a53a0b59871b04f7e7c0b84d5e12207a271b0fb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ncurses-6.3-3.20220501.fc37.x86_64.rpm"
+          },
+          "sha256:82909f3b2c48da81c37425947ca7b331bdd49ecaa404aba1443bf0885622ea6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glibc-minimal-langpack-2.36.9000-10.fc38.x86_64.rpm"
+          },
+          "sha256:83518b7a45109407fcac3427dad51a9f7f7d3668e0a0942ad2158da82b869476": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:84933208c4c2cd87bfdf08817f28fd8b2ea2f4920d63739cea1b937d63c5d0bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/polkit-libs-121-4.fc38.x86_64.rpm"
+          },
+          "sha256:84b793fda6304051e2bbb6358e4c4f42a83ec68dc2a9a6b15884eb8ec401ca6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/NetworkManager-1.41.3-1.fc38.x86_64.rpm"
+          },
+          "sha256:8551d1552725100d8649b44cc51cbbe8c9e70b9c16c017a95001b701c2ff9b4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/oniguruma-6.9.8-2.D20220919gitb041f6d.fc38.x86_64.rpm"
+          },
+          "sha256:857b1e118da83981a1996af675ac5607f4267e1349ed1f05f90ad994404e0208": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nspr-4.35.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:85bb1aa32f6345349c9cf09c35217caae441dca6b2be8f21619ea6808d3c5af6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/shim-x64-15.6-2.x86_64.rpm"
+          },
+          "sha256:85c8fd5be189f301742d731b537578fd181b2be52c158fb5840900fe25d61e08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-unbound-1.16.3-3.fc38.x86_64.rpm"
+          },
+          "sha256:86b85375ee031abc705f8cf1af528f761a5a5ef73418cb52ae58f44d1405f793": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/udisks2-2.9.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:873a81a4fe3a7364f2b93cfc72f6a0153e26051cf4937604fd9394e405600753": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/passwd-0.80-13.fc37.x86_64.rpm"
+          },
+          "sha256:88d3170c87aa58df1b10b0f385302c7154375d1c06bc253462b2999989baac2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/protobuf-c-1.4.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:891ca4669541cb323a77e6d2224baeebccb8d0bb892670521f63ecf4a5d490d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsolv-0.7.22-3.fc37.x86_64.rpm"
+          },
+          "sha256:898b382eabfaa94f782cafb61fdbc1bef82d69e3f616bb9f00e1ab080f41ccb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gettext-envsubst-0.21.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:89ef8e879fd7ae5dd9e54405accaf1b558bb98edb423eaf27cd44a45c7c443bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-gpg-keys-38-0.3.noarch.rpm"
+          },
+          "sha256:89fc69c405e600d7667df2cb98d4c7d62259c72545db6267f234b28761244224": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsecret-0.20.5-2.fc37.x86_64.rpm"
+          },
+          "sha256:8a337038500fb016e11c6d3b507c166cc3d3c3f82b5d4d288deb7322485c7522": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sqlite-libs-3.39.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:8a35bd31f378f8c866577017f750248571fdf2d9b4f8f1c1d58c67c847ec1fb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glibc-2.36.9000-10.fc38.x86_64.rpm"
+          },
+          "sha256:8a66d6e4a4d83cb48ab7ca731da9c63c3e40d3f8fa2e9c1d4ea41cf3924c0415": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm"
+          },
+          "sha256:8afe733f094d886431d500e2c5aac11bf8bcef0a05314160a968684cb006d574": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libudisks2-2.9.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm"
+          },
+          "sha256:8b42966c07956a13614b5cdb76a6e06a22b1e875df9d7fab0ecfb11f6729581a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsss_sudo-2.8.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:8b79f85fa9266e4ed110f75e71125593d7de788a3f8242a69acfb4be56e92190": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libftdi-1.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:8c42725936f017feea8989faa8a90b966377185d42344ac3a3642cad14e0820e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openssh-9.0p1-8.fc38.x86_64.rpm"
+          },
+          "sha256:8cd7312e2810f706aeec6985c277f1500be87f0e58f4311f1fd2d9ee00f5eb3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sed-4.8-11.fc37.x86_64.rpm"
+          },
+          "sha256:8d599d9a7ce446f0c7e2040422fec9a241f6c45dc0371372e9704abdaa8bd21d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:8dd6e8a9176e9902effd883bf722f9e66cc931df831bd0ac070faf6c51ea9531": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dnf-plugins-core-4.3.1-1.fc38.noarch.rpm"
+          },
+          "sha256:8fcbd5077df15f8c8d3f3df2139087238868ef26ecdd68669364b4fb3e355c7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:8fd7c1aa26f19b023a252e7edc5bf42372bece3b15de889c882ff276f8445f2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gettext-runtime-0.21.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:9021392d34a59f5c717cc4523d38574a4e110fd24ff554b771e5c17f42369df0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libidn2-2.3.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:922d0eab6721af3757cb60b4c0b79abd47e32897ece35bf02f08bc4951c2fc65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libibverbs-41.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:940a47c7c4ac5950d7c5b455077cff86629084d494be38eed3daf533d7eb5428": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsss_certmap-2.8.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:95897c4f7822c7a154b19754b820171f06558c58487476755ec3e2e43f4656c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-3.11.0~rc2-1.fc38.x86_64.rpm"
+          },
+          "sha256:95aac8f490ae408be49651cba31d9ae7805157013629317cd5f13eaf6ce4696d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsmbios-2.4.3-7.fc37.x86_64.rpm"
+          },
+          "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kbd-legacy-2.5.1-3.fc38.noarch.rpm"
+          },
+          "sha256:962c21812673023f39908e6872018f254fea94c46312a1d50a5efb0a553ffa25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dhcp-common-4.4.3-4.P1.fc38.noarch.rpm"
+          },
+          "sha256:96bc81e214ddc10849313be4f9503366bd39d7d727222e9f3ba5119fbbd85a3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pcsc-lite-1.9.9-1.fc38.x86_64.rpm"
+          },
+          "sha256:96f465090b634df32e8d5c1e95e915b82da5537f38c46f9eec88484b719786c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/setup-2.14.2-1.fc38.noarch.rpm"
+          },
+          "sha256:972aa39dadfa549706a4e5b1e021495060aad322663960d273f06ec093a1c009": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/shared-mime-info-2.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:978de409a64943493b270e96c146b501414df01a880ce29306ef3b48d6346f68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-firewall-1.2.1-1.fc38.noarch.rpm"
+          },
+          "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-release-identity-basic-38-0.4.noarch.rpm"
+          },
+          "sha256:981c202e4e80078691f7aa5227305987d76b4614cb6a6fd0d4a2ff6c6e281077": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nss-softokn-3.83.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:98da69aa484ccd357cc76312774d53a64f552b21b594d74a2fd01be5e21f300b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxcrypt-compat-4.4.28-3.fc38.x86_64.rpm"
+          },
+          "sha256:995659e1f0c39fb758160120c68ece8446d14ab3e3b0527aeadb90b0547e5a7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.x86_64.rpm"
+          },
+          "sha256:997a1f939ff6c65d45f48e4f7496ec97aa091f4274084a9cac776ec94c6127c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc38.x86_64.rpm"
+          },
+          "sha256:9afc19fb507521ee32f35e2cad4b530d863b2cc3810cb9b8408eb61bbb50b6b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libbytesize-2.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:9b4b1667e8dad494e6437505e2caf52501ef6eb8ad7668fab2c2c591397812b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/z/zlib-1.2.12-5.fc38.x86_64.rpm"
+          },
+          "sha256:9b4e2edcab2b0876625a00d939f8e415e1ba52c70bc5e21d6ed0713fe7c44a8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pciutils-libs-3.8.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:9b788ac65ce0f002c0ec43e639ecd7cd65db2ac42f8ca2619d00c29a9a473cec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-libdnf-0.68.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:9c7cf01ca9153dbd45cc44987044797a628af29d97cdf7af8a4466363c758ca9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/plymouth-22.02.122-3.fc38.x86_64.rpm"
+          },
+          "sha256:9cecd9c301c808e795c6d33b1440bbd552e71ad20a2bd3e523cdd8459210e62a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/linux-firmware-whence-20221012-142.fc38.noarch.rpm"
+          },
+          "sha256:9de9a79d1dc9c8937b1df541dedce3cd01be557bfa1187c46ab7353a73edd19b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgusb-0.4.2-1.fc38.x86_64.rpm"
+          },
+          "sha256:9fb93562eb8a553196dd8133a422161c0c54f396338e2467a6830cf79db37f38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm"
+          },
+          "sha256:a0527ff7d382107084ff5a8d5a5c9c95e4f2b526fbff98dfb251c947f4003efa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/w/whois-nls-5.5.14-1.fc38.noarch.rpm"
+          },
+          "sha256:a069111178e08a8e414eb9a738f927cadbba2817b343142489f63e8c3e592100": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm"
+          },
+          "sha256:a09dc2a014eed705062f6ce9ad7520ec5f02b705d7fe515ed9fd17880c7ea330": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kernel-core-6.1.0-0.rc2.21.fc38.x86_64.rpm"
+          },
+          "sha256:a0c055b565c6514d2f8d7be063202e550357c6146b2c92cc17bac6cad59aab2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:a275005b6cd03f94919a8db25ba6615e017d82d659edc9deab146202cbddeed8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/b/bash-5.2.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:a452e760f5b524cd86b3c2f252816d07bb62e1d59fdda8883148dfd6bbfcb973": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/intel-gpu-firmware-20221012-142.fc38.noarch.rpm"
+          },
+          "sha256:a518008b5801ccdf9b233818e47b6533d7b7be9729065475836c7fbb1fdac0e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-252~rc2-612.fc38.x86_64.rpm"
+          },
+          "sha256:a51a769a3a49965980b3ddf74cc8dd8380265a14bb76fc3a78645dee87bc828e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm"
+          },
+          "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm"
+          },
+          "sha256:a6c2d07340d47de477613c6c3ef2f643f26b00d6b47dea2fa6078a076268004d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/firewalld-filesystem-1.2.1-1.fc38.noarch.rpm"
+          },
+          "sha256:a847f339173fd09197887df7f84218b2cba1020e80b78399fca3e084751b77df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kmod-30-2.fc37.x86_64.rpm"
+          },
+          "sha256:aa1981728f4d99093e379a6cdf6815257afd48a940b3fcedeea53799234e662b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:aa71f4f1c3cc79edc9343ea0fcf558bdfed408a094ddda0bbc7582a0c647fc7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/t/tzdata-2022e-1.fc38.noarch.rpm"
+          },
+          "sha256:aa9327946e86d20192948513e27b5314e565bd533f4e801215cf62190314056e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm"
+          },
+          "sha256:aad543b786b8f870cd0a7a1d472199b5ac3f10a87e58133146470c3183d6862a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:abfd9ef518fca89f4db8d12165229e5abb5155e187af197617f690512e3af302": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/initscripts-service-10.17-1.fc38.noarch.rpm"
+          },
+          "sha256:aca40dd03fc1eb93703ea43d9a96a70ad87792e1d675f7a9a762be71d8908c33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc38.noarch.rpm"
+          },
+          "sha256:acf915225bc2597876fb3cc3241edab02490c2679f8429933328084ea0a04b2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/device-mapper-1.02.185-1.fc38.x86_64.rpm"
+          },
+          "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm"
+          },
+          "sha256:ade1098a8b124d57f0f5154e6918819e2a6f63206a55e84326a5a79498c9f817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:ae3f201e386217e734ab85b1744505ed5346cb70c049ca8ee7f122b2550de38c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm"
+          },
+          "sha256:ae6ef1c1cfb61f9940bb23f79d271e8b6e4ca7cec9825dfe992cb8ef7a2b1aa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm"
+          },
+          "sha256:af4bf71d9a3cb9f325925a951710e50b92a188f87edac5ca2384520520845d51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxmlb-0.3.10-1.fc38.x86_64.rpm"
+          },
+          "sha256:b02ca8808bb8cd14dfc9da4fac4d1a0e90a5cd9a41c801686c2c4b61dcc3de48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:b032f2edc13137e4d101bb58bb8c7da4c6e9bf06d489f7bc612c58a66797fad8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/unbound-libs-1.16.3-3.fc38.x86_64.rpm"
+          },
+          "sha256:b2d2472284b2f589e360c7c49705812112322e53110b98faee4088f94933e9ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm"
+          },
+          "sha256:b39adb12197f08a665204c5628eca9a8025b24f12a77d6c7b4e04a2e11532a03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/j/jq-1.6-14.fc37.x86_64.rpm"
+          },
+          "sha256:b4d348f2385b36bdc1a818b36511e491ccff83cbb24040472303e8bc02a1ca7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:b52d63173a94b61eead79ec9146111a5877b2e9f5a21c947e385fdef8304969c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:b657f57a69a3851254fd572330a6edc79c8b48661ead3c647834023031e14184": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/plymouth-scripts-22.02.122-3.fc38.x86_64.rpm"
+          },
+          "sha256:b7548d4dced9671ae77294541ce1c82c7db90e5e1634413bd49e0d4830452969": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nettle-3.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:b763867cad65628e83ce7bad924692eb5e597bbbea3ad03167c51698f0b15239": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/amd-gpu-firmware-20221012-142.fc38.noarch.rpm"
+          },
+          "sha256:bb7bb8b78456dbd0b94511b26becb472ada8a5482871ebe7e2f8a8a044fae3a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm"
+          },
+          "sha256:bc47bfd4eef2547fcd6980a6b0a4f19ba84d9dab159bed6bbbf7a5dd43fee25b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libmount-2.38.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:be840ed4c79ce5eb22c1870864120d1280d723731b88504d175337506cb4d680": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:beb040c019a273d6f8b189dbe5898fbcce953fc8ed82a44b038177b2d5e50e60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm"
+          },
+          "sha256:bf3eba90b87e314919d683f8c934451cd1d0e9e64ab6d726c03fbc2dc2e984b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/plymouth-core-libs-22.02.122-3.fc38.x86_64.rpm"
+          },
+          "sha256:bf584be55e7774395bea83a383c28d148fee267ef396d5a6b3b520cf1e724db4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/curl-7.85.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:bfe6c6e0137845e5df00d636e6e68ebf690c0a4fdf1d8fcd645d94789cfd2c09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/npth-1.6-10.fc38.x86_64.rpm"
+          },
+          "sha256:bfeb9c999a64412b461c9e9e4a94dbb0bc09bd40cab55fd0043173b893b92760": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-build-libs-4.18.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:c09b8285b4fa856c472ff33e8220186fb35220161fcdd2b6054dc27574cf5066": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/crypto-policies-20221003-1.gitcb1ad32.fc38.noarch.rpm"
+          },
+          "sha256:c0ac75db74de456c8d7b94cde11ab5501b7575ec6bb63af3fa50a83b26dc281d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dracut-config-generic-057-4.fc38.x86_64.rpm"
+          },
+          "sha256:c0b8633a4977c2307590bd9b629ad88e2b8c5e07961eb3ae5f6700b86ade4f0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sssd-kcm-2.8.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:c0bc33ff5df85f2c9a1bf645a20c77b60a7c270b1dfd54305d5ae3b75e89f4a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/j/jansson-2.13.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:c0c845989f397bc869c787b032f32f070aa7c64549c5bbc8de7ad8ab2fb997df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-loop-2.28-2.fc38.x86_64.rpm"
+          },
+          "sha256:c3b4d41f2e0c05622a18888d356210282cc3309fb132a0e967edd8aa0fafc58c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm"
+          },
+          "sha256:c416cd702ce78583b177eb152e87424e4e65a706cad8966904d10f3b413ddc54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.x86_64.rpm"
+          },
+          "sha256:c417bdcb698e2f835a0663ced24bde7003378000f5512015dc4f265dc58bb0bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/unbound-anchor-1.16.3-3.fc38.x86_64.rpm"
+          },
+          "sha256:c420528bee4010117e5e5c5dedf1a30811136175e4d165f19162295066d224b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:c51e6fdb4353a2fce7758af9c1fcc97e6a54f7b7162464b7888ac2796aa3e442": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/ipset-7.15-5.fc38.x86_64.rpm"
+          },
+          "sha256:c6e1018e5327403c955cb766feaa112687b3210f06afc7702abae185de061506": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/duktape-2.6.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:c6fdb21908848e96e58d0ea2b495701eedad190b01f9df44c16e35f760cacae4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgcab1-1.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:c74fd7795d471046edbd2ba1eb6a984025519aa076b2e856363ca8c2c4e26e6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libldb-2.6.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:c7931f5dc4a593808c00346a9a452e24e79d5a70201da6ffbd3fc18d9a0e04a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/ipcalc-1.0.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:c8a3d24889c2c77145c7ec6734290188651f84ac1cb7a3d283189b5010e326dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libdnf-0.68.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:c91dbcccb9f11de00029b63890d10d496f58e51731b5f4afb6700685a4bfa264": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/file-5.42-4.fc37.x86_64.rpm"
+          },
+          "sha256:c96af87a1d3aad0cb63953fb402ae37d14823288dd74e910686d0322172140d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:c9c6ccb93cbf9b7a962b10432d64d88f0a91fe856ab104eb04adc31d75dff2f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-dnf-4.14.0-1.fc38.noarch.rpm"
+          },
+          "sha256:ca34df9ec9bc66a150d308568c53e462a6f35b48a07354982a1773eb9cd0abe3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libpipeline-1.5.6-2.fc37.x86_64.rpm"
+          },
+          "sha256:ca68536ce8790ceb00a99633e973da9a66da80d15b992801cd351976ff6baeaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/v/vim-minimal-9.0.803-1.fc38.x86_64.rpm"
+          },
+          "sha256:cb37630c680e8b9ba2480e862c81cd42994147fad219b44006840e8642e144ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gnutls-3.7.8-8.fc38.x86_64.rpm"
+          },
+          "sha256:cb56399a89890eb0b198977815af29059ff1e10f3a4d350e597ce2948c428980": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-2.28-2.fc38.x86_64.rpm"
+          },
+          "sha256:cb8340f6d2151b97e54df3fe09c063ac8f820bfe096753cfe395e2516030c70c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm"
+          },
+          "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm"
+          },
+          "sha256:cd577dc1b6787341ec0d89a688a9e5c5450badbebe8abdc1049aca4f8553c3b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/j/json-c-0.16-2.fc37.x86_64.rpm"
+          },
+          "sha256:cd5ceea29405a70d0751933a5c3d6178b671c80ff97e04aec2614caf6156d238": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libini_config-1.3.1-52.fc37.x86_64.rpm"
+          },
+          "sha256:cd8987f528bf3bd926c809d492f64374dcbf4a95252b569fd9cbf804848c319f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fwupd-efi-1.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:cde5a2b8b2b57ca5986327f5aea5eda780e3fce2a38de4bc93d1098c94781d50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcap-2.48-5.fc37.x86_64.rpm"
+          },
+          "sha256:cf8017c6cb5e00fc35157fe47d6d13ed86079d9fe793c225ecaddac105834c96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxml2-2.10.3-1.fc38.x86_64.rpm"
+          },
+          "sha256:cfd13bf9a8723dc1d74d68155e59692e83707928c7f1366be13472da7612acb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libref_array-0.1.5-52.fc37.x86_64.rpm"
+          },
+          "sha256:d012a020c6e80fb827881e026d572022730cc86c16d0b6b3d3935c2860e49d10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:d0be81593c6a700d883ff95b06a92afef5790a5fbcdb8d35d6cbfc9c4e87e5a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ntfsprogs-2022.5.17-2.fc37.x86_64.rpm"
+          },
+          "sha256:d1d7d815ca8cc5ce4e8df78f2ddfcffec6742e482861ba670a3f7db5d418bbd9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libmaxminddb-1.7.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:d1fa9e0323d3f21e5949b86c66a15b50b6b8d1c80e7514efa693f90ef3e2561a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:d238b2e8d817b89bc0d1d22d716c3695185a96bf939b548e1143ff76c4d5def8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:d460ef02a880ed345a255e6bdc6920ac30d40668edd43b233bf28f71e235088b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-part-2.28-2.fc38.x86_64.rpm"
+          },
+          "sha256:d52620cf80bde19169fca7ce66fa7cff416b04b7a0cf2bd7dae8446578dc999b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:d655e5491ee4ced0bf5a9a374e5bd513ec0c82f1d606a534312824280c111fc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.x86_64.rpm"
+          },
+          "sha256:d77164c603273f980bf9152290c2b507df0c6ea6b907c93f1de73c50eb489f76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:d7f3c8c057eb68b6b5838ff0738826b996c847f2452ee62fb5c1c344161f633e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libqmi-1.30.6-2.fc37.x86_64.rpm"
+          },
+          "sha256:d927c7a593e01c56c79d90e8be3a5d3de10a8efc8a5206e78081967881b96da8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/x/xz-libs-5.2.7-1.fc38.x86_64.rpm"
+          },
+          "sha256:d9572a1494fa167b5073b7a8633eb278b40d85d9d57426e2fec190cef713551b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm"
+          },
+          "sha256:d96a131abbdbea273866174699f0c7c563fa35481fc8ea198064ad1857d5e979": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dmidecode-3.4-2.fc37.x86_64.rpm"
+          },
+          "sha256:da0bfef07d054d11e12db8c5026302f80895d45f5cabfec3fd4f340ed7935a95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cpio-2.13-13.fc38.x86_64.rpm"
+          },
+          "sha256:dabc9574f3b57343367de49c90ee35d83c9429c27d756f5a2cf52ee1788c9247": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-networkd-252~rc2-612.fc38.x86_64.rpm"
+          },
+          "sha256:dc7f1b56cadb7d7c1f4b1dba4bca9a87b22071d592f1e06e25d0be7106dd418f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/selinux-policy-37.13-1.fc38.noarch.rpm"
+          },
+          "sha256:dc8a30844c2e5a519e69bc35e9a12571698a99c89dbe4e6e4febaaac623636d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:dd593e435ea68265fe742c4c6e3acc7240abaf9b9d75882205c4f434b727e1aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libpath_utils-0.2.1-52.fc37.x86_64.rpm"
+          },
+          "sha256:dd981fc525ac4e032e36d2e8519288304936d3f5e89c866f22878491f46df8be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/lua-libs-5.4.4-6.fc38.x86_64.rpm"
+          },
+          "sha256:de8607703bf0476f4d60389d03d15780450bf30d2b0ee138965261107a2ee937": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kernel-6.1.0-0.rc2.21.fc38.x86_64.rpm"
+          },
+          "sha256:debc0be72012ae50ae10caa306ad14b7a4f61e6bc43161da7036e3091900297f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nano-6.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:df36f338c43b86547adf17d9bfdadcad07f1ac7d6456bc416c29d3373e6287c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/crypto-policies-scripts-20221003-1.gitcb1ad32.fc38.noarch.rpm"
+          },
+          "sha256:e0aba1be1f5587c603583c56572bd40e54cee9789e2bc58ae7c0d4ab3a84848d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openssl-libs-3.0.5-5.fc38.x86_64.rpm"
+          },
+          "sha256:e0c0c018d4123a23c789a078f73a0bc4e026b74281e5dbfe049c5f2b8266937f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/efivar-libs-38-5.fc37.x86_64.rpm"
+          },
+          "sha256:e204891e00573ee6e4d11ff11f373d345f1694ca657af48d2d3aabf7767ef7ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dnf-4.14.0-1.fc38.noarch.rpm"
+          },
+          "sha256:e2e124d9f28bc74b9987ea9414e1a5d2cac1dafa437085f5f93a6b00bd328ced": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/procps-ng-3.3.17-8.fc38.x86_64.rpm"
+          },
+          "sha256:e2f0e9e62e8309396833c485f185a928bcf9617db1f7e79ff24109857f217632": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fwupd-plugin-flashrom-1.8.6-1.fc38.x86_64.rpm"
+          },
+          "sha256:e35838c07a6255862edc0a3b020a294626c2f2c1c966c65b79734aea54dbd4f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dbus-1.14.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:e3a4e9b6e68360f24bb2b92bf23068c47e96d6d705f546648b2e10dd88e44e84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/less-590-5.fc37.x86_64.rpm"
+          },
+          "sha256:e4c60148da66b03578e6593b7b498ccbef81464b2456be1ccd84918aa2ae8d84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gnupg2-2.3.8-1.fc38.x86_64.rpm"
+          },
+          "sha256:e576e370fe923be6cbe8f23a72687eea55b259d0b846c638e11bce7b894413cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/elfutils-libelf-0.187-8.fc38.x86_64.rpm"
+          },
+          "sha256:e66f6a75e909357289e07d9ce9801a0662527aebee680bc255637012b956e66c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libassuan-2.5.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:e77404faa136326e63c2a943466b97ca43ef448feb7ce10ce50aac6c2f8fea9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nss-3.83.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:e7b80b715ca72917a9662b48c040f07fdb4343f69fe5f1b628b3a759dbc4537c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gobject-introspection-1.74.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:e82a29caed678de72840ce2b5911d67a68bfaa9a69da576649becde2811b46c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glib2-2.74.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:e915e3507eb1e877251ac175df26c3be8022b31daedc39fcfa2e05c1ef190911": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python-setuptools-wheel-65.3.0-1.fc38.noarch.rpm"
+          },
+          "sha256:ea22a10ee200ce742b5eb4924e78edbcfb16848853ba4944129a2fe8758e5fb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-distro-1.8.0-1.fc38.noarch.rpm"
+          },
+          "sha256:eaad7eb1db33cd9a7d75dc22f93fedf00d5cb5e58c4b91da4efc08394b6a3465": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:eb0e0ae250fb3fb0abf5fa3e958148a5a0ecccf59b41b23adf96ab3f34c3fce8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libjcat-0.1.12-1.fc38.x86_64.rpm"
+          },
+          "sha256:efb40dbd73db04020f2212ae13e8f781424bc0463c4e0ed30875e46737c1ee60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fwupd-plugin-modem-manager-1.8.6-1.fc38.x86_64.rpm"
+          },
+          "sha256:eff1051e94730b8b50fcd37a109b3eb9ba0e9fed80745eead6a180b9135dd16a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-mdraid-2.28-2.fc38.x86_64.rpm"
+          },
+          "sha256:f02595d2c580ab3f0cd4048137140898e09f2b7092d3c26b8d7e7a234498d091": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:f0315d368bde2128992a58c09596af85d39ef7a37e097bfc94612f3dd7178dad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libqrtr-glib-1.0.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:f1379517e611bd4235f3fea36107cd095392d05bc7d5c6d9cb5aacf0a87946f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm"
+          },
+          "sha256:f14c5249a75f2813499b6b49b59929c8c4c390237a909aad8cc4c902b8e60d62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/audit-libs-3.0.9-1.fc38.x86_64.rpm"
+          },
+          "sha256:f202dbd3bbaf0710ead0a34ec18563d0835cbf169854afee778f2a07919c6e9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-resolved-252~rc2-612.fc38.x86_64.rpm"
+          },
+          "sha256:f216369a72a6f3cd932463e7d236c853b1bf2f63526b1637d0aa1269ac35ce57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm"
+          },
+          "sha256:f23e684c367b3f1b3494d0b84dd98d33a60cc803f3670367c4e79b4ef57977f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc38.x86_64.rpm"
+          },
+          "sha256:f295d316d8aaa426972fd9fff029497b28f9a7572da5faf7e1b121fc0868bd23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-repos-38-0.3.noarch.rpm"
+          },
+          "sha256:f3822e08a6fa781057ae121ff8fc105ca0e42ecc95f3789cebd18944c7cc79e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libksba-1.6.2-1.fc38.x86_64.rpm"
+          },
+          "sha256:f491ed8c89370dd6b50559848f3a6f1da15dca574fb8f223522f7eab6709434c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/shadow-utils-4.12.3-3.fc38.x86_64.rpm"
+          },
+          "sha256:f4cfae4f2e8ebb6772c7c5d6ca6212f776c36e5da5c47bb0ef51f444e4a68d3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc38.noarch.rpm"
+          },
+          "sha256:f5d52ea60f458ae82a7924187ada1a537407ec86186211c0a3bac2f0d1f7a654": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-crypto-2.28-2.fc38.x86_64.rpm"
+          },
+          "sha256:f5f0521c7a9e1cd8fbd0e1fe82f3f91de9ed38b4680bf2eb929cd592522c6652": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm"
+          },
+          "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm"
+          },
+          "sha256:f74da1c044980e6bfcdfc8340fa91899f9a944800e3e6f71bd6e99e7693df5e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/j/json-glib-1.6.6-3.fc37.x86_64.rpm"
+          },
+          "sha256:f7f29a0e81b5049ae1882f1e6656133818b46d3923be2fcea41ff5e0ef10c622": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm"
+          },
+          "sha256:f93547eeb6911beb0ed3c4082d2b81fd9fc3c80b77557568133eb80c9744af82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glibc-gconv-extra-2.36.9000-10.fc38.x86_64.rpm"
+          },
+          "sha256:fbe8a6710d8146771ce0c68a9f91c6515ec2d58f1ef3737aa08992abfbe29fc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grub2-tools-minimal-2.06-60.fc38.x86_64.rpm"
+          },
+          "sha256:fc809c6aedb53823e5ec114794e529db7adb287ed66b4773620c4a1c2f2b3001": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libfdisk-2.38.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:fcb77480c5ed23e8b582a83b43661ce8ef6fc091f187d66794f315c41bc7db7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-udev-252~rc2-612.fc38.x86_64.rpm"
+          },
+          "sha256:fcb97e83814f4229c89c00e82bcd25ab41c69aee5157582376adc4963abd142f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/mokutil-0.6.0-5.fc37.x86_64.rpm"
+          },
+          "sha256:ff017b16ca598f61547ca1f70a677c8e8bc87794b646686acdd55a70ac12cc48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nvidia-gpu-firmware-20221012-142.fc38.noarch.rpm"
+          },
+          "sha256:ff1cb7ddb5c0ebf0b4dbd9e307591dad5de749f9a8226ad5fe38ce1dd6fc9b39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:ffefe533dcad6a1b8688fd24d675b7eb00bc5763913aa584be5f0a02762a66fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc38.x86_64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/alternatives-1.21-1.fc38.x86_64.rpm",
+        "checksum": "sha256:70592f23f23dd66ea9dc8014026eb63d87db185dd5350fa646710f70c6754631",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/audit-libs-3.0.9-1.fc38.x86_64.rpm",
+        "checksum": "sha256:f14c5249a75f2813499b6b49b59929c8c4c390237a909aad8cc4c902b8e60d62",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b02ca8808bb8cd14dfc9da4fac4d1a0e90a5cd9a41c801686c2c4b61dcc3de48",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c420528bee4010117e5e5c5dedf1a30811136175e4d165f19162295066d224b0",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/b/bash-5.2.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:a275005b6cd03f94919a8db25ba6615e017d82d659edc9deab146202cbddeed8",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm",
+        "checksum": "sha256:f1379517e611bd4235f3fea36107cd095392d05bc7d5c6d9cb5aacf0a87946f4",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/coreutils-9.1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:28d665711b8c7b76a067b53a55127d06d361e911e33179b14d203bd06888e07a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/coreutils-common-9.1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:559efa0bdbec897dbfb2011b498b075b4491502aba95b913ddc2fff84df614cc",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cpio-2.13-13.fc38.x86_64.rpm",
+        "checksum": "sha256:da0bfef07d054d11e12db8c5026302f80895d45f5cabfec3fd4f340ed7935a95",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cracklib-2.9.7-30.fc38.x86_64.rpm",
+        "checksum": "sha256:75f5ed61039c566fff9e769f3bd632c194d9f112128e71a7c4494bc85a6d57e1",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20221003",
+        "release": "1.gitcb1ad32.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/crypto-policies-20221003-1.gitcb1ad32.fc38.noarch.rpm",
+        "checksum": "sha256:c09b8285b4fa856c472ff33e8220186fb35220161fcdd2b6054dc27574cf5066",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20221003",
+        "release": "1.gitcb1ad32.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/crypto-policies-scripts-20221003-1.gitcb1ad32.fc38.noarch.rpm",
+        "checksum": "sha256:df36f338c43b86547adf17d9bfdadcad07f1ac7d6456bc416c29d3373e6287c6",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:ade1098a8b124d57f0f5154e6918819e2a6f63206a55e84326a5a79498c9f817",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/curl-7.85.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:bf584be55e7774395bea83a383c28d148fee267ef396d5a6b3b520cf1e724db4",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc38.x86_64.rpm",
+        "checksum": "sha256:997a1f939ff6c65d45f48e4f7496ec97aa091f4274084a9cac776ec94c6127c9",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dbus-1.14.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:e35838c07a6255862edc0a3b020a294626c2f2c1c966c65b79734aea54dbd4f4",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm",
+        "checksum": "sha256:a069111178e08a8e414eb9a738f927cadbba2817b343142489f63e8c3e592100",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dbus-common-1.14.4-1.fc38.noarch.rpm",
+        "checksum": "sha256:313910bb3c90cc31b7c82212fa71121c54b311f1d9af4eb78e50c7d39446ac86",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.185",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/device-mapper-1.02.185-1.fc38.x86_64.rpm",
+        "checksum": "sha256:acf915225bc2597876fb3cc3241edab02490c2679f8429933328084ea0a04b2d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.185",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/device-mapper-libs-1.02.185-1.fc38.x86_64.rpm",
+        "checksum": "sha256:2a77dccadd29c0f522090b7bb5720fc3bbeb6cec5ae32eb044c8bb2d1f4b8768",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:22cceb6527dbd46ee35cf2d461003df43bc2637b48b86dd8a677ad50bb7e3f84",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:74026fb802867ad2d70544e1ebee0d6d699dfa01890a4044b385ba435803760f",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dracut-057-4.fc38.x86_64.rpm",
+        "checksum": "sha256:781a96f533f2338c4732f93fa48a5ff2690f544a38c506fdfa4100292c882933",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:be840ed4c79ce5eb22c1870864120d1280d723731b88504d175337506cb4d680",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:f02595d2c580ab3f0cd4048137140898e09f2b7092d3c26b8d7e7a234498d091",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc38.x86_64.rpm",
+        "checksum": "sha256:ffefe533dcad6a1b8688fd24d675b7eb00bc5763913aa584be5f0a02762a66fe",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc38.noarch.rpm",
+        "checksum": "sha256:f4cfae4f2e8ebb6772c7c5d6ca6212f776c36e5da5c47bb0ef51f444e4a68d3f",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/elfutils-libelf-0.187-8.fc38.x86_64.rpm",
+        "checksum": "sha256:e576e370fe923be6cbe8f23a72687eea55b259d0b846c638e11bce7b894413cb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/elfutils-libs-0.187-8.fc38.x86_64.rpm",
+        "checksum": "sha256:64deb61911d55fc1c9ba0d9e1e7eb10b77b6a1963e67266a9bea17dbd6f74238",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:a0c055b565c6514d2f8d7be063202e550357c6146b2c92cc17bac6cad59aab2d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-gpg-keys-38-0.3.noarch.rpm",
+        "checksum": "sha256:89ef8e879fd7ae5dd9e54405accaf1b558bb98edb423eaf27cd44a45c7c443bf",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-release-38-0.4.noarch.rpm",
+        "checksum": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-release-common-38-0.4.noarch.rpm",
+        "checksum": "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-release-identity-basic-38-0.4.noarch.rpm",
+        "checksum": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-repos-38-0.3.noarch.rpm",
+        "checksum": "sha256:f295d316d8aaa426972fd9fff029497b28f9a7572da5faf7e1b121fc0868bd23",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-repos-rawhide-38-0.3.noarch.rpm",
+        "checksum": "sha256:2be19d631bc2c3399af9c4a02a73c882cfc79a0296e3101304f5f41bdd5587a3",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/file-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c91dbcccb9f11de00029b63890d10d496f58e51731b5f4afb6700685a4bfa264",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:bb7bb8b78456dbd0b94511b26becb472ada8a5482871ebe7e2f8a8a044fae3a7",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3598c5f780a4a3af6ec93a80183361d0339f7b94da25a09e6356d260fee96fdf",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:7a0b7208d4fa48eff55578ad2e99d8d4a53888ede87df804c6bb89d125417c46",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm",
+        "checksum": "sha256:cb8340f6d2151b97e54df3fe09c063ac8f820bfe096753cfe395e2516030c70c",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:336b5d44b186dbfa29e8c4a2c387a6225671787812395bd49c05249d969008d7",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:408b6c8214a6fbdc2b921d3d1acb056b3a8fba0e7d5f51ca7817b5e55c59270b",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm",
+        "checksum": "sha256:58a55546644acbbf49ac082cd4855f475192caadc835722c38dd86ef9d285057",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gettext-envsubst-0.21.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:898b382eabfaa94f782cafb61fdbc1bef82d69e3f616bb9f00e1ab080f41ccb9",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gettext-libs-0.21.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:7da4199722fa5db76e95dc503f62cb954c90b588d0db49d096565fa8a74bdbe0",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gettext-runtime-0.21.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:8fd7c1aa26f19b023a252e7edc5bf42372bece3b15de889c882ff276f8445f2e",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glibc-2.36.9000-10.fc38.x86_64.rpm",
+        "checksum": "sha256:8a35bd31f378f8c866577017f750248571fdf2d9b4f8f1c1d58c67c847ec1fb6",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glibc-common-2.36.9000-10.fc38.x86_64.rpm",
+        "checksum": "sha256:238e13f764c6efc503e17f5a8c98dba1c1a01cb2d5ef8a7d037df4a6f3741f1b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glibc-gconv-extra-2.36.9000-10.fc38.x86_64.rpm",
+        "checksum": "sha256:f93547eeb6911beb0ed3c4082d2b81fd9fc3c80b77557568133eb80c9744af82",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glibc-minimal-langpack-2.36.9000-10.fc38.x86_64.rpm",
+        "checksum": "sha256:82909f3b2c48da81c37425947ca7b331bdd49ecaa404aba1443bf0885622ea6f",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:718b9103f02d5aebee50918c1d324cda6e3c5aec8e63ed8daaed3b1b104acd7c",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grep-3.8-1.fc38.x86_64.rpm",
+        "checksum": "sha256:154c20ac5d2a2a1286018dfce619fd883c520307322ca3a3513aaeca755130fc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grub2-common-2.06-60.fc38.noarch.rpm",
+        "checksum": "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grub2-tools-2.06-60.fc38.x86_64.rpm",
+        "checksum": "sha256:623394bbabadd7595dd001d9909de43fa4ac339be2b2cce66d94f4e3418c3ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grub2-tools-minimal-2.06-60.fc38.x86_64.rpm",
+        "checksum": "sha256:fbe8a6710d8146771ce0c68a9f91c6515ec2d58f1ef3737aa08992abfbe29fc6",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "67.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grubby-8.40-67.fc38.x86_64.rpm",
+        "checksum": "sha256:0bfa7c7b3371a5fe0130d4f26aab83270fce96f819ccf45d1def09c39ac1b0fa",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gzip-1.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:38b7d5c5f8aae3b697e3a9d21ca78465f66980acd0cfd8bcccf100c2cc6400f0",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/j/json-c-0.16-2.fc37.x86_64.rpm",
+        "checksum": "sha256:cd577dc1b6787341ec0d89a688a9e5c5450badbebe8abdc1049aca4f8553c3b5",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kbd-2.5.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:6bc9869c8ba8704f16fcec7543d4b029dd51213ff171fee7cb8e0a3da167b77a",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kbd-legacy-2.5.1-3.fc38.noarch.rpm",
+        "checksum": "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kbd-misc-2.5.1-3.fc38.noarch.rpm",
+        "checksum": "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:8fcbd5077df15f8c8d3f3df2139087238868ef26ecdd68669364b4fb3e355c7f",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kmod-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:a847f339173fd09197887df7f84218b2cba1020e80b78399fca3e084751b77df",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c3b4d41f2e0c05622a18888d356210282cc3309fb132a0e967edd8aa0fafc58c",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kpartx-0.9.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:6722c48276ab3dc0ba58692892d06056097e973f44e416b94bd26a5a975f2b40",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm",
+        "checksum": "sha256:9fb93562eb8a553196dd8133a422161c0c54f396338e2467a6830cf79db37f38",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:34fb99840e8800b5f105b18aed42c33371421e1cd6c4092727cd9a01587a072e",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:dc8a30844c2e5a519e69bc35e9a12571698a99c89dbe4e6e4febaaac623636d6",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm",
+        "checksum": "sha256:36ce047183f8e73f9dc2e675f800001e9656dc31641360224c04a47a8f1437c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:b52d63173a94b61eead79ec9146111a5877b2e9f5a21c947e385fdef8304969c",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:25cd4bedd47325a47e47a27062fa6c139ee56a92ed119fe88eefd6263a2e09df",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblkid-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:1a9f3b0a766c4436de5242a0a6f1f52c94f3d009b963ef3c2385472d12ecc88d",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d012a020c6e80fb827881e026d572022730cc86c16d0b6b3d3935c2860e49d10",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm",
+        "checksum": "sha256:aa9327946e86d20192948513e27b5314e565bd533f4e801215cf62190314056e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcap-2.48-5.fc37.x86_64.rpm",
+        "checksum": "sha256:cde5a2b8b2b57ca5986327f5aea5eda780e3fce2a38de4bc93d1098c94781d50",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:66797ffb041aa8f8df7259c33063a328c641ca6a9b2c01b226877d7369d0ac91",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm",
+        "checksum": "sha256:a51a769a3a49965980b3ddf74cc8dd8380265a14bb76fc3a78645dee87bc828e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d77164c603273f980bf9152290c2b507df0c6ea6b907c93f1de73c50eb489f76",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcurl-7.85.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:0719f5a4f1e14196f2ef1cca8107ca91585a1b4fe8b382e84e306c3bcab4f2a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm",
+        "checksum": "sha256:3201b65c3a8178d52164089dfe5800314b803d1a88367fbe12c8906f1c05da02",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ff1cb7ddb5c0ebf0b4dbd9e307591dad5de749f9a8226ad5fe38ce1dd6fc9b39",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm",
+        "checksum": "sha256:8a66d6e4a4d83cb48ab7ca731da9c63c3e40d3f8fa2e9c1d4ea41cf3924c0415",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libfdisk-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:fc809c6aedb53823e5ec114794e529db7adb287ed66b4773620c4a1c2f2b3001",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm",
+        "checksum": "sha256:f216369a72a6f3cd932463e7d236c853b1bf2f63526b1637d0aa1269ac35ce57",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.12.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libfido2-1.12.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:2f6ce4010c06399729060921fbea0e39c25f87b0dd7820143cceedc9e858441f",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgcc-12.2.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:6114461c8756323c5470f2be5ab45e7405bcb9e1f54b01f6c82c80c1595af34b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgomp-12.2.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:1b38f041914297b8dbd7e4f04571eda70ddb58c39babc276af8352c2552dfd60",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libidn2-2.3.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:9021392d34a59f5c717cc4523d38574a4e110fd24ff554b771e5c17f42369df0",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libkcapi-1.4.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:348b04d1e81b64dc688fff396798a364212e27cada55e87ed1eed7336782fccb",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:4aafc48fc095f171d20fd31e1a4a88784ca8017a75d167bf794dae3394661517",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libmount-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:bc47bfd4eef2547fcd6980a6b0a4f19ba84d9dab159bed6bbbf7a5dd43fee25b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.50.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnghttp2-1.50.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:5394d42b3f062b40e98b594f338122b3cbd4d8dd4e3469ee8d02908148a27122",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:2dbcefd797e17c3e6b73bb43351003f8fdb5236bdd6f4e288301119b663a0c7a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:20925047133a5303a51f4e376b537c3d14c2a4ab0c239c5b480327a948b948ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm",
+        "checksum": "sha256:093d967abc65b0810e20724e9f8e446d4a3901ef0bbd0aed7756e7a1535644d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:aa1981728f4d99093e379a6cdf6815257afd48a940b3fcedeea53799234e662b",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:b4d348f2385b36bdc1a818b36511e491ccff83cbb24040472303e8bc02a1ca7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:c96af87a1d3aad0cb63953fb402ae37d14823288dd74e910686d0322172140d2",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:83518b7a45109407fcac3427dad51a9f7f7d3668e0a0942ad2158da82b869476",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:aad543b786b8f870cd0a7a1d472199b5ac3f10a87e58133146470c3183d6862a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:f5f0521c7a9e1cd8fbd0e1fe82f3f91de9ed38b4680bf2eb929cd592522c6652",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsmartcols-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:4b480e6b6364e9e1b048f2b17eb5c2e628e97956b5c448c8753998e5a253ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:2d8cedf110833c4652b589953178498f3d6ec9218b3419f3e25da8f89fbd379c",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libssh-0.10.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:78636eaf09ba4e85ef46c9f53cf8832a5458817ee3c948683eeff253e0013716",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libssh-config-0.10.4-2.fc38.noarch.rpm",
+        "checksum": "sha256:0f658f37cc911a0ed122c445ee07555c27d8f98ddf30424bdaa528cdf0cfe166",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libstdc++-12.2.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:6269bc8372cbde95f4b6fd1189030903a5dbf0310fabbe5fece6cf60de79dd37",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:6206e39671991eb0ee840e2daf92cd84ff72aa04b8d089e7dfe7ab29602c088b",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm",
+        "checksum": "sha256:beb040c019a273d6f8b189dbe5898fbcce953fc8ed82a44b038177b2d5e50e60",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:39f7b9690b91d195a45782d7aaf37e407eb553027bbed89e9a9a2abaca6c461e",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:12a585c3a3636f88abcc9afb60d2a691006dc5b40879a8abd5e903a7a78a6a62",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libuuid-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:5a3cfdfce26f9b7d7f3d3626e464f47e465308765d58366feff06371eccd1fec",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f7f29a0e81b5049ae1882f1e6656133818b46d3923be2fcea41ff5e0ef10c622",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxcrypt-4.4.28-3.fc38.x86_64.rpm",
+        "checksum": "sha256:76bbb5d3dacb6b5d086d4c425ca05a2b63b8ef6f17e905d523acf4659b71c865",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxcrypt-compat-4.4.28-3.fc38.x86_64.rpm",
+        "checksum": "sha256:98da69aa484ccd357cc76312774d53a64f552b21b594d74a2fd01be5e21f300b",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:7552ec8b34844ba0cdc2f8c19dbac36b898e3d303e778888ff30193333d0a859",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxml2-2.10.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:cf8017c6cb5e00fc35157fe47d6d13ed86079d9fe793c225ecaddac105834c96",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4f0e83dae6f1df1074aed8bd8a072edb2fed894f734ab55f07f31dd214e6db25",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/lua-libs-5.4.4-6.fc38.x86_64.rpm",
+        "checksum": "sha256:dd981fc525ac4e032e36d2e8519288304936d3f5e89c866f22878491f46df8be",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm",
+        "checksum": "sha256:695c89729d68929af4096102abc3b40ae12ce8cf18f0a6c85703474ffaca5bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:7eae9fb9787d66887be6131718a6769fa6b963a6c3df9f9248ac0296aa7a6538",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.14",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/mkpasswd-5.5.14-1.fc38.x86_64.rpm",
+        "checksum": "sha256:5e0812486718e1af122081b977142ec70c1b5046416db99c8c00901003520c2d",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:0679744c52934c2f7285aa54209e7a3bc6db713f9570652894b8ebbc4a4b6fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:3e0e9ba133c66e1858baa05017c196c75c59fe4c9df6d7b3476470164a8f17f8",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:ae3f201e386217e734ab85b1744505ed5346cb70c049ca8ee7f122b2550de38c",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openldap-2.6.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:3b4358d599ab4a52ee8509d33635a8cdd5da34487a7225a24b3fc72696adadfb",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openssl-libs-3.0.5-5.fc38.x86_64.rpm",
+        "checksum": "sha256:e0aba1be1f5587c603583c56572bd40e54cee9789e2bc58ae7c0d4ab3a84848d",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c416cd702ce78583b177eb152e87424e4e65a706cad8966904d10f3b413ddc54",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm",
+        "checksum": "sha256:79426b7b91b26682579cab6943516b32797f6c3028008e9c52d3299fb8299f1c",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d238b2e8d817b89bc0d1d22d716c3695185a96bf939b548e1143ff76c4d5def8",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:05172ef8afc62632b5e7c395dc9ed2f801e84ace131d36b1df777109df138797",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:1cb235881ac5c89085fe28e6fde153920cde9f4bdcebc17fca86723f3cc19310",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:043bbdc6ac7341dd00c1857c68d50f8fc91e2d589e1020c5c4678ef6327fd03c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm",
+        "checksum": "sha256:6d2bb2cef78697952123b3a7a6a21dcd244d3fbfea20f577f75fd09b9d52fd74",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pigz-2.7-2.fc37.x86_64.rpm",
+        "checksum": "sha256:5b03af8ac2ea38b815d942ec3acd99ecc6628c2047395f5c9667c044972fa114",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm",
+        "checksum": "sha256:05b63669a849d7cfac20c627dc0bfaaab33ed479f7be9623154adaccceb68476",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/popt-1.19-1.fc38.x86_64.rpm",
+        "checksum": "sha256:4512d87241a25cc9e36731cc02119a5dff8fc576fb6526fa69732028b728d1f6",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/procps-ng-3.3.17-8.fc38.x86_64.rpm",
+        "checksum": "sha256:e2e124d9f28bc74b9987ea9414e1a5d2cac1dafa437085f5f93a6b00bd328ced",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2.2",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc38.noarch.rpm",
+        "checksum": "sha256:aca40dd03fc1eb93703ea43d9a96a70ad87792e1d675f7a9a762be71d8908c33",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "65.3.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python-setuptools-wheel-65.3.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:e915e3507eb1e877251ac175df26c3be8022b31daedc39fcfa2e05c1ef190911",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc38.noarch.rpm",
+        "checksum": "sha256:310078572de43cf8be4ae7dd9041028fcdf4b4cba315ed3c97a53cf2049d6793",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-3.11.0~rc2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:95897c4f7822c7a154b19754b820171f06558c58487476755ec3e2e43f4656c6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:74a9c81894135aa917bcc1e202a05b1825d17eefeda9f4cd0be5dcb51cbfb402",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/readline-8.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:216fed7a0ac19abeb145eea54e4d9accfa066aea30e68b7886467f7e4bb5fad7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-4.18.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:7965785a37ec727d85958b6130c2270ed3bd0dc9b2acd2fb3f1b8ea833dad27a",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-libs-4.18.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:58dfffe5230e210f2b0ea5256e826d4ad14934c96e6671aa4d5cdef9c50fdb37",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-plugin-selinux-4.18.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:30802b6ca4d505cc587b2ddb566450526262753d8d3640dd7000098808be9e24",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sed-4.8-11.fc37.x86_64.rpm",
+        "checksum": "sha256:8cd7312e2810f706aeec6985c277f1500be87f0e58f4311f1fd2d9ee00f5eb3f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.13",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/selinux-policy-37.13-1.fc38.noarch.rpm",
+        "checksum": "sha256:dc7f1b56cadb7d7c1f4b1dba4bca9a87b22071d592f1e06e25d0be7106dd418f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.13",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/selinux-policy-targeted-37.13-1.fc38.noarch.rpm",
+        "checksum": "sha256:36e6835f02c897ea7d1929163cf0dba9317a9fe38637bfa349ecd291ba4b36ae",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.2",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/setup-2.14.2-1.fc38.noarch.rpm",
+        "checksum": "sha256:96f465090b634df32e8d5c1e95e915b82da5537f38c46f9eec88484b719786c8",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.12.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/shadow-utils-4.12.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:f491ed8c89370dd6b50559848f3a6f1da15dca574fb8f223522f7eab6709434c",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sqlite-libs-3.39.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:8a337038500fb016e11c6d3b507c166cc3d3c3f82b5d4d288deb7322485c7522",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-252~rc2-612.fc38.x86_64.rpm",
+        "checksum": "sha256:a518008b5801ccdf9b233818e47b6533d7b7be9729065475836c7fbb1fdac0e6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-libs-252~rc2-612.fc38.x86_64.rpm",
+        "checksum": "sha256:35b99038400405fdf56e8562ece4b2efb82148f0b51d4a4bf71f565839842d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-networkd-252~rc2-612.fc38.x86_64.rpm",
+        "checksum": "sha256:dabc9574f3b57343367de49c90ee35d83c9429c27d756f5a2cf52ee1788c9247",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-pam-252~rc2-612.fc38.x86_64.rpm",
+        "checksum": "sha256:76c7caf66231bf06e65b6ef30f97d923da9705d1923d5765d4b726558ab116a4",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-resolved-252~rc2-612.fc38.x86_64.rpm",
+        "checksum": "sha256:f202dbd3bbaf0710ead0a34ec18563d0835cbf169854afee778f2a07919c6e9c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-udev-252~rc2-612.fc38.x86_64.rpm",
+        "checksum": "sha256:fcb77480c5ed23e8b582a83b43661ce8ef6fc091f187d66794f315c41bc7db7d",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/t/tpm2-tools-5.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:0c614e41af121bf40bf33a48eb0886d99a9cc17665ea3120b063e1013c821d61",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d52620cf80bde19169fca7ce66fa7cff416b04b7a0cf2bd7dae8446578dc999b",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022e",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/t/tzdata-2022e-1.fc38.noarch.rpm",
+        "checksum": "sha256:aa71f4f1c3cc79edc9343ea0fcf558bdfed408a094ddda0bbc7582a0c647fc7e",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/util-linux-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:747b441efd11d03e0170939848dd6d7dde39ae798f8d934777fbaf80cb622510",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/util-linux-core-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:798fb2747499e270c152059a31d15456dc426c8e9dc3448bc200bff78457cc91",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.14",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/w/whois-nls-5.5.14-1.fc38.noarch.rpm",
+        "checksum": "sha256:a0527ff7d382107084ff5a8d5a5c9c95e4f2b526fbff98dfb251c947f4003efa",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.7",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/x/xz-5.2.7-1.fc38.x86_64.rpm",
+        "checksum": "sha256:3e74ae013ee0e8f2294b9c4947d1a729005755528cac4a577f8a0d7f2e89a039",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.7",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/x/xz-libs-5.2.7-1.fc38.x86_64.rpm",
+        "checksum": "sha256:d927c7a593e01c56c79d90e8be3a5d3de10a8efc8a5206e78081967881b96da8",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/z/zlib-1.2.12-5.fc38.x86_64.rpm",
+        "checksum": "sha256:9b4b1667e8dad494e6437505e2caf52501ef6eb8ad7668fab2c2c591397812b7",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/ModemManager-glib-1.18.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:777f6e31853070aba2797e9332ef135032be2a40291da87e40795dfd0b7c6e07",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.41.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/NetworkManager-1.41.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:84b793fda6304051e2bbb6358e4c4f42a83ec68dc2a9a6b15884eb8ec401ca6e",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.41.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/NetworkManager-libnm-1.41.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:34c9b59f820d71dd7d5b46a39f5b0377adc8f272ee5bee136734464bc17b268e",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/alternatives-1.21-1.fc38.x86_64.rpm",
+        "checksum": "sha256:70592f23f23dd66ea9dc8014026eb63d87db185dd5350fa646710f70c6754631",
+        "check_gpg": true
+      },
+      {
+        "name": "amd-gpu-firmware",
+        "epoch": 0,
+        "version": "20221012",
+        "release": "142.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/amd-gpu-firmware-20221012-142.fc38.noarch.rpm",
+        "checksum": "sha256:b763867cad65628e83ce7bad924692eb5e597bbbea3ad03167c51698f0b15239",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/audit-3.0.9-1.fc38.x86_64.rpm",
+        "checksum": "sha256:5f27c5c6787f59696ceee324176b0b9ba64c4b1709ddd30fa0fc5cd2dc4c83f0",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/audit-libs-3.0.9-1.fc38.x86_64.rpm",
+        "checksum": "sha256:f14c5249a75f2813499b6b49b59929c8c4c390237a909aad8cc4c902b8e60d62",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b02ca8808bb8cd14dfc9da4fac4d1a0e90a5cd9a41c801686c2c4b61dcc3de48",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c420528bee4010117e5e5c5dedf1a30811136175e4d165f19162295066d224b0",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/b/bash-5.2.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:a275005b6cd03f94919a8db25ba6615e017d82d659edc9deab146202cbddeed8",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.65",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/b/bluez-5.65-3.fc38.x86_64.rpm",
+        "checksum": "sha256:0cfbbd0a959d3acba32a3af8be1095733a00814417390c6e7b5e9f43048e79fc",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm",
+        "checksum": "sha256:f1379517e611bd4235f3fea36107cd095392d05bc7d5c6d9cb5aacf0a87946f4",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/c-ares-1.17.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:627a4f6c12cfe958371ed4829de0eda73ab4fca3e696167f5780586d0dfef5c5",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/coreutils-9.1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:28d665711b8c7b76a067b53a55127d06d361e911e33179b14d203bd06888e07a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/coreutils-common-9.1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:559efa0bdbec897dbfb2011b498b075b4491502aba95b913ddc2fff84df614cc",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cpio-2.13-13.fc38.x86_64.rpm",
+        "checksum": "sha256:da0bfef07d054d11e12db8c5026302f80895d45f5cabfec3fd4f340ed7935a95",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cracklib-2.9.7-30.fc38.x86_64.rpm",
+        "checksum": "sha256:75f5ed61039c566fff9e769f3bd632c194d9f112128e71a7c4494bc85a6d57e1",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cracklib-dicts-2.9.7-30.fc38.x86_64.rpm",
+        "checksum": "sha256:794645f5d6035cd473486ba62cd7ccd96b755a5c51244ddbc406350f20410fd6",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20221003",
+        "release": "1.gitcb1ad32.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/crypto-policies-20221003-1.gitcb1ad32.fc38.noarch.rpm",
+        "checksum": "sha256:c09b8285b4fa856c472ff33e8220186fb35220161fcdd2b6054dc27574cf5066",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20221003",
+        "release": "1.gitcb1ad32.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/crypto-policies-scripts-20221003-1.gitcb1ad32.fc38.noarch.rpm",
+        "checksum": "sha256:df36f338c43b86547adf17d9bfdadcad07f1ac7d6456bc416c29d3373e6287c6",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:ade1098a8b124d57f0f5154e6918819e2a6f63206a55e84326a5a79498c9f817",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/curl-7.85.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:bf584be55e7774395bea83a383c28d148fee267ef396d5a6b3b520cf1e724db4",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc38.x86_64.rpm",
+        "checksum": "sha256:997a1f939ff6c65d45f48e4f7496ec97aa091f4274084a9cac776ec94c6127c9",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dbus-1.14.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:e35838c07a6255862edc0a3b020a294626c2f2c1c966c65b79734aea54dbd4f4",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm",
+        "checksum": "sha256:a069111178e08a8e414eb9a738f927cadbba2817b343142489f63e8c3e592100",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dbus-common-1.14.4-1.fc38.noarch.rpm",
+        "checksum": "sha256:313910bb3c90cc31b7c82212fa71121c54b311f1d9af4eb78e50c7d39446ac86",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dbus-libs-1.14.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:361151172e791126195e46c380cd04cdc62c9729c64a88a479e774ddf11a9bb2",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.3",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/deltarpm-3.6.3-4.fc37.x86_64.rpm",
+        "checksum": "sha256:39b86b1de69f52c26e72945d84c5767248a6ef3280289dc7c3fd5d55d251b504",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.185",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/device-mapper-1.02.185-1.fc38.x86_64.rpm",
+        "checksum": "sha256:acf915225bc2597876fb3cc3241edab02490c2679f8429933328084ea0a04b2d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.185",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/device-mapper-libs-1.02.185-1.fc38.x86_64.rpm",
+        "checksum": "sha256:2a77dccadd29c0f522090b7bb5720fc3bbeb6cec5ae32eb044c8bb2d1f4b8768",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "4.P1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dhcp-client-4.4.3-4.P1.fc38.x86_64.rpm",
+        "checksum": "sha256:680ab3372d3e91f57f0a8852c3f18c1416a7208ab6d48233e4dcc1543a39d8a4",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "4.P1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dhcp-common-4.4.3-4.P1.fc38.noarch.rpm",
+        "checksum": "sha256:962c21812673023f39908e6872018f254fea94c46312a1d50a5efb0a553ffa25",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:22cceb6527dbd46ee35cf2d461003df43bc2637b48b86dd8a677ad50bb7e3f84",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.4",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dmidecode-3.4-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d96a131abbdbea273866174699f0c7c563fa35481fc8ea198064ad1857d5e979",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dnf-4.14.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:e204891e00573ee6e4d11ff11f373d345f1694ca657af48d2d3aabf7767ef7ba",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dnf-data-4.14.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:7191d8248bdd79d99bd96734ccdff48f8396cb8ed2d6e3685e1b26e08574c40d",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dnf-plugins-core-4.3.1-1.fc38.noarch.rpm",
+        "checksum": "sha256:8dd6e8a9176e9902effd883bf722f9e66cc931df831bd0ac070faf6c51ea9531",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:74026fb802867ad2d70544e1ebee0d6d699dfa01890a4044b385ba435803760f",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dracut-057-4.fc38.x86_64.rpm",
+        "checksum": "sha256:781a96f533f2338c4732f93fa48a5ff2690f544a38c506fdfa4100292c882933",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "057",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dracut-config-generic-057-4.fc38.x86_64.rpm",
+        "checksum": "sha256:c0ac75db74de456c8d7b94cde11ab5501b7575ec6bb63af3fa50a83b26dc281d",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "057",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/dracut-config-rescue-057-4.fc38.x86_64.rpm",
+        "checksum": "sha256:2c42abbb29dd2811fb9ecf7ddac81e844fee21a27674f32543a31de51f67c69a",
+        "check_gpg": true
+      },
+      {
+        "name": "duktape",
+        "epoch": 0,
+        "version": "2.6.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/d/duktape-2.6.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c6e1018e5327403c955cb766feaa112687b3210f06afc7702abae185de061506",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:be840ed4c79ce5eb22c1870864120d1280d723731b88504d175337506cb4d680",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:f02595d2c580ab3f0cd4048137140898e09f2b7092d3c26b8d7e7a234498d091",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm",
+        "checksum": "sha256:433b6f621d595b607c4a9f73201e4be9b2a54535191b214b5905278e064c32cf",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/efibootmgr-18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:7a0c31c6ec6c1bee4c9f4f5004a1090447b823cabc97636846ff080b5bec411a",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/efivar-libs-38-5.fc37.x86_64.rpm",
+        "checksum": "sha256:e0c0c018d4123a23c789a078f73a0bc4e026b74281e5dbfe049c5f2b8266937f",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc38.x86_64.rpm",
+        "checksum": "sha256:ffefe533dcad6a1b8688fd24d675b7eb00bc5763913aa584be5f0a02762a66fe",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc38.noarch.rpm",
+        "checksum": "sha256:f4cfae4f2e8ebb6772c7c5d6ca6212f776c36e5da5c47bb0ef51f444e4a68d3f",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/elfutils-libelf-0.187-8.fc38.x86_64.rpm",
+        "checksum": "sha256:e576e370fe923be6cbe8f23a72687eea55b259d0b846c638e11bce7b894413cb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/elfutils-libs-0.187-8.fc38.x86_64.rpm",
+        "checksum": "sha256:64deb61911d55fc1c9ba0d9e1e7eb10b77b6a1963e67266a9bea17dbd6f74238",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:a0c055b565c6514d2f8d7be063202e550357c6146b2c92cc17bac6cad59aab2d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-gpg-keys-38-0.3.noarch.rpm",
+        "checksum": "sha256:89ef8e879fd7ae5dd9e54405accaf1b558bb98edb423eaf27cd44a45c7c443bf",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-release-38-0.4.noarch.rpm",
+        "checksum": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-release-common-38-0.4.noarch.rpm",
+        "checksum": "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-release-identity-basic-38-0.4.noarch.rpm",
+        "checksum": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-repos-38-0.3.noarch.rpm",
+        "checksum": "sha256:f295d316d8aaa426972fd9fff029497b28f9a7572da5faf7e1b121fc0868bd23",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-repos-modular-38-0.3.noarch.rpm",
+        "checksum": "sha256:39b66e5e65abdb4c25ea38a0c70083fbe94a77907388fd521bfcc799494a8d98",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-repos-rawhide-38-0.3.noarch.rpm",
+        "checksum": "sha256:2be19d631bc2c3399af9c4a02a73c882cfc79a0296e3101304f5f41bdd5587a3",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide-modular",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fedora-repos-rawhide-modular-38-0.3.noarch.rpm",
+        "checksum": "sha256:2af1c9ecfcad5bba54169861492eaa97ed3ecd54c295abdc373c226e7879158a",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/file-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c91dbcccb9f11de00029b63890d10d496f58e51731b5f4afb6700685a4bfa264",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:bb7bb8b78456dbd0b94511b26becb472ada8a5482871ebe7e2f8a8a044fae3a7",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3598c5f780a4a3af6ec93a80183361d0339f7b94da25a09e6356d260fee96fdf",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:7a0b7208d4fa48eff55578ad2e99d8d4a53888ede87df804c6bb89d125417c46",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/firewalld-1.2.1-1.fc38.noarch.rpm",
+        "checksum": "sha256:0654cefcc22d52fcdbf7b3d0a7077babb6491a7d812a7c6caa68652da617672f",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/firewalld-filesystem-1.2.1-1.fc38.noarch.rpm",
+        "checksum": "sha256:a6c2d07340d47de477613c6c3ef2f643f26b00d6b47dea2fa6078a076268004d",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/flashrom-1.2-9.fc37.x86_64.rpm",
+        "checksum": "sha256:2af369b0f500f875bf394b437524ba072cc317b0841cd62815691bc36d487ff1",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm",
+        "checksum": "sha256:cb8340f6d2151b97e54df3fe09c063ac8f820bfe096753cfe395e2516030c70c",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.6",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fwupd-1.8.6-1.fc38.x86_64.rpm",
+        "checksum": "sha256:709f71501e54efff438b6b418d8e69cc85887c6ff8b7a21dd8835d435f1668d5",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fwupd-efi-1.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:cd8987f528bf3bd926c809d492f64374dcbf4a95252b569fd9cbf804848c319f",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.6",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fwupd-plugin-flashrom-1.8.6-1.fc38.x86_64.rpm",
+        "checksum": "sha256:e2f0e9e62e8309396833c485f185a928bcf9617db1f7e79ff24109857f217632",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.6",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fwupd-plugin-modem-manager-1.8.6-1.fc38.x86_64.rpm",
+        "checksum": "sha256:efb40dbd73db04020f2212ae13e8f781424bc0463c4e0ed30875e46737c1ee60",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.6",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.6-1.fc38.x86_64.rpm",
+        "checksum": "sha256:583f171c10924f83bf4916eb98bb64a4d8d5c1d8522a721d3c2bee8c48e753ee",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:336b5d44b186dbfa29e8c4a2c387a6225671787812395bd49c05249d969008d7",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:408b6c8214a6fbdc2b921d3d1acb056b3a8fba0e7d5f51ca7817b5e55c59270b",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm",
+        "checksum": "sha256:58a55546644acbbf49ac082cd4855f475192caadc835722c38dd86ef9d285057",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gdisk-1.0.9-4.fc38.x86_64.rpm",
+        "checksum": "sha256:382de44811c7f29aa781faf4c701f54304fae4b41dae49e73b113a165feed110",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:00054d4310ddebcfd966ebcbd42c072bfb69d0709f6165e2c0bc0ee1337efba2",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:4cfd593ae556df6f8e3ace44379261ab2d44044a2ab25c2fd4a4323b73cd17d8",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gettext-envsubst-0.21.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:898b382eabfaa94f782cafb61fdbc1bef82d69e3f616bb9f00e1ab080f41ccb9",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gettext-libs-0.21.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:7da4199722fa5db76e95dc503f62cb954c90b588d0db49d096565fa8a74bdbe0",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gettext-runtime-0.21.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:8fd7c1aa26f19b023a252e7edc5bf42372bece3b15de889c882ff276f8445f2e",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.74.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glib2-2.74.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:e82a29caed678de72840ce2b5911d67a68bfaa9a69da576649becde2811b46c8",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glibc-2.36.9000-10.fc38.x86_64.rpm",
+        "checksum": "sha256:8a35bd31f378f8c866577017f750248571fdf2d9b4f8f1c1d58c67c847ec1fb6",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glibc-common-2.36.9000-10.fc38.x86_64.rpm",
+        "checksum": "sha256:238e13f764c6efc503e17f5a8c98dba1c1a01cb2d5ef8a7d037df4a6f3741f1b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glibc-gconv-extra-2.36.9000-10.fc38.x86_64.rpm",
+        "checksum": "sha256:f93547eeb6911beb0ed3c4082d2b81fd9fc3c80b77557568133eb80c9744af82",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/glibc-minimal-langpack-2.36.9000-10.fc38.x86_64.rpm",
+        "checksum": "sha256:82909f3b2c48da81c37425947ca7b331bdd49ecaa404aba1443bf0885622ea6f",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:718b9103f02d5aebee50918c1d324cda6e3c5aec8e63ed8daaed3b1b104acd7c",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.8",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gnupg2-2.3.8-1.fc38.x86_64.rpm",
+        "checksum": "sha256:e4c60148da66b03578e6593b7b498ccbef81464b2456be1ccd84918aa2ae8d84",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.8",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gnupg2-smime-2.3.8-1.fc38.x86_64.rpm",
+        "checksum": "sha256:3e953af5a5b8f5d9d4d21779c1925af9f5ddf6e9f9ebb1ce8aac547de19ac742",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.8",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gnutls-3.7.8-8.fc38.x86_64.rpm",
+        "checksum": "sha256:cb37630c680e8b9ba2480e862c81cd42994147fad219b44006840e8642e144ba",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.74.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gobject-introspection-1.74.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:e7b80b715ca72917a9662b48c040f07fdb4343f69fe5f1b628b3a759dbc4537c",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gpgme-1.17.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:368fb99245a0a78c0c229a9a53791b7ec0c4aaaf22d64451f36637d652a4aa55",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grep-3.8-1.fc38.x86_64.rpm",
+        "checksum": "sha256:154c20ac5d2a2a1286018dfce619fd883c520307322ca3a3513aaeca755130fc",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/groff-base-1.22.4-10.fc37.x86_64.rpm",
+        "checksum": "sha256:648b73a8211d7b165c80bf366895cb39a3b86dbbf1d971258de653be0b6cb289",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grub2-common-2.06-60.fc38.noarch.rpm",
+        "checksum": "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grub2-efi-x64-2.06-60.fc38.x86_64.rpm",
+        "checksum": "sha256:6d20c06c82e13eb08ce603b9a676bd16ce74f78bcfeec0f67d8140523ba84649",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grub2-tools-2.06-60.fc38.x86_64.rpm",
+        "checksum": "sha256:623394bbabadd7595dd001d9909de43fa4ac339be2b2cce66d94f4e3418c3ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grub2-tools-minimal-2.06-60.fc38.x86_64.rpm",
+        "checksum": "sha256:fbe8a6710d8146771ce0c68a9f91c6515ec2d58f1ef3737aa08992abfbe29fc6",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "67.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/grubby-8.40-67.fc38.x86_64.rpm",
+        "checksum": "sha256:0bfa7c7b3371a5fe0130d4f26aab83270fce96f819ccf45d1def09c39ac1b0fa",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/g/gzip-1.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:38b7d5c5f8aae3b697e3a9d21ca78465f66980acd0cfd8bcccf100c2cc6400f0",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/h/hostname-3.23-7.fc37.x86_64.rpm",
+        "checksum": "sha256:1cd7cb3a9dcb03e1a3322200060b02fea694400f5c58ca1143a78758c55b6304",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/ima-evm-utils-1.4-6.fc37.x86_64.rpm",
+        "checksum": "sha256:18238fedd785dbfe55bed864c13635a9feee9f4b929ffbd258c58e61736e4236",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "56",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/inih-56-2.fc37.x86_64.rpm",
+        "checksum": "sha256:12cb09ac132e4945809adfa22d3edbdc7fb458361d37032d6300830c052490c0",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.17",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/initscripts-service-10.17-1.fc38.noarch.rpm",
+        "checksum": "sha256:abfd9ef518fca89f4db8d12165229e5abb5155e187af197617f690512e3af302",
+        "check_gpg": true
+      },
+      {
+        "name": "intel-gpu-firmware",
+        "epoch": 0,
+        "version": "20221012",
+        "release": "142.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/intel-gpu-firmware-20221012-142.fc38.noarch.rpm",
+        "checksum": "sha256:a452e760f5b524cd86b3c2f252816d07bb62e1d59fdda8883148dfd6bbfcb973",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/ipcalc-1.0.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c7931f5dc4a593808c00346a9a452e24e79d5a70201da6ffbd3fc18d9a0e04a2",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "6.0.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/iproute-6.0.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:0d604c93f87f6115968da6415b286ce60ac7a423cbf174beed96bada597ff5dd",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/ipset-7.15-5.fc38.x86_64.rpm",
+        "checksum": "sha256:c51e6fdb4353a2fce7758af9c1fcc97e6a54f7b7162464b7888ac2796aa3e442",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/ipset-libs-7.15-5.fc38.x86_64.rpm",
+        "checksum": "sha256:3eb234e9d0b498ca0c700d97ee48b0d107c8454d93e0d51704de4d9f5c6552d3",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/iptables-libs-1.8.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:6d3f733c72e0a227747d0c3319f35c197126a84cea362b4c32f34ea253d0e3b2",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/iptables-nft-1.8.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:089e516a282a6611d8ccb37ed05870860c71d0fe0a00fcc75dfdc70e082d49cb",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/i/iputils-20211215-3.fc37.x86_64.rpm",
+        "checksum": "sha256:1dbb1fc38e0bac0925353d24aa78aeb2030f5eed9ef4b2637ccf5811d37fc807",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/j/jansson-2.13.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:c0bc33ff5df85f2c9a1bf645a20c77b60a7c270b1dfd54305d5ae3b75e89f4a8",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/j/jq-1.6-14.fc37.x86_64.rpm",
+        "checksum": "sha256:b39adb12197f08a665204c5628eca9a8025b24f12a77d6c7b4e04a2e11532a03",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/j/json-c-0.16-2.fc37.x86_64.rpm",
+        "checksum": "sha256:cd577dc1b6787341ec0d89a688a9e5c5450badbebe8abdc1049aca4f8553c3b5",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/j/json-glib-1.6.6-3.fc37.x86_64.rpm",
+        "checksum": "sha256:f74da1c044980e6bfcdfc8340fa91899f9a944800e3e6f71bd6e99e7693df5e3",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kbd-2.5.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:6bc9869c8ba8704f16fcec7543d4b029dd51213ff171fee7cb8e0a3da167b77a",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kbd-legacy-2.5.1-3.fc38.noarch.rpm",
+        "checksum": "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kbd-misc-2.5.1-3.fc38.noarch.rpm",
+        "checksum": "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "6.1.0",
+        "release": "0.rc2.21.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kernel-6.1.0-0.rc2.21.fc38.x86_64.rpm",
+        "checksum": "sha256:de8607703bf0476f4d60389d03d15780450bf30d2b0ee138965261107a2ee937",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "6.1.0",
+        "release": "0.rc2.21.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kernel-core-6.1.0-0.rc2.21.fc38.x86_64.rpm",
+        "checksum": "sha256:a09dc2a014eed705062f6ce9ad7520ec5f02b705d7fe515ed9fd17880c7ea330",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "6.1.0",
+        "release": "0.rc2.21.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kernel-modules-6.1.0-0.rc2.21.fc38.x86_64.rpm",
+        "checksum": "sha256:4380ca3d259f47ea47a80ae46fc397cb536ba9c2491c643bc20d61001983b47f",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:8fcbd5077df15f8c8d3f3df2139087238868ef26ecdd68669364b4fb3e355c7f",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kmod-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:a847f339173fd09197887df7f84218b2cba1020e80b78399fca3e084751b77df",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c3b4d41f2e0c05622a18888d356210282cc3309fb132a0e967edd8aa0fafc58c",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/kpartx-0.9.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:6722c48276ab3dc0ba58692892d06056097e973f44e416b94bd26a5a975f2b40",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm",
+        "checksum": "sha256:9fb93562eb8a553196dd8133a422161c0c54f396338e2467a6830cf79db37f38",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/less-590-5.fc37.x86_64.rpm",
+        "checksum": "sha256:e3a4e9b6e68360f24bb2b92bf23068c47e96d6d705f546648b2e10dd88e44e84",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:34fb99840e8800b5f105b18aed42c33371421e1cd6c4092727cd9a01587a072e",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:dc8a30844c2e5a519e69bc35e9a12571698a99c89dbe4e6e4febaaac623636d6",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm",
+        "checksum": "sha256:36ce047183f8e73f9dc2e675f800001e9656dc31641360224c04a47a8f1437c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libassuan-2.5.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:e66f6a75e909357289e07d9ce9801a0662527aebee680bc255637012b956e66c",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "23.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libatasmart-0.19-23.fc37.x86_64.rpm",
+        "checksum": "sha256:6b79e53815bf9ccfdced5dc732b9d20ef47ab8dd20a5777e136adfc1740bf570",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:b52d63173a94b61eead79ec9146111a5877b2e9f5a21c947e385fdef8304969c",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:25cd4bedd47325a47e47a27062fa6c139ee56a92ed119fe88eefd6263a2e09df",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libbasicobjects-0.1.1-52.fc37.x86_64.rpm",
+        "checksum": "sha256:193f1fe42eef13e768d599bc89b07a2bfaab4223e66b35b1a6f89e3712fa73f5",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblkid-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:1a9f3b0a766c4436de5242a0a6f1f52c94f3d009b963ef3c2385472d12ecc88d",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-2.28-2.fc38.x86_64.rpm",
+        "checksum": "sha256:cb56399a89890eb0b198977815af29059ff1e10f3a4d350e597ce2948c428980",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-crypto-2.28-2.fc38.x86_64.rpm",
+        "checksum": "sha256:f5d52ea60f458ae82a7924187ada1a537407ec86186211c0a3bac2f0d1f7a654",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-fs-2.28-2.fc38.x86_64.rpm",
+        "checksum": "sha256:372abc48a1a19e06e788e4d5e8b4f20b498585e99db9d9cbf1a19bae64d80c58",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-loop-2.28-2.fc38.x86_64.rpm",
+        "checksum": "sha256:c0c845989f397bc869c787b032f32f070aa7c64549c5bbc8de7ad8ab2fb997df",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-mdraid-2.28-2.fc38.x86_64.rpm",
+        "checksum": "sha256:eff1051e94730b8b50fcd37a109b3eb9ba0e9fed80745eead6a180b9135dd16a",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-part-2.28-2.fc38.x86_64.rpm",
+        "checksum": "sha256:d460ef02a880ed345a255e6bdc6920ac30d40668edd43b233bf28f71e235088b",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-swap-2.28-2.fc38.x86_64.rpm",
+        "checksum": "sha256:418a3538d59143ef1fe383afd0438b9807d3e5ab7e8d5ca563cf1609d6d696f5",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.28",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libblockdev-utils-2.28-2.fc38.x86_64.rpm",
+        "checksum": "sha256:2fd247fbf630e9ea2775669d319b5bdef6679740b80062e886923eb791b49a42",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d012a020c6e80fb827881e026d572022730cc86c16d0b6b3d3935c2860e49d10",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm",
+        "checksum": "sha256:aa9327946e86d20192948513e27b5314e565bd533f4e801215cf62190314056e",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libbytesize-2.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9afc19fb507521ee32f35e2cad4b530d863b2cc3810cb9b8408eb61bbb50b6b1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcap-2.48-5.fc37.x86_64.rpm",
+        "checksum": "sha256:cde5a2b8b2b57ca5986327f5aea5eda780e3fce2a38de4bc93d1098c94781d50",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:66797ffb041aa8f8df7259c33063a328c641ca6a9b2c01b226877d7369d0ac91",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcap-ng-python3-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:633d70b8df9fbd3a9a66ac186e5827525a1d01adeed448147e40a2b7c2a30ba4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm",
+        "checksum": "sha256:a51a769a3a49965980b3ddf74cc8dd8380265a14bb76fc3a78645dee87bc828e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcollection-0.7.0-52.fc37.x86_64.rpm",
+        "checksum": "sha256:115f36517e2b9c7cab9ee7b092f8bfff6c1d53b09d0d774969c3884ecec1b601",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d77164c603273f980bf9152290c2b507df0c6ea6b907c93f1de73c50eb489f76",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcomps-0.1.18-4.fc37.x86_64.rpm",
+        "checksum": "sha256:6a0f03d9442843a9df7468a5a926a43c76d4c6437405db90598faea2f35434d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libcurl-7.85.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:0719f5a4f1e14196f2ef1cca8107ca91585a1b4fe8b382e84e306c3bcab4f2a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm",
+        "checksum": "sha256:3201b65c3a8178d52164089dfe5800314b803d1a88367fbe12c8906f1c05da02",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libdhash-0.5.0-52.fc37.x86_64.rpm",
+        "checksum": "sha256:453eec881996f5c80bec7ac779f7973ba8c2244e83d01e87daf4c3381b88a1ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libdnf-0.68.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:c8a3d24889c2c77145c7ec6734290188651f84ac1cb7a3d283189b5010e326dd",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ff1cb7ddb5c0ebf0b4dbd9e307591dad5de749f9a8226ad5fe38ce1dd6fc9b39",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "43.20221009cvs.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libedit-3.1-43.20221009cvs.fc38.x86_64.rpm",
+        "checksum": "sha256:65874efe12ae8f0816cc2ce6aacf65383eb01bcff313284424f6a4bad23e7726",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm",
+        "checksum": "sha256:8a66d6e4a4d83cb48ab7ca731da9c63c3e40d3f8fa2e9c1d4ea41cf3924c0415",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libfdisk-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:fc809c6aedb53823e5ec114794e529db7adb287ed66b4773620c4a1c2f2b3001",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm",
+        "checksum": "sha256:f216369a72a6f3cd932463e7d236c853b1bf2f63526b1637d0aa1269ac35ce57",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.12.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libfido2-1.12.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:2f6ce4010c06399729060921fbea0e39c25f87b0dd7820143cceedc9e858441f",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libfsverity-1.4-8.fc37.x86_64.rpm",
+        "checksum": "sha256:48c3829c4b7616d6985737c5c8552d49ac9d80e41780af6daa34963b8d5b9225",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libftdi-1.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:8b79f85fa9266e4ed110f75e71125593d7de788a3f8242a69acfb4be56e92190",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgcab1-1.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c6fdb21908848e96e58d0ea2b495701eedad190b01f9df44c16e35f760cacae4",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgcc-12.2.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:6114461c8756323c5470f2be5ab45e7405bcb9e1f54b01f6c82c80c1595af34b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:8d599d9a7ce446f0c7e2040422fec9a241f6c45dc0371372e9704abdaa8bd21d",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgomp-12.2.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:1b38f041914297b8dbd7e4f04571eda70ddb58c39babc276af8352c2552dfd60",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.46",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgpg-error-1.46-1.fc38.x86_64.rpm",
+        "checksum": "sha256:0a3dbe2cf5ac3caacb44785b6c5005b6d2e3792a7ff6a53c26dac66b2675681b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgudev-237-3.fc37.x86_64.rpm",
+        "checksum": "sha256:50a0828e3f1eba2ec053d15a3412b2ca62ae513c3899ac5a6e88e9d91a21041f",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.4.2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libgusb-0.4.2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:9de9a79d1dc9c8937b1df541dedce3cd01be557bfa1187c46ab7353a73edd19b",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "41.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libibverbs-41.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:922d0eab6721af3757cb60b4c0b79abd47e32897ece35bf02f08bc4951c2fc65",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libidn2-2.3.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:9021392d34a59f5c717cc4523d38574a4e110fd24ff554b771e5c17f42369df0",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libini_config-1.3.1-52.fc37.x86_64.rpm",
+        "checksum": "sha256:cd5ceea29405a70d0751933a5c3d6178b671c80ff97e04aec2614caf6156d238",
+        "check_gpg": true
+      },
+      {
+        "name": "libjaylink",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libjaylink-0.3.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:09fc65ab51d47ada940766c145b96f738bf592e0359bb2a42ba2a398fdc7f6cc",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.12",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libjcat-0.1.12-1.fc38.x86_64.rpm",
+        "checksum": "sha256:eb0e0ae250fb3fb0abf5fa3e958148a5a0ecccf59b41b23adf96ab3f34c3fce8",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libkcapi-1.4.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:348b04d1e81b64dc688fff396798a364212e27cada55e87ed1eed7336782fccb",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:4aafc48fc095f171d20fd31e1a4a88784ca8017a75d167bf794dae3394661517",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libksba-1.6.2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:f3822e08a6fa781057ae121ff8fc105ca0e42ecc95f3789cebd18944c7cc79e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libldb-2.6.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c74fd7795d471046edbd2ba1eb6a984025519aa076b2e856363ca8c2c4e26e6f",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libmaxminddb-1.7.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:d1d7d815ca8cc5ce4e8df78f2ddfcffec6742e482861ba670a3f7db5d418bbd9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libmbim-1.26.4-2.fc37.x86_64.rpm",
+        "checksum": "sha256:65d61922e3a2b117b79e44ffd2945ee5c8ee53e6d3603dff792982c04eb13d9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libmnl-1.0.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:2acc31ad50943cab96867bee157c29e08d1b56f384c804cf33db0cf49f6cd026",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:15358af44d005789cfda790606bd60c162b673167bbfe7153a97a043e1083768",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libmount-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:bc47bfd4eef2547fcd6980a6b0a4f19ba84d9dab159bed6bbbf7a5dd43fee25b",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libndp-1.8-4.fc37.x86_64.rpm",
+        "checksum": "sha256:092a0396068edc5fbc4e77aa49aa5c312184ef4b0b7435c604107a52f712a19e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.x86_64.rpm",
+        "checksum": "sha256:995659e1f0c39fb758160120c68ece8446d14ab3e3b0527aeadb90b0547e5a7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "22.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnfnetlink-1.0.1-22.fc37.x86_64.rpm",
+        "checksum": "sha256:1a056805ee78f023e3dcabda0c298c6dcc16515a86153459c01905ab2b43e9be",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnftnl-1.2.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:324c6e6d4a55b3ac12198e8c6a528be517d57cb38d27e3dd961bc0efd487b292",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.50.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnghttp2-1.50.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:5394d42b3f062b40e98b594f338122b3cbd4d8dd4e3469ee8d02908148a27122",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnl3-3.7.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:118b3e835f01f45feb29c6c1eea1a50925ada9d5ff2804d6d7de74453aba5fbd",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:2dbcefd797e17c3e6b73bb43351003f8fdb5236bdd6f4e288301119b663a0c7a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libpath_utils-0.2.1-52.fc37.x86_64.rpm",
+        "checksum": "sha256:dd593e435ea68265fe742c4c6e3acc7240abaf9b9d75882205c4f434b727e1aa",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libpcap-1.10.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:149011e66fc747517ea929ff80d4f88e72961b10e352a324a7ea4ec3d20503bc",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.6",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libpipeline-1.5.6-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ca34df9ec9bc66a150d308568c53e462a6f35b48a07354982a1773eb9cd0abe3",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:20925047133a5303a51f4e376b537c3d14c2a4ab0c239c5b480327a948b948ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm",
+        "checksum": "sha256:093d967abc65b0810e20724e9f8e446d4a3901ef0bbd0aed7756e7a1535644d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libqmi-1.30.6-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d7f3c8c057eb68b6b5838ff0738826b996c847f2452ee62fb5c1c344161f633e",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libqrtr-glib-1.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f0315d368bde2128992a58c09596af85d39ef7a37e097bfc94612f3dd7178dad",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libref_array-0.1.5-52.fc37.x86_64.rpm",
+        "checksum": "sha256:cfd13bf9a8723dc1d74d68155e59692e83707928c7f1366be13472da7612acb5",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/librepo-1.14.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:008045c0fbc85a1b9a077567294efbaa56f61c75ab4100e86fa30a569480a2a3",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.5",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libreport-filesystem-2.17.5-2.fc38.noarch.rpm",
+        "checksum": "sha256:17f2d670442cfb22138f3eaf331e045c2b0526d0d9ec4c68f3b215db15168cd7",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:aa1981728f4d99093e379a6cdf6815257afd48a940b3fcedeea53799234e662b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsecret-0.20.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:89fc69c405e600d7667df2cb98d4c7d62259c72545db6267f234b28761244224",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:b4d348f2385b36bdc1a818b36511e491ccff83cbb24040472303e8bc02a1ca7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:c96af87a1d3aad0cb63953fb402ae37d14823288dd74e910686d0322172140d2",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:83518b7a45109407fcac3427dad51a9f7f7d3668e0a0942ad2158da82b869476",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:aad543b786b8f870cd0a7a1d472199b5ac3f10a87e58133146470c3183d6862a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:f5f0521c7a9e1cd8fbd0e1fe82f3f91de9ed38b4680bf2eb929cd592522c6652",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsmartcols-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:4b480e6b6364e9e1b048f2b17eb5c2e628e97956b5c448c8753998e5a253ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmbios",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsmbios-2.4.3-7.fc37.x86_64.rpm",
+        "checksum": "sha256:95aac8f490ae408be49651cba31d9ae7805157013629317cd5f13eaf6ce4696d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsolv-0.7.22-3.fc37.x86_64.rpm",
+        "checksum": "sha256:891ca4669541cb323a77e6d2224baeebccb8d0bb892670521f63ecf4a5d490d3",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:2d8cedf110833c4652b589953178498f3d6ec9218b3419f3e25da8f89fbd379c",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libssh-0.10.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:78636eaf09ba4e85ef46c9f53cf8832a5458817ee3c948683eeff253e0013716",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libssh-config-0.10.4-2.fc38.noarch.rpm",
+        "checksum": "sha256:0f658f37cc911a0ed122c445ee07555c27d8f98ddf30424bdaa528cdf0cfe166",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsss_certmap-2.8.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:940a47c7c4ac5950d7c5b455077cff86629084d494be38eed3daf533d7eb5428",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsss_idmap-2.8.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:01ac72679f09426833e1f1c205dd530edd10c1120918e603048add5c88f25ea0",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsss_nss_idmap-2.8.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:42efbc1fcfb7f8d67b57d8a126aa3dc8cf7319e04fc5cf25b1d877abbd41fe6a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libsss_sudo-2.8.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:8b42966c07956a13614b5cdb76a6e06a22b1e875df9d7fab0ecfb11f6729581a",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libstdc++-12.2.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:6269bc8372cbde95f4b6fd1189030903a5dbf0310fabbe5fece6cf60de79dd37",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libtalloc-2.3.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0f3e6504aef91fc641678229a4f9d8d5428dd7b837cc4b0fb57038583025cdbd",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:6206e39671991eb0ee840e2daf92cd84ff72aa04b8d089e7dfe7ab29602c088b",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libtdb-1.4.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4eb90ba78d6ebbc54758ec1787b3c1adf2608962d183a101da8de1013bcb7cef",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libtevent-0.13.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:0eaddcdfd370876db1241bf7251c8f87e0565dc818887d2bc95d7a211c77b3a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm",
+        "checksum": "sha256:beb040c019a273d6f8b189dbe5898fbcce953fc8ed82a44b038177b2d5e50e60",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libudisks2-2.9.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:8afe733f094d886431d500e2c5aac11bf8bcef0a05314160a968684cb006d574",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:39f7b9690b91d195a45782d7aaf37e407eb553027bbed89e9a9a2abaca6c461e",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.26",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libusb1-1.0.26-1.fc38.x86_64.rpm",
+        "checksum": "sha256:2c18e137d6a407e789f0f97718977096ad976198de4b161df87ffebe270634e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "13.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libuser-0.63-13.fc38.x86_64.rpm",
+        "checksum": "sha256:55384f7ceb51716e0153951f3b1d9a43e9369738110aa92e2c92d1d8db6a700a",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:12a585c3a3636f88abcc9afb60d2a691006dc5b40879a8abd5e903a7a78a6a62",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libuuid-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:5a3cfdfce26f9b7d7f3d3626e464f47e465308765d58366feff06371eccd1fec",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f7f29a0e81b5049ae1882f1e6656133818b46d3923be2fcea41ff5e0ef10c622",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxcrypt-4.4.28-3.fc38.x86_64.rpm",
+        "checksum": "sha256:76bbb5d3dacb6b5d086d4c425ca05a2b63b8ef6f17e905d523acf4659b71c865",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxcrypt-compat-4.4.28-3.fc38.x86_64.rpm",
+        "checksum": "sha256:98da69aa484ccd357cc76312774d53a64f552b21b594d74a2fd01be5e21f300b",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:7552ec8b34844ba0cdc2f8c19dbac36b898e3d303e778888ff30193333d0a859",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxml2-2.10.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:cf8017c6cb5e00fc35157fe47d6d13ed86079d9fe793c225ecaddac105834c96",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libxmlb-0.3.10-1.fc38.x86_64.rpm",
+        "checksum": "sha256:af4bf71d9a3cb9f325925a951710e50b92a188f87edac5ca2384520520845d51",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libyaml-0.2.5-8.fc37.x86_64.rpm",
+        "checksum": "sha256:6183bae674287b17dd36e3f5c01f0abcb021875895959fa63fb5061f18ccc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4f0e83dae6f1df1074aed8bd8a072edb2fed894f734ab55f07f31dd214e6db25",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20221012",
+        "release": "142.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/linux-firmware-20221012-142.fc38.noarch.rpm",
+        "checksum": "sha256:7011f454ba6e5d9f934fb2ad7c47e5c13e56ce7e9e1ac67f0c81cbca943b2792",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20221012",
+        "release": "142.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/linux-firmware-whence-20221012-142.fc38.noarch.rpm",
+        "checksum": "sha256:9cecd9c301c808e795c6d33b1440bbd552e71ad20a2bd3e523cdd8459210e62a",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/lmdb-libs-0.9.29-4.fc37.x86_64.rpm",
+        "checksum": "sha256:7c28ce263b298c1f526718c1cb0f055bdbb455e1130a4bbcf7113fcc992b448e",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/lua-libs-5.4.4-6.fc38.x86_64.rpm",
+        "checksum": "sha256:dd981fc525ac4e032e36d2e8519288304936d3f5e89c866f22878491f46df8be",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm",
+        "checksum": "sha256:695c89729d68929af4096102abc3b40ae12ce8cf18f0a6c85703474ffaca5bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.11.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/man-db-2.11.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:5c835c03812834ed898e6b55802fe5a725cf4da1e2ac0ba44d41281184a6acb7",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/mdadm-4.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:2022bb0fe9c17df96734f4667357ddb956fd82004e9297504649ac60081b5464",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:7eae9fb9787d66887be6131718a6769fa6b963a6c3df9f9248ac0296aa7a6538",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.14",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/mkpasswd-5.5.14-1.fc38.x86_64.rpm",
+        "checksum": "sha256:5e0812486718e1af122081b977142ec70c1b5046416db99c8c00901003520c2d",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/mokutil-0.6.0-5.fc37.x86_64.rpm",
+        "checksum": "sha256:fcb97e83814f4229c89c00e82bcd25ab41c69aee5157582376adc4963abd142f",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:0679744c52934c2f7285aa54209e7a3bc6db713f9570652894b8ebbc4a4b6fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:3e0e9ba133c66e1858baa05017c196c75c59fe4c9df6d7b3476470164a8f17f8",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nano-6.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:debc0be72012ae50ae10caa306ad14b7a4f61e6bc43161da7036e3091900297f",
+        "check_gpg": true
+      },
+      {
+        "name": "nano-default-editor",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:60040f8563239848aabd3a655c2bc185a7d7f47dcf59228353a6713eec036269",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ncurses-6.3-3.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:81b81aee93d47f3a869b2582a53a0b59871b04f7e7c0b84d5e12207a271b0fb9",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:ae3f201e386217e734ab85b1744505ed5346cb70c049ca8ee7f122b2550de38c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nettle-3.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b7548d4dced9671ae77294541ce1c82c7db90e5e1634413bd49e0d4830452969",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nftables-1.0.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:80d01a8159d6c89b9e41b743a26a7148cb4ba043d2c8667c80738cf2e7efdd8f",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "10.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/npth-1.6-10.fc38.x86_64.rpm",
+        "checksum": "sha256:bfe6c6e0137845e5df00d636e6e68ebf690c0a4fdf1d8fcd645d94789cfd2c09",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.35.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nspr-4.35.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:857b1e118da83981a1996af675ac5607f4267e1349ed1f05f90ad994404e0208",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nss-3.83.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:e77404faa136326e63c2a943466b97ca43ef448feb7ce10ce50aac6c2f8fea9b",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nss-softokn-3.83.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:981c202e4e80078691f7aa5227305987d76b4614cb6a6fd0d4a2ff6c6e281077",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nss-softokn-freebl-3.83.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:234bda5eee845cc15508ef8fcd46651ed15da4e363a6d1bbf5453b7a22bd2e02",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nss-sysinit-3.83.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:12f08f59c8fce365914e1df0cbb2e0765c6fb7cbd55afbb138558c21ec78fe3f",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.83.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nss-util-3.83.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:388b23668bd8281624d23b3a78f42a5441e3775e08e541fb52f405b056170170",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ntfs-3g-2022.5.17-2.fc37.x86_64.rpm",
+        "checksum": "sha256:39e14c4ed790fe4d47bd984afc47f291cac78bdfc9cae7d220979ca52c7301d5",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.x86_64.rpm",
+        "checksum": "sha256:6fc5af931ae4e106fac29e38db61b4ac4e86331088ab085cb2e9ff0c33dc55bf",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:7c6819de5a54218e8d69921d7e9cab759b794c4d65c5b9199e0da3e05fc31ec1",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/ntfsprogs-2022.5.17-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d0be81593c6a700d883ff95b06a92afef5790a5fbcdb8d35d6cbfc9c4e87e5a9",
+        "check_gpg": true
+      },
+      {
+        "name": "nvidia-gpu-firmware",
+        "epoch": 0,
+        "version": "20221012",
+        "release": "142.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/n/nvidia-gpu-firmware-20221012-142.fc38.noarch.rpm",
+        "checksum": "sha256:ff017b16ca598f61547ca1f70a677c8e8bc87794b646686acdd55a70ac12cc48",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "2.D20220919gitb041f6d.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/oniguruma-6.9.8-2.D20220919gitb041f6d.fc38.x86_64.rpm",
+        "checksum": "sha256:8551d1552725100d8649b44cc51cbbe8c9e70b9c16c017a95001b701c2ff9b4b",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openldap-2.6.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:3b4358d599ab4a52ee8509d33635a8cdd5da34487a7225a24b3fc72696adadfb",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "9.0p1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openssh-9.0p1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:8c42725936f017feea8989faa8a90b966377185d42344ac3a3642cad14e0820e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "9.0p1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openssh-clients-9.0p1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:4750930ebe4765c67d3c6065e0a92e6a1a4359d85fd819a18dcf6370b9ff4102",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "9.0p1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openssh-server-9.0p1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:219f4432383b48bfacb028bdc7ef9afe372cf213e05c82a875afd5759216cde8",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openssl-libs-3.0.5-5.fc38.x86_64.rpm",
+        "checksum": "sha256:e0aba1be1f5587c603583c56572bd40e54cee9789e2bc58ae7c0d4ab3a84848d",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c416cd702ce78583b177eb152e87424e4e65a706cad8966904d10f3b413ddc54",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm",
+        "checksum": "sha256:79426b7b91b26682579cab6943516b32797f6c3028008e9c52d3299fb8299f1c",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d238b2e8d817b89bc0d1d22d716c3695185a96bf939b548e1143ff76c4d5def8",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:05172ef8afc62632b5e7c395dc9ed2f801e84ace131d36b1df777109df138797",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:1cb235881ac5c89085fe28e6fde153920cde9f4bdcebc17fca86723f3cc19310",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:043bbdc6ac7341dd00c1857c68d50f8fc91e2d589e1020c5c4678ef6327fd03c",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/parted-3.5-6.fc38.x86_64.rpm",
+        "checksum": "sha256:003ce0d20116e00e8b521e5b7451ea0606950387352596c066fa983d3b709d9f",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/passwd-0.80-13.fc37.x86_64.rpm",
+        "checksum": "sha256:873a81a4fe3a7364f2b93cfc72f6a0153e26051cf4937604fd9394e405600753",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pciutils-libs-3.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:9b4e2edcab2b0876625a00d939f8e415e1ba52c70bc5e21d6ed0713fe7c44a8c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm",
+        "checksum": "sha256:6d2bb2cef78697952123b3a7a6a21dcd244d3fbfea20f577f75fd09b9d52fd74",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pcsc-lite-1.9.9-1.fc38.x86_64.rpm",
+        "checksum": "sha256:96bc81e214ddc10849313be4f9503366bd39d7d727222e9f3ba5119fbbd85a3c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:eaad7eb1db33cd9a7d75dc22f93fedf00d5cb5e58c4b91da4efc08394b6a3465",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc38.x86_64.rpm",
+        "checksum": "sha256:f23e684c367b3f1b3494d0b84dd98d33a60cc803f3670367c4e79b4ef57977f2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pigz-2.7-2.fc37.x86_64.rpm",
+        "checksum": "sha256:5b03af8ac2ea38b815d942ec3acd99ecc6628c2047395f5c9667c044972fa114",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/pinentry-1.2.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:4bba3f7ef03c6c0f17a9362291b39641d6777bac223b90168b6a18b9a7f8108f",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/plymouth-22.02.122-3.fc38.x86_64.rpm",
+        "checksum": "sha256:9c7cf01ca9153dbd45cc44987044797a628af29d97cdf7af8a4466363c758ca9",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/plymouth-core-libs-22.02.122-3.fc38.x86_64.rpm",
+        "checksum": "sha256:bf3eba90b87e314919d683f8c934451cd1d0e9e64ab6d726c03fbc2dc2e984b3",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/plymouth-scripts-22.02.122-3.fc38.x86_64.rpm",
+        "checksum": "sha256:b657f57a69a3851254fd572330a6edc79c8b48661ead3c647834023031e14184",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm",
+        "checksum": "sha256:05b63669a849d7cfac20c627dc0bfaaab33ed479f7be9623154adaccceb68476",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/polkit-121-4.fc38.x86_64.rpm",
+        "checksum": "sha256:151d21077d158b81f0b444fe3c819179f235db61e889245610f2474494781055",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/polkit-libs-121-4.fc38.x86_64.rpm",
+        "checksum": "sha256:84933208c4c2cd87bfdf08817f28fd8b2ea2f4920d63739cea1b937d63c5d0bc",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "22.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.x86_64.rpm",
+        "checksum": "sha256:d655e5491ee4ced0bf5a9a374e5bd513ec0c82f1d606a534312824280c111fc7",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/popt-1.19-1.fc38.x86_64.rpm",
+        "checksum": "sha256:4512d87241a25cc9e36731cc02119a5dff8fc576fb6526fa69732028b728d1f6",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/procps-ng-3.3.17-8.fc38.x86_64.rpm",
+        "checksum": "sha256:e2e124d9f28bc74b9987ea9414e1a5d2cac1dafa437085f5f93a6b00bd328ced",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/protobuf-c-1.4.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:88d3170c87aa58df1b10b0f385302c7154375d1c06bc253462b2999989baac2b",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/psmisc-23.4-4.fc37.x86_64.rpm",
+        "checksum": "sha256:692a5ce3d939ef1069eb54cdd3c67ca814f604199ae10dd40e1d1a6305d368d9",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2.2",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc38.noarch.rpm",
+        "checksum": "sha256:aca40dd03fc1eb93703ea43d9a96a70ad87792e1d675f7a9a762be71d8908c33",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "65.3.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python-setuptools-wheel-65.3.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:e915e3507eb1e877251ac175df26c3be8022b31daedc39fcfa2e05c1ef190911",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc38.noarch.rpm",
+        "checksum": "sha256:310078572de43cf8be4ae7dd9041028fcdf4b4cba315ed3c97a53cf2049d6793",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-3.11.0~rc2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:95897c4f7822c7a154b19754b820171f06558c58487476755ec3e2e43f4656c6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.2",
+        "release": "4.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm",
+        "checksum": "sha256:d9572a1494fa167b5073b7a8633eb278b40d85d9d57426e2fec190cef713551b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-dbus-1.3.2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:5f4574b0789a4724c8a80e83408443a94f78a79b28770f87e3ffed7a991c7edc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-distro-1.8.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:ea22a10ee200ce742b5eb4924e78edbcfb16848853ba4944129a2fe8758e5fb2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-dnf-4.14.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:c9c6ccb93cbf9b7a962b10432d64d88f0a91fe856ab104eb04adc31d75dff2f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-dnf-plugins-core-4.3.1-1.fc38.noarch.rpm",
+        "checksum": "sha256:4d59c2e3c373b76eeecff57b35f8839c4b4c9c0eb877de739f582d56ac38a00b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-firewall-1.2.1-1.fc38.noarch.rpm",
+        "checksum": "sha256:978de409a64943493b270e96c146b501414df01a880ce29306ef3b48d6346f68",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-gobject-base-3.42.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:23de5abc3a9620f7f8c5917cfd452892cfcab34fcae502de4d04f83964ca716f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:358de9892f2947ad5ae159ae918e9a568e1ae5f8e8ee56d875e21bc758230914",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-gpg-1.17.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:3ae53041ff5534b34434f74420fe2726ee16da7807058475993c1035c729d477",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-hawkey-0.68.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:4ddfb8d7e3cc7379135eed9e730f5b14d248e6d603f53076688a0a1070ed1431",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-libcomps-0.1.18-4.fc37.x86_64.rpm",
+        "checksum": "sha256:4e62e029027cfae50e42f483e2e275cf33f6e24e4bfd8dd0b88b9be7ed719ef6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-libdnf-0.68.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:9b788ac65ce0f002c0ec43e639ecd7cd65db2ac42f8ca2619d00c29a9a473cec",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:74a9c81894135aa917bcc1e202a05b1825d17eefeda9f4cd0be5dcb51cbfb402",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-nftables-1.0.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:729c2e05903cc91e4bfa594265d346440e1dc72d52ae17b80edd998223660743",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-rpm-4.18.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:2a30ad509cd74be817eb4a3bfa648524f3908ea1eac8b08975bf785d76cbc209",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm",
+        "checksum": "sha256:47a875f1e20f6981847217e875699f645665dc968dd77149289ddff4de1fd76a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/p/python3-unbound-1.16.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:85c8fd5be189f301742d731b537578fd181b2be52c158fb5840900fe25d61e08",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/readline-8.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:216fed7a0ac19abeb145eea54e4d9accfa066aea30e68b7886467f7e4bb5fad7",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "32.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm",
+        "checksum": "sha256:b2d2472284b2f589e360c7c49705812112322e53110b98faee4088f94933e9ad",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-4.18.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:7965785a37ec727d85958b6130c2270ed3bd0dc9b2acd2fb3f1b8ea833dad27a",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-build-libs-4.18.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:bfeb9c999a64412b461c9e9e4a94dbb0bc09bd40cab55fd0043173b893b92760",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-libs-4.18.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:58dfffe5230e210f2b0ea5256e826d4ad14934c96e6671aa4d5cdef9c50fdb37",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-plugin-selinux-4.18.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:30802b6ca4d505cc587b2ddb566450526262753d8d3640dd7000098808be9e24",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:d1fa9e0323d3f21e5949b86c66a15b50b6b8d1c80e7514efa693f90ef3e2561a",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rpm-sign-libs-4.18.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:1e9c718fcce11ef6e3b46a0c99a29711f14292ffc14dfc7653378f32e1c5c295",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sed-4.8-11.fc37.x86_64.rpm",
+        "checksum": "sha256:8cd7312e2810f706aeec6985c277f1500be87f0e58f4311f1fd2d9ee00f5eb3f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.13",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/selinux-policy-37.13-1.fc38.noarch.rpm",
+        "checksum": "sha256:dc7f1b56cadb7d7c1f4b1dba4bca9a87b22071d592f1e06e25d0be7106dd418f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.13",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/selinux-policy-targeted-37.13-1.fc38.noarch.rpm",
+        "checksum": "sha256:36e6835f02c897ea7d1929163cf0dba9317a9fe38637bfa349ecd291ba4b36ae",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.2",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/setup-2.14.2-1.fc38.noarch.rpm",
+        "checksum": "sha256:96f465090b634df32e8d5c1e95e915b82da5537f38c46f9eec88484b719786c8",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.12.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/shadow-utils-4.12.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:f491ed8c89370dd6b50559848f3a6f1da15dca574fb8f223522f7eab6709434c",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/shared-mime-info-2.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:972aa39dadfa549706a4e5b1e021495060aad322663960d273f06ec093a1c009",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/shim-x64-15.6-2.x86_64.rpm",
+        "checksum": "sha256:85bb1aa32f6345349c9cf09c35217caae441dca6b2be8f21619ea6808d3c5af6",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sqlite-libs-3.39.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:8a337038500fb016e11c6d3b507c166cc3d3c3f82b5d4d288deb7322485c7522",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sssd-client-2.8.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:402d2da4ec5556004211e1e3e56fa57dc0d77d0f1aef9b34affb1ca3017fbf1b",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sssd-common-2.8.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:47553267529003e6657b8bbd288fc9918c81c798389ccf9e817b194f14a0715f",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.8.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sssd-kcm-2.8.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:c0b8633a4977c2307590bd9b629ad88e2b8c5e07961eb3ae5f6700b86ade4f0a",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sudo-1.9.11-4.p3.fc37.x86_64.rpm",
+        "checksum": "sha256:59613aa4a26e2b338742edee7dc99d5fb1b2c7c81d500b5977a7a69a7174886e",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.x86_64.rpm",
+        "checksum": "sha256:2b750d60543a4c45b5d663859d1372a041b2eb1c5d808c460cf536079e64ae02",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-252~rc2-612.fc38.x86_64.rpm",
+        "checksum": "sha256:a518008b5801ccdf9b233818e47b6533d7b7be9729065475836c7fbb1fdac0e6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-libs-252~rc2-612.fc38.x86_64.rpm",
+        "checksum": "sha256:35b99038400405fdf56e8562ece4b2efb82148f0b51d4a4bf71f565839842d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-networkd-252~rc2-612.fc38.x86_64.rpm",
+        "checksum": "sha256:dabc9574f3b57343367de49c90ee35d83c9429c27d756f5a2cf52ee1788c9247",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-pam-252~rc2-612.fc38.x86_64.rpm",
+        "checksum": "sha256:76c7caf66231bf06e65b6ef30f97d923da9705d1923d5765d4b726558ab116a4",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-resolved-252~rc2-612.fc38.x86_64.rpm",
+        "checksum": "sha256:f202dbd3bbaf0710ead0a34ec18563d0835cbf169854afee778f2a07919c6e9c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/s/systemd-udev-252~rc2-612.fc38.x86_64.rpm",
+        "checksum": "sha256:fcb77480c5ed23e8b582a83b43661ce8ef6fc091f187d66794f315c41bc7db7d",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/t/tpm2-tools-5.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:0c614e41af121bf40bf33a48eb0886d99a9cc17665ea3120b063e1013c821d61",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d52620cf80bde19169fca7ce66fa7cff416b04b7a0cf2bd7dae8446578dc999b",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022e",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/t/tzdata-2022e-1.fc38.noarch.rpm",
+        "checksum": "sha256:aa71f4f1c3cc79edc9343ea0fcf558bdfed408a094ddda0bbc7582a0c647fc7e",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/udisks2-2.9.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:86b85375ee031abc705f8cf1af528f761a5a5ef73418cb52ae58f44d1405f793",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-anchor",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/unbound-anchor-1.16.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:c417bdcb698e2f835a0663ced24bde7003378000f5512015dc4f265dc58bb0bc",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/unbound-libs-1.16.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:b032f2edc13137e4d101bb58bb8c7da4c6e9bf06d489f7bc612c58a66797fad8",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/userspace-rcu-0.13.0-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7e674c68dc9d3b7b254b677696c12743e1fd79e31c9b315bc700d9f545d145fc",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/util-linux-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:747b441efd11d03e0170939848dd6d7dde39ae798f8d934777fbaf80cb622510",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/u/util-linux-core-2.38.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:798fb2747499e270c152059a31d15456dc426c8e9dc3448bc200bff78457cc91",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "9.0.803",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/v/vim-data-9.0.803-1.fc38.noarch.rpm",
+        "checksum": "sha256:59f140bbc5ba53d4b5c7aac0012bfc4c6d638047e3c335f46cb532bb884b46ff",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "9.0.803",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/v/vim-minimal-9.0.803-1.fc38.x86_64.rpm",
+        "checksum": "sha256:ca68536ce8790ceb00a99633e973da9a66da80d15b992801cd351976ff6baeaf",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "17.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/v/volume_key-libs-0.3.12-17.fc37.x86_64.rpm",
+        "checksum": "sha256:0088c48b167cc56fde621d2ced4addc70c1097f0ea57f91939ccba67a2b22f28",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.14",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/w/whois-nls-5.5.14-1.fc38.noarch.rpm",
+        "checksum": "sha256:a0527ff7d382107084ff5a8d5a5c9c95e4f2b526fbff98dfb251c947f4003efa",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.19.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/x/xfsprogs-5.19.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:7998e07ae6dc75167fbb10dc3ee39e3cff89c129aa84166ee38449b01ac3e877",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.7",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/x/xz-5.2.7-1.fc38.x86_64.rpm",
+        "checksum": "sha256:3e74ae013ee0e8f2294b9c4947d1a729005755528cac4a577f8a0d7f2e89a039",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.7",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/x/xz-libs-5.2.7-1.fc38.x86_64.rpm",
+        "checksum": "sha256:d927c7a593e01c56c79d90e8be3a5d3de10a8efc8a5206e78081967881b96da8",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.14.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/y/yum-4.14.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:28dae95fc01ad9a74e93e6c4a76ba4807cc2d920aaf99c2124133a2fc5a4e54d",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/z/zchunk-libs-1.2.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:5a20d3aa298872db33035c6aa55473dc24001bb24bcfbb9052718a1c9a2371a9",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/z/zlib-1.2.12-5.fc38.x86_64.rpm",
+        "checksum": "sha256:9b4b1667e8dad494e6437505e2caf52501ef6eb8ad7668fab2c2c591397812b7",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/z/zram-generator-1.1.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:26a3e46f75e0213db137674dbaadabb14e2164a6146236e1f8bc3f7a6b56780e",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:ae6ef1c1cfb61f9940bb23f79d271e8b6e4ca7cec9825dfe992cb8ef7a2b1aa5",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -1095,5 +1095,17 @@
       }
     },
     "overrides": {}
+  },
+  "minimal-raw": {
+    "compose-request": {
+      "distro": "",
+      "arch": "",
+      "image-type": "minimal-raw",
+      "repositories": [],
+      "filename": "raw.img",
+      "blueprint": {}
+    },
+    "no-image-info": true,
+    "overrides": {}
   }
 }


### PR DESCRIPTION
Signed-off-by: Sarita Mahajan <sarmahaj@redhat.com>

This pull request includes:
New image type named 'minimal-raw' has been added to fedora.
Reference taken from https://github.com/osbuild/osbuild-composer/pull/3077 
Image is basically a minimal rpm bootable image supports aarch64 & x86
Image is tested manually.
From a RHEL PoV this will enable us to support similar devices as part of the SystemReady "Edge on Arm" initiative where the customer may not wish to run R4E or to use for development/testing/prototyping where a ostree image may not be the most straight forward way to do things.

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
