### PR TITLE
Enable isolinux only for x86_64 (removed stage)

### DIFF
--- a/internal/image/image_installer.go
+++ b/internal/image/image_installer.go
@@ -128,6 +128,9 @@ func (img *ImageInstaller) InstantiateManifest(m *manifest.Manifest,
 	osPipeline.Environment = img.Environment
 	osPipeline.Workload = img.Workload
 
+	// enable ISOLinux on x86_64 only
+	isoLinuxEnabled := img.Platform.GetArch() == platform.ARCH_X86_64
+
 	isoTreePipeline := manifest.NewAnacondaISOTree(m,
 		buildPipeline,
 		anacondaPipeline,
@@ -148,10 +151,11 @@ func (img *ImageInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	isoTreePipeline.OSPipeline = osPipeline
 	isoTreePipeline.KernelOpts = img.AdditionalKernelOpts
+	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
 	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline, isoLabel)
 	isoPipeline.Filename = img.Filename
-	isoPipeline.ISOLinux = img.Platform.GetArch() == platform.ARCH_X86_64
+	isoPipeline.ISOLinux = isoLinuxEnabled
 
 	artifact := isoPipeline.Export()
 

--- a/internal/image/ostree_installer.go
+++ b/internal/image/ostree_installer.go
@@ -95,6 +95,9 @@ func (img *OSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	bootTreePipeline.ISOLabel = isoLabel
 	bootTreePipeline.KernelOpts = []string{fmt.Sprintf("inst.stage2=hd:LABEL=%s", isoLabel), fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", isoLabel, kspath)}
 
+	// enable ISOLinux on x86_64 only
+	isoLinuxEnabled := img.Platform.GetArch() == platform.ARCH_X86_64
+
 	isoTreePipeline := manifest.NewAnacondaISOTree(m,
 		buildPipeline,
 		anacondaPipeline,
@@ -114,10 +117,11 @@ func (img *OSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.PayloadPath = "/ostree/repo"
 
 	isoTreePipeline.OSTree = &img.Commit
+	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
 	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline, isoLabel)
 	isoPipeline.Filename = img.Filename
-	isoPipeline.ISOLinux = img.Platform.GetArch() == platform.ARCH_X86_64
+	isoPipeline.ISOLinux = isoLinuxEnabled
 	artifact := isoPipeline.Export()
 
 	return artifact, nil

--- a/internal/manifest/iso_tree.go
+++ b/internal/manifest/iso_tree.go
@@ -46,6 +46,9 @@ type AnacondaISOTree struct {
 	OSTree     *ostree.CommitSpec
 
 	KernelOpts []string
+
+	// Enable ISOLinux stage
+	ISOLinux bool
 }
 
 func NewAnacondaISOTree(m *Manifest,
@@ -169,18 +172,21 @@ func (p *AnacondaISOTree) serialize() osbuild.Pipeline {
 	squashfsStage := osbuild.NewSquashfsStage(&squashfsOptions, p.rootfsPipeline.Name())
 	pipeline.AddStage(squashfsStage)
 
-	isoLinuxOptions := &osbuild.ISOLinuxStageOptions{
-		Product: osbuild.ISOLinuxProduct{
-			Name:    p.anacondaPipeline.product,
-			Version: p.anacondaPipeline.version,
-		},
-		Kernel: osbuild.ISOLinuxKernel{
-			Dir:  "/images/pxeboot",
-			Opts: kernelOpts,
-		},
+	if p.ISOLinux {
+		isoLinuxOptions := &osbuild.ISOLinuxStageOptions{
+			Product: osbuild.ISOLinuxProduct{
+				Name:    p.anacondaPipeline.product,
+				Version: p.anacondaPipeline.version,
+			},
+			Kernel: osbuild.ISOLinuxKernel{
+				Dir:  "/images/pxeboot",
+				Opts: kernelOpts,
+			},
+		}
+
+		isoLinuxStage := osbuild.NewISOLinuxStage(isoLinuxOptions, p.anacondaPipeline.Name())
+		pipeline.AddStage(isoLinuxStage)
 	}
-	isoLinuxStage := osbuild.NewISOLinuxStage(isoLinuxOptions, p.anacondaPipeline.Name())
-	pipeline.AddStage(isoLinuxStage)
 
 	filename := "images/efiboot.img"
 	pipeline.AddStage(osbuild.NewTruncateStage(&osbuild.TruncateStageOptions{

--- a/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
@@ -9588,31 +9588,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "CentOS Stream",
-                "version": "9-stream"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
@@ -9617,31 +9617,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "CentOS Stream",
-                "version": "9-stream"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/centos_9-aarch64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer-boot.json
@@ -13168,31 +13168,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "CentOS Stream",
-                "version": "9-stream"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/centos_9-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer_with_users-boot.json
@@ -13355,31 +13355,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "CentOS Stream",
-                "version": "9-stream"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_35-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-image_installer-boot.json
@@ -12816,30 +12816,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "35"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-35-BaseOS-aarch64"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_35-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-image_installer_with_users-boot.json
@@ -12969,30 +12969,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "35"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-35-BaseOS-aarch64"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_35-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-iot_installer-boot.json
@@ -10152,31 +10152,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "35"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-35-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=Fedora-35-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_35-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-iot_installer_with_users-boot.json
@@ -10181,31 +10181,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "35"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-35-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=Fedora-35-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_36-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-image_installer-boot.json
@@ -13472,30 +13472,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "36"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-36-BaseOS-aarch64"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_36-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-image_installer_with_users-boot.json
@@ -13633,30 +13633,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "36"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-36-BaseOS-aarch64"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
@@ -10673,31 +10673,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "36"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-36-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=Fedora-36-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
@@ -10702,31 +10702,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "36"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-36-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=Fedora-36-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_37-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-image_installer-boot.json
@@ -13644,30 +13644,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "37"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-37-BaseOS-aarch64"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_37-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-image_installer_with_users-boot.json
@@ -13821,30 +13821,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "37"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-37-BaseOS-aarch64"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
@@ -10799,31 +10799,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "37"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-37-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=Fedora-37-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
@@ -10828,31 +10828,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "37"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-37-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=Fedora-37-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_38-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-image_installer-boot.json
@@ -13522,32 +13522,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "38"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-38-BaseOS-aarch64",
-                  "inst.webui",
-                  "inst.webui.remote"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_38-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-image_installer_with_users-boot.json
@@ -13691,32 +13691,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "38"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-38-BaseOS-aarch64",
-                  "inst.webui",
-                  "inst.webui.remote"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
@@ -10438,31 +10438,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "38"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-38-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=Fedora-38-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
@@ -10467,31 +10467,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Fedora",
-                "version": "38"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=Fedora-38-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=Fedora-38-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
@@ -3723,31 +3723,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Red Hat Enterprise Linux",
-                "version": "9.0"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
@@ -3752,31 +3752,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Red Hat Enterprise Linux",
-                "version": "9.0"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
@@ -5188,31 +5188,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Red Hat Enterprise Linux",
-                "version": "9.0"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
@@ -5283,31 +5283,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Red Hat Enterprise Linux",
-                "version": "9.0"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
@@ -9700,31 +9700,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Red Hat Enterprise Linux",
-                "version": "9.1"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
@@ -9729,31 +9729,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Red Hat Enterprise Linux",
-                "version": "9.1"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
@@ -13384,31 +13384,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Red Hat Enterprise Linux",
-                "version": "9.1"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
@@ -13571,31 +13571,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Red Hat Enterprise Linux",
-                "version": "9.1"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/rhel_92-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_installer-boot.json
@@ -9716,31 +9716,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Red Hat Enterprise Linux",
-                "version": "9.2"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/rhel_92-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_installer_with_users-boot.json
@@ -9745,31 +9745,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Red Hat Enterprise Linux",
-                "version": "9.2"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/rhel_92-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-image_installer-boot.json
@@ -13408,31 +13408,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Red Hat Enterprise Linux",
-                "version": "9.2"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",

--- a/test/data/manifests/rhel_92-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-image_installer_with_users-boot.json
@@ -13595,31 +13595,6 @@
             }
           },
           {
-            "type": "org.osbuild.isolinux",
-            "inputs": {
-              "data": {
-                "type": "org.osbuild.tree",
-                "origin": "org.osbuild.pipeline",
-                "references": [
-                  "name:anaconda-tree"
-                ]
-              }
-            },
-            "options": {
-              "product": {
-                "name": "Red Hat Enterprise Linux",
-                "version": "9.2"
-              },
-              "kernel": {
-                "dir": "/images/pxeboot",
-                "opts": [
-                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64",
-                  "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64:/osbuild.ks"
-                ]
-              }
-            }
-          },
-          {
             "type": "org.osbuild.truncate",
             "options": {
               "filename": "images/efiboot.img",


### PR DESCRIPTION
The previous fix (https://github.com/osbuild/osbuild-composer/commit/9e66ee13e76b431197528d119405656444cac295) only fixed half the problem with this bug.  The ISOLinux stage was still added to the iso-tree pipeline for Anaconda builds.

This is now removed.

Built and tested on an arm beaker machine with Fedora 37.