### PR TITLE
Fix new issues reported by ShellCheck 0.9.0

### DIFF
--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -189,18 +189,20 @@ checkEnv
 # Check that needed variables are set to register to RHSM (RHEL only)
 [[ "$ID" == "rhel" ]] && printenv API_TEST_SUBSCRIPTION_ORG_ID API_TEST_SUBSCRIPTION_ACTIVATION_KEY_V2 > /dev/null
 
+# shellcheck disable=SC2317
 function dump_db() {
   # Disable -x for these commands to avoid printing the whole result and manifest into the log
   set +x
 
   # Save the result, including the manifest, for the job, straight from the db
-  sudo ${CONTAINER_RUNTIME} exec "${DB_CONTAINER_NAME}" psql -U postgres -d osbuildcomposer -c "SELECT result FROM jobs WHERE type='manifest-id-only'" \
+  sudo "${CONTAINER_RUNTIME}" exec "${DB_CONTAINER_NAME}" psql -U postgres -d osbuildcomposer -c "SELECT result FROM jobs WHERE type='manifest-id-only'" \
     | sudo tee "${ARTIFACTS}/build-result.txt"
   set -x
 }
 
 WORKDIR=$(mktemp -d)
 KILL_PIDS=()
+# shellcheck disable=SC2317
 function cleanups() {
   set +eu
 
@@ -209,8 +211,8 @@ function cleanups() {
   # dump the DB here to ensure that it gets dumped even if the test fails
   dump_db
 
-  sudo ${CONTAINER_RUNTIME} kill "${DB_CONTAINER_NAME}"
-  sudo ${CONTAINER_RUNTIME} rm "${DB_CONTAINER_NAME}"
+  sudo "${CONTAINER_RUNTIME}" kill "${DB_CONTAINER_NAME}"
+  sudo "${CONTAINER_RUNTIME}" rm "${DB_CONTAINER_NAME}"
 
   sudo rm -rf "$WORKDIR"
 

--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -30,6 +30,7 @@ else
 fi
 
 TEMPDIR=$(mktemp -d)
+# shellcheck disable=SC2317
 function cleanup() {
     greenprint "== Script execution stopped or finished - Cleaning up =="
     sudo rm -rf "$TEMPDIR"
@@ -206,7 +207,7 @@ fi
 
 CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val-test:$TAG"
 
-sudo ${CONTAINER_RUNTIME} pull ${CONTAINER_CLOUD_IMAGE_VAL}
+sudo "${CONTAINER_RUNTIME}" pull "${CONTAINER_CLOUD_IMAGE_VAL}"
 
 greenprint "Running cloud-image-val on generated image"
 
@@ -229,13 +230,13 @@ if [ "$ARCH" == "aarch64" ]; then
     sed -i s/t3.medium/a1.large/ "${TEMPDIR}/resource-file.json"
 fi
 
-sudo ${CONTAINER_RUNTIME} run \
+sudo "${CONTAINER_RUNTIME}" run \
     -a stdout -a stderr \
     -e AWS_ACCESS_KEY_ID="${V2_AWS_ACCESS_KEY_ID}" \
     -e AWS_SECRET_ACCESS_KEY="${V2_AWS_SECRET_ACCESS_KEY}" \
     -e AWS_REGION="${AWS_REGION}" \
     -v "${TEMPDIR}":/tmp:Z \
-    ${CONTAINER_CLOUD_IMAGE_VAL} \
+    "${CONTAINER_CLOUD_IMAGE_VAL}" \
     python cloud-image-val.py -r /tmp/resource-file.json -d -o /tmp/report.xml -m 'not pub' && RESULTS=1 || RESULTS=0
 
 mv "${TEMPDIR}"/report.html "${ARTIFACTS}"

--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -34,6 +34,7 @@ else
 fi
 
 TEMPDIR=$(mktemp -d)
+# shellcheck disable=SC2317
 function cleanup() {
     greenprint "== Script execution stopped or finished - Cleaning up =="
     sudo rm -rf "$TEMPDIR"
@@ -206,7 +207,7 @@ fi
 
 CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val-test:$TAG"
 
-sudo ${CONTAINER_RUNTIME} pull ${CONTAINER_CLOUD_IMAGE_VAL}
+sudo "${CONTAINER_RUNTIME}" pull "${CONTAINER_CLOUD_IMAGE_VAL}"
 
 greenprint "Running cloud-image-val on generated image"
 
@@ -232,7 +233,7 @@ sudo ${CONTAINER_RUNTIME} run \
     -e ARM_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
     -e ARM_TENANT_ID="${AZURE_TENANT_ID}" \
     -v "${TEMPDIR}":/tmp:Z \
-    ${CONTAINER_CLOUD_IMAGE_VAL} \
+    "${CONTAINER_CLOUD_IMAGE_VAL}" \
     python cloud-image-val.py -r /tmp/resource-file.json -d -o /tmp/report.xml -m 'not pub' && RESULTS=1 || RESULTS=0
 
 mv "${TEMPDIR}"/report.html "${ARTIFACTS}"

--- a/test/cases/diff-manifests.sh
+++ b/test/cases/diff-manifests.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # NOTE: This script is executed differently in .gitlab-ci.yml so use a relative path
 source ./test/cases/shared_lib.sh
 
+# shellcheck disable=SC2317
 function revert_to_head {
    git checkout "$head"
 }

--- a/test/cases/gcp.sh
+++ b/test/cases/gcp.sh
@@ -29,6 +29,7 @@ else
     exit 2
 fi
 
+# shellcheck disable=SC2317
 function cleanupGCP() {
     # since this function can be called at any time, ensure that we don't expand unbound variables
     GCP_CMD="${GCP_CMD:-}"
@@ -43,6 +44,7 @@ function cleanupGCP() {
 }
 
 TEMPDIR=$(mktemp -d)
+# shellcheck disable=SC2317
 function cleanup() {
     greenprint "== Script execution stopped or finished - Cleaning up =="
     cleanupGCP

--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -27,6 +27,7 @@ function modksiso {
     echo "Mounting ${iso} -> ${isomount}"
     sudo mount -v -o ro "${iso}" "${isomount}"
 
+    # shellcheck disable=SC2317
     cleanup() {
         sudo umount -v "${isomount}"
         rmdir -v "${isomount}"

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -139,6 +139,7 @@ function modksiso {
     echo "Mounting ${iso} -> ${isomount}"
     sudo mount -v -o ro "${iso}" "${isomount}"
 
+    # shellcheck disable=SC2317
     cleanup() {
         sudo umount -v "${isomount}"
         rmdir -v "${isomount}"

--- a/test/cases/regression-composer-works-behind-satellite-fallback.sh
+++ b/test/cases/regression-composer-works-behind-satellite-fallback.sh
@@ -62,6 +62,7 @@ case "${ID}" in
         exit 1
 esac
 
+# shellcheck disable=SC2317
 function cleanup {
     greenprint "== Script execution stopped or finished - Cleaning up =="
     # Make the cleanup function best effort

--- a/test/cases/regression-composer-works-behind-satellite.sh
+++ b/test/cases/regression-composer-works-behind-satellite.sh
@@ -28,6 +28,7 @@ function generate_certificates {
     sudo openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 365 -sha256
 }
 
+# shellcheck disable=SC2317
 function cleanup {
     greenprint "== Script execution stopped or finished - Cleaning up =="
     # Make the cleanup function best effort

--- a/test/cases/regression-insecure-repo.sh
+++ b/test/cases/regression-insecure-repo.sh
@@ -14,6 +14,7 @@ source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
 greenprint "Registering clean ups"
 kill_pids=()
+# shellcheck disable=SC2317
 function cleanup() {
     greenprint "== Script execution stopped or finished - Cleaning up =="
     set +eu

--- a/test/cases/regression-old-worker-new-composer.sh
+++ b/test/cases/regression-old-worker-new-composer.sh
@@ -136,6 +136,7 @@ printenv AWS_REGION AWS_BUCKET V2_AWS_ACCESS_KEY_ID V2_AWS_SECRET_ACCESS_KEY AWS
 # Check that needed variables are set to register to RHSM
 printenv API_TEST_SUBSCRIPTION_ORG_ID API_TEST_SUBSCRIPTION_ACTIVATION_KEY_V2 > /dev/null
 
+# shellcheck disable=SC2317
 function cleanupAWSS3() {
   local S3_URL
   S3_URL=$(echo "$UPLOAD_OPTIONS" | jq -r '.url')
@@ -161,13 +162,15 @@ function cleanupAWSS3() {
 # terminates in any way.
 WORKDIR=$(mktemp -d)
 KILL_PIDS=()
+
+# shellcheck disable=SC2317
 function cleanup() {
   greenprint "== Script execution stopped or finished - Cleaning up =="
   set +eu
   cleanupAWSS3
 
-  sudo ${CONTAINER_RUNTIME} kill composer
-  sudo ${CONTAINER_RUNTIME} rm composer
+  sudo "${CONTAINER_RUNTIME}" kill composer
+  sudo "${CONTAINER_RUNTIME}" rm composer
 
   sudo rm -rf "$WORKDIR"
 

--- a/test/data/upgrade8to9/upgrade_verify.sh
+++ b/test/data/upgrade8to9/upgrade_verify.sh
@@ -5,6 +5,7 @@ set -euxo pipefail
 source shared_lib.sh
 
 WORKSPACE=$(mktemp -d)
+# shellcheck disable=SC2317
 function cleanup() {
     echo "== Script execution stopped or finished - Cleaning up =="
     rm -rf "$WORKSPACE"

--- a/tools/generic_s3_https_test.sh
+++ b/tools/generic_s3_https_test.sh
@@ -29,4 +29,4 @@ sudo mv private.key public.crt "${CERTS_DIR}"
 popd
 
 # Test upload to HTTPS S3 server
-/usr/libexec/osbuild-composer-test/generic_s3_test.sh "${CERTS_DIR}" ${CA_CERT_NAME:-""}
+/usr/libexec/osbuild-composer-test/generic_s3_test.sh "${CERTS_DIR}" "${CA_CERT_NAME:-''}"


### PR DESCRIPTION
mainly ignore warnings for unreachable commands in cleanup functions b/c ShellCheck doesn't understand these functions are executed via `trap`.

