### PR TITLE
RHEL 9: Do not enable user module in Anaconda Edge Installer when no users are specified

### DIFF
--- a/internal/distro/fedora/images.go
+++ b/internal/distro/fedora/images.go
@@ -211,12 +211,12 @@ func imageInstallerImage(workload workload.Workload,
 	if strings.HasPrefix(distro.Name(), "fedora") && !common.VersionLessThan(distro.Releasever(), "38") {
 		img.AdditionalAnacondaModules = []string{
 			"org.fedoraproject.Anaconda.Modules.Security",
-			"org.fedoraproject.Anaconda.Modules.Users",
 			"org.fedoraproject.Anaconda.Modules.Timezone",
 			"org.fedoraproject.Anaconda.Modules.Localization",
 		}
 		img.AdditionalKernelOpts = []string{"inst.webui", "inst.webui.remote"}
 	}
+	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, "org.fedoraproject.Anaconda.Modules.Users")
 
 	img.Platform = t.platform
 	img.Workload = workload
@@ -325,6 +325,7 @@ func iotInstallerImage(workload workload.Workload,
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
+	img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
 
 	img.SquashfsCompression = "lz4"
 

--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -1069,7 +1069,7 @@ func anacondaTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec
 	if users {
 		anacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
 	}
-	p.AddStage(osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(false, anacondaModules)))
+	p.AddStage(osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(anacondaModules)))
 	p.AddStage(osbuild.NewLoraxScriptStage(loraxScriptStageOptions(arch)))
 	p.AddStage(osbuild.NewDracutStage(dracutStageOptions(kernelVer, arch, []string{
 		"anaconda",

--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -1064,7 +1064,12 @@ func anacondaTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec
 	}
 
 	p.AddStage(osbuild.NewUsersStage(usersStageOptions))
-	p.AddStage(osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(users, []string{})))
+
+	anacondaModules := []string{}
+	if users {
+		anacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
+	}
+	p.AddStage(osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(false, anacondaModules)))
 	p.AddStage(osbuild.NewLoraxScriptStage(loraxScriptStageOptions(arch)))
 	p.AddStage(osbuild.NewDracutStage(dracutStageOptions(kernelVer, arch, []string{
 		"anaconda",

--- a/internal/distro/rhel9/images.go
+++ b/internal/distro/rhel9/images.go
@@ -294,7 +294,11 @@ func edgeInstallerImage(workload workload.Workload,
 
 	img.SquashfsCompression = "xz"
 	img.AdditionalDracutModules = []string{"prefixdevname", "prefixdevname-tools"}
-	img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
+
+	if len(img.Users)+len(img.Groups) > 0 {
+		// only enable the users module if needed
+		img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
+	}
 
 	img.ISOLabelTempl = d.isolabelTmpl
 	img.Product = d.product

--- a/internal/distro/rhel9/images.go
+++ b/internal/distro/rhel9/images.go
@@ -294,6 +294,7 @@ func edgeInstallerImage(workload workload.Workload,
 
 	img.SquashfsCompression = "xz"
 	img.AdditionalDracutModules = []string{"prefixdevname", "prefixdevname-tools"}
+	img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
 
 	img.ISOLabelTempl = d.isolabelTmpl
 	img.Product = d.product
@@ -436,6 +437,7 @@ func imageInstallerImage(workload workload.Workload,
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
 	img.AdditionalDracutModules = []string{"prefixdevname", "prefixdevname-tools"}
+	img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
 
 	img.SquashfsCompression = "xz"
 

--- a/internal/image/ostree_installer.go
+++ b/internal/image/ostree_installer.go
@@ -35,7 +35,8 @@ type OSTreeInstaller struct {
 
 	Filename string
 
-	AdditionalDracutModules []string
+	AdditionalDracutModules   []string
+	AdditionalAnacondaModules []string
 }
 
 func NewOSTreeInstaller(commit ostree.CommitSpec) *OSTreeInstaller {
@@ -67,6 +68,7 @@ func (img *OSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.Biosdevname = (img.Platform.GetArch() == platform.ARCH_X86_64)
 	anacondaPipeline.Checkpoint()
 	anacondaPipeline.AdditionalDracutModules = img.AdditionalDracutModules
+	anacondaPipeline.AdditionalAnacondaModules = img.AdditionalAnacondaModules
 
 	rootfsPartitionTable := &disk.PartitionTable{
 		Size: 20 * common.MebiByte,

--- a/internal/manifest/anaconda.go
+++ b/internal/manifest/anaconda.go
@@ -197,8 +197,8 @@ func (p *Anaconda) serialize() osbuild.Pipeline {
 	}
 
 	pipeline.AddStage(osbuild.NewUsersStage(usersStageOptions))
-	// always enable users module in anaconda
-	pipeline.AddStage(osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(true, p.AdditionalAnacondaModules)))
+
+	pipeline.AddStage(osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(false, p.AdditionalAnacondaModules)))
 	pipeline.AddStage(osbuild.NewLoraxScriptStage(&osbuild.LoraxScriptStageOptions{
 		Path:     "99-generic/runtime-postinstall.tmpl",
 		BaseArch: p.platform.GetArch().String(),

--- a/internal/manifest/anaconda.go
+++ b/internal/manifest/anaconda.go
@@ -198,7 +198,7 @@ func (p *Anaconda) serialize() osbuild.Pipeline {
 
 	pipeline.AddStage(osbuild.NewUsersStage(usersStageOptions))
 
-	pipeline.AddStage(osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(false, p.AdditionalAnacondaModules)))
+	pipeline.AddStage(osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(p.AdditionalAnacondaModules)))
 	pipeline.AddStage(osbuild.NewLoraxScriptStage(&osbuild.LoraxScriptStageOptions{
 		Path:     "99-generic/runtime-postinstall.tmpl",
 		BaseArch: p.platform.GetArch().String(),

--- a/internal/osbuild/anaconda_stage.go
+++ b/internal/osbuild/anaconda_stage.go
@@ -15,15 +15,11 @@ func NewAnacondaStage(options *AnacondaStageOptions) *Stage {
 	}
 }
 
-func NewAnacondaStageOptions(users bool, additionalModules []string) *AnacondaStageOptions {
+func NewAnacondaStageOptions(additionalModules []string) *AnacondaStageOptions {
 	modules := []string{
 		"org.fedoraproject.Anaconda.Modules.Network",
 		"org.fedoraproject.Anaconda.Modules.Payloads",
 		"org.fedoraproject.Anaconda.Modules.Storage",
-	}
-
-	if users {
-		modules = append(modules, "org.fedoraproject.Anaconda.Modules.Users")
 	}
 
 	if len(additionalModules) > 0 {

--- a/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
@@ -9339,8 +9339,7 @@
               "kickstart-modules": [
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
-                "org.fedoraproject.Anaconda.Modules.Storage",
-                "org.fedoraproject.Anaconda.Modules.Users"
+                "org.fedoraproject.Anaconda.Modules.Storage"
               ]
             }
           },

--- a/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
@@ -9499,8 +9499,7 @@
               "kickstart-modules": [
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
-                "org.fedoraproject.Anaconda.Modules.Storage",
-                "org.fedoraproject.Anaconda.Modules.Users"
+                "org.fedoraproject.Anaconda.Modules.Storage"
               ]
             }
           },

--- a/test/data/manifests/fedora_38-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-image_installer-boot.json
@@ -10126,11 +10126,10 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
-                "org.fedoraproject.Anaconda.Modules.Users",
                 "org.fedoraproject.Anaconda.Modules.Security",
-                "org.fedoraproject.Anaconda.Modules.Users",
                 "org.fedoraproject.Anaconda.Modules.Timezone",
-                "org.fedoraproject.Anaconda.Modules.Localization"
+                "org.fedoraproject.Anaconda.Modules.Localization",
+                "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }
           },

--- a/test/data/manifests/fedora_38-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-image_installer_with_users-boot.json
@@ -10161,11 +10161,10 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
-                "org.fedoraproject.Anaconda.Modules.Users",
                 "org.fedoraproject.Anaconda.Modules.Security",
-                "org.fedoraproject.Anaconda.Modules.Users",
                 "org.fedoraproject.Anaconda.Modules.Timezone",
-                "org.fedoraproject.Anaconda.Modules.Localization"
+                "org.fedoraproject.Anaconda.Modules.Localization",
+                "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }
           },

--- a/test/data/manifests/fedora_38-x86_64-image_installer-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-image_installer-boot.json
@@ -10310,11 +10310,10 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
-                "org.fedoraproject.Anaconda.Modules.Users",
                 "org.fedoraproject.Anaconda.Modules.Security",
-                "org.fedoraproject.Anaconda.Modules.Users",
                 "org.fedoraproject.Anaconda.Modules.Timezone",
-                "org.fedoraproject.Anaconda.Modules.Localization"
+                "org.fedoraproject.Anaconda.Modules.Localization",
+                "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }
           },

--- a/test/data/manifests/fedora_38-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-image_installer_with_users-boot.json
@@ -10345,11 +10345,10 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
-                "org.fedoraproject.Anaconda.Modules.Users",
                 "org.fedoraproject.Anaconda.Modules.Security",
-                "org.fedoraproject.Anaconda.Modules.Users",
                 "org.fedoraproject.Anaconda.Modules.Timezone",
-                "org.fedoraproject.Anaconda.Modules.Localization"
+                "org.fedoraproject.Anaconda.Modules.Localization",
+                "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }
           },

--- a/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
@@ -3474,8 +3474,7 @@
               "kickstart-modules": [
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
-                "org.fedoraproject.Anaconda.Modules.Storage",
-                "org.fedoraproject.Anaconda.Modules.Users"
+                "org.fedoraproject.Anaconda.Modules.Storage"
               ]
             }
           },

--- a/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
@@ -3537,8 +3537,7 @@
               "kickstart-modules": [
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
-                "org.fedoraproject.Anaconda.Modules.Storage",
-                "org.fedoraproject.Anaconda.Modules.Users"
+                "org.fedoraproject.Anaconda.Modules.Storage"
               ]
             }
           },

--- a/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
@@ -9451,8 +9451,7 @@
               "kickstart-modules": [
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
-                "org.fedoraproject.Anaconda.Modules.Storage",
-                "org.fedoraproject.Anaconda.Modules.Users"
+                "org.fedoraproject.Anaconda.Modules.Storage"
               ]
             }
           },

--- a/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
@@ -9595,8 +9595,7 @@
               "kickstart-modules": [
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
-                "org.fedoraproject.Anaconda.Modules.Storage",
-                "org.fedoraproject.Anaconda.Modules.Users"
+                "org.fedoraproject.Anaconda.Modules.Storage"
               ]
             }
           },

--- a/test/data/manifests/rhel_92-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_installer-boot.json
@@ -9467,8 +9467,7 @@
               "kickstart-modules": [
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
-                "org.fedoraproject.Anaconda.Modules.Storage",
-                "org.fedoraproject.Anaconda.Modules.Users"
+                "org.fedoraproject.Anaconda.Modules.Storage"
               ]
             }
           },

--- a/test/data/manifests/rhel_92-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_installer-boot.json
@@ -9611,8 +9611,7 @@
               "kickstart-modules": [
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
-                "org.fedoraproject.Anaconda.Modules.Storage",
-                "org.fedoraproject.Anaconda.Modules.Users"
+                "org.fedoraproject.Anaconda.Modules.Storage"
               ]
             }
           },


### PR DESCRIPTION
In RHEL 9, for the edge installer, only enable the users module when it is required for creating a user specified in the blueprint or request.  This was the behaviour until recently.  We changed it to enable interactive user creation even when no users were defined in the request.  However this interferes with tooling for fully automated installations.

Note that the `edge_installer_with_users` manifests are unaffected.  The module is enabled in these manifests so that the user specified in the build request can be created during installation.

Also, the image installer continues to always enable the Users module.  This is required for the service, since there is no way to specify users during the request in the frontend and creating users interactively at install time is the only way to create a user (aside from injecting a kickstart file).

**TESTING UPDATE**: I built a test image and shared it with Edge Fleet Management and they confirmed it's working.