### PR TITLE
DO NOT MERGE: regenerate mainfests on a clean checkout

### DIFF
--- a/test/data/manifests/centos_8-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_commit-boot.json
@@ -12474,6 +12474,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_8-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_commit_with_container-boot.json
@@ -13014,15 +13014,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_8-aarch64-edge_container-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_container-boot.json
@@ -16861,6 +16861,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_8-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_raw_image-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -10033,6 +10032,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -34,6 +33,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -16979,6 +16979,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_8-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit-boot.json
@@ -12942,6 +12942,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_8-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit_rt-boot.json
@@ -21,8 +21,7 @@
     "blueprint": {
       "customizations": {
         "kernel": {
-          "name": "kernel-rt",
-          "append": ""
+          "name": "kernel-rt"
         }
       }
     }
@@ -12907,6 +12906,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_8-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit_with_container-boot.json
@@ -13482,15 +13482,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_8-x86_64-edge_container-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_container-boot.json
@@ -17329,6 +17329,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_8-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_raw_image-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -10186,6 +10185,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -34,6 +33,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -17293,6 +17293,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_commit-boot.json
@@ -11102,6 +11102,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
@@ -11174,15 +11174,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-aarch64-edge_container-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_container-boot.json
@@ -12800,6 +12800,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_raw_image-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -6196,6 +6195,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -34,6 +33,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -14105,6 +14105,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit-boot.json
@@ -11602,6 +11602,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit_rt-boot.json
@@ -27,8 +27,7 @@
     "blueprint": {
       "customizations": {
         "kernel": {
-          "name": "kernel-rt",
-          "append": ""
+          "name": "kernel-rt"
         }
       }
     }
@@ -12050,6 +12049,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
@@ -11674,15 +11674,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-x86_64-edge_container-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_container-boot.json
@@ -13301,6 +13301,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_raw_image-boot.json
@@ -27,8 +27,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -6545,6 +6544,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
@@ -27,8 +27,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -40,6 +39,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -14397,6 +14397,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_commit-boot.json
@@ -1958,14 +1958,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -8799,6 +8791,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
@@ -2080,14 +2080,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9177,15 +9169,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_container-boot.json
@@ -1958,14 +1958,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -11806,6 +11798,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_raw_image-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -7907,6 +7906,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_simplified_installer-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -32,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -12723,6 +12723,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit-boot.json
@@ -2037,14 +2037,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9139,6 +9131,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit_rt-boot.json
@@ -27,8 +27,7 @@
     "blueprint": {
       "customizations": {
         "kernel": {
-          "name": "kernel-rt",
-          "append": ""
+          "name": "kernel-rt"
         }
       }
     }
@@ -2109,14 +2108,6 @@
               "network": {
                 "networking": true,
                 "no_zero_conf": true
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
               }
             }
           },
@@ -9485,6 +9476,5 @@
         "checksum": "sha256:6a0d8e83e24239dd7592253068fa4a0b917ed35b525fd374e12d30ddcf86999f"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
@@ -2159,14 +2159,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9517,15 +9509,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_container-boot.json
@@ -2027,14 +2027,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -12136,6 +12128,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_raw_image-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -8024,6 +8023,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_simplified_installer-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -32,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -12953,6 +12953,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_84-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_commit-boot.json
@@ -2022,14 +2022,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9070,6 +9062,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_84-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_commit_with_container-boot.json
@@ -2087,14 +2087,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9220,15 +9212,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_84-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_container-boot.json
@@ -2022,14 +2022,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -12173,6 +12165,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_84-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_commit-boot.json
@@ -2101,14 +2101,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9410,6 +9402,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_84-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_commit_rt-boot.json
@@ -27,8 +27,7 @@
     "blueprint": {
       "customizations": {
         "kernel": {
-          "name": "kernel-rt",
-          "append": ""
+          "name": "kernel-rt"
         }
       }
     }
@@ -2173,14 +2172,6 @@
               "network": {
                 "networking": true,
                 "no_zero_conf": true
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
               }
             }
           },
@@ -9756,6 +9747,5 @@
         "checksum": "sha256:5388cbfd3c82c613c0c83f291cccc5b536c668a5ed35ba2ad0f857018ce57f3e"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_84-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_commit_with_container-boot.json
@@ -2166,14 +2166,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9560,15 +9552,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_84-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_container-boot.json
@@ -2091,14 +2091,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -12503,6 +12495,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_85-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_commit-boot.json
@@ -1963,14 +1963,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -8834,6 +8826,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_85-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_commit_with_container-boot.json
@@ -2097,14 +2097,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9260,15 +9252,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_85-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_container-boot.json
@@ -1963,14 +1963,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -11829,6 +11821,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_85-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit-boot.json
@@ -2042,14 +2042,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9174,6 +9166,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_85-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit_rt-boot.json
@@ -27,8 +27,7 @@
     "blueprint": {
       "customizations": {
         "kernel": {
-          "name": "kernel-rt",
-          "append": ""
+          "name": "kernel-rt"
         }
       }
     }
@@ -2111,14 +2110,6 @@
               "network": {
                 "networking": true,
                 "no_zero_conf": true
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
               }
             }
           },
@@ -9505,6 +9496,5 @@
         "checksum": "sha256:6a0d8e83e24239dd7592253068fa4a0b917ed35b525fd374e12d30ddcf86999f"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_85-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit_with_container-boot.json
@@ -2176,14 +2176,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9600,15 +9592,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_85-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_container-boot.json
@@ -2032,14 +2032,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -12159,6 +12151,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
@@ -1958,14 +1958,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -8799,6 +8791,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
@@ -2080,14 +2080,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9177,15 +9169,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_container-boot.json
@@ -1958,14 +1958,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -11806,6 +11798,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_raw_image-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -7907,6 +7906,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -32,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -12723,6 +12723,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
@@ -2037,14 +2037,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9139,6 +9131,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
@@ -27,8 +27,7 @@
     "blueprint": {
       "customizations": {
         "kernel": {
-          "name": "kernel-rt",
-          "append": ""
+          "name": "kernel-rt"
         }
       }
     }
@@ -2109,14 +2108,6 @@
               "network": {
                 "networking": true,
                 "no_zero_conf": true
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
               }
             }
           },
@@ -9485,6 +9476,5 @@
         "checksum": "sha256:6a0d8e83e24239dd7592253068fa4a0b917ed35b525fd374e12d30ddcf86999f"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
@@ -2159,14 +2159,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9517,15 +9509,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_container-boot.json
@@ -2027,14 +2027,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -12136,6 +12128,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_raw_image-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -8024,6 +8023,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -32,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -12953,6 +12953,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_87-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_commit-boot.json
@@ -1961,14 +1961,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -8811,6 +8803,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
@@ -2083,14 +2083,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9189,15 +9181,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_87-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_container-boot.json
@@ -1961,14 +1961,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -11818,6 +11810,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_87-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_raw_image-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -7892,6 +7891,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_87-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_simplified_installer-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -32,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -12711,6 +12711,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_87-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit-boot.json
@@ -2040,14 +2040,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9151,6 +9143,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_87-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit_rt-boot.json
@@ -27,8 +27,7 @@
     "blueprint": {
       "customizations": {
         "kernel": {
-          "name": "kernel-rt",
-          "append": ""
+          "name": "kernel-rt"
         }
       }
     }
@@ -2109,14 +2108,6 @@
               "network": {
                 "networking": true,
                 "no_zero_conf": true
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
               }
             }
           },
@@ -9482,6 +9473,5 @@
         "checksum": "sha256:398d3f98a41f7c04648e20421c8f171eb2451a0ccbeb110a3f379060bf64969d"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
@@ -2162,14 +2162,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9529,15 +9521,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_87-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_container-boot.json
@@ -2030,14 +2030,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -12148,6 +12140,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_87-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_raw_image-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -8009,6 +8008,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_87-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_simplified_installer-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -32,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -12941,6 +12941,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_88-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_commit-boot.json
@@ -1961,14 +1961,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -8811,6 +8803,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
@@ -2083,14 +2083,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9189,15 +9181,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_88-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_container-boot.json
@@ -1961,14 +1961,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -11818,6 +11810,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_88-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_raw_image-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -7892,6 +7891,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_88-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_simplified_installer-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -32,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -12711,6 +12711,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_88-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit-boot.json
@@ -2040,14 +2040,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9151,6 +9143,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_88-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit_rt-boot.json
@@ -27,8 +27,7 @@
     "blueprint": {
       "customizations": {
         "kernel": {
-          "name": "kernel-rt",
-          "append": ""
+          "name": "kernel-rt"
         }
       }
     }
@@ -2106,14 +2105,6 @@
               "network": {
                 "networking": true,
                 "no_zero_conf": true
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
               }
             }
           },
@@ -9467,6 +9458,5 @@
         "checksum": "sha256:398d3f98a41f7c04648e20421c8f171eb2451a0ccbeb110a3f379060bf64969d"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
@@ -2162,14 +2162,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9529,15 +9521,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_88-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_container-boot.json
@@ -2030,14 +2030,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -12148,6 +12140,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_88-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_raw_image-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -8009,6 +8008,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_88-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_simplified_installer-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -32,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -12941,6 +12941,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
@@ -1681,14 +1681,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -7544,6 +7536,5 @@
         "checksum": "sha256:8de0339e02fae6983120ba46ecc1018b52bc9d309770b64933345de3ad956a9e"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
@@ -1794,14 +1794,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -7886,15 +7878,5 @@
         "checksum": "sha256:8de0339e02fae6983120ba46ecc1018b52bc9d309770b64933345de3ad956a9e"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_container-boot.json
@@ -1681,14 +1681,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -8723,6 +8715,5 @@
         "checksum": "sha256:8de0339e02fae6983120ba46ecc1018b52bc9d309770b64933345de3ad956a9e"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_raw_image-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -4270,6 +4269,5 @@
         "checksum": "sha256:4d3605105404fa6c82ff03f8bf3254fef7c04160878f92a7345b37a4e411141f"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -32,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -9785,6 +9785,5 @@
         "checksum": "sha256:4d3605105404fa6c82ff03f8bf3254fef7c04160878f92a7345b37a4e411141f"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
@@ -1769,14 +1769,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -7911,6 +7903,5 @@
         "checksum": "sha256:903161548bb5566c7882e47a03b990d3f68b86b52b72f87d03674aa42b3993db"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
@@ -27,8 +27,7 @@
     "blueprint": {
       "customizations": {
         "kernel": {
-          "name": "kernel-rt",
-          "append": ""
+          "name": "kernel-rt"
         }
       }
     }
@@ -1934,14 +1933,6 @@
               "network": {
                 "networking": true,
                 "no_zero_conf": true
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
               }
             }
           },
@@ -8728,6 +8719,5 @@
         "checksum": "sha256:3bc65e818b94d23c7ff6cc66633c25b0368da38ab38cadac9569633140b45d2b"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
@@ -1882,14 +1882,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -8253,15 +8245,5 @@
         "checksum": "sha256:903161548bb5566c7882e47a03b990d3f68b86b52b72f87d03674aa42b3993db"
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_container-boot.json
@@ -1759,14 +1759,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -9080,6 +9072,5 @@
         "checksum": "sha256:903161548bb5566c7882e47a03b990d3f68b86b52b72f87d03674aa42b3993db"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_raw_image-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -4537,6 +4536,5 @@
         "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
@@ -19,8 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -32,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -10012,6 +10012,5 @@
         "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_91-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_commit-boot.json
@@ -4488,14 +4488,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -11128,6 +11120,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
@@ -4537,14 +4537,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -11200,15 +11192,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_91-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_container-boot.json
@@ -4488,14 +4488,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -12808,6 +12800,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_91-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_raw_image-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -6217,6 +6216,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_91-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_simplified_installer-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -34,6 +33,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -14105,6 +14105,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_91-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit-boot.json
@@ -4699,14 +4699,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -11631,6 +11623,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_91-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit_rt-boot.json
@@ -30,8 +30,7 @@
     "blueprint": {
       "customizations": {
         "kernel": {
-          "name": "kernel-rt",
-          "append": ""
+          "name": "kernel-rt"
         }
       }
     }
@@ -5126,14 +5125,6 @@
               "network": {
                 "networking": true,
                 "no_zero_conf": true
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
               }
             }
           },
@@ -12751,6 +12742,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
@@ -4748,14 +4748,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -11703,15 +11695,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_91-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_container-boot.json
@@ -4688,14 +4688,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -13300,6 +13292,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_91-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_raw_image-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -6559,6 +6558,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_91-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_simplified_installer-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -34,6 +33,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -14389,6 +14389,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_92-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_commit-boot.json
@@ -4488,14 +4488,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -11128,6 +11120,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
@@ -4537,14 +4537,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -11200,15 +11192,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_92-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_container-boot.json
@@ -4488,14 +4488,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -12808,6 +12800,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_92-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_raw_image-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -6217,6 +6216,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_92-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_simplified_installer-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -34,6 +33,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -14105,6 +14105,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_92-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit-boot.json
@@ -4699,14 +4699,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -11631,6 +11623,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_92-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit_rt-boot.json
@@ -30,8 +30,7 @@
     "blueprint": {
       "customizations": {
         "kernel": {
-          "name": "kernel-rt",
-          "append": ""
+          "name": "kernel-rt"
         }
       }
     }
@@ -5126,14 +5125,6 @@
               "network": {
                 "networking": true,
                 "no_zero_conf": true
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
               }
             }
           },
@@ -12751,6 +12742,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
@@ -4748,14 +4748,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -11703,15 +11695,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "containers": [
-    {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
-      "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
-      "TLSVerify": null,
-      "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
-    }
-  ],
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_92-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_container-boot.json
@@ -4688,14 +4688,6 @@
             }
           },
           {
-            "type": "org.osbuild.rhsm.facts",
-            "options": {
-              "facts": {
-                "image-builder.osbuild-composer.api-type": "test-manifest"
-              }
-            }
-          },
-          {
             "type": "org.osbuild.systemd-journald",
             "options": {
               "filename": "10-persistent.conf",
@@ -13300,6 +13292,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_92-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_raw_image-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {}
   },
@@ -6559,6 +6558,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_92-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_simplified_installer-boot.json
@@ -21,8 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "rhsm": false
+      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "blueprint": {
       "customizations": {
@@ -34,6 +33,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -14389,6 +14389,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }


### PR DESCRIPTION
On a clean main checkout, on F37,, runinng `./tools/test-case-generators/generate-all-test-cases -i /dev/null --output test/data/manifests --image-type edge-commit --image-type edge-simplified-installer --image-type edge-container --image-type edge-raw-image manifests` I get the diff in this PR - something must be off on either my side or projects (likely mine). The workaround I did was to run:

- `go run ./cmd/gen-manifests -output test/data/manifests -workers 20 -images edge-container`
- `go run ./cmd/gen-manifests -output test/data/manifests -workers 20 -images edge-commit`

but I'd have expected the command above to just work like it did in the past

Signed-off-by: Antonio Murdaca <antoniomurdaca@gmail.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
