### PR TITLE
Schutzfile: update osbuild version to current main (v75)

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -79,7 +79,7 @@
   "fedora-36": {
     "dependencies": {
       "osbuild": {
-        "commit": "cb989f79b110b4b18d372deace94a7c6c7137b93"
+        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
       }
     },
     "repos": [
@@ -156,7 +156,7 @@
   "fedora-37": {
     "dependencies": {
       "osbuild": {
-        "commit": "cb989f79b110b4b18d372deace94a7c6c7137b93"
+        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
       }
     },
     "repos": [
@@ -233,21 +233,21 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "cb989f79b110b4b18d372deace94a7c6c7137b93"
+        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
       }
     }
   },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {
-        "commit": "cb989f79b110b4b18d372deace94a7c6c7137b93"
+        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
       }
     }
   },
   "rhel-8.7": {
     "dependencies": {
       "osbuild": {
-        "commit": "cb989f79b110b4b18d372deace94a7c6c7137b93"
+        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
       }
     },
     "repos": [
@@ -334,14 +334,14 @@
   "rhel-9.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "cb989f79b110b4b18d372deace94a7c6c7137b93"
+        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
       }
     }
   },
   "rhel-9.1": {
     "dependencies": {
       "osbuild": {
-        "commit": "cb989f79b110b4b18d372deace94a7c6c7137b93"
+        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
       }
     },
     "repos": [
@@ -428,21 +428,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "cb989f79b110b4b18d372deace94a7c6c7137b93"
+        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "cb989f79b110b4b18d372deace94a7c6c7137b93"
+        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "cb989f79b110b4b18d372deace94a7c6c7137b93"
+        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
       }
     },
     "repos": [
@@ -488,7 +488,7 @@
   "centos-stream-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "cb989f79b110b4b18d372deace94a7c6c7137b93"
+        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
       }
     },
     "repos": [


### PR DESCRIPTION
Updating osbuild version in Schutzfile to current main (minus version bump) which includes a fix for the SELinux labels of the RHSM fact: https://github.com/osbuild/osbuild/pull/1220

The Fedora 35 config hasn't been modified to avoid conflicting with #3179.