### PR TITLE
distro/rhel8: enable autoregistration for all Azure images

### DIFF
--- a/internal/distro/rhel8/azure.go
+++ b/internal/distro/rhel8/azure.go
@@ -450,6 +450,23 @@ var defaultAzureImageConfig = &distro.ImageConfig{
 		},
 	},
 	DefaultTarget: common.StringToPtr("multi-user.target"),
+	RHSMConfig: map[distro.RHSMSubscriptionStatus]*osbuild.RHSMStageOptions{
+		// Nowadays, we want autoregistration everywhere.
+		distro.RHSMConfigNoSubscription: {
+			SubMan: &osbuild.RHSMStageOptionsSubMan{
+				Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{
+					AutoRegistration: common.BoolToPtr(true),
+				},
+			},
+		},
+		distro.RHSMConfigWithSubscription: {
+			SubMan: &osbuild.RHSMStageOptionsSubMan{
+				Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{
+					AutoRegistration: common.BoolToPtr(true),
+				},
+			},
+		},
+	},
 }
 
 // Azure non-RHEL image type
@@ -480,31 +497,6 @@ var azureImgType = imageType{
 var defaultAzureByosImageConfig = &distro.ImageConfig{
 	GPGKeyFiles: []string{
 		"/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
-	},
-	RHSMConfig: map[distro.RHSMSubscriptionStatus]*osbuild.RHSMStageOptions{
-		distro.RHSMConfigNoSubscription: {
-			SubMan: &osbuild.RHSMStageOptionsSubMan{
-				Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{
-					AutoRegistration: common.BoolToPtr(true),
-				},
-				// Don't disable RHSM redhat.repo management on the GCE
-				// image, which is BYOS and does not use RHUI for content.
-				// Otherwise subscribing the system manually after booting
-				// it would result in empty redhat.repo. Without RHUI, such
-				// system would have no way to get Red Hat content, but
-				// enable the repo management manually, which would be very
-				// confusing.
-			},
-		},
-		distro.RHSMConfigWithSubscription: {
-			SubMan: &osbuild.RHSMStageOptionsSubMan{
-				Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{
-					AutoRegistration: common.BoolToPtr(true),
-				},
-				// do not disable the redhat.repo management if the user
-				// explicitly request the system to be subscribed
-			},
-		},
 	},
 }
 
@@ -539,6 +531,8 @@ var defaultAzureRhuiImageConfig = &distro.ImageConfig{
 		"/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
 	},
 	RHSMConfig: map[distro.RHSMSubscriptionStatus]*osbuild.RHSMStageOptions{
+		// This is a RHUI-enabled image, thus we don't want dnf to use subman
+		// nor subman to manage the redhat.repo file.
 		distro.RHSMConfigNoSubscription: {
 			DnfPlugins: &osbuild.RHSMStageOptionsDnfPlugins{
 				SubscriptionManager: &osbuild.RHSMStageOptionsDnfPlugin{

--- a/test/data/manifests/rhel_8-x86_64-azure_sap_rhui-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-azure_sap_rhui-boot.json
@@ -3339,6 +3339,16 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.cloud-init",
             "options": {
               "filename": "10-azure-kvp.cfg",

--- a/test/data/manifests/rhel_84-x86_64-azure_sap_rhui-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-azure_sap_rhui-boot.json
@@ -3302,6 +3302,16 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.cloud-init",
             "options": {
               "filename": "10-azure-kvp.cfg",

--- a/test/data/manifests/rhel_85-x86_64-azure_sap_rhui-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-azure_sap_rhui-boot.json
@@ -3278,6 +3278,16 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.cloud-init",
             "options": {
               "filename": "10-azure-kvp.cfg",

--- a/test/data/manifests/rhel_86-x86_64-azure_sap_rhui-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-azure_sap_rhui-boot.json
@@ -3350,6 +3350,16 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.cloud-init",
             "options": {
               "filename": "10-azure-kvp.cfg",

--- a/test/data/manifests/rhel_87-x86_64-azure_sap_rhui-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-azure_sap_rhui-boot.json
@@ -3309,6 +3309,16 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.cloud-init",
             "options": {
               "filename": "10-azure-kvp.cfg",

--- a/test/data/manifests/rhel_88-x86_64-azure_sap_rhui-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-azure_sap_rhui-boot.json
@@ -3309,6 +3309,16 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "subscription-manager": {
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.cloud-init",
             "options": {
               "filename": "10-azure-kvp.cfg",


### PR DESCRIPTION
COMPOSER-1866 reported that Azure SAP images should also have rhsm autoregistration enabled. Since all Azure images except for the SAP one already have autoreg enabled, we can just move the config into the default image config that's inherited by all azure-related image config.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
