### PR TITLE
worker/server: log unresponsive job removal

### DIFF
--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -114,6 +114,9 @@ func (s *Server) WatchHeartbeats() {
 	//nolint:staticcheck // avoid SA1015, this is an endless function
 	for range time.Tick(time.Second * 30) {
 		for _, token := range s.jobs.Heartbeats(time.Second * 120) {
+			id, _ := s.jobs.IdFromToken(token)
+			logrus.Infof("Removing unresponsive job: %s\n", id)
+
 			missingHeartbeatResult := JobResult{
 				JobError: clienterrors.WorkerClientError(clienterrors.ErrorJobMissingHeartbeat,
 					fmt.Sprintf("Workers running this job stopped responding more than %d times.", maxHeartbeatRetries),


### PR DESCRIPTION
Re-add the logging for when unresponsive heartbeats are being removed so we can verify that they
are correctly being logged as 5xx errors. As per https://github.com/osbuild/osbuild-composer/issues/3103#issuecomment-1375636679


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
