### PR TITLE
internal/prometheus: remove compose fail metrics

### DIFF
--- a/internal/cloudapi/v2/errors.go
+++ b/internal/cloudapi/v2/errors.go
@@ -3,11 +3,8 @@ package v2
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/labstack/echo/v4"
-
-	"github.com/osbuild/osbuild-composer/internal/prometheus"
 )
 
 const (
@@ -300,13 +297,6 @@ func (s *Server) HTTPErrorHandler(echoError error, c echo.Context) {
 		c.Logger().Errorf("ErrorNotHTTPError %v", echoError)
 		doResponse(nil, ErrorNotHTTPError, c, echoError)
 		return
-	}
-
-	internalError := he.Code >= http.StatusInternalServerError && he.Code <= http.StatusNetworkAuthenticationRequired
-	if internalError {
-		if strings.HasSuffix(c.Path(), "/compose") {
-			prometheus.ComposeFailures.Inc()
-		}
 	}
 
 	err, ok := he.Message.(detailsError)

--- a/internal/prometheus/http_metrics.go
+++ b/internal/prometheus/http_metrics.go
@@ -15,16 +15,6 @@ var (
 )
 
 var (
-	// update this to count all 500s
-	ComposeFailures = promauto.NewCounter(prometheus.CounterOpts{
-		Name:      "total_failed_compose_requests",
-		Namespace: Namespace,
-		Subsystem: ComposerSubsystem,
-		Help:      "total number of failed compose requests",
-	})
-)
-
-var (
 	ComposeRequests = promauto.NewCounter(prometheus.CounterOpts{
 		Name:      "total_compose_requests",
 		Namespace: Namespace,


### PR DESCRIPTION
We have switched how 5xx errors are being recorded internally and we are now recording all failures
for all endpoints. As a result, a dedicated metric only for compose failures is no longer required.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
