### PR TITLE
fix ostree cannot boot on fedora37

### DIFF
--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -450,6 +450,13 @@ curl -O "$BOOT_LOCATION"/images/boot.iso
 sudo mv boot.iso /var/lib/libvirt/images
 LOCAL_BOOT_LOCATION="/var/lib/libvirt/images/boot.iso"
 
+# Workaround to fix issue https://github.com/osbuild/osbuild-composer/issues/3216
+if [[ "${ID}-${VERSION_ID}" == "fedora-37" ]]; then
+    location_arg="${LOCAL_BOOT_LOCATION}",initrd=images/pxeboot/initrd.img,kernel=images/pxeboot/vmlinuz
+else
+    location_arg="${LOCAL_BOOT_LOCATION}"
+fi
+
 # Install ostree image via anaconda.
 greenprint "Install ostree image via anaconda"
 sudo virt-install  --initrd-inject="${KS_FILE}" \
@@ -461,7 +468,7 @@ sudo virt-install  --initrd-inject="${KS_FILE}" \
                    --network network=integration,mac=34:49:22:B0:83:30 \
                    --os-type linux \
                    --os-variant ${OS_VARIANT} \
-                   --location "${LOCAL_BOOT_LOCATION}" \
+                   --location ${location_arg} \
                    --nographics \
                    --noautoconsole \
                    --wait=-1 \


### PR DESCRIPTION
This pull request includes:

this pr is to fix bug https://github.com/osbuild/osbuild-composer/issues/3216 , virt-install failed to provision vm using edge commit on fedora37.

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
