### PR TITLE
osbuild/mkdir: support new stage options and small fixes

### DIFF
--- a/internal/manifest/coi_iso_tree.go
+++ b/internal/manifest/coi_iso_tree.go
@@ -92,7 +92,7 @@ func (p *CoreOSISOTree) serialize() osbuild.Pipeline {
 	}
 
 	pipeline.AddStage(osbuild.NewMkdirStage(&osbuild.MkdirStageOptions{
-		Paths: []osbuild.Path{
+		Paths: []osbuild.MkdirStagePath{
 			{
 				Path: "images",
 			},

--- a/internal/manifest/commit_deployment.go
+++ b/internal/manifest/commit_deployment.go
@@ -90,7 +90,7 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 		},
 	))
 	pipeline.AddStage(osbuild.NewMkdirStage(&osbuild.MkdirStageOptions{
-		Paths: []osbuild.Path{
+		Paths: []osbuild.MkdirStagePath{
 			{
 				Path: "/boot/efi",
 				Mode: os.FileMode(0700),

--- a/internal/manifest/commit_deployment.go
+++ b/internal/manifest/commit_deployment.go
@@ -93,7 +93,7 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 		Paths: []osbuild.MkdirStagePath{
 			{
 				Path: "/boot/efi",
-				Mode: os.FileMode(0700),
+				Mode: common.ToPtr(os.FileMode(0700)),
 			},
 		},
 	}))

--- a/internal/manifest/iso_rootfs.go
+++ b/internal/manifest/iso_rootfs.go
@@ -28,7 +28,7 @@ func (p *ISORootfsImg) serialize() osbuild.Pipeline {
 	pipeline := p.Base.serialize()
 
 	pipeline.AddStage(osbuild.NewMkdirStage(&osbuild.MkdirStageOptions{
-		Paths: []osbuild.Path{
+		Paths: []osbuild.MkdirStagePath{
 			{
 				Path: "LiveOS",
 			},

--- a/internal/manifest/iso_tree.go
+++ b/internal/manifest/iso_tree.go
@@ -125,7 +125,7 @@ func (p *AnacondaISOTree) serialize() osbuild.Pipeline {
 	}
 
 	pipeline.AddStage(osbuild.NewMkdirStage(&osbuild.MkdirStageOptions{
-		Paths: []osbuild.Path{
+		Paths: []osbuild.MkdirStagePath{
 			{
 				Path: "images",
 			},

--- a/internal/osbuild/mkdir_stage.go
+++ b/internal/osbuild/mkdir_stage.go
@@ -8,10 +8,10 @@ type MkdirStageOptions struct {
 }
 
 type MkdirStagePath struct {
-	Path    string      `json:"path"`
-	Mode    os.FileMode `json:"mode,omitempty"`     // If not specified, the default mode is 0777
-	Parents bool        `json:"parents,omitempty"`  // If true, create parent directories as needed
-	ExistOk bool        `json:"exist_ok,omitempty"` // If true, do not fail if the target directory already exists
+	Path    string       `json:"path"`
+	Mode    *os.FileMode `json:"mode,omitempty"`     // If not specified, the default mode is 0777
+	Parents bool         `json:"parents,omitempty"`  // If true, create parent directories as needed
+	ExistOk bool         `json:"exist_ok,omitempty"` // If true, do not fail if the target directory already exists
 }
 
 func (MkdirStageOptions) isStageOptions() {}

--- a/internal/osbuild/mkdir_stage.go
+++ b/internal/osbuild/mkdir_stage.go
@@ -15,7 +15,7 @@ type MkdirStagePath struct {
 
 func (MkdirStageOptions) isStageOptions() {}
 
-// A new org.osbuild.ostree.init stage to create an OSTree repository
+// NewMkdirStage creates a new org.osbuild.mkdir stage to create FS directories
 func NewMkdirStage(options *MkdirStageOptions) *Stage {
 	return &Stage{
 		Type:    "org.osbuild.mkdir",

--- a/internal/osbuild/mkdir_stage.go
+++ b/internal/osbuild/mkdir_stage.go
@@ -8,9 +8,9 @@ type MkdirStageOptions struct {
 }
 
 type MkdirStagePath struct {
-	Path string `json:"path"`
-
-	Mode os.FileMode `json:"mode,omitempty"`
+	Path    string      `json:"path"`
+	Mode    os.FileMode `json:"mode,omitempty"`    // If not specified, the default mode is 0777
+	Parents bool        `json:"parents,omitempty"` // If true, create parent directories as needed
 }
 
 func (MkdirStageOptions) isStageOptions() {}

--- a/internal/osbuild/mkdir_stage.go
+++ b/internal/osbuild/mkdir_stage.go
@@ -4,10 +4,10 @@ import "os"
 
 // Options for the org.osbuild.ostree.config stage.
 type MkdirStageOptions struct {
-	Paths []Path `json:"paths"`
+	Paths []MkdirStagePath `json:"paths"`
 }
 
-type Path struct {
+type MkdirStagePath struct {
 	Path string `json:"path"`
 
 	Mode os.FileMode `json:"mode,omitempty"`

--- a/internal/osbuild/mkdir_stage.go
+++ b/internal/osbuild/mkdir_stage.go
@@ -9,8 +9,9 @@ type MkdirStageOptions struct {
 
 type MkdirStagePath struct {
 	Path    string      `json:"path"`
-	Mode    os.FileMode `json:"mode,omitempty"`    // If not specified, the default mode is 0777
-	Parents bool        `json:"parents,omitempty"` // If true, create parent directories as needed
+	Mode    os.FileMode `json:"mode,omitempty"`     // If not specified, the default mode is 0777
+	Parents bool        `json:"parents,omitempty"`  // If true, create parent directories as needed
+	ExistOk bool        `json:"exist_ok,omitempty"` // If true, do not fail if the target directory already exists
 }
 
 func (MkdirStageOptions) isStageOptions() {}


### PR DESCRIPTION
- rename Path struct to MkdirStagePath
- fix copy&paste error in function comment
- support `parents` stage option
- support `exist_ok` stage option (related to https://github.com/osbuild/osbuild/pull/1224)

Details are in each commit message.

This is a pre-work to support custom files and directories in `/etc` done via customizations.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
