### PR TITLE
Add custom repos to /etc/yum.repos.d

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -571,6 +571,11 @@ filesystem.sh:
   variables:
     SCRIPT: filesystem.sh
 
+custom-repos.sh:
+  extends: .integration
+  variables:
+    SCRIPT: custom-repos.sh
+
 cross-distro.sh:
   extends: .integration
   variables:

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -187,6 +187,11 @@ func makeManifestJob(name string, imgType distro.ImageType, cr composeRequest, d
 type DistroArchRepoMap map[string]map[string][]repository
 
 func convertRepo(r repository) rpmmd.RepoConfig {
+	var urls []string
+	if r.BaseURL != "" {
+		urls = []string{r.BaseURL}
+	}
+
 	var keys []string
 	if r.GPGKey != "" {
 		keys = []string{r.GPGKey}
@@ -194,7 +199,7 @@ func convertRepo(r repository) rpmmd.RepoConfig {
 
 	return rpmmd.RepoConfig{
 		Name:           r.Name,
-		BaseURL:        r.BaseURL,
+		BaseURLs:       urls,
 		Metalink:       r.Metalink,
 		MirrorList:     r.MirrorList,
 		GPGKeys:        keys,

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
-	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/container"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/distroregistry"
@@ -39,11 +38,14 @@ func (mv *multiValue) Set(v string) error {
 
 type repository struct {
 	Name           string   `json:"name"`
+	Id             string   `json:"id,omitempty"`
 	BaseURL        string   `json:"baseurl,omitempty"`
 	Metalink       string   `json:"metalink,omitempty"`
 	MirrorList     string   `json:"mirrorlist,omitempty"`
 	GPGKey         string   `json:"gpgkey,omitempty"`
 	CheckGPG       bool     `json:"check_gpg,omitempty"`
+	CheckRepoGPG   bool     `json:"check_repo_gpg,omitempty"`
+	IgnoreSSL      bool     `json:"ignore_ssl,omitempty"`
 	RHSM           bool     `json:"rhsm,omitempty"`
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
 	ImageTypeTags  []string `json:"image_type_tags,omitempty"`
@@ -199,14 +201,15 @@ func convertRepo(r repository) rpmmd.RepoConfig {
 	}
 
 	return rpmmd.RepoConfig{
+		Id:             r.Id,
 		Name:           r.Name,
 		BaseURLs:       urls,
 		Metalink:       r.Metalink,
 		MirrorList:     r.MirrorList,
 		GPGKeys:        keys,
 		CheckGPG:       &r.CheckGPG,
-		CheckRepoGPG:   common.ToPtr(false),
-		IgnoreSSL:      false,
+		CheckRepoGPG:   &r.CheckRepoGPG,
+		IgnoreSSL:      r.IgnoreSSL,
 		MetadataExpire: r.MetadataExpire,
 		RHSM:           r.RHSM,
 		ImageTypeTags:  r.ImageTypeTags,

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/container"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/distroregistry"
@@ -203,8 +204,8 @@ func convertRepo(r repository) rpmmd.RepoConfig {
 		Metalink:       r.Metalink,
 		MirrorList:     r.MirrorList,
 		GPGKeys:        keys,
-		CheckGPG:       r.CheckGPG,
-		CheckRepoGPG:   false,
+		CheckGPG:       &r.CheckGPG,
+		CheckRepoGPG:   common.ToPtr(false),
 		IgnoreSSL:      false,
 		MetadataExpire: r.MetadataExpire,
 		RHSM:           r.RHSM,

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -140,15 +140,17 @@ func main() {
 		if repoName == "" {
 			repoName = fmt.Sprintf("repo-%d", i)
 		}
-
+		var urls []string
+		if repo.BaseURL != "" {
+			urls = []string{repo.BaseURL}
+		}
 		var keys []string
 		if repo.GPGKey != "" {
 			keys = []string{repo.GPGKey}
 		}
-
 		repos[i] = rpmmd.RepoConfig{
 			Name:        repoName,
-			BaseURL:     repo.BaseURL,
+			BaseURLs:    urls,
 			Metalink:    repo.Metalink,
 			MirrorList:  repo.MirrorList,
 			GPGKeys:     keys,

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/container"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/distroregistry"
@@ -149,14 +150,16 @@ func main() {
 			keys = []string{repo.GPGKey}
 		}
 		repos[i] = rpmmd.RepoConfig{
-			Name:        repoName,
-			BaseURLs:    urls,
-			Metalink:    repo.Metalink,
-			MirrorList:  repo.MirrorList,
-			GPGKeys:     keys,
-			CheckGPG:    repo.CheckGPG,
-			PackageSets: repo.PackageSets,
-			RHSM:        repo.RHSM,
+			Name:         repoName,
+			BaseURLs:     urls,
+			Metalink:     repo.Metalink,
+			MirrorList:   repo.MirrorList,
+			GPGKeys:      keys,
+			CheckGPG:     &repo.CheckGPG,
+			CheckRepoGPG: common.ToPtr(false),
+			IgnoreSSL:    false,
+			PackageSets:  repo.PackageSets,
+			RHSM:         repo.RHSM,
 		}
 	}
 

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -19,14 +19,17 @@ import (
 )
 
 type repository struct {
-	Name        string   `json:"name,omitempty"`
-	BaseURL     string   `json:"baseurl,omitempty"`
-	Metalink    string   `json:"metalink,omitempty"`
-	MirrorList  string   `json:"mirrorlist,omitempty"`
-	GPGKey      string   `json:"gpgkey,omitempty"`
-	CheckGPG    bool     `json:"check_gpg,omitempty"`
-	PackageSets []string `json:"package_sets,omitempty"`
-	RHSM        bool     `json:"rhsm,omitempty"`
+	Id           string   `json:"id,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	BaseURL      string   `json:"baseurl,omitempty"`
+	Metalink     string   `json:"metalink,omitempty"`
+	MirrorList   string   `json:"mirrorlist,omitempty"`
+	GPGKey       string   `json:"gpgkey,omitempty"`
+	CheckGPG     bool     `json:"check_gpg,omitempty"`
+	CheckRepoGPG bool     `json:"repo_check_gpg,omitempty"`
+	IgnoreSSL    bool     `json:"ignore_ssl,omitempty"`
+	PackageSets  []string `json:"package_sets,omitempty"`
+	RHSM         bool     `json:"rhsm,omitempty"`
 }
 
 type ostreeOptions struct {
@@ -141,6 +144,10 @@ func main() {
 		if repoName == "" {
 			repoName = fmt.Sprintf("repo-%d", i)
 		}
+		repoId := repo.Id
+		if repoId == "" {
+			repoId = fmt.Sprintf("repo-%d", i)
+		}
 		var urls []string
 		if repo.BaseURL != "" {
 			urls = []string{repo.BaseURL}
@@ -149,7 +156,9 @@ func main() {
 		if repo.GPGKey != "" {
 			keys = []string{repo.GPGKey}
 		}
+
 		repos[i] = rpmmd.RepoConfig{
+			Id:           repoId,
 			Name:         repoName,
 			BaseURLs:     urls,
 			Metalink:     repo.Metalink,

--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -23,6 +23,7 @@ type Customizations struct {
 	Ignition           *IgnitionCustomization    `json:"ignition,omitempty" toml:"ignition,omitempty"`
 	Directories        []DirectoryCustomization  `json:"directories,omitempty" toml:"directories,omitempty"`
 	Files              []FileCustomization       `json:"files,omitempty" toml:"files,omitempty"`
+	Repositories       []RepositoryCustomization `json:"repositories,omitempty" toml:"repositories,omitempty"`
 }
 
 type IgnitionCustomization struct {
@@ -332,4 +333,19 @@ func (c *Customizations) GetFiles() []FileCustomization {
 		return nil
 	}
 	return c.Files
+}
+
+func (c *Customizations) GetRepositories() ([]RepositoryCustomization, error) {
+	if c == nil {
+		return nil, nil
+	}
+
+	for idx := range c.Repositories {
+		err := validateCustomRepository(&c.Repositories[idx])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return c.Repositories, nil
 }

--- a/internal/blueprint/repository_customizations.go
+++ b/internal/blueprint/repository_customizations.go
@@ -1,0 +1,35 @@
+package blueprint
+
+import (
+	"fmt"
+)
+
+type RepositoryCustomization struct {
+	Id           string   `json:"id" toml:"id"`
+	BaseURLs     []string `json:"baseurls,omitempty" toml:"baseurls,omitempty"`
+	GPGKeys      []string `json:"gpgkeys,omitempty" toml:"gpgkeys,omitempty"`
+	Metalink     string   `json:"metalink,omitempty" toml:"metalink,omitempty"`
+	Mirrorlist   string   `json:"mirrorlist,omitempty" toml:"mirrorlist,omitempty"`
+	Name         string   `json:"name,omitempty" toml:"name,omitempty"`
+	Priority     *int     `json:"priority,omitempty" toml:"priority,omitempty"`
+	Enabled      *bool    `json:"enabled,omitempty" toml:"enabled,omitempty"`
+	GPGCheck     *bool    `json:"gpgcheck,omitempty" toml:"gpgcheck,omitempty"`
+	RepoGPGCheck *bool    `json:"repo_gpgcheck,omitempty" toml:"repo_gpgcheck,omitempty"`
+	SSLVerify    bool     `json:"sslverify,omitempty" toml:"sslverify,omitempty"`
+	Filename     string   `json:"filename,omitempty" toml:"filename,omitempty"`
+}
+
+func validateCustomRepository(repo *RepositoryCustomization) error {
+	if repo.Id == "" {
+		return fmt.Errorf("Repository ID is required")
+	}
+
+	if len(repo.BaseURLs) == 0 && repo.Mirrorlist == "" && repo.Metalink == "" {
+		return fmt.Errorf("Repository base URL, mirrorlist or metalink is required")
+	}
+
+	if repo.GPGCheck != nil && *repo.GPGCheck && len(repo.GPGKeys) == 0 {
+		return fmt.Errorf("Repository gpg check is set to true but no gpg keys are provided")
+	}
+	return nil
+}

--- a/internal/blueprint/repository_customizations_test.go
+++ b/internal/blueprint/repository_customizations_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/blueprint/repository_customizations_test.go
+++ b/internal/blueprint/repository_customizations_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/fsnode"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,6 +77,259 @@ func TestGetCustomRepositories(t *testing.T) {
 				_, err := tt.expectedCustomizations.GetRepositories()
 				assert.Equal(t, tt.wantErr, err)
 			}
+		})
+	}
+}
+
+func TestCustomRepoFilename(t *testing.T) {
+	testCases := []struct {
+		Name         string
+		Repo         RepositoryCustomization
+		WantFilename string
+	}{
+		{
+			Name: "Test default filename #1",
+			Repo: RepositoryCustomization{
+				Id:       "example-1",
+				BaseURLs: []string{"http://example-1.com"},
+			},
+			WantFilename: "example-1.repo",
+		},
+		{
+			Name: "Test default filename #2",
+			Repo: RepositoryCustomization{
+				Id:       "example-2",
+				BaseURLs: []string{"http://example-1.com"},
+			},
+			WantFilename: "example-2.repo",
+		},
+		{
+			Name: "Test custom filename",
+			Repo: RepositoryCustomization{
+				Id:       "example-1",
+				BaseURLs: []string{"http://example-1.com"},
+				Filename: "test.repo",
+			},
+			WantFilename: "test.repo",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.Name, func(t *testing.T) {
+			got := tt.Repo.getFilename()
+			assert.Equal(t, tt.WantFilename, got)
+		})
+	}
+}
+
+func TestCustomRepoToRepoConfigAndGPGKeys(t *testing.T) {
+	ensureFileCreation := func(file *fsnode.File, err error) *fsnode.File {
+		t.Helper()
+		assert.NoError(t, err)
+		assert.NotNil(t, file)
+		return file
+	}
+	testCases := []struct {
+		Name           string
+		Repos          []RepositoryCustomization
+		WantRepoConfig map[string][]rpmmd.RepoConfig
+		WantGPGKeys    []*fsnode.File
+	}{
+		{
+			Name: "Test no gpg keys, no filenames",
+			Repos: []RepositoryCustomization{
+				{
+					Id:        "example-1",
+					BaseURLs:  []string{"http://example-1.com"},
+					SSLVerify: true,
+				},
+				{
+					Id:        "example-2",
+					BaseURLs:  []string{"http://example-2.com"},
+					SSLVerify: true,
+				},
+			},
+			WantRepoConfig: map[string][]rpmmd.RepoConfig{
+				"example-1.repo": {
+					{
+						Id:       "example-1",
+						BaseURLs: []string{"http://example-1.com"},
+						GPGKeys:  []string{},
+					},
+				},
+				"example-2.repo": {
+					{
+						Id:       "example-2",
+						BaseURLs: []string{"http://example-2.com"},
+						GPGKeys:  []string{},
+					},
+				},
+			},
+			WantGPGKeys: nil,
+		},
+		{
+			Name: "Test no gpg keys, filenames",
+			Repos: []RepositoryCustomization{
+				{
+					Id:        "example-1",
+					BaseURLs:  []string{"http://example-1.com"},
+					SSLVerify: true,
+					Filename:  "test-1.repo",
+				},
+				{
+					Id:        "example-2",
+					BaseURLs:  []string{"http://example-2.com"},
+					SSLVerify: true,
+					Filename:  "test-2.repo",
+				},
+			},
+			WantRepoConfig: map[string][]rpmmd.RepoConfig{
+				"test-1.repo": {
+					{
+						Id:       "example-1",
+						BaseURLs: []string{"http://example-1.com"},
+						GPGKeys:  []string{},
+					},
+				},
+				"test-2.repo": {
+					{
+						Id:       "example-2",
+						BaseURLs: []string{"http://example-2.com"},
+						GPGKeys:  []string{},
+					},
+				},
+			},
+			WantGPGKeys: nil,
+		},
+		{
+			Name: "Test remote gpgkeys",
+			Repos: []RepositoryCustomization{
+				{
+					Id:        "example-1",
+					BaseURLs:  []string{"http://example-1.com"},
+					GPGKeys:   []string{"http://example-1.com/gpgkey"},
+					GPGCheck:  common.ToPtr(true),
+					SSLVerify: true,
+				},
+				{
+					Id:        "example-2",
+					BaseURLs:  []string{"http://example-2.com"},
+					GPGKeys:   []string{"http://example-2.com/gpgkey"},
+					GPGCheck:  common.ToPtr(true),
+					SSLVerify: true,
+				},
+			},
+			WantRepoConfig: map[string][]rpmmd.RepoConfig{
+				"example-1.repo": {
+					{
+						Id:       "example-1",
+						BaseURLs: []string{"http://example-1.com"},
+						GPGKeys:  []string{"http://example-1.com/gpgkey"},
+						CheckGPG: common.ToPtr(true),
+					},
+				},
+				"example-2.repo": {
+					{
+						Id:       "example-2",
+						BaseURLs: []string{"http://example-2.com"},
+						GPGKeys:  []string{"http://example-2.com/gpgkey"},
+						CheckGPG: common.ToPtr(true),
+					},
+				},
+			},
+			WantGPGKeys: nil,
+		},
+		{
+			Name: "Test inline gpgkeys",
+			Repos: []RepositoryCustomization{
+				{
+					Id:        "example-1",
+					BaseURLs:  []string{"http://example-1.com"},
+					GPGKeys:   []string{"fake-gpg-key-1"},
+					GPGCheck:  common.ToPtr(true),
+					SSLVerify: true,
+				},
+				{
+					Id:        "example-2",
+					BaseURLs:  []string{"http://example-2.com"},
+					GPGKeys:   []string{"fake-gpg-key-2"},
+					GPGCheck:  common.ToPtr(true),
+					SSLVerify: true,
+				},
+			},
+			WantRepoConfig: map[string][]rpmmd.RepoConfig{
+				"example-1.repo": {
+					{
+						Id:       "example-1",
+						BaseURLs: []string{"http://example-1.com"},
+						GPGKeys:  []string{"file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-1-0"},
+						CheckGPG: common.ToPtr(true),
+					},
+				},
+				"example-2.repo": {
+					{
+						Id:       "example-2",
+						BaseURLs: []string{"http://example-2.com"},
+						GPGKeys:  []string{"file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-2-0"},
+						CheckGPG: common.ToPtr(true),
+					},
+				},
+			},
+			WantGPGKeys: []*fsnode.File{
+				ensureFileCreation(fsnode.NewFile("/etc/pki/rpm-gpg/RPM-GPG-KEY-example-1-0", nil, nil, nil, []byte("fake-gpg-key-1"))),
+				ensureFileCreation(fsnode.NewFile("/etc/pki/rpm-gpg/RPM-GPG-KEY-example-2-0", nil, nil, nil, []byte("fake-gpg-key-1"))),
+			},
+		},
+		{
+			Name: "Test multiple inline gpgkeys",
+			Repos: []RepositoryCustomization{
+				{
+					Id:        "example-1",
+					BaseURLs:  []string{"http://example-1.com"},
+					GPGKeys:   []string{"fake-gpg-key-1", "fake-gpg-key-2"},
+					GPGCheck:  common.ToPtr(true),
+					SSLVerify: true,
+				},
+				{
+					Id:        "example-2",
+					BaseURLs:  []string{"http://example-2.com"},
+					GPGKeys:   []string{"fake-gpg-key-1", "fake-gpg-key-2"},
+					GPGCheck:  common.ToPtr(true),
+					SSLVerify: true,
+				},
+			},
+			WantRepoConfig: map[string][]rpmmd.RepoConfig{
+				"example-1.repo": {
+					{
+						Id:       "example-1",
+						BaseURLs: []string{"http://example-1.com"},
+						GPGKeys:  []string{"file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-1-0", "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-1-1"},
+						CheckGPG: common.ToPtr(true),
+					},
+				},
+				"example-2.repo": {
+					{
+						Id:       "example-2",
+						BaseURLs: []string{"http://example-2.com"},
+						GPGKeys:  []string{"file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-2-0", "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-2-1"},
+						CheckGPG: common.ToPtr(true),
+					},
+				},
+			},
+			WantGPGKeys: []*fsnode.File{
+				ensureFileCreation(fsnode.NewFile("/etc/pki/rpm-gpg/RPM-GPG-KEY-example-1-0", nil, nil, nil, []byte("fake-gpg-key-1"))),
+				ensureFileCreation(fsnode.NewFile("/etc/pki/rpm-gpg/RPM-GPG-KEY-example-1-1", nil, nil, nil, []byte("fake-gpg-key-2"))),
+				ensureFileCreation(fsnode.NewFile("/etc/pki/rpm-gpg/RPM-GPG-KEY-example-2-0", nil, nil, nil, []byte("fake-gpg-key-1"))),
+				ensureFileCreation(fsnode.NewFile("/etc/pki/rpm-gpg/RPM-GPG-KEY-example-2-1", nil, nil, nil, []byte("fake-gpg-key-2"))),
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.Name, func(t *testing.T) {
+			got, _, err := RepoCustomizationsToRepoConfigAndGPGKeyFiles(tt.Repos)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.WantRepoConfig, got)
 		})
 	}
 }

--- a/internal/blueprint/repository_customizations_test.go
+++ b/internal/blueprint/repository_customizations_test.go
@@ -1,0 +1,79 @@
+package blueprint
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCustomRepositories(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		expectedCustomizations Customizations
+		wantErr                error
+	}{
+		{
+			name: "Test no errors",
+			expectedCustomizations: Customizations{
+				Repositories: []RepositoryCustomization{
+					{
+						Id:       "example-1",
+						BaseURLs: []string{"http://example-1.com"},
+					},
+					{
+						Id:       "example-2",
+						BaseURLs: []string{"http://example-2.com"},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Test empty id error",
+			expectedCustomizations: Customizations{
+				Repositories: []RepositoryCustomization{
+					{},
+				},
+			},
+			wantErr: fmt.Errorf("Repository ID is required"),
+		},
+		{
+			name: "Test empty baseurl, mirrorlist or metalink error",
+			expectedCustomizations: Customizations{
+				Repositories: []RepositoryCustomization{
+					{
+						Id: "example-1",
+					},
+				},
+			},
+			wantErr: fmt.Errorf("Repository base URL, mirrorlist or metalink is required"),
+		},
+		{
+			name: "Test missing GPG keys error",
+			expectedCustomizations: Customizations{
+				Repositories: []RepositoryCustomization{
+					{
+						Id:       "example-1",
+						BaseURLs: []string{"http://example-1.com"},
+						GPGCheck: common.ToPtr(true),
+					},
+				},
+			},
+			wantErr: fmt.Errorf("Repository gpg check is set to true but no gpg keys are provided"),
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr == nil {
+				retCustomizations, err := tt.expectedCustomizations.GetRepositories()
+				assert.NoError(t, err)
+				assert.EqualValues(t, tt.expectedCustomizations.Repositories, retCustomizations)
+			} else {
+				_, err := tt.expectedCustomizations.GetRepositories()
+				assert.Equal(t, tt.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/client/unit_test.go
+++ b/internal/client/unit_test.go
@@ -75,7 +75,7 @@ func executeTests(m *testing.M) int {
 	rr := reporegistry.NewFromDistrosRepoConfigs(rpmmd.DistrosRepoConfigs{
 		test_distro.TestDistroName: {
 			test_distro.TestArchName: {
-				{Name: "test-system-repo", BaseURL: "http://example.com/test/os/test_arch"},
+				{Name: "test-system-repo", BaseURLs: []string{"http://example.com/test/os/test_arch"}},
 			},
 		},
 	})

--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -1363,7 +1363,7 @@ func genRepoConfig(repo Repository) (*rpmmd.RepoConfig, error) {
 	}
 
 	if repo.CheckGpg != nil {
-		repoConfig.CheckGPG = *repo.CheckGpg
+		repoConfig.CheckGPG = repo.CheckGpg
 	}
 	if repo.Gpgkey != nil && *repo.Gpgkey != "" {
 		repoConfig.GPGKeys = []string{*repo.Gpgkey}
@@ -1372,10 +1372,10 @@ func genRepoConfig(repo Repository) (*rpmmd.RepoConfig, error) {
 		repoConfig.IgnoreSSL = *repo.IgnoreSsl
 	}
 	if repo.CheckRepoGpg != nil {
-		repoConfig.CheckRepoGPG = *repo.CheckRepoGpg
+		repoConfig.CheckRepoGPG = repo.CheckRepoGpg
 	}
 
-	if repoConfig.CheckGPG && len(repoConfig.GPGKeys) == 0 {
+	if repoConfig.CheckGPG != nil && *repoConfig.CheckGPG && len(repoConfig.GPGKeys) == 0 {
 		return nil, HTTPError(ErrorNoGPGKey)
 	}
 

--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -1352,8 +1352,8 @@ func genRepoConfig(repo Repository) (*rpmmd.RepoConfig, error) {
 
 	repoConfig.RHSM = repo.Rhsm != nil && *repo.Rhsm
 
-	if repo.Baseurl != nil {
-		repoConfig.BaseURL = *repo.Baseurl
+	if repo.Baseurl != nil && *repo.Baseurl != "" {
+		repoConfig.BaseURLs = []string{*repo.Baseurl}
 	} else if repo.Mirrorlist != nil {
 		repoConfig.MirrorList = *repo.Mirrorlist
 	} else if repo.Metalink != nil {

--- a/internal/cloudapi/v2/v2_internal_test.go
+++ b/internal/cloudapi/v2/v2_internal_test.go
@@ -65,13 +65,13 @@ func TestCollectRepos(t *testing.T) {
 	}
 
 	expectedRepos := []rpmmd.RepoConfig{
-		{BaseURL: "http://example.com/baseos", PackageSets: nil},
-		{BaseURL: "http://example.com/appstream", PackageSets: nil},
-		{BaseURL: "http://example.com/baseos-rhel7", PackageSets: []string{"build"}},
-		{BaseURL: "http://example.com/extra-tools", PackageSets: []string{"build", "archive"}},
-		{BaseURL: "http://example.com/custom-os-stuff", PackageSets: []string{"blueprint"}},
-		{BaseURL: "http://example.com/repoone", PackageSets: []string{"blueprint"}},
-		{BaseURL: "http://example.com/repotwo", PackageSets: []string{"blueprint"}},
+		{BaseURLs: []string{"http://example.com/baseos"}, PackageSets: nil},
+		{BaseURLs: []string{"http://example.com/appstream"}, PackageSets: nil},
+		{BaseURLs: []string{"http://example.com/baseos-rhel7"}, PackageSets: []string{"build"}},
+		{BaseURLs: []string{"http://example.com/extra-tools"}, PackageSets: []string{"build", "archive"}},
+		{BaseURLs: []string{"http://example.com/custom-os-stuff"}, PackageSets: []string{"blueprint"}},
+		{BaseURLs: []string{"http://example.com/repoone"}, PackageSets: []string{"blueprint"}},
+		{BaseURLs: []string{"http://example.com/repotwo"}, PackageSets: []string{"blueprint"}},
 	}
 
 	payloadPkgSets := []string{"blueprint"}
@@ -104,7 +104,7 @@ func TestRepoConfigConversion(t *testing.T) {
 			},
 			repoConfig: rpmmd.RepoConfig{
 				Name:           "",
-				BaseURL:        "http://base.url",
+				BaseURLs:       []string{"http://base.url"},
 				Metalink:       "",
 				MirrorList:     "",
 				GPGKeys:        []string{"some-kind-of-key"},
@@ -128,7 +128,7 @@ func TestRepoConfigConversion(t *testing.T) {
 			},
 			repoConfig: rpmmd.RepoConfig{
 				Name:           "",
-				BaseURL:        "http://base.url",
+				BaseURLs:       []string{"http://base.url"},
 				Metalink:       "", // since BaseURL is specified, MetaLink is not copied
 				MirrorList:     "", // since BaseURL is specified, MirrorList is not copied
 				CheckGPG:       false,
@@ -151,7 +151,6 @@ func TestRepoConfigConversion(t *testing.T) {
 			},
 			repoConfig: rpmmd.RepoConfig{
 				Name:           "",
-				BaseURL:        "",
 				Metalink:       "", // since MirrorList is specified, MetaLink is not copied
 				MirrorList:     "http://example.org/mirrorlist",
 				CheckGPG:       false,
@@ -174,7 +173,6 @@ func TestRepoConfigConversion(t *testing.T) {
 			},
 			repoConfig: rpmmd.RepoConfig{
 				Name:           "",
-				BaseURL:        "",
 				Metalink:       "http://example.org/metalink",
 				MirrorList:     "",
 				CheckGPG:       false,
@@ -214,7 +212,6 @@ func TestRepoConfigConversion(t *testing.T) {
 		// check gpg required but no gpgkey given
 		{
 			repo: Repository{
-				Baseurl:     nil,
 				CheckGpg:    common.ToPtr(true),
 				Gpgkey:      nil,
 				IgnoreSsl:   common.ToPtr(true),

--- a/internal/cloudapi/v2/v2_internal_test.go
+++ b/internal/cloudapi/v2/v2_internal_test.go
@@ -189,7 +189,7 @@ func TestRepoConfigConversion(t *testing.T) {
 	for idx, tc := range testCases {
 		rc, err := genRepoConfig(tc.repo)
 		assert.NoError(err)
-		assert.Equal(rc, &tc.repoConfig, "mismatch in test case %d", idx)
+		assert.Equal(&tc.repoConfig, rc, "mismatch in test case %d", idx)
 	}
 
 	errorTestCases := []struct {

--- a/internal/cloudapi/v2/v2_internal_test.go
+++ b/internal/cloudapi/v2/v2_internal_test.go
@@ -108,7 +108,7 @@ func TestRepoConfigConversion(t *testing.T) {
 				Metalink:       "",
 				MirrorList:     "",
 				GPGKeys:        []string{"some-kind-of-key"},
-				CheckGPG:       true,
+				CheckGPG:       common.ToPtr(true),
 				IgnoreSSL:      false,
 				MetadataExpire: "",
 				RHSM:           false,
@@ -131,7 +131,7 @@ func TestRepoConfigConversion(t *testing.T) {
 				BaseURLs:       []string{"http://base.url"},
 				Metalink:       "", // since BaseURL is specified, MetaLink is not copied
 				MirrorList:     "", // since BaseURL is specified, MirrorList is not copied
-				CheckGPG:       false,
+				CheckGPG:       nil,
 				IgnoreSSL:      true,
 				MetadataExpire: "",
 				RHSM:           false,
@@ -153,7 +153,7 @@ func TestRepoConfigConversion(t *testing.T) {
 				Name:           "",
 				Metalink:       "", // since MirrorList is specified, MetaLink is not copied
 				MirrorList:     "http://example.org/mirrorlist",
-				CheckGPG:       false,
+				CheckGPG:       nil,
 				IgnoreSSL:      true,
 				MetadataExpire: "",
 				RHSM:           false,
@@ -175,7 +175,7 @@ func TestRepoConfigConversion(t *testing.T) {
 				Name:           "",
 				Metalink:       "http://example.org/metalink",
 				MirrorList:     "",
-				CheckGPG:       false,
+				CheckGPG:       nil,
 				IgnoreSSL:      true,
 				MetadataExpire: "",
 				RHSM:           true,

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -200,7 +200,7 @@ func TestImageTypePipelineNames(t *testing.T) {
 					repos := []rpmmd.RepoConfig{
 						{
 							Name:        "payload",
-							BaseURL:     "http://payload.example.com",
+							BaseURLs:    []string{"http://payload.example.com"},
 							PackageSets: imageType.PayloadPackageSets(),
 							GPGKeys:     []string{"payload-gpg-key"},
 							CheckGPG:    true,
@@ -287,12 +287,12 @@ func TestPipelineRepositories(t *testing.T) {
 		"globalonly": { // only global repos: most common scenario
 			repos: []rpmmd.RepoConfig{
 				{
-					Name:    "global-1",
-					BaseURL: "http://global-1.example.com",
+					Name:     "global-1",
+					BaseURLs: []string{"http://global-1.example.com"},
 				},
 				{
-					Name:    "global-2",
-					BaseURL: "http://global-2.example.com",
+					Name:     "global-2",
+					BaseURLs: []string{"http://global-2.example.com"},
 				},
 			},
 			result: map[string][]stringSet{
@@ -302,21 +302,21 @@ func TestPipelineRepositories(t *testing.T) {
 		"global+build": { // global repos with build-specific repos: secondary common scenario
 			repos: []rpmmd.RepoConfig{
 				{
-					Name:    "global-11",
-					BaseURL: "http://global-11.example.com",
+					Name:     "global-11",
+					BaseURLs: []string{"http://global-11.example.com"},
 				},
 				{
-					Name:    "global-12",
-					BaseURL: "http://global-12.example.com",
+					Name:     "global-12",
+					BaseURLs: []string{"http://global-12.example.com"},
 				},
 				{
 					Name:        "build-1",
-					BaseURL:     "http://build-1.example.com",
+					BaseURLs:    []string{"http://build-1.example.com"},
 					PackageSets: []string{"build"},
 				},
 				{
 					Name:        "build-2",
-					BaseURL:     "http://build-2.example.com",
+					BaseURLs:    []string{"http://build-2.example.com"},
 					PackageSets: []string{"build"},
 				},
 			},
@@ -328,21 +328,21 @@ func TestPipelineRepositories(t *testing.T) {
 		"global+os": { // global repos with os-specific repos
 			repos: []rpmmd.RepoConfig{
 				{
-					Name:    "global-21",
-					BaseURL: "http://global-11.example.com",
+					Name:     "global-21",
+					BaseURLs: []string{"http://global-11.example.com"},
 				},
 				{
-					Name:    "global-22",
-					BaseURL: "http://global-12.example.com",
+					Name:     "global-22",
+					BaseURLs: []string{"http://global-12.example.com"},
 				},
 				{
 					Name:        "os-1",
-					BaseURL:     "http://os-1.example.com",
+					BaseURLs:    []string{"http://os-1.example.com"},
 					PackageSets: []string{"os"},
 				},
 				{
 					Name:        "os-2",
-					BaseURL:     "http://os-2.example.com",
+					BaseURLs:    []string{"http://os-2.example.com"},
 					PackageSets: []string{"os"},
 				},
 			},
@@ -354,26 +354,26 @@ func TestPipelineRepositories(t *testing.T) {
 		"global+os+payload": { // global repos with os-specific repos and (user-defined) payload repositories
 			repos: []rpmmd.RepoConfig{
 				{
-					Name:    "global-21",
-					BaseURL: "http://global-11.example.com",
+					Name:     "global-21",
+					BaseURLs: []string{"http://global-11.example.com"},
 				},
 				{
-					Name:    "global-22",
-					BaseURL: "http://global-12.example.com",
+					Name:     "global-22",
+					BaseURLs: []string{"http://global-12.example.com"},
 				},
 				{
 					Name:        "os-1",
-					BaseURL:     "http://os-1.example.com",
+					BaseURLs:    []string{"http://os-1.example.com"},
 					PackageSets: []string{"os"},
 				},
 				{
 					Name:        "os-2",
-					BaseURL:     "http://os-2.example.com",
+					BaseURLs:    []string{"http://os-2.example.com"},
 					PackageSets: []string{"os"},
 				},
 				{
-					Name:    "payload",
-					BaseURL: "http://payload.example.com",
+					Name:     "payload",
+					BaseURLs: []string{"http://payload.example.com"},
 					// User-defined payload repositories automatically get the "blueprint" key.
 					// This is handled by the APIs.
 					PackageSets: []string{"blueprint"},
@@ -391,37 +391,37 @@ func TestPipelineRepositories(t *testing.T) {
 			repos: []rpmmd.RepoConfig{
 				{
 					Name:        "build-1",
-					BaseURL:     "http://build-1.example.com",
+					BaseURLs:    []string{"http://build-1.example.com"},
 					PackageSets: []string{"build"},
 				},
 				{
 					Name:        "build-2",
-					BaseURL:     "http://build-2.example.com",
+					BaseURLs:    []string{"http://build-2.example.com"},
 					PackageSets: []string{"build"},
 				},
 				{
 					Name:        "os-1",
-					BaseURL:     "http://os-1.example.com",
+					BaseURLs:    []string{"http://os-1.example.com"},
 					PackageSets: []string{"os"},
 				},
 				{
 					Name:        "os-2",
-					BaseURL:     "http://os-2.example.com",
+					BaseURLs:    []string{"http://os-2.example.com"},
 					PackageSets: []string{"os"},
 				},
 				{
 					Name:        "anaconda-1",
-					BaseURL:     "http://anaconda-1.example.com",
+					BaseURLs:    []string{"http://anaconda-1.example.com"},
 					PackageSets: []string{"anaconda-tree"},
 				},
 				{
 					Name:        "container-1",
-					BaseURL:     "http://container-1.example.com",
+					BaseURLs:    []string{"http://container-1.example.com"},
 					PackageSets: []string{"container-tree"},
 				},
 				{
 					Name:        "coi-1",
-					BaseURL:     "http://coi-1.example.com",
+					BaseURLs:    []string{"http://coi-1.example.com"},
 					PackageSets: []string{"coi-tree"},
 				},
 			},
@@ -437,16 +437,16 @@ func TestPipelineRepositories(t *testing.T) {
 		"global+unknown": { // package set names that don't match a pipeline are ignored
 			repos: []rpmmd.RepoConfig{
 				{
-					Name:    "global-1",
-					BaseURL: "http://global-1.example.com",
+					Name:     "global-1",
+					BaseURLs: []string{"http://global-1.example.com"},
 				},
 				{
-					Name:    "global-2",
-					BaseURL: "http://global-2.example.com",
+					Name:     "global-2",
+					BaseURLs: []string{"http://global-2.example.com"},
 				},
 				{
 					Name:        "custom-1",
-					BaseURL:     "http://custom.example.com",
+					BaseURLs:    []string{"http://custom.example.com"},
 					PackageSets: []string{"notapipeline"},
 				},
 			},

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/container"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/distro/distro_test_common"
@@ -203,7 +204,7 @@ func TestImageTypePipelineNames(t *testing.T) {
 							BaseURLs:    []string{"http://payload.example.com"},
 							PackageSets: imageType.PayloadPackageSets(),
 							GPGKeys:     []string{"payload-gpg-key"},
-							CheckGPG:    true,
+							CheckGPG:    common.ToPtr(true),
 						},
 					}
 					containers := make([]container.Spec, 0)

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -62,14 +62,17 @@ func TestDistro_Manifest(t *testing.T, pipelinePath string, prefix string, regis
 
 		repos := make([]rpmmd.RepoConfig, len(tt.ComposeRequest.Repositories))
 		for i, repo := range tt.ComposeRequest.Repositories {
+			var urls []string
+			if repo.BaseURL != "" {
+				urls = []string{repo.BaseURL}
+			}
 			var keys []string
 			if repo.GPGKey != "" {
 				keys = []string{repo.GPGKey}
 			}
-
 			repos[i] = rpmmd.RepoConfig{
 				Name:        fmt.Sprintf("repo-%d", i),
-				BaseURL:     repo.BaseURL,
+				BaseURLs:    urls,
 				Metalink:    repo.Metalink,
 				MirrorList:  repo.MirrorList,
 				GPGKeys:     keys,

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/container"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/distroregistry"
@@ -76,7 +77,7 @@ func TestDistro_Manifest(t *testing.T, pipelinePath string, prefix string, regis
 				Metalink:    repo.Metalink,
 				MirrorList:  repo.MirrorList,
 				GPGKeys:     keys,
-				CheckGPG:    repo.CheckGPG,
+				CheckGPG:    common.ToPtr(repo.CheckGPG),
 				PackageSets: repo.PackageSets,
 			}
 		}

--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -845,6 +845,12 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 		return nil, err
 	}
 
+	// check if repository customizations are valid
+	_, err = customizations.GetRepositories()
+	if err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 

--- a/internal/distro/rhel7/distro.go
+++ b/internal/distro/rhel7/distro.go
@@ -558,6 +558,12 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 		return warnings, err
 	}
 
+	// check if repository customizations are valid
+	_, err = customizations.GetRepositories()
+	if err != nil {
+		return warnings, err
+	}
+
 	return warnings, nil
 }
 

--- a/internal/distro/rhel7/images.go
+++ b/internal/distro/rhel7/images.go
@@ -156,6 +156,36 @@ func osCustomizations(
 		// should have been validated before this point.
 		panic(fmt.Sprintf("failed to convert file customizations to fs node files: %v", err))
 	}
+
+	// set yum repos first, so it doesn't get overridden by
+	// imageConfig.YUMRepos
+	osc.YUMRepos = imageConfig.YUMRepos
+
+	customRepos, err := c.GetRepositories()
+	if err != nil {
+		// This shouldn't happen and since the repos
+		// should have already been validated
+		panic(fmt.Sprintf("failed to get custom repos: %v", err))
+	}
+
+	// This function returns a map of filename and corresponding yum repos
+	// and a list of fs node files for the inline gpg keys so we can save
+	// them to disk. This step also swaps the inline gpg key with the path
+	// to the file in the os file tree
+	yumRepos, gpgKeyFiles, err := blueprint.RepoCustomizationsToRepoConfigAndGPGKeyFiles(customRepos)
+	if err != nil {
+		panic(fmt.Sprintf("failed to convert inline gpgkeys to fs node files: %v", err))
+	}
+
+	// add the gpg key files to the list of files to be added to the tree
+	if len(gpgKeyFiles) > 0 {
+		osc.Files = append(osc.Files, gpgKeyFiles...)
+	}
+
+	for filename, repos := range yumRepos {
+		osc.YUMRepos = append(osc.YUMRepos, osbuild.NewYumReposStageOptions(filename, repos))
+	}
+
 	osc.ShellInit = imageConfig.ShellInit
 
 	osc.Grub2Config = imageConfig.Grub2Config
@@ -173,7 +203,6 @@ func osCustomizations(
 	osc.Sysctld = imageConfig.Sysctld
 	osc.DNFConfig = imageConfig.DNFConfig
 	osc.DNFAutomaticConfig = imageConfig.DNFAutomaticConfig
-	osc.YUMRepos = imageConfig.YUMRepos
 	osc.YUMConfig = imageConfig.YumConfig
 	osc.SshdConfig = imageConfig.SshdConfig
 	osc.AuthConfig = imageConfig.Authconfig

--- a/internal/distro/rhel8/gce.go
+++ b/internal/distro/rhel8/gce.go
@@ -99,7 +99,7 @@ func defaultGceByosImageConfig(rd distribution) *distro.ImageConfig {
 					{
 						Id:           "google-compute-engine",
 						Name:         "Google Compute Engine",
-						BaseURL:      []string{"https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable"},
+						BaseURLs:     []string{"https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable"},
 						Enabled:      common.ToPtr(true),
 						GPGCheck:     common.ToPtr(true),
 						RepoGPGCheck: common.ToPtr(false),

--- a/internal/distro/rhel8/images.go
+++ b/internal/distro/rhel8/images.go
@@ -162,6 +162,36 @@ func osCustomizations(
 		// should have been validated before this point.
 		panic(fmt.Sprintf("failed to convert file customizations to fs node files: %v", err))
 	}
+
+	// set yum repos first, so it doesn't get overridden by
+	// imageConfig.YUMRepos
+	osc.YUMRepos = imageConfig.YUMRepos
+
+	customRepos, err := c.GetRepositories()
+	if err != nil {
+		// This shouldn't happen and since the repos
+		// should have already been validated
+		panic(fmt.Sprintf("failed to get custom repos: %v", err))
+	}
+
+	// This function returns a map of filename and corresponding yum repos
+	// and a list of fs node files for the inline gpg keys so we can save
+	// them to disk. This step also swaps the inline gpg key with the path
+	// to the file in the os file tree
+	yumRepos, gpgKeyFiles, err := blueprint.RepoCustomizationsToRepoConfigAndGPGKeyFiles(customRepos)
+	if err != nil {
+		panic(fmt.Sprintf("failed to convert inline gpgkeys to fs node files: %v", err))
+	}
+
+	// add the gpg key files to the list of files to be added to the tree
+	if len(gpgKeyFiles) > 0 {
+		osc.Files = append(osc.Files, gpgKeyFiles...)
+	}
+
+	for filename, repos := range yumRepos {
+		osc.YUMRepos = append(osc.YUMRepos, osbuild.NewYumReposStageOptions(filename, repos))
+	}
+
 	osc.ShellInit = imageConfig.ShellInit
 
 	osc.Grub2Config = imageConfig.Grub2Config
@@ -179,7 +209,6 @@ func osCustomizations(
 	osc.Sysctld = imageConfig.Sysctld
 	osc.DNFConfig = imageConfig.DNFConfig
 	osc.DNFAutomaticConfig = imageConfig.DNFAutomaticConfig
-	osc.YUMRepos = imageConfig.YUMRepos
 	osc.SshdConfig = imageConfig.SshdConfig
 	osc.AuthConfig = imageConfig.Authconfig
 	osc.PwQuality = imageConfig.PwQuality

--- a/internal/distro/rhel8/imagetype.go
+++ b/internal/distro/rhel8/imagetype.go
@@ -508,5 +508,11 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 		return warnings, err
 	}
 
+	// check if repository customizations are valid
+	_, err = customizations.GetRepositories()
+	if err != nil {
+		return warnings, err
+	}
+
 	return warnings, nil
 }

--- a/internal/distro/rhel9/gce.go
+++ b/internal/distro/rhel9/gce.go
@@ -104,10 +104,10 @@ func baseGCEImageConfig(rhsm bool) *distro.ImageConfig {
 				Filename: "google-cloud.repo",
 				Repos: []osbuild.YumRepository{
 					{
-						Id:      "google-compute-engine",
-						Name:    "Google Compute Engine",
-						BaseURL: []string{"https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable"},
-						Enabled: common.ToPtr(true),
+						Id:       "google-compute-engine",
+						Name:     "Google Compute Engine",
+						BaseURLs: []string{"https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable"},
+						Enabled:  common.ToPtr(true),
 						// TODO: enable GPG check once Google stops using SHA-1 in their keys
 						// https://issuetracker.google.com/issues/223626963
 						GPGCheck:     common.ToPtr(false),

--- a/internal/distro/rhel9/imagetype.go
+++ b/internal/distro/rhel9/imagetype.go
@@ -485,5 +485,11 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 		return warnings, err
 	}
 
+	// check if repository customizations are valid
+	_, err = customizations.GetRepositories()
+	if err != nil {
+		return warnings, err
+	}
+
 	return warnings, nil
 }

--- a/internal/dnfjson/dnfjson.go
+++ b/internal/dnfjson/dnfjson.go
@@ -266,11 +266,18 @@ func (s *Solver) reposFromRPMMD(rpmRepos []rpmmd.RepoConfig) ([]repoConfig, erro
 			Metalink:       rr.Metalink,
 			MirrorList:     rr.MirrorList,
 			GPGKeys:        rr.GPGKeys,
-			CheckGPG:       rr.CheckGPG,
-			CheckRepoGPG:   rr.CheckRepoGPG,
 			IgnoreSSL:      rr.IgnoreSSL,
 			MetadataExpire: rr.MetadataExpire,
 		}
+
+		if rr.CheckGPG != nil {
+			dr.CheckGPG = *rr.CheckGPG
+		}
+
+		if rr.CheckRepoGPG != nil {
+			dr.CheckRepoGPG = *rr.CheckRepoGPG
+		}
+
 		if rr.RHSM {
 			if s.subscriptions == nil {
 				return nil, fmt.Errorf("This system does not have any valid subscriptions. Subscribe it before specifying rhsm: true in sources.")
@@ -457,7 +464,9 @@ func (pkgs packageSpecs) toRPMMD(repos map[string]rpmmd.RepoConfig) []rpmmd.Pack
 		rpmDependencies[i].Arch = dep.Arch
 		rpmDependencies[i].RemoteLocation = dep.RemoteLocation
 		rpmDependencies[i].Checksum = dep.Checksum
-		rpmDependencies[i].CheckGPG = repo.CheckGPG
+		if repo.CheckGPG != nil {
+			rpmDependencies[i].CheckGPG = *repo.CheckGPG
+		}
 		rpmDependencies[i].IgnoreSSL = repo.IgnoreSSL
 		if repo.RHSM {
 			rpmDependencies[i].Secrets = "org.osbuild.rhsm"

--- a/internal/dnfjson/dnfjson_test.go
+++ b/internal/dnfjson/dnfjson_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/osbuild/osbuild-composer/internal/mocks/rpmrepo"
@@ -69,20 +70,20 @@ func TestDepsolver(t *testing.T) {
 func TestMakeDepsolveRequest(t *testing.T) {
 
 	baseOS := rpmmd.RepoConfig{
-		Name:    "baseos",
-		BaseURL: "https://example.org/baseos",
+		Name:     "baseos",
+		BaseURLs: []string{"https://example.org/baseos"},
 	}
 	appstream := rpmmd.RepoConfig{
-		Name:    "appstream",
-		BaseURL: "https://example.org/appstream",
+		Name:     "appstream",
+		BaseURLs: []string{"https://example.org/appstream"},
 	}
 	userRepo := rpmmd.RepoConfig{
-		Name:    "user-repo",
-		BaseURL: "https://example.org/user-repo",
+		Name:     "user-repo",
+		BaseURLs: []string{"https://example.org/user-repo"},
 	}
 	userRepo2 := rpmmd.RepoConfig{
-		Name:    "user-repo-2",
-		BaseURL: "https://example.org/user-repo-2",
+		Name:     "user-repo-2",
+		BaseURLs: []string{"https://example.org/user-repo-2"},
 	}
 	tests := []struct {
 		packageSets []rpmmd.PackageSet
@@ -111,14 +112,14 @@ func TestMakeDepsolveRequest(t *testing.T) {
 			},
 			wantRepos: []repoConfig{
 				{
-					ID:      baseOS.Hash(),
-					Name:    "baseos",
-					BaseURL: "https://example.org/baseos",
+					ID:       baseOS.Hash(),
+					Name:     "baseos",
+					BaseURLs: []string{"https://example.org/baseos"},
 				},
 				{
-					ID:      appstream.Hash(),
-					Name:    "appstream",
-					BaseURL: "https://example.org/appstream",
+					ID:       appstream.Hash(),
+					Name:     "appstream",
+					BaseURLs: []string{"https://example.org/appstream"},
 				},
 			},
 		},
@@ -148,19 +149,19 @@ func TestMakeDepsolveRequest(t *testing.T) {
 			},
 			wantRepos: []repoConfig{
 				{
-					ID:      baseOS.Hash(),
-					Name:    "baseos",
-					BaseURL: "https://example.org/baseos",
+					ID:       baseOS.Hash(),
+					Name:     "baseos",
+					BaseURLs: []string{"https://example.org/baseos"},
 				},
 				{
-					ID:      appstream.Hash(),
-					Name:    "appstream",
-					BaseURL: "https://example.org/appstream",
+					ID:       appstream.Hash(),
+					Name:     "appstream",
+					BaseURLs: []string{"https://example.org/appstream"},
 				},
 				{
-					ID:      userRepo.Hash(),
-					Name:    "user-repo",
-					BaseURL: "https://example.org/user-repo",
+					ID:       userRepo.Hash(),
+					Name:     "user-repo",
+					BaseURLs: []string{"https://example.org/user-repo"},
 				},
 			},
 		},
@@ -190,14 +191,14 @@ func TestMakeDepsolveRequest(t *testing.T) {
 			},
 			wantRepos: []repoConfig{
 				{
-					ID:      baseOS.Hash(),
-					Name:    "baseos",
-					BaseURL: "https://example.org/baseos",
+					ID:       baseOS.Hash(),
+					Name:     "baseos",
+					BaseURLs: []string{"https://example.org/baseos"},
 				},
 				{
-					ID:      appstream.Hash(),
-					Name:    "appstream",
-					BaseURL: "https://example.org/appstream",
+					ID:       appstream.Hash(),
+					Name:     "appstream",
+					BaseURLs: []string{"https://example.org/appstream"},
 				},
 			},
 		},
@@ -235,19 +236,19 @@ func TestMakeDepsolveRequest(t *testing.T) {
 			},
 			wantRepos: []repoConfig{
 				{
-					ID:      baseOS.Hash(),
-					Name:    "baseos",
-					BaseURL: "https://example.org/baseos",
+					ID:       baseOS.Hash(),
+					Name:     "baseos",
+					BaseURLs: []string{"https://example.org/baseos"},
 				},
 				{
-					ID:      appstream.Hash(),
-					Name:    "appstream",
-					BaseURL: "https://example.org/appstream",
+					ID:       appstream.Hash(),
+					Name:     "appstream",
+					BaseURLs: []string{"https://example.org/appstream"},
 				},
 				{
-					ID:      userRepo.Hash(),
-					Name:    "user-repo",
-					BaseURL: "https://example.org/user-repo",
+					ID:       userRepo.Hash(),
+					Name:     "user-repo",
+					BaseURLs: []string{"https://example.org/user-repo"},
 				},
 			},
 		},
@@ -286,24 +287,24 @@ func TestMakeDepsolveRequest(t *testing.T) {
 			},
 			wantRepos: []repoConfig{
 				{
-					ID:      baseOS.Hash(),
-					Name:    "baseos",
-					BaseURL: "https://example.org/baseos",
+					ID:       baseOS.Hash(),
+					Name:     "baseos",
+					BaseURLs: []string{"https://example.org/baseos"},
 				},
 				{
-					ID:      appstream.Hash(),
-					Name:    "appstream",
-					BaseURL: "https://example.org/appstream",
+					ID:       appstream.Hash(),
+					Name:     "appstream",
+					BaseURLs: []string{"https://example.org/appstream"},
 				},
 				{
-					ID:      userRepo.Hash(),
-					Name:    "user-repo",
-					BaseURL: "https://example.org/user-repo",
+					ID:       userRepo.Hash(),
+					Name:     "user-repo",
+					BaseURLs: []string{"https://example.org/user-repo"},
 				},
 				{
-					ID:      userRepo2.Hash(),
-					Name:    "user-repo-2",
-					BaseURL: "https://example.org/user-repo-2",
+					ID:       userRepo2.Hash(),
+					Name:     "user-repo-2",
+					BaseURLs: []string{"https://example.org/user-repo-2"},
 				},
 			},
 		},
@@ -479,7 +480,7 @@ func expectedResult(repo rpmmd.RepoConfig) []rpmmd.PackageSpec {
 	exp := []rpmmd.PackageSpec(expectedTemplate)
 	for idx := range exp {
 		urlTemplate := exp[idx].RemoteLocation
-		exp[idx].RemoteLocation = fmt.Sprintf(urlTemplate, repo.BaseURL)
+		exp[idx].RemoteLocation = fmt.Sprintf(urlTemplate, strings.Join(repo.BaseURLs, ","))
 	}
 	return exp
 }
@@ -503,7 +504,7 @@ func TestErrorRepoInfo(t *testing.T) {
 		{
 			repo: rpmmd.RepoConfig{
 				Name:     "",
-				BaseURL:  "https://0.0.0.0/baseos/repo",
+				BaseURLs: []string{"https://0.0.0.0/baseos/repo"},
 				Metalink: "https://0.0.0.0/baseos/metalink",
 			},
 			expMsg: "[https://0.0.0.0/baseos/repo]",
@@ -511,7 +512,7 @@ func TestErrorRepoInfo(t *testing.T) {
 		{
 			repo: rpmmd.RepoConfig{
 				Name:     "baseos",
-				BaseURL:  "https://0.0.0.0/baseos/repo",
+				BaseURLs: []string{"https://0.0.0.0/baseos/repo"},
 				Metalink: "https://0.0.0.0/baseos/metalink",
 			},
 			expMsg: "[baseos: https://0.0.0.0/baseos/repo]",
@@ -553,14 +554,14 @@ func TestRepoConfigHash(t *testing.T) {
 	rc := repoConfig{
 		ID:        "repoid-1",
 		Name:      "A test repository",
-		BaseURL:   "https://arepourl/",
+		BaseURLs:  []string{"https://arepourl/"},
 		IgnoreSSL: false,
 	}
 
 	hash := rc.Hash()
 	assert.Equal(t, 64, len(hash))
 
-	rc.BaseURL = "https://adifferenturl/"
+	rc.BaseURLs = []string{"https://adifferenturl/"}
 	assert.NotEqual(t, hash, rc.Hash())
 }
 
@@ -569,7 +570,7 @@ func TestRequestHash(t *testing.T) {
 	repos := []rpmmd.RepoConfig{
 		rpmmd.RepoConfig{
 			Name:      "A test repository",
-			BaseURL:   "https://arepourl/",
+			BaseURLs:  []string{"https://arepourl/"},
 			IgnoreSSL: false,
 		},
 	}

--- a/internal/mocks/rpmrepo/rpmrepo.go
+++ b/internal/mocks/rpmrepo/rpmrepo.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
@@ -19,7 +20,7 @@ func NewTestServer() *testRepoServer {
 	testrepo := rpmmd.RepoConfig{
 		Name:      "cs9-baseos",
 		BaseURLs:  []string{server.URL},
-		CheckGPG:  false,
+		CheckGPG:  common.ToPtr(false),
 		IgnoreSSL: true,
 		RHSM:      false,
 	}

--- a/internal/mocks/rpmrepo/rpmrepo.go
+++ b/internal/mocks/rpmrepo/rpmrepo.go
@@ -18,7 +18,7 @@ func NewTestServer() *testRepoServer {
 	server := httptest.NewServer(http.FileServer(http.Dir("../../test/data/testrepo/")))
 	testrepo := rpmmd.RepoConfig{
 		Name:      "cs9-baseos",
-		BaseURL:   server.URL,
+		BaseURLs:  []string{server.URL},
 		CheckGPG:  false,
 		IgnoreSSL: true,
 		RHSM:      false,

--- a/internal/osbuild/yum_repos_stage.go
+++ b/internal/osbuild/yum_repos_stage.go
@@ -11,7 +11,7 @@ const repoIDRegex = "^[\\w.\\-:]+$"
 // YumRepository represents a single DNF / YUM repository.
 type YumRepository struct {
 	Id             string   `json:"id"`
-	BaseURL        []string `json:"baseurl,omitempty"`
+	BaseURLs       []string `json:"baseurl,omitempty"`
 	Cost           *int     `json:"cost,omitempty"`
 	Enabled        *bool    `json:"enabled,omitempty"`
 	GPGKey         []string `json:"gpgkey,omitempty"`
@@ -38,11 +38,11 @@ func (r YumRepository) validate() error {
 	}
 
 	// at least one of baseurl, metalink or mirrorlist must be provided
-	if len(r.BaseURL) == 0 && r.Metalink == "" && r.Mirrorlist == "" {
+	if len(r.BaseURLs) == 0 && r.Metalink == "" && r.Mirrorlist == "" {
 		return fmt.Errorf("at least one of baseurl, metalink or mirrorlist values must be provided")
 	}
 
-	for idx, url := range r.BaseURL {
+	for idx, url := range r.BaseURLs {
 		if url == "" {
 			return fmt.Errorf("baseurl must not be an empty string (idx %d)", idx)
 		}

--- a/internal/osbuild/yum_repos_stage_test.go
+++ b/internal/osbuild/yum_repos_stage_test.go
@@ -11,8 +11,8 @@ import (
 func TestNewYumReposStage(t *testing.T) {
 	stageOptions := NewYumReposStageOptions("testing.repo", []YumRepository{
 		{
-			Id:      "cool-id",
-			BaseURL: []string{"http://example.org/repo"},
+			Id:       "cool-id",
+			BaseURLs: []string{"http://example.org/repo"},
 		},
 	})
 	expectedStage := &Stage{
@@ -48,8 +48,8 @@ func TestYumReposStageOptionsValidate(t *testing.T) {
 				Filename: "@#$%^&.rap",
 				Repos: []YumRepository{
 					{
-						Id:      "cool-id",
-						BaseURL: []string{"http://example.org/repo"},
+						Id:       "cool-id",
+						BaseURLs: []string{"http://example.org/repo"},
 					},
 				},
 			},
@@ -60,8 +60,8 @@ func TestYumReposStageOptionsValidate(t *testing.T) {
 			options: YumReposStageOptions{
 				Repos: []YumRepository{
 					{
-						Id:      "cool-id",
-						BaseURL: []string{"http://example.org/repo"},
+						Id:       "cool-id",
+						BaseURLs: []string{"http://example.org/repo"},
 					},
 				},
 			},
@@ -85,8 +85,8 @@ func TestYumReposStageOptionsValidate(t *testing.T) {
 				Filename: "test.repo",
 				Repos: []YumRepository{
 					{
-						Id:      "cool-id",
-						BaseURL: []string{""},
+						Id:       "cool-id",
+						BaseURLs: []string{""},
 					},
 				},
 			},
@@ -98,9 +98,9 @@ func TestYumReposStageOptionsValidate(t *testing.T) {
 				Filename: "test.repo",
 				Repos: []YumRepository{
 					{
-						Id:      "cool-id",
-						BaseURL: []string{"http://example.org/repo"},
-						GPGKey:  []string{""},
+						Id:       "cool-id",
+						BaseURLs: []string{"http://example.org/repo"},
+						GPGKey:   []string{""},
 					},
 				},
 			},
@@ -112,8 +112,8 @@ func TestYumReposStageOptionsValidate(t *testing.T) {
 				Filename: "test.repo",
 				Repos: []YumRepository{
 					{
-						Id:      "c@@l-id",
-						BaseURL: []string{"http://example.org/repo"},
+						Id:       "c@@l-id",
+						BaseURLs: []string{"http://example.org/repo"},
 					},
 				},
 			},
@@ -132,7 +132,7 @@ func TestYumReposStageOptionsValidate(t *testing.T) {
 						Name:           "c@@l-name",
 						GPGCheck:       common.ToPtr(true),
 						RepoGPGCheck:   common.ToPtr(true),
-						BaseURL:        []string{"http://example.org/repo"},
+						BaseURLs:       []string{"http://example.org/repo"},
 						GPGKey:         []string{"secretkey"},
 					},
 				},

--- a/internal/osbuild/yum_repos_stage_test.go
+++ b/internal/osbuild/yum_repos_stage_test.go
@@ -6,10 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
 func TestNewYumReposStage(t *testing.T) {
-	stageOptions := NewYumReposStageOptions("testing.repo", []YumRepository{
+	stageOptions := NewYumReposStageOptions("testing.repo", []rpmmd.RepoConfig{
 		{
 			Id:       "cool-id",
 			BaseURLs: []string{"http://example.org/repo"},

--- a/internal/reporegistry/reporegistry_test.go
+++ b/internal/reporegistry/reporegistry_test.go
@@ -16,32 +16,32 @@ func getTestingRepoRegistry() *RepoRegistry {
 			test_distro.TestDistroName: {
 				test_distro.TestArchName: {
 					{
-						Name:    "baseos",
-						BaseURL: "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os",
+						Name:     "baseos",
+						BaseURLs: []string{"https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os"},
 					},
 					{
-						Name:    "appstream",
-						BaseURL: "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os",
+						Name:     "appstream",
+						BaseURLs: []string{"https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os"},
 					},
 				},
 				test_distro.TestArch2Name: {
 					{
-						Name:    "baseos",
-						BaseURL: "https://cdn.redhat.com/content/dist/rhel8/8/aarch64/baseos/os",
+						Name:     "baseos",
+						BaseURLs: []string{"https://cdn.redhat.com/content/dist/rhel8/8/aarch64/baseos/os"},
 					},
 					{
 						Name:          "appstream",
-						BaseURL:       "https://cdn.redhat.com/content/dist/rhel8/8/aarch64/appstream/os",
+						BaseURLs:      []string{"https://cdn.redhat.com/content/dist/rhel8/8/aarch64/appstream/os"},
 						ImageTypeTags: []string{},
 					},
 					{
 						Name:          "google-compute-engine",
-						BaseURL:       "https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable",
+						BaseURLs:      []string{"https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable"},
 						ImageTypeTags: []string{test_distro.TestImageType2Name},
 					},
 					{
 						Name:          "google-cloud-sdk",
-						BaseURL:       "https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64",
+						BaseURLs:      []string{"https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64"},
 						ImageTypeTags: []string{test_distro.TestImageType2Name},
 					},
 				},

--- a/internal/rhsm/secrets.go
+++ b/internal/rhsm/secrets.go
@@ -168,16 +168,18 @@ func parseRepoFile(content []byte) ([]subscription, error) {
 }
 
 // GetSecretsForBaseurl queries the Subscriptions structure for a RHSMSecrets of a single repository.
-func (s *Subscriptions) GetSecretsForBaseurl(baseurl string, arch, releasever string) (*RHSMSecrets, error) {
+func (s *Subscriptions) GetSecretsForBaseurl(baseurls []string, arch, releasever string) (*RHSMSecrets, error) {
 	for _, subs := range s.available {
-		url := strings.Replace(subs.baseurl, "$basearch", arch, -1)
-		url = strings.Replace(url, "$releasever", releasever, -1)
-		if url == baseurl {
-			return &RHSMSecrets{
-				SSLCACert:     subs.sslCACert,
-				SSLClientKey:  subs.sslClientKey,
-				SSLClientCert: subs.sslClientCert,
-			}, nil
+		for _, baseurl := range baseurls {
+			url := strings.Replace(subs.baseurl, "$basearch", arch, -1)
+			url = strings.Replace(url, "$releasever", releasever, -1)
+			if url == baseurl {
+				return &RHSMSecrets{
+					SSLCACert:     subs.sslCACert,
+					SSLClientKey:  subs.sslClientKey,
+					SSLClientCert: subs.sslClientCert,
+				}, nil
+			}
 		}
 	}
 	// If there is no matching URL, fall back to the global secrets

--- a/internal/rhsm/secrets_test.go
+++ b/internal/rhsm/secrets_test.go
@@ -41,7 +41,7 @@ func TestParseRepoFile(t *testing.T) {
 	subscriptions := Subscriptions{
 		available: repoFileContent,
 	}
-	secrets, err := subscriptions.GetSecretsForBaseurl("https://cdn.redhat.com/content/dist/middleware/jws/1.0/x86_64/os", "x86_64", "")
+	secrets, err := subscriptions.GetSecretsForBaseurl([]string{"https://cdn.redhat.com/content/dist/middleware/jws/1.0/x86_64/os"}, "x86_64", "")
 	require.NoError(t, err, "Failed to get secrets for a baseurl")
 	assert.Equal(t, secrets.SSLCACert, "/etc/rhsm/ca/redhat-uep.pem", "Unexpected path to the CA certificate")
 	assert.Equal(t, secrets.SSLClientCert, "/etc/pki/entitlement/456.pem", "Unexpected path to the client cert")

--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -33,8 +33,8 @@ type RepoConfig struct {
 	Metalink       string   `json:"metalink,omitempty"`
 	MirrorList     string   `json:"mirrorlist,omitempty"`
 	GPGKeys        []string `json:"gpgkeys,omitempty"`
-	CheckGPG       bool     `json:"check_gpg,omitempty"`
-	CheckRepoGPG   bool     `json:"check_repo_gpg,omitempty"`
+	CheckGPG       *bool    `json:"check_gpg,omitempty"`
+	CheckRepoGPG   *bool    `json:"check_repo_gpg,omitempty"`
 	IgnoreSSL      bool     `json:"ignore_ssl,omitempty"`
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
 	RHSM           bool     `json:"rhsm,omitempty"`
@@ -49,6 +49,9 @@ func (r *RepoConfig) Hash() string {
 	bts := func(b bool) string {
 		return fmt.Sprintf("%T", b)
 	}
+	bpts := func(b *bool) string {
+		return fmt.Sprintf("%T", b)
+	}
 	ats := func(s []string) string {
 		return strings.Join(s, "")
 	}
@@ -56,8 +59,8 @@ func (r *RepoConfig) Hash() string {
 		r.Metalink+
 		r.MirrorList+
 		ats(r.GPGKeys)+
-		bts(r.CheckGPG)+
-		bts(r.CheckRepoGPG)+
+		bpts(r.CheckGPG)+
+		bpts(r.CheckRepoGPG)+
 		bts(r.IgnoreSSL)+
 		r.MetadataExpire+
 		bts(r.RHSM))))
@@ -237,7 +240,7 @@ func loadRepositoriesFromFile(filename string) (map[string][]RepoConfig, error) 
 				Metalink:       repo.Metalink,
 				MirrorList:     repo.MirrorList,
 				GPGKeys:        keys,
-				CheckGPG:       repo.CheckGPG,
+				CheckGPG:       &repo.CheckGPG,
 				RHSM:           repo.RHSM,
 				MetadataExpire: repo.MetadataExpire,
 				ImageTypeTags:  repo.ImageTypeTags,

--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -28,6 +28,10 @@ type repository struct {
 }
 
 type RepoConfig struct {
+	// the repo id is not always required and is ignored in some cases.
+	// For example, it is not required in dnf-json, but it is a required
+	// field for creating a repo file in `/etc/yum.repos.d/`
+	Id             string   `json:"id,omitempty"`
 	Name           string   `json:"name,omitempty"`
 	BaseURLs       []string `json:"baseurls,omitempty"`
 	Metalink       string   `json:"metalink,omitempty"`
@@ -35,9 +39,11 @@ type RepoConfig struct {
 	GPGKeys        []string `json:"gpgkeys,omitempty"`
 	CheckGPG       *bool    `json:"check_gpg,omitempty"`
 	CheckRepoGPG   *bool    `json:"check_repo_gpg,omitempty"`
+	Priority       *int     `json:"priority,omitempty"`
 	IgnoreSSL      bool     `json:"ignore_ssl,omitempty"`
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
 	RHSM           bool     `json:"rhsm,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
 	ImageTypeTags  []string `json:"image_type_tags,omitempty"`
 	PackageSets    []string `json:"package_sets,omitempty"`
 }

--- a/internal/rpmmd/test/repository_test.go
+++ b/internal/rpmmd/test/repository_test.go
@@ -212,8 +212,9 @@ func TestOldWorkerRepositoryCompatUnmarshal(t *testing.T) {
 			},
 		},
 		{
-			repoJSON: []byte(`{"name":"all","baseurls":["http://example.com/all"],"metalink":"http://example.com/metalink","mirrorlist":"http://example.com/mirrorlist","gpgkeys":["key1","key2"],"check_gpg":true,"check_repo_gpg":true,"ignore_ssl":true,"metadata_expire":"test","rhsm":true,"image_type_tags":["one","two"],"package_sets":["1","2"],"baseurl":"http://example.com/all"}`),
+			repoJSON: []byte(`{"id":"all","name":"all","baseurls":["http://example.com/all"],"metalink":"http://example.com/metalink","mirrorlist":"http://example.com/mirrorlist","gpgkeys":["key1","key2"],"check_gpg":true,"check_repo_gpg":true,"ignore_ssl":true,"priority":10,"metadata_expire":"test","rhsm":true,"enabled":true,"image_type_tags":["one","two"],"package_sets":["1","2"],"baseurl":"http://example.com/all"}`),
 			repo: rpmmd.RepoConfig{
+				Id:             "all",
 				Name:           "all",
 				BaseURLs:       []string{"http://example.com/all"},
 				Metalink:       "http://example.com/metalink",
@@ -222,8 +223,10 @@ func TestOldWorkerRepositoryCompatUnmarshal(t *testing.T) {
 				CheckGPG:       common.ToPtr(true),
 				CheckRepoGPG:   common.ToPtr(true),
 				IgnoreSSL:      true,
+				Priority:       common.ToPtr(10),
 				MetadataExpire: "test",
 				RHSM:           true,
+				Enabled:        common.ToPtr(true),
 				ImageTypeTags:  []string{"one", "two"},
 				PackageSets:    []string{"1", "2"},
 			},
@@ -246,22 +249,25 @@ func TestOldWorkerRepositoryCompatMarshal(t *testing.T) {
 		repo     rpmmd.RepoConfig
 	}{
 		{
-			repoJSON: []byte(`{"name":"fedora","baseurls":["http://example.com/fedora"],"baseurl":"http://example.com/fedora"}`),
+			repoJSON: []byte(`{"id":"fedora","name":"fedora","baseurls":["http://example.com/fedora"],"baseurl":"http://example.com/fedora"}`),
 			repo: rpmmd.RepoConfig{
+				Id:       "fedora",
 				Name:     "fedora",
 				BaseURLs: []string{"http://example.com/fedora"},
 			},
 		},
 		{
-			repoJSON: []byte(`{"name":"multiple","baseurls":["http://example.com/one","http://example.com/two"],"baseurl":"http://example.com/one,http://example.com/two"}`),
+			repoJSON: []byte(`{"id":"multiple","name":"multiple","baseurls":["http://example.com/one","http://example.com/two"],"baseurl":"http://example.com/one,http://example.com/two"}`),
 			repo: rpmmd.RepoConfig{
+				Id:       "multiple",
 				Name:     "multiple",
 				BaseURLs: []string{"http://example.com/one", "http://example.com/two"},
 			},
 		},
 		{
-			repoJSON: []byte(`{"name":"all","baseurls":["http://example.com/all"],"metalink":"http://example.com/metalink","mirrorlist":"http://example.com/mirrorlist","gpgkeys":["key1","key2"],"check_gpg":true,"check_repo_gpg":true,"ignore_ssl":true,"metadata_expire":"test","rhsm":true,"image_type_tags":["one","two"],"package_sets":["1","2"],"baseurl":"http://example.com/all"}`),
+			repoJSON: []byte(`{"id":"all","name":"all","baseurls":["http://example.com/all"],"metalink":"http://example.com/metalink","mirrorlist":"http://example.com/mirrorlist","gpgkeys":["key1","key2"],"check_gpg":true,"check_repo_gpg":true,"priority":10,"ignore_ssl":true,"metadata_expire":"test","rhsm":true,"enabled":true,"image_type_tags":["one","two"],"package_sets":["1","2"],"baseurl":"http://example.com/all"}`),
 			repo: rpmmd.RepoConfig{
+				Id:             "all",
 				Name:           "all",
 				BaseURLs:       []string{"http://example.com/all"},
 				Metalink:       "http://example.com/metalink",
@@ -269,9 +275,11 @@ func TestOldWorkerRepositoryCompatMarshal(t *testing.T) {
 				GPGKeys:        []string{"key1", "key2"},
 				CheckGPG:       common.ToPtr(true),
 				CheckRepoGPG:   common.ToPtr(true),
+				Priority:       common.ToPtr(10),
 				IgnoreSSL:      true,
 				MetadataExpire: "test",
 				RHSM:           true,
+				Enabled:        common.ToPtr(true),
 				ImageTypeTags:  []string{"one", "two"},
 				PackageSets:    []string{"1", "2"},
 			},

--- a/internal/rpmmd/test/repository_test.go
+++ b/internal/rpmmd/test/repository_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/distro/test_distro"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/stretchr/testify/assert"
@@ -218,8 +219,8 @@ func TestOldWorkerRepositoryCompatUnmarshal(t *testing.T) {
 				Metalink:       "http://example.com/metalink",
 				MirrorList:     "http://example.com/mirrorlist",
 				GPGKeys:        []string{"key1", "key2"},
-				CheckGPG:       true,
-				CheckRepoGPG:   true,
+				CheckGPG:       common.ToPtr(true),
+				CheckRepoGPG:   common.ToPtr(true),
 				IgnoreSSL:      true,
 				MetadataExpire: "test",
 				RHSM:           true,
@@ -266,8 +267,8 @@ func TestOldWorkerRepositoryCompatMarshal(t *testing.T) {
 				Metalink:       "http://example.com/metalink",
 				MirrorList:     "http://example.com/mirrorlist",
 				GPGKeys:        []string{"key1", "key2"},
-				CheckGPG:       true,
-				CheckRepoGPG:   true,
+				CheckGPG:       common.ToPtr(true),
+				CheckRepoGPG:   common.ToPtr(true),
 				IgnoreSSL:      true,
 				MetadataExpire: "test",
 				RHSM:           true,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -582,13 +582,19 @@ func (s *Store) GetAllDistroSources(distro string) map[string]SourceConfig {
 
 func NewSourceConfig(repo rpmmd.RepoConfig, system bool) SourceConfig {
 	sc := SourceConfig{
-		Name:         repo.Name,
-		CheckGPG:     repo.CheckGPG,
-		CheckSSL:     !repo.IgnoreSSL,
-		System:       system,
-		RHSM:         repo.RHSM,
-		CheckRepoGPG: repo.CheckRepoGPG,
-		GPGKeys:      repo.GPGKeys,
+		Name:     repo.Name,
+		System:   system,
+		RHSM:     repo.RHSM,
+		GPGKeys:  repo.GPGKeys,
+		CheckSSL: !repo.IgnoreSSL,
+	}
+
+	if repo.CheckGPG != nil {
+		sc.CheckGPG = *repo.CheckGPG
+	}
+
+	if repo.CheckRepoGPG != nil {
+		sc.CheckRepoGPG = *repo.CheckRepoGPG
 	}
 
 	if len(repo.BaseURLs) != 0 {
@@ -610,9 +616,9 @@ func (s *SourceConfig) RepoConfig(name string) rpmmd.RepoConfig {
 
 	repo.Name = name
 	repo.IgnoreSSL = !s.CheckSSL
-	repo.CheckGPG = s.CheckGPG
+	repo.CheckGPG = &s.CheckGPG
 	repo.RHSM = s.RHSM
-	repo.CheckRepoGPG = s.CheckRepoGPG
+	repo.CheckRepoGPG = &s.CheckRepoGPG
 	repo.GPGKeys = s.GPGKeys
 
 	var urls []string

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,6 +4,8 @@ package store
 
 import (
 	"crypto/rand"
+	"strings"
+
 	// The use of SHA1 is valid here
 	/* #nosec G505 */
 	"crypto/sha1"
@@ -589,8 +591,8 @@ func NewSourceConfig(repo rpmmd.RepoConfig, system bool) SourceConfig {
 		GPGKeys:      repo.GPGKeys,
 	}
 
-	if repo.BaseURL != "" {
-		sc.URL = repo.BaseURL
+	if len(repo.BaseURLs) != 0 {
+		sc.URL = strings.Join(repo.BaseURLs, ",")
 		sc.Type = "yum-baseurl"
 	} else if repo.Metalink != "" {
 		sc.URL = repo.Metalink
@@ -613,8 +615,13 @@ func (s *SourceConfig) RepoConfig(name string) rpmmd.RepoConfig {
 	repo.CheckRepoGPG = s.CheckRepoGPG
 	repo.GPGKeys = s.GPGKeys
 
+	var urls []string
+	if s.URL != "" {
+		urls = []string{s.URL}
+	}
+
 	if s.Type == "yum-baseurl" {
-		repo.BaseURL = s.URL
+		repo.BaseURLs = urls
 	} else if s.Type == "yum-metalink" {
 		repo.Metalink = s.URL
 	} else if s.Type == "yum-mirrorlist" {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -422,7 +422,7 @@ func (suite *storeTest) TestNewSourceConfigWithBaseURL() {
 	myRepoConfig := rpmmd.RepoConfig{
 		Name:     "testRepo",
 		BaseURLs: []string{"testURL"},
-		CheckGPG: true,
+		CheckGPG: common.ToPtr(true),
 	}
 	expectedSource := SourceConfig{Name: "testRepo", Type: "yum-baseurl", URL: "testURL", CheckGPG: true, CheckSSL: true, System: true}
 	actualSource := NewSourceConfig(myRepoConfig, true)
@@ -433,7 +433,7 @@ func (suite *storeTest) TestNewSourceConfigWithMetaLink() {
 	myRepoConfig := rpmmd.RepoConfig{
 		Name:     "testRepo",
 		Metalink: "testURL",
-		CheckGPG: true,
+		CheckGPG: common.ToPtr(true),
 	}
 	expectedSource := SourceConfig{Name: "testRepo", Type: "yum-metalink", URL: "testURL", CheckGPG: true, CheckSSL: true, System: true}
 	actualSource := NewSourceConfig(myRepoConfig, true)
@@ -452,7 +452,7 @@ func (suite *storeTest) TestNewSourceConfigWithMirrorList() {
 
 // Test converting a SourceConfig with GPGkeys to a RepoConfig
 func (suite *storeTest) TestRepoConfigGPGKeys() {
-	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", BaseURLs: []string{"testURL"}, Metalink: "", MirrorList: "", IgnoreSSL: true, MetadataExpire: "", CheckRepoGPG: true, GPGKeys: []string{"http://path.to.gpgkeys/key.pub", "-----BEGIN PGP PUBLIC KEY BLOCK-----\nFULL GPG KEY HERE\n-----END PGP PUBLIC KEY BLOCK-----"}}
+	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", BaseURLs: []string{"testURL"}, Metalink: "", MirrorList: "", IgnoreSSL: true, MetadataExpire: "", CheckGPG: common.ToPtr(false), CheckRepoGPG: common.ToPtr(true), GPGKeys: []string{"http://path.to.gpgkeys/key.pub", "-----BEGIN PGP PUBLIC KEY BLOCK-----\nFULL GPG KEY HERE\n-----END PGP PUBLIC KEY BLOCK-----"}}
 	mySourceConfig := suite.mySourceConfig
 	mySourceConfig.Type = "yum-baseurl"
 	mySourceConfig.URL = "testURL"
@@ -463,7 +463,7 @@ func (suite *storeTest) TestRepoConfigGPGKeys() {
 }
 
 func (suite *storeTest) TestRepoConfigBaseURL() {
-	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", BaseURLs: []string{"testURL"}, Metalink: "", MirrorList: "", IgnoreSSL: true, MetadataExpire: ""}
+	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", BaseURLs: []string{"testURL"}, Metalink: "", MirrorList: "", IgnoreSSL: true, CheckGPG: common.ToPtr(false), CheckRepoGPG: common.ToPtr(false), MetadataExpire: ""}
 	suite.mySourceConfig.Type = "yum-baseurl"
 	suite.mySourceConfig.URL = "testURL"
 	actualRepo := suite.mySourceConfig.RepoConfig("testSourceConfig")
@@ -471,7 +471,7 @@ func (suite *storeTest) TestRepoConfigBaseURL() {
 }
 
 func (suite *storeTest) TestRepoConfigMetalink() {
-	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", Metalink: "testURL", MirrorList: "", IgnoreSSL: true, MetadataExpire: ""}
+	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", Metalink: "testURL", MirrorList: "", IgnoreSSL: true, CheckGPG: common.ToPtr(false), CheckRepoGPG: common.ToPtr(false), MetadataExpire: ""}
 	suite.mySourceConfig.Type = "yum-metalink"
 	suite.mySourceConfig.URL = "testURL"
 	actualRepo := suite.mySourceConfig.RepoConfig("testSourceConfig")
@@ -479,7 +479,7 @@ func (suite *storeTest) TestRepoConfigMetalink() {
 }
 
 func (suite *storeTest) TestRepoConfigMirrorlist() {
-	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", Metalink: "", MirrorList: "testURL", IgnoreSSL: true, MetadataExpire: ""}
+	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", Metalink: "", MirrorList: "testURL", IgnoreSSL: true, CheckGPG: common.ToPtr(false), CheckRepoGPG: common.ToPtr(false), MetadataExpire: ""}
 	suite.mySourceConfig.Type = "yum-mirrorlist"
 	suite.mySourceConfig.URL = "testURL"
 	actualRepo := suite.mySourceConfig.RepoConfig("testSourceConfig")

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -421,7 +421,7 @@ func (suite *storeTest) TestGetAllSourcesByID() {
 func (suite *storeTest) TestNewSourceConfigWithBaseURL() {
 	myRepoConfig := rpmmd.RepoConfig{
 		Name:     "testRepo",
-		BaseURL:  "testURL",
+		BaseURLs: []string{"testURL"},
 		CheckGPG: true,
 	}
 	expectedSource := SourceConfig{Name: "testRepo", Type: "yum-baseurl", URL: "testURL", CheckGPG: true, CheckSSL: true, System: true}
@@ -452,7 +452,7 @@ func (suite *storeTest) TestNewSourceConfigWithMirrorList() {
 
 // Test converting a SourceConfig with GPGkeys to a RepoConfig
 func (suite *storeTest) TestRepoConfigGPGKeys() {
-	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", BaseURL: "testURL", Metalink: "", MirrorList: "", IgnoreSSL: true, MetadataExpire: "", CheckRepoGPG: true, GPGKeys: []string{"http://path.to.gpgkeys/key.pub", "-----BEGIN PGP PUBLIC KEY BLOCK-----\nFULL GPG KEY HERE\n-----END PGP PUBLIC KEY BLOCK-----"}}
+	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", BaseURLs: []string{"testURL"}, Metalink: "", MirrorList: "", IgnoreSSL: true, MetadataExpire: "", CheckRepoGPG: true, GPGKeys: []string{"http://path.to.gpgkeys/key.pub", "-----BEGIN PGP PUBLIC KEY BLOCK-----\nFULL GPG KEY HERE\n-----END PGP PUBLIC KEY BLOCK-----"}}
 	mySourceConfig := suite.mySourceConfig
 	mySourceConfig.Type = "yum-baseurl"
 	mySourceConfig.URL = "testURL"
@@ -463,7 +463,7 @@ func (suite *storeTest) TestRepoConfigGPGKeys() {
 }
 
 func (suite *storeTest) TestRepoConfigBaseURL() {
-	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", BaseURL: "testURL", Metalink: "", MirrorList: "", IgnoreSSL: true, MetadataExpire: ""}
+	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", BaseURLs: []string{"testURL"}, Metalink: "", MirrorList: "", IgnoreSSL: true, MetadataExpire: ""}
 	suite.mySourceConfig.Type = "yum-baseurl"
 	suite.mySourceConfig.URL = "testURL"
 	actualRepo := suite.mySourceConfig.RepoConfig("testSourceConfig")
@@ -471,7 +471,7 @@ func (suite *storeTest) TestRepoConfigBaseURL() {
 }
 
 func (suite *storeTest) TestRepoConfigMetalink() {
-	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", BaseURL: "", Metalink: "testURL", MirrorList: "", IgnoreSSL: true, MetadataExpire: ""}
+	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", Metalink: "testURL", MirrorList: "", IgnoreSSL: true, MetadataExpire: ""}
 	suite.mySourceConfig.Type = "yum-metalink"
 	suite.mySourceConfig.URL = "testURL"
 	actualRepo := suite.mySourceConfig.RepoConfig("testSourceConfig")
@@ -479,7 +479,7 @@ func (suite *storeTest) TestRepoConfigMetalink() {
 }
 
 func (suite *storeTest) TestRepoConfigMirrorlist() {
-	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", BaseURL: "", Metalink: "", MirrorList: "testURL", IgnoreSSL: true, MetadataExpire: ""}
+	expectedRepo := rpmmd.RepoConfig{Name: "testSourceConfig", Metalink: "", MirrorList: "testURL", IgnoreSSL: true, MetadataExpire: ""}
 	suite.mySourceConfig.Type = "yum-mirrorlist"
 	suite.mySourceConfig.URL = "testURL"
 	actualRepo := suite.mySourceConfig.RepoConfig("testSourceConfig")

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -63,12 +63,12 @@ func createWeldrAPI(tempdir string, fixtureGenerator rpmmd_mock.FixtureGenerator
 	rr := reporegistry.NewFromDistrosRepoConfigs(rpmmd.DistrosRepoConfigs{
 		test_distro.TestDistroName: {
 			test_distro.TestArchName: {
-				{Name: "test-id", BaseURLs: []string{"http://example.com/test/os/x86_64"}, CheckGPG: true},
+				{Name: "test-id", BaseURLs: []string{"http://example.com/test/os/x86_64"}, CheckGPG: common.ToPtr(true)},
 			},
 		},
 		test_distro.TestDistro2Name: {
 			test_distro.TestArchName: {
-				{Name: "test-id-2", BaseURLs: []string{"http://example.com/test-2/os/x86_64"}, CheckGPG: true},
+				{Name: "test-id-2", BaseURLs: []string{"http://example.com/test-2/os/x86_64"}, CheckGPG: common.ToPtr(true)},
 			},
 		},
 	})
@@ -112,12 +112,12 @@ func createWeldrAPI2(tempdir string, fixtureGenerator rpmmd_mock.FixtureGenerato
 	rr := reporegistry.NewFromDistrosRepoConfigs(rpmmd.DistrosRepoConfigs{
 		test_distro.TestDistroName: {
 			test_distro.TestArch2Name: {
-				{Name: "test-id", BaseURLs: []string{"http://example.com/test/os/x86_64"}, CheckGPG: true},
+				{Name: "test-id", BaseURLs: []string{"http://example.com/test/os/x86_64"}, CheckGPG: common.ToPtr(true)},
 			},
 		},
 		test_distro.TestDistro2Name: {
 			test_distro.TestArch2Name: {
-				{Name: "test-id-2", BaseURLs: []string{"http://example.com/test-2/os/x86_64"}, CheckGPG: true},
+				{Name: "test-id-2", BaseURLs: []string{"http://example.com/test-2/os/x86_64"}, CheckGPG: common.ToPtr(true)},
 			},
 		},
 	})

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -63,12 +63,12 @@ func createWeldrAPI(tempdir string, fixtureGenerator rpmmd_mock.FixtureGenerator
 	rr := reporegistry.NewFromDistrosRepoConfigs(rpmmd.DistrosRepoConfigs{
 		test_distro.TestDistroName: {
 			test_distro.TestArchName: {
-				{Name: "test-id", BaseURL: "http://example.com/test/os/x86_64", CheckGPG: true},
+				{Name: "test-id", BaseURLs: []string{"http://example.com/test/os/x86_64"}, CheckGPG: true},
 			},
 		},
 		test_distro.TestDistro2Name: {
 			test_distro.TestArchName: {
-				{Name: "test-id-2", BaseURL: "http://example.com/test-2/os/x86_64", CheckGPG: true},
+				{Name: "test-id-2", BaseURLs: []string{"http://example.com/test-2/os/x86_64"}, CheckGPG: true},
 			},
 		},
 	})
@@ -112,12 +112,12 @@ func createWeldrAPI2(tempdir string, fixtureGenerator rpmmd_mock.FixtureGenerato
 	rr := reporegistry.NewFromDistrosRepoConfigs(rpmmd.DistrosRepoConfigs{
 		test_distro.TestDistroName: {
 			test_distro.TestArch2Name: {
-				{Name: "test-id", BaseURL: "http://example.com/test/os/x86_64", CheckGPG: true},
+				{Name: "test-id", BaseURLs: []string{"http://example.com/test/os/x86_64"}, CheckGPG: true},
 			},
 		},
 		test_distro.TestDistro2Name: {
 			test_distro.TestArch2Name: {
-				{Name: "test-id-2", BaseURL: "http://example.com/test-2/os/x86_64", CheckGPG: true},
+				{Name: "test-id-2", BaseURLs: []string{"http://example.com/test-2/os/x86_64"}, CheckGPG: true},
 			},
 		},
 	})

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -616,20 +616,20 @@ func TestDepsolveJobArgsCompat(t *testing.T) {
 
 	// common elements
 	baseos := rpmmd.RepoConfig{
-		Name:    "baseos",
-		BaseURL: "https://example.com/baseos",
+		Name:     "baseos",
+		BaseURLs: []string{"https://example.com/baseos"},
 	}
 	appstream := rpmmd.RepoConfig{
-		Name:    "appstream",
-		BaseURL: "https://example.com/appstream",
+		Name:     "appstream",
+		BaseURLs: []string{"https://example.com/appstream"},
 	}
 	user1 := rpmmd.RepoConfig{
-		Name:    "user1",
-		BaseURL: "https://example.com/user/1",
+		Name:     "user1",
+		BaseURLs: []string{"https://example.com/user/1"},
 	}
 	user2 := rpmmd.RepoConfig{
-		Name:    "user2",
-		BaseURL: "https://example.com/user/2",
+		Name:     "user2",
+		BaseURLs: []string{"https://example.com/user/2"},
 	}
 
 	osIncludes := []string{"os1", "os2", "os3"}

--- a/test/cases/custom-repos.sh
+++ b/test/cases/custom-repos.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/bash
+
+#
+# Test the ability to specify custom repositories
+#
+set -euo pipefail
+
+source /etc/os-release
+
+# Provision the software under test.
+/usr/libexec/osbuild-composer-test/provision.sh none
+
+source /usr/libexec/osbuild-composer-test/set-env-variables.sh
+source /usr/libexec/tests/osbuild-composer/shared_lib.sh
+
+# Set up variables.
+case "${ID}-${VERSION_ID}" in
+    fedora*)
+        ;;
+    rhel-*)
+        ;;
+    centos-*)
+        ;;
+    *)
+        echo "unsupported distro: ${ID}-${VERSION_ID}"
+        exit 1;;
+esac
+
+TEST_UUID=$(uuidgen)
+IMAGE_KEY="osbuild-composer-test-${TEST_UUID}"
+ARTIFACTS="ci-artifacts"
+mkdir -p "${ARTIFACTS}"
+
+# Set up temporary files.
+TEMPDIR=$(mktemp -d)
+BLUEPRINT_FILE=${TEMPDIR}/blueprint.toml
+COMPOSE_START=${TEMPDIR}/compose-start-${IMAGE_KEY}.json
+COMPOSE_INFO=${TEMPDIR}/compose-info-${IMAGE_KEY}.json
+
+# Workaround the problem that 'image-info' can not read SELinux labels unknown to the host from the image
+OSBUILD_LABEL=$(matchpathcon -n "$(which osbuild)")
+sudo chcon "$OSBUILD_LABEL" /usr/libexec/osbuild-composer-test/image-info
+
+# Get the compose log.
+get_compose_log () {
+    COMPOSE_ID=$1
+    LOG_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-${COMPOSE_ID}.log
+
+    # Download the logs.
+    sudo composer-cli compose log "${COMPOSE_ID}" | tee "${LOG_FILE}" > /dev/null
+}
+
+# Get the compose metadata.
+get_compose_metadata () {
+    COMPOSE_ID=$1
+    METADATA_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-${COMPOSE_ID}.json
+
+    # Download the metadata.
+    sudo composer-cli compose metadata "${COMPOSE_ID}" > /dev/null
+
+    # Find the tarball and extract it.
+    TARBALL=$(basename "$(find . -maxdepth 1 -type f -name "*-metadata.tar")")
+    sudo tar -xf "${TARBALL}" -C "${TEMPDIR}"
+    sudo rm -f "${TARBALL}"
+
+    # Move the JSON file into place.
+    sudo cat "${TEMPDIR}"/"${COMPOSE_ID}".json | jq -M '.' | tee "${METADATA_FILE}" > /dev/null
+}
+
+# Build ostree image.
+build_image() {
+    blueprint_name=$1
+    image_type=$2
+
+    # Get worker unit file so we can watch the journal.
+    WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
+    sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
+    WORKER_JOURNAL_PID=$!
+    # Stop watching the worker journal when exiting.
+    trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
+
+    # Start the compose.
+    greenprint "🚀 Starting compose"
+    sudo composer-cli --json compose start "${blueprint_name}" "${image_type}" | tee "${COMPOSE_START}"
+    COMPOSE_ID=$(get_build_info ".build_id" "${COMPOSE_START}")
+
+    # Wait for the compose to finish.
+    greenprint "⏱ Waiting for compose to finish: ${COMPOSE_ID}"
+    while true; do
+        sudo composer-cli --json compose info "${COMPOSE_ID}" | tee "${COMPOSE_INFO}" > /dev/null
+        COMPOSE_STATUS=$(get_build_info ".queue_status" "${COMPOSE_INFO}")
+
+        # Is the compose finished?
+        if [[ ${COMPOSE_STATUS} != RUNNING ]] && [[ ${COMPOSE_STATUS} != WAITING ]]; then
+            break
+        fi
+
+        # Wait 30 seconds and try again.
+        sleep 5
+    done
+
+    # Capture the compose logs from osbuild.
+    greenprint "💬 Getting compose log and metadata"
+    get_compose_log "${COMPOSE_ID}"
+    get_compose_metadata "${COMPOSE_ID}"
+
+    # Kill the journal monitor immediately and remove the trap
+    sudo pkill -P "${WORKER_JOURNAL_PID}"
+    trap - EXIT
+
+    # Did the compose finish with success?
+    if [[ ${COMPOSE_STATUS} != FINISHED ]]; then
+        echo "Something went wrong with the compose. 😢"
+        exit 1
+    fi
+}
+
+greenprint "🚀 Checking custom repositories"
+
+REPO_ID="example"
+REPO_NAME="Example repo"
+REPO_FILENAME="custom.repo"
+REPO_BASEURL="https://example.com/download/yum"
+REPO_GPGKEY_URL="https://example.com/example-key.asc"
+REPO_GPGKEY="-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+REPO_GPGCHECK="true"
+REPO_ENABLED="true"
+
+# Write a basic blueprint for our image.
+tee "$BLUEPRINT_FILE" > /dev/null << EOF
+name = "custom-repo"
+description = "A base system with custom repositories enabled"
+version = "0.0.1"
+
+[[customizations.repositories]]
+id="${REPO_ID}"
+name="${REPO_NAME}"
+filename="${REPO_FILENAME}"
+baseurls=[ "${REPO_BASEURL}" ]
+gpgkeys=[ "${REPO_GPGKEY}", "${REPO_GPGKEY_URL}" ]
+gpgcheck=${REPO_GPGCHECK}
+enabled=${REPO_ENABLED}
+EOF
+
+# Prepare the blueprint for the compose.
+greenprint "📋 Preparing custom-repo blueprint"
+sudo composer-cli blueprints push "${BLUEPRINT_FILE}"
+sudo composer-cli blueprints depsolve custom-repo
+
+build_image custom-repo qcow2
+
+# Download the image
+greenprint "📥 Downloading the image"
+sudo composer-cli compose image "${COMPOSE_ID}" > /dev/null
+IMAGE_FILENAME="${COMPOSE_ID}-disk.qcow2"
+
+greenprint "💬 Getting image info"
+INFO="$(sudo /usr/libexec/osbuild-composer-test/image-info "${IMAGE_FILENAME}")"
+
+# Clean compose and blueprints.
+greenprint "🧼 Clean up osbuild-composer"
+sudo composer-cli compose delete "${COMPOSE_ID}" > /dev/null
+sudo composer-cli blueprints delete custom-repo > /dev/null
+
+greenprint "📗 Checking results"
+CUSTOM_REPO_EXISTS=$(jq --arg r "custom.repo" 'any(.yum_repos[] | keys | .[] == $r; .)' <<< "${INFO}")
+echo "CUSTOM_REPO_EXISTS: ${CUSTOM_REPO_EXISTS}"
+if "${CUSTOM_REPO_EXISTS}"; then
+    greenprint "✅ Custom image-builder repo file has been created"
+else
+    echo "❌ Custom repo has not been created"
+    exit 1
+fi
+
+REPO_CONTAINS_PATH_TO_KEY=$(jq --arg r "$REPO_ID" --arg k "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-$REPO_ID-0" \
+  '.yum_repos[]."custom.repo" | to_entries | map(select(.key == $r) | .value) | any(.[] | .gpgkey | contains($k); .)' \
+  <<< "${INFO}")
+echo "REPO_CONTAINS_PATH_TO_KEY ${REPO_CONTAINS_PATH_TO_KEY}"
+if "${REPO_CONTAINS_PATH_TO_KEY}"; then
+    greenprint "✅ Custom image-builder repo file contains gpgkey file location"
+else
+    echo "❌ Custom repo does not contain gpgkey file location"
+    exit 1
+fi
+
+REPO_CONTAINS_KEY_URL=$(jq --arg r "$REPO_ID" --arg k "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-$REPO_ID-0" \
+  '.yum_repos[]."custom.repo" | to_entries | map(select(.key == $r) | .value) | any(.[] | .gpgkey | contains($k); .)' \
+  <<< "${INFO}")
+echo "REPO_CONTAINS_KEY_URL: ${REPO_CONTAINS_KEY_URL}"
+if "${REPO_CONTAINS_KEY_URL}"; then
+    greenprint "✅ Custom image-builder repo file contains gpgkey url"
+else
+    echo "❌ Custom repo does not contain gpgkey url"
+    exit 1
+fi
+
+echo "🎉 All tests passed."
+exit 0

--- a/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5464,6 +5479,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5583,6 +5619,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5605,6 +5650,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7383,6 +7433,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5864,6 +5879,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5974,6 +6010,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5996,6 +6041,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7893,6 +7943,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5536,6 +5551,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5656,6 +5692,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5678,6 +5723,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7494,6 +7544,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/centos_9-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-aarch64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -4847,6 +4862,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -4968,6 +5004,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -4990,6 +5035,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -6652,6 +6702,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/centos_9-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-ppc64le-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5479,6 +5494,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5590,6 +5626,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5612,6 +5657,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7411,6 +7461,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/centos_9-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-s390x-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5720,6 +5735,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5821,6 +5857,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5843,6 +5888,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7644,6 +7694,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/centos_9-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-x86_64-qcow2_customize-boot.json
@@ -146,6 +146,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5215,6 +5230,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5337,6 +5373,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5359,6 +5404,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7098,6 +7148,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/fedora_36-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-qcow2_customize-boot.json
@@ -154,6 +154,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5308,6 +5323,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5429,6 +5465,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5451,6 +5496,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7147,6 +7197,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/fedora_36-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-qcow2_customize-boot.json
@@ -154,6 +154,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5452,6 +5467,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5574,6 +5610,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5596,6 +5641,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7360,6 +7410,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/fedora_37-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5306,6 +5321,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5427,6 +5463,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5449,6 +5494,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7145,6 +7195,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/fedora_37-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5418,6 +5433,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5540,6 +5576,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5562,6 +5607,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7314,6 +7364,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/fedora_38-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5314,6 +5329,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5435,6 +5471,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5457,6 +5502,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7156,6 +7206,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/fedora_38-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5538,6 +5553,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5660,6 +5696,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5682,6 +5727,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7476,6 +7526,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/fedora_39-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5490,6 +5505,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5611,6 +5647,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5633,6 +5678,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7392,6 +7442,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/fedora_39-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5570,6 +5585,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [
@@ -5692,6 +5728,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5714,6 +5759,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7517,6 +7567,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_7-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-qcow2-boot.json
@@ -29,7 +29,7 @@
       },
       {
         "name": "azure-rhui-7",
-        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-rhui-azure-20220530"
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-rhui-azure-20230418"
       }
     ],
     "filename": "disk.qcow2",

--- a/test/data/manifests/rhel_7-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-qcow2_customize-boot.json
@@ -29,7 +29,7 @@
       },
       {
         "name": "azure-rhui-7",
-        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-rhui-azure-20220530"
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-rhui-azure-20230418"
       }
     ],
     "filename": "disk.qcow2",
@@ -154,6 +154,21 @@
             "path": "/etc/empty_file.txt",
             "user": 0,
             "group": 0
+          }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
           }
         ]
       }
@@ -1987,6 +2002,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "yum-plugins": {
@@ -2154,6 +2190,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2176,6 +2221,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -3816,6 +3866,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_8-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2298,6 +2313,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2438,6 +2474,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2460,6 +2505,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4301,6 +4351,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_8-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2448,6 +2463,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2579,6 +2615,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2601,6 +2646,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4561,6 +4611,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_8-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-s390x-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2465,6 +2480,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2587,6 +2623,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2609,6 +2654,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4556,6 +4606,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_8-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2328,6 +2343,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2469,6 +2505,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2491,6 +2536,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4373,6 +4423,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2295,6 +2310,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2435,6 +2471,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2457,6 +2502,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4295,6 +4345,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2445,6 +2460,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2576,6 +2612,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2598,6 +2643,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4555,6 +4605,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2453,6 +2468,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2575,6 +2611,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2597,6 +2642,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4535,6 +4585,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2325,6 +2340,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2466,6 +2502,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2488,6 +2533,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4367,6 +4417,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_87-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2298,6 +2313,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2438,6 +2474,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2460,6 +2505,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4301,6 +4351,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_87-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-ppc64le-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2448,6 +2463,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2579,6 +2615,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2601,6 +2646,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4561,6 +4611,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_87-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-s390x-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2465,6 +2480,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2587,6 +2623,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2609,6 +2654,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4556,6 +4606,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_87-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2328,6 +2343,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2469,6 +2505,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2491,6 +2536,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4373,6 +4423,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_88-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2298,6 +2313,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2438,6 +2474,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2460,6 +2505,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4301,6 +4351,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_88-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_88-ppc64le-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2448,6 +2463,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2579,6 +2615,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2601,6 +2646,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4561,6 +4611,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_88-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_88-s390x-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2465,6 +2480,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2587,6 +2623,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2609,6 +2654,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4556,6 +4606,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_88-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2328,6 +2343,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2469,6 +2505,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2491,6 +2536,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4373,6 +4423,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_89-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_89-aarch64-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2298,6 +2313,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2438,6 +2474,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2460,6 +2505,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4301,6 +4351,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_89-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_89-ppc64le-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2448,6 +2463,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2579,6 +2615,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2601,6 +2646,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4561,6 +4611,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_89-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_89-s390x-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2459,6 +2474,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2581,6 +2617,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2603,6 +2648,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4547,6 +4597,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_89-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_89-x86_64-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2328,6 +2343,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2469,6 +2505,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2491,6 +2536,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4373,6 +4423,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_9-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5023,6 +5038,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -5165,6 +5201,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5187,6 +5232,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -6903,6 +6953,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_9-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_9-ppc64le-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5631,6 +5646,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -5763,6 +5799,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5785,6 +5830,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7638,6 +7688,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_9-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_9-s390x-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5872,6 +5887,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -5994,6 +6030,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -6016,6 +6061,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7871,6 +7921,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_9-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5359,6 +5374,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -5502,6 +5538,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5524,6 +5569,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7314,6 +7364,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2053,6 +2068,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2195,6 +2231,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2217,6 +2262,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -3909,6 +3959,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2284,6 +2299,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2416,6 +2452,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2438,6 +2483,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4270,6 +4320,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2366,6 +2381,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2488,6 +2524,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2510,6 +2555,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4338,6 +4388,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
@@ -138,6 +138,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -2185,6 +2200,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -2328,6 +2364,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -2350,6 +2395,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -4122,6 +4172,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
@@ -136,6 +136,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5280,6 +5295,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -5422,6 +5458,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5444,6 +5489,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7205,6 +7255,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       },

--- a/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
@@ -136,6 +136,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5888,6 +5903,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -6020,6 +6056,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -6042,6 +6087,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7940,6 +7990,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       },

--- a/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
@@ -136,6 +136,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -6112,6 +6127,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -6234,6 +6270,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -6256,6 +6301,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -8153,6 +8203,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       },

--- a/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
@@ -136,6 +136,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5616,6 +5631,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -5759,6 +5795,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5781,6 +5826,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7616,6 +7666,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       },

--- a/test/data/manifests/rhel_92-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -4999,6 +5014,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -5141,6 +5177,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5163,6 +5208,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -6876,6 +6926,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_92-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-ppc64le-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5639,6 +5654,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -5771,6 +5807,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5793,6 +5838,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7649,6 +7699,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_92-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-s390x-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5880,6 +5895,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -6002,6 +6038,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -6024,6 +6069,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7882,6 +7932,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_92-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5359,6 +5374,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -5502,6 +5538,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5524,6 +5569,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7314,6 +7364,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_93-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_93-aarch64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -4999,6 +5014,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -5141,6 +5177,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5163,6 +5208,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -6876,6 +6926,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_93-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_93-ppc64le-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5631,6 +5646,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -5763,6 +5799,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5785,6 +5830,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7638,6 +7688,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_93-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_93-s390x-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5848,6 +5863,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -5970,6 +6006,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5992,6 +6037,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7844,6 +7894,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/test/data/manifests/rhel_93-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_93-x86_64-qcow2_customize-boot.json
@@ -140,6 +140,21 @@
             "user": 0,
             "group": 0
           }
+        ],
+        "repositories": [
+          {
+            "id": "example",
+            "baseurls": [
+              "https://example.com/download/yum"
+            ],
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "name": "Example repo",
+            "enabled": true,
+            "gpgcheck": true,
+            "repo_gpgcheck": false
+          }
         ]
       }
     }
@@ -5359,6 +5374,27 @@
             }
           },
           {
+            "type": "org.osbuild.yum.repos",
+            "options": {
+              "filename": "example.repo",
+              "repos": [
+                {
+                  "id": "example",
+                  "baseurl": [
+                    "https://example.com/download/yum"
+                  ],
+                  "enabled": true,
+                  "gpgkey": [
+                    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0"
+                  ],
+                  "name": "Example repo",
+                  "gpgcheck": true,
+                  "repo_gpgcheck": false
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.rhsm",
             "options": {
               "dnf-plugins": {
@@ -5502,6 +5538,15 @@
                     "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                   }
                 ]
+              },
+              "file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1"
+                  }
+                ]
               }
             },
             "options": {
@@ -5524,6 +5569,11 @@
                 {
                   "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                   "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1/sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1",
+                  "to": "tree:///etc/pki/rpm-gpg/RPM-GPG-KEY-example-0",
                   "remove_destination": true
                 }
               ]
@@ -7314,6 +7364,10 @@
           "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
             "encoding": "base64",
             "data": ""
+          },
+          "sha256:e6e7e40c00b4d4aceb64629e41b6f31904359447a47f9c2eb603eb530804c5b1": {
+            "encoding": "base64",
+            "data": "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUdpQkdSQlNKVVJCQUN6Q29lOVVOZnhPVWlGTHE5YjYwd2VTQkZkcjM5bUxWaXNjZWNEV0FUTnZYdGdSb0svCnhsLzRxcGF5ekFMUkNRMkVrL3BNcmJLUEYvM25nRUN1QnY3UytySTRuL3JJaWE0Rk5jcXpZZVpBejRERTROUC8KZVVHdno0OXRXaG1IMTdoWC9ybUY5a3o1a0xxMmJEWkk0R0RnWlcvb01EZHQyaXZqMDkyTGptOWpSd0NneVF5MwpXRUs2Ukp2SWNTRWg5dmJkd1ZkTVBPY0QvaUhxTmVqVE1Gd0d5WmZDV0IwZUlPb3hVT1VuL1pacEVMVEwyVXBXCkdkdUNmM3R4YjVTa0s3TStXRGJiMFM1SXZOWG9pMHRjMTNTVGlENk94ZzJPOVBrU3Z2WWIrOHp4bGhOb1NUd3kKNTRqN1JmNUZsblEzVEFGZmp0UTVMQ3g1NkxLSzczajRSanZLVy8va3RtNW41NGV4c2dvOVJ5L2UxMlQ0NmRSZwo3dElsQS85MXJ6TG01N1F5YzczQTd6amdJemVmOU82VjVaem93QytwcC9qZmI1cFM5aFhnUk9la0xrTWdYMHZnCmlBNXJNNU9wcUs0YkFyVlAxbFJXbkx5dmdod08rVFc3NjNSVnVYbFMwc2Nmek15NGcwTmdyRzZqN1RJT0tFcXoKNHhReE91d2t1ZHFpUXIva09xS3VMeFFCWGErNU1Ka3loZlBtcVl3NXdwcXlDd0ZhLzdRNGIzTmlkV2xzWkNCMApaWE4wSUNodmMySjFhV3hrSUhSbGMzUWdaM0JuYTJWNUtTQThiM05pZFdsc1pFQmxlR0Z0Y0d4bExtTnZiVDZJCmV3UVRFUUlBT3hZaEJHQjh3b2lFUFJLQk84Q3IzMWx1bHBRZ01lanpCUUprUVVpVkFoc2pCUXNKQ0FjQ0FpSUMKQmhVS0NRZ0xBZ1FXQWdNQkFoNEhBaGVBQUFvSkVGbHVscFFnTWVqemFwTUFvTG1VZzFtTkRUUlVhQ3JOL2Z6bQpIWUxITDZqa0FKOXBFS2tKUWlIQjZTZkQwZmtpRDJHa0VMWUx1YmtCRFFSa1FVaVZFQVFBbEFBWHJRNTcydnV3CnhJM1c4R1NabU9RaUFZT1FtT0tSbG9MRXk2VlozTlNPYjl5MlRYajMzUVRrSkJQT00xN0F6QjdFK1lqWnJwVXQKZ2w2TGxYbWZqTWNKQWNYaEZhVUJDaWxBY013TWxMbDdEdG5Ta0xuTElYWW1IaU4wdjgzQkgvSDBFUHV0T2M1bAowUUl5dWd1dGlmcDlTSnoyK0VXcEM0YmpBN0dGa1E4QUF3VUQvMXRMRUdxQ0ozN084Z2Z6WXQyUFdrcUJFb09ZCjBaM3p3VlM2UFdXL0lJa2FrOWRBSjBpWDVOTWVGV3B6Rk5mdmlEUEhxaEVkVVI1NXpzeHlVWklabENYNWp3bUEKdDdxbTNjYkg0SE5VMU9ncTNROWh5a2JUUFdQWlZrcHZObS9UTzhUQTJicmhrejNudVM4SGJtaCtyalhGT1NaagpEUUJVeEl0dXVqMmhocFFFaUdBRUdCRUNBQ0FXSVFSZ2ZNS0loRDBTZ1R2QXE5OVpicGFVSURIbzh3VUNaRUZJCmxRSWJEQUFLQ1JCWmJwYVVJREhvODNmUUFLREhnRklhZ2dhTnN2RFFrajd2TVgwZmVjSFJoQUNmUzlCdnhuMlcKV1NiNlQrZ0NobVlCc2Vad2svaz0KPURRM2kKLS0tLS1FTkQgUEdQIFBVQkxJQyBLRVkgQkxPQ0stLS0tLQo="
           }
         }
       }

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -943,6 +943,21 @@
               "user": 0,
               "group": 0
             }
+          ],
+          "repositories": [
+            {
+              "id": "example",
+              "name": "Example repo",
+              "baseurls": [
+                "https://example.com/download/yum"
+              ],
+              "gpgcheck": true,
+              "enabled": true,
+              "repo_gpgcheck": false,
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
           ]
         }
       }
@@ -1062,6 +1077,21 @@
                 "path": "/etc/empty_file.txt",
                 "user": 0,
                 "group": 0
+              }
+            ],
+            "repositories": [
+              {
+                "id": "example",
+                "name": "Example repo",
+                "baseurls": [
+                  "https://example.com/download/yum"
+                ],
+                "gpgcheck": true,
+                "enabled": true,
+                "repo_gpgcheck": false,
+                "gpgkeys": [
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQGiBGRBSJURBACzCoe9UNfxOUiFLq9b60weSBFdr39mLViscecDWATNvXtgRoK/\nxl/4qpayzALRCQ2Ek/pMrbKPF/3ngECuBv7S+rI4n/rIia4FNcqzYeZAz4DE4NP/\neUGvz49tWhmH17hX/rmF9kz5kLq2bDZI4GDgZW/oMDdt2ivj092Ljm9jRwCgyQy3\nWEK6RJvIcSEh9vbdwVdMPOcD/iHqNejTMFwGyZfCWB0eIOoxUOUn/ZZpELTL2UpW\nGduCf3txb5SkK7M+WDbb0S5IvNXoi0tc13STiD6Oxg2O9PkSvvYb+8zxlhNoSTwy\n54j7Rf5FlnQ3TAFfjtQ5LCx56LKK73j4RjvKW//ktm5n54exsgo9Ry/e12T46dRg\n7tIlA/91rzLm57Qyc73A7zjgIzef9O6V5ZzowC+pp/jfb5pS9hXgROekLkMgX0vg\niA5rM5OpqK4bArVP1lRWnLyvghwO+TW763RVuXlS0scfzMy4g0NgrG6j7TIOKEqz\n4xQxOuwkudqiQr/kOqKuLxQBXa+5MJkyhfPmqYw5wpqyCwFa/7Q4b3NidWlsZCB0\nZXN0IChvc2J1aWxkIHRlc3QgZ3Bna2V5KSA8b3NidWlsZEBleGFtcGxlLmNvbT6I\newQTEQIAOxYhBGB8woiEPRKBO8Cr31lulpQgMejzBQJkQUiVAhsjBQsJCAcCAiIC\nBhUKCQgLAgQWAgMBAh4HAheAAAoJEFlulpQgMejzapMAoLmUg1mNDTRUaCrN/fzm\nHYLHL6jkAJ9pEKkJQiHB6SfD0fkiD2GkELYLubkBDQRkQUiVEAQAlAAXrQ572vuw\nxI3W8GSZmOQiAYOQmOKRloLEy6VZ3NSOb9y2TXj33QTkJBPOM17AzB7E+YjZrpUt\ngl6LlXmfjMcJAcXhFaUBCilAcMwMlLl7DtnSkLnLIXYmHiN0v83BH/H0EPutOc5l\n0QIyugutifp9SJz2+EWpC4bjA7GFkQ8AAwUD/1tLEGqCJ37O8gfzYt2PWkqBEoOY\n0Z3zwVS6PWW/IIkak9dAJ0iX5NMeFWpzFNfviDPHqhEdUR55zsxyUZIZlCX5jwmA\nt7qm3cbH4HNU1Ogq3Q9hykbTPWPZVkpvNm/TO8TA2brhkz3nuS8Hbmh+rjXFOSZj\nDQBUxItuuj2hhpQEiGAEGBECACAWIQRgfMKIhD0SgTvAq99ZbpaUIDHo8wUCZEFI\nlQIbDAAKCRBZbpaUIDHo83fQAKDHgFIaggaNsvDQkj7vMX0fecHRhACfS9Bvxn2W\nWSb6T+gChmYBseZwk/k=\n=DQ3i\n-----END PGP PUBLIC KEY BLOCK-----\n"
+                ]
               }
             ]
           },


### PR DESCRIPTION
This pull request includes:
The ability to specify repo customizations so that custom repositories will be saved to
the `/etc/yum.repos.d` directory in the built image. 

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
