### PR TITLE
Update customized test manifests to include bluez

### DIFF
--- a/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -1657,6 +1661,14 @@
                   },
                   {
                     "id": "sha256:a06f199eb558420baa213d65e30e85e754eacadd97dbd4f05f0c108a9a0fd7a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40a4e84e4d3f2e14fa2d730ad6a6f03b1d31f793fb8c1697d5fe7b9d18a39abb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6102,6 +6114,9 @@
           "sha256:406140d0a2d6fe921875898b24b91376870fb9ab1b1baf7778cff060bbbe0d72": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/unbound-libs-1.7.3-17.el8.aarch64.rpm"
           },
+          "sha256:40a4e84e4d3f2e14fa2d730ad6a6f03b1d31f793fb8c1697d5fe7b9d18a39abb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/bluez-5.56-3.el8.aarch64.rpm"
+          },
           "sha256:4156413385dce1692e46bc8bc42c74bc6b4f9748230bbd4a2134a17e69ea79d9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libini_config-1.3.1-39.el8.aarch64.rpm"
           },
@@ -9079,6 +9094,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/bind-export-libs-9.11.36-2.el8.aarch64.rpm",
         "checksum": "sha256:a06f199eb558420baa213d65e30e85e754eacadd97dbd4f05f0c108a9a0fd7a0",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/bluez-5.56-3.el8.aarch64.rpm",
+        "checksum": "sha256:40a4e84e4d3f2e14fa2d730ad6a6f03b1d31f793fb8c1697d5fe7b9d18a39abb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -1705,6 +1709,14 @@
                   },
                   {
                     "id": "sha256:61ef33407ce28bd2476544ed9d5b21b10134a5e63ccff1c80b3fbb20ae4c2f66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f99a22d0596b33d7d59ef478bdff0384ce4b9448e52066c4a3f05f6193f7803",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6588,6 +6600,9 @@
           "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/diffutils-3.6-6.el8.ppc64le.rpm"
           },
+          "sha256:4f99a22d0596b33d7d59ef478bdff0384ce4b9448e52066c4a3f05f6193f7803": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/bluez-5.56-3.el8.ppc64le.rpm"
+          },
           "sha256:4fc1c84b4434df8a5ccd960d906896e4094236f43ad4aea083a12fb5b8a824f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/gdk-pixbuf2-2.36.12-5.el8.ppc64le.rpm"
           },
@@ -9649,6 +9664,16 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/bind-export-libs-9.11.36-2.el8.ppc64le.rpm",
         "checksum": "sha256:61ef33407ce28bd2476544ed9d5b21b10134a5e63ccff1c80b3fbb20ae4c2f66",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/bluez-5.56-3.el8.ppc64le.rpm",
+        "checksum": "sha256:4f99a22d0596b33d7d59ef478bdff0384ce4b9448e52066c4a3f05f6193f7803",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -1705,6 +1709,14 @@
                   },
                   {
                     "id": "sha256:0caa72888379f82fae1bc8f448bcf0dbaead20e92f2ef4c714afadf8979c3181",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55c14cc832750339fe5d988cb398f1959622a76d987744fa5cfbe1f98e960bd7",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6321,6 +6333,9 @@
           "sha256:54609dd070a57a14a6103f0c06bea99bb0a4e568d1fbc6a22b8ba67c954d90bf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/ncurses-libs-6.1-9.20180224.el8.x86_64.rpm"
           },
+          "sha256:55c14cc832750339fe5d988cb398f1959622a76d987744fa5cfbe1f98e960bd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bluez-5.56-3.el8.x86_64.rpm"
+          },
           "sha256:561b5fdadd60370b5d0a91b7ed35df95d7f60650cbade8c7e744323982ac82db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/chkconfig-1.19.1-1.el8.x86_64.rpm"
           },
@@ -9250,6 +9265,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/biosdevname-0.7.3-2.el8.x86_64.rpm",
         "checksum": "sha256:0caa72888379f82fae1bc8f448bcf0dbaead20e92f2ef4c714afadf8979c3181",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bluez-5.56-3.el8.x86_64.rpm",
+        "checksum": "sha256:55c14cc832750339fe5d988cb398f1959622a76d987744fa5cfbe1f98e960bd7",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-aarch64-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -1776,6 +1780,14 @@
                   },
                   {
                     "id": "sha256:adbea9afe78b2f67de854fdf5440326dda5383763797eb9ac486969edeecaef0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7d855d0ba4d5cd6e6a51f086c72f9f63accdbce0f10cab833e811782c476e44",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6147,6 +6159,9 @@
           "sha256:c79fa96aa7fb447975497dd50c94002ee73d01171343f8ee14032d06adb58a92": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/fonts-filesystem-2.0.5-7.el9.1.noarch.rpm"
           },
+          "sha256:c7d855d0ba4d5cd6e6a51f086c72f9f63accdbce0f10cab833e811782c476e44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/bluez-5.56-6.el9.aarch64.rpm"
+          },
           "sha256:c862cafcf9eef105043a07035a4d78fee7752344c236dd9e497650b7ffa675c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20230101/Packages/rpm-plugin-systemd-inhibit-4.16.1.3-21.el9.aarch64.rpm"
           },
@@ -8487,6 +8502,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/bash-5.1.8-6.el9.aarch64.rpm",
         "checksum": "sha256:adbea9afe78b2f67de854fdf5440326dda5383763797eb9ac486969edeecaef0",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "6.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/bluez-5.56-6.el9.aarch64.rpm",
+        "checksum": "sha256:c7d855d0ba4d5cd6e6a51f086c72f9f63accdbce0f10cab833e811782c476e44",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-ppc64le-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -2464,6 +2468,14 @@
                   },
                   {
                     "id": "sha256:9f9f06e225620fac21139163bef58102acca8e589098ce549af21df43beb120b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbad0ce273c27454325491a7014084275d5ef0b6cb119b2aebd348afd881efa6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -7182,6 +7194,9 @@
           "sha256:fb8c67957abedd57e6ba2f5f6d191291598af351079aa61fdf1aeeecf67fd967": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20221124/Packages/systemd-udev-250-11.el9.ppc64le.rpm"
           },
+          "sha256:fbad0ce273c27454325491a7014084275d5ef0b6cb119b2aebd348afd881efa6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20221124/Packages/bluez-5.56-6.el9.ppc64le.rpm"
+          },
           "sha256:fbafe805fea4fcfc03449684589e80db162894d7f09a972cf9370200aee57bbb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20221124/Packages/zlib-1.2.11-35.el9.ppc64le.rpm"
           },
@@ -10106,6 +10121,16 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20221124/Packages/bc-1.07.1-14.el9.ppc64le.rpm",
         "checksum": "sha256:9f9f06e225620fac21139163bef58102acca8e589098ce549af21df43beb120b",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "6.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20221124/Packages/bluez-5.56-6.el9.ppc64le.rpm",
+        "checksum": "sha256:fbad0ce273c27454325491a7014084275d5ef0b6cb119b2aebd348afd881efa6",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-s390x-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -2841,6 +2845,14 @@
                   },
                   {
                     "id": "sha256:033abec66b742dff9768dc97aea81b4ac9662c8129ee1aca541f8d4d9e02ccf5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33c00415720bba4b323bb36b039de0666aab6f2b06e84e3db9b276d29729b507",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6371,6 +6383,9 @@
           },
           "sha256:334c9689bd1dab7d37a807bb167c43b0dfcddc4c0ef042d6594202dec9f39221": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20221124/Packages/libeconf-0.4.1-2.el9.s390x.rpm"
+          },
+          "sha256:33c00415720bba4b323bb36b039de0666aab6f2b06e84e3db9b276d29729b507": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20221124/Packages/bluez-5.56-6.el9.s390x.rpm"
           },
           "sha256:33dd7f7bdf677e4a235d57afe612b76a681700cc1db3018fac9f74e1145e3e99": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20221124/Packages/python3-3.9.14-1.el9.s390x.rpm"
@@ -10810,6 +10825,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20221124/Packages/bash-5.1.8-5.el9.s390x.rpm",
         "checksum": "sha256:033abec66b742dff9768dc97aea81b4ac9662c8129ee1aca541f8d4d9e02ccf5",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "6.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20221124/Packages/bluez-5.56-6.el9.s390x.rpm",
+        "checksum": "sha256:33c00415720bba4b323bb36b039de0666aab6f2b06e84e3db9b276d29729b507",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-x86_64-qcow2_customize-boot.json
@@ -31,6 +31,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -2015,6 +2019,14 @@
                   },
                   {
                     "id": "sha256:09f700a94e187a74f6f4a5f750082732e193d41392a85f042bdeb0bcbabe0a1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d91ac027660a536ce829ada04371dfea803b1b253d5ee292dd3c4478485f9df7",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6644,6 +6656,9 @@
           "sha256:d8b557f4a808e6ec9052ad1037f5b18b7e042d05a9556c4d3a8605378e59348d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/firewalld-1.2.1-1.el9.noarch.rpm"
           },
+          "sha256:d91ac027660a536ce829ada04371dfea803b1b253d5ee292dd3c4478485f9df7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bluez-5.56-6.el9.x86_64.rpm"
+          },
           "sha256:da167e41efd19cf25fd1c708b6f123d0203824324b14dd32401d49f2aa0ef0a6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/p11-kit-0.24.1-2.el9.x86_64.rpm"
           },
@@ -9223,6 +9238,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bash-5.1.8-6.el9.x86_64.rpm",
         "checksum": "sha256:09f700a94e187a74f6f4a5f750082732e193d41392a85f042bdeb0bcbabe0a1f",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "6.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bluez-5.56-6.el9.x86_64.rpm",
+        "checksum": "sha256:d91ac027660a536ce829ada04371dfea803b1b253d5ee292dd3c4478485f9df7",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-qcow2_customize-boot.json
@@ -39,6 +39,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [

--- a/test/data/manifests/fedora_36-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-qcow2_customize-boot.json
@@ -39,6 +39,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [

--- a/test/data/manifests/fedora_37-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [

--- a/test/data/manifests/fedora_37-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [

--- a/test/data/manifests/fedora_38-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [

--- a/test/data/manifests/fedora_38-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [

--- a/test/data/manifests/rhel_7-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-qcow2_customize-boot.json
@@ -40,6 +40,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -2775,6 +2779,9 @@
           "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-pem-1.0.3-7.el7.x86_64.rpm"
           },
+          "sha256:72e259b72e9345c09d6d06056fd93f8ea31c10cd69e78c95899f44a8777a04b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libical-3.0.3-2.el7.x86_64.rpm"
+          },
           "sha256:732503bcffcd921ba9b084090852726b5d443c82a2fc3bbe4a7928eb743c8061": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libbasicobjects-0.1.1-32.el7.x86_64.rpm"
           },
@@ -2867,6 +2874,9 @@
           },
           "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-2.5-14.el7.x86_64.rpm"
+          },
+          "sha256:86fa352092d56520903a819fc02fb0bc7396ef86df9b89f7b6689dc492ba392d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bluez-5.44-7.el7.x86_64.rpm"
           },
           "sha256:88e7108ff671d4e161a1fc1bd72c41c4cec8e80b74c5300b327183551824cc49": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpath_utils-0.2.1-32.el7.x86_64.rpm"
@@ -2966,6 +2976,9 @@
           },
           "sha256:9ae89ba6e5533df2ee1af8cab3ed8fd6be99a432eff3519783095a37cd710a66": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-config-server-1.18.8-1.el7.noarch.rpm"
+          },
+          "sha256:9b8a185b88e6d414b5d744aabd5817950d112a8f351bff3c2a01b1ab2b766b1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libicu-50.2-4.el7_7.x86_64.rpm"
           },
           "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgudev1-219-78.el7.x86_64.rpm"
@@ -3614,6 +3627,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/biosdevname-0.7.3-2.el7.x86_64.rpm",
         "checksum": "sha256:838e27cadbb77a140e9c26664d37cd22d38f22500b8e9b587405e926bbb7c18f"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bluez-5.44-7.el7.x86_64.rpm",
+        "checksum": "sha256:86fa352092d56520903a819fc02fb0bc7396ef86df9b89f7b6689dc492ba392d"
       },
       {
         "name": "btrfs-progs",
@@ -4766,6 +4788,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgudev1-219-78.el7.x86_64.rpm",
         "checksum": "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43"
+      },
+      {
+        "name": "libical",
+        "epoch": 0,
+        "version": "3.0.3",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libical-3.0.3-2.el7.x86_64.rpm",
+        "checksum": "sha256:72e259b72e9345c09d6d06056fd93f8ea31c10cd69e78c95899f44a8777a04b5"
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "50.2",
+        "release": "4.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libicu-50.2-4.el7_7.x86_64.rpm",
+        "checksum": "sha256:9b8a185b88e6d414b5d744aabd5817950d112a8f351bff3c2a01b1ab2b766b1e"
       },
       {
         "name": "libidn",

--- a/test/data/manifests/rhel_8-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -713,6 +717,9 @@
                   },
                   {
                     "id": "sha256:21abf221b294dabd9f54246e990dc0294937ad3ab54c357167401f7bfb2e74bd"
+                  },
+                  {
+                    "id": "sha256:124aa6cddbdf52f1c60fdefd002b3a69532f07b5a4029be8b8424037589e4b73"
                   },
                   {
                     "id": "sha256:14df7263bcc35cb6633321f36149ddadd479ca334798bb33544109a2c61a6213"
@@ -2724,6 +2731,9 @@
           },
           "sha256:1143ac623a74d7feaaaf293c18d942d243248f6356628f87216670c10d11687b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/json-glib-1.4.4-1.el8.aarch64.rpm"
+          },
+          "sha256:124aa6cddbdf52f1c60fdefd002b3a69532f07b5a4029be8b8424037589e4b73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.aarch64.rpm"
           },
           "sha256:137a8ee6c1f8500fa0de50d6bf894e9aaeb04dd2fb4d6e347e2b4f7db89a948a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libX11-1.6.8-5.el8.aarch64.rpm"
@@ -5822,6 +5832,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bind-export-libs-9.11.36-5.el8.aarch64.rpm",
         "checksum": "sha256:21abf221b294dabd9f54246e990dc0294937ad3ab54c357167401f7bfb2e74bd"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.aarch64.rpm",
+        "checksum": "sha256:124aa6cddbdf52f1c60fdefd002b3a69532f07b5a4029be8b8424037589e4b73"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_8-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -731,6 +735,9 @@
                   },
                   {
                     "id": "sha256:93a2f00fd5ff983abf2923d2fe0cde54628302aa3e180ccec7e5686f74a62bfb"
+                  },
+                  {
+                    "id": "sha256:cede866e5700f9fce4664ef7731a6e208eb598f2391642b9aefd708d225f3ed1"
                   },
                   {
                     "id": "sha256:e695072a3790e6c1229abfa1f703f081941be82064a9faab686cb7122838759f"
@@ -4050,6 +4057,9 @@
           "sha256:ce4c3c1a7b545ba47da5993965acb341461487edd2f3f0f2eba662e85ac4ff24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.7-20221015/Packages/ncurses-libs-6.1-9.20180224.el8.ppc64le.rpm"
           },
+          "sha256:cede866e5700f9fce4664ef7731a6e208eb598f2391642b9aefd708d225f3ed1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.ppc64le.rpm"
+          },
           "sha256:cf726c1b70ee7c004e9fc03becd099ad6b3fede8efd8a99610e9a204b75a3cbb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-appstream-n8.7-20221015/Packages/insights-client-3.1.7-8.el8.noarch.rpm"
           },
@@ -6136,6 +6146,15 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.7-20221015/Packages/bind-export-libs-9.11.36-5.el8.ppc64le.rpm",
         "checksum": "sha256:93a2f00fd5ff983abf2923d2fe0cde54628302aa3e180ccec7e5686f74a62bfb"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.ppc64le.rpm",
+        "checksum": "sha256:cede866e5700f9fce4664ef7731a6e208eb598f2391642b9aefd708d225f3ed1"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_8-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-s390x-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -805,6 +809,9 @@
                   },
                   {
                     "id": "sha256:e22b5160fff19bdd88bc0d3097584970f476ca09397ae120e02022296b984f7a"
+                  },
+                  {
+                    "id": "sha256:ead363f014185dd1882513c5309f780104e0c52e6adf093d8a5ff0c3324bcdca"
                   },
                   {
                     "id": "sha256:e134da086a66848af20f21dcebbeca19fde6a4af3016a09d5fde3984317e2c33"
@@ -4216,6 +4223,9 @@
           "sha256:ea8e98525aaeb63aea1e85a98ea93207cb2a88c82e921047e56f50a13b74a4fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.7-20221015/Packages/prefixdevname-0.1.0-6.el8.s390x.rpm"
           },
+          "sha256:ead363f014185dd1882513c5309f780104e0c52e6adf093d8a5ff0c3324bcdca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.s390x.rpm"
+          },
           "sha256:eaea4907a76867e75875d14a5ec659f6a80dfca805a21d3d1d3f55b4329cd8f1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-appstream-n8.7-20221015/Packages/rhc-0.2.1-9.el8.s390x.rpm"
           },
@@ -6329,6 +6339,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.7-20221015/Packages/bind-export-libs-9.11.36-5.el8.s390x.rpm",
         "checksum": "sha256:e22b5160fff19bdd88bc0d3097584970f476ca09397ae120e02022296b984f7a"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.s390x.rpm",
+        "checksum": "sha256:ead363f014185dd1882513c5309f780104e0c52e6adf093d8a5ff0c3324bcdca"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_8-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -731,6 +735,9 @@
                   },
                   {
                     "id": "sha256:78926ec2c75db8bcbdd4f4fbd8c06b373f85bd7ecce0e6aac8c75dda95fcae2c"
+                  },
+                  {
+                    "id": "sha256:2c80c4561489a13cc092992d30639e3cebb7acd1e282eedf1df285c8640dc2e0"
                   },
                   {
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
@@ -2907,6 +2914,9 @@
           },
           "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dnf-plugins-core-4.0.21-14.1.el8.noarch.rpm"
+          },
+          "sha256:2c80c4561489a13cc092992d30639e3cebb7acd1e282eedf1df285c8640dc2e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.x86_64.rpm"
           },
           "sha256:2d3abde6a8de3e2b73933735daf067a57d627c43d90e65b7bb98cba4967bd2c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libX11-1.6.8-5.el8.x86_64.rpm"
@@ -5948,6 +5958,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/biosdevname-0.7.3-2.el8.x86_64.rpm",
         "checksum": "sha256:78926ec2c75db8bcbdd4f4fbd8c06b373f85bd7ecce0e6aac8c75dda95fcae2c"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.x86_64.rpm",
+        "checksum": "sha256:2c80c4561489a13cc092992d30639e3cebb7acd1e282eedf1df285c8640dc2e0"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_84-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -716,6 +720,9 @@
                   },
                   {
                     "id": "sha256:e840fd00286fb6ec3916138596ea7c5c7f6891bfe7d9ba82627219020e37cc4c"
+                  },
+                  {
+                    "id": "sha256:129fb54ca0fc5f6f6a6ff6bfb1b996df7a054916fbe5fa7a4ab28c5326defb51"
                   },
                   {
                     "id": "sha256:14df7263bcc35cb6633321f36149ddadd479ca334798bb33544109a2c61a6213"
@@ -2578,6 +2585,9 @@
           },
           "sha256:127e1278120a526dd0ff2ac1b92b46f579f1bbd6b33f9a0f31d917e6c323e016": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.4-20210921/Packages/systemd-pam-239-45.el8.aarch64.rpm"
+          },
+          "sha256:129fb54ca0fc5f6f6a6ff6bfb1b996df7a054916fbe5fa7a4ab28c5326defb51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.4-20210921/Packages/bluez-5.52-4.el8.aarch64.rpm"
           },
           "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.4-20210921/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
@@ -5649,6 +5659,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.4-20210921/Packages/bind-export-libs-9.11.26-3.el8.aarch64.rpm",
         "checksum": "sha256:e840fd00286fb6ec3916138596ea7c5c7f6891bfe7d9ba82627219020e37cc4c"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.52",
+        "release": "4.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.4-20210921/Packages/bluez-5.52-4.el8.aarch64.rpm",
+        "checksum": "sha256:129fb54ca0fc5f6f6a6ff6bfb1b996df7a054916fbe5fa7a4ab28c5326defb51"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_84-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_84-ppc64le-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -734,6 +738,9 @@
                   },
                   {
                     "id": "sha256:ebeaad718be6041c7e4b510f84f6b12e7d8adeaaf3f53bf609e989bd021fc74f"
+                  },
+                  {
+                    "id": "sha256:83e836ca4ffa8ac074dba2c44b580434a0f62fac8f0a945e5a29598fe6bd5029"
                   },
                   {
                     "id": "sha256:e695072a3790e6c1229abfa1f703f081941be82064a9faab686cb7122838759f"
@@ -3392,6 +3399,9 @@
           "sha256:8373993533b0671cf77930fe3e685a648f1393acc2231a12ce84d8f8ef0216fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-r8.4-20210921/Packages/openssh-clients-8.0p1-5.el8.ppc64le.rpm"
           },
+          "sha256:83e836ca4ffa8ac074dba2c44b580434a0f62fac8f0a945e5a29598fe6bd5029": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-r8.4-20210921/Packages/bluez-5.52-4.el8.ppc64le.rpm"
+          },
           "sha256:848e59a9e9836ac1c7300da6958b25b64527078a4e6547e011f5ada16ce2fa4a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-r8.4-20210921/Packages/libsysfs-2.1.0-24.el8.ppc64le.rpm"
           },
@@ -5964,6 +5974,15 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-r8.4-20210921/Packages/bind-export-libs-9.11.26-3.el8.ppc64le.rpm",
         "checksum": "sha256:ebeaad718be6041c7e4b510f84f6b12e7d8adeaaf3f53bf609e989bd021fc74f"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.52",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-r8.4-20210921/Packages/bluez-5.52-4.el8.ppc64le.rpm",
+        "checksum": "sha256:83e836ca4ffa8ac074dba2c44b580434a0f62fac8f0a945e5a29598fe6bd5029"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_84-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_84-s390x-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -802,6 +806,9 @@
                   },
                   {
                     "id": "sha256:97b07bfd05de6fa982fd370fa1718b461fded2521c81220cf4a87739b881e619"
+                  },
+                  {
+                    "id": "sha256:27d99d453cd8c984f2aee19b4ee72aa7ccd398a985083031a16edebbd6f65dc1"
                   },
                   {
                     "id": "sha256:e134da086a66848af20f21dcebbeca19fde6a4af3016a09d5fde3984317e2c33"
@@ -2792,6 +2799,9 @@
           },
           "sha256:27978a24f19805d828fb29c6fd8306260484859bc234e86e42255ab716b1a169": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-r8.4-20210921/Packages/bzip2-1.0.6-26.el8.s390x.rpm"
+          },
+          "sha256:27d99d453cd8c984f2aee19b4ee72aa7ccd398a985083031a16edebbd6f65dc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-r8.4-20210921/Packages/bluez-5.52-4.el8.s390x.rpm"
           },
           "sha256:2829ee7cd506bfadd391e04c6281fec277f2681e6b360bdbfc0305c48d429c3c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-appstream-r8.4-20210921/Packages/abattis-cantarell-fonts-0.0.25-6.el8.noarch.rpm"
@@ -6100,6 +6110,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-r8.4-20210921/Packages/bind-export-libs-9.11.26-3.el8.s390x.rpm",
         "checksum": "sha256:97b07bfd05de6fa982fd370fa1718b461fded2521c81220cf4a87739b881e619"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.52",
+        "release": "4.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-r8.4-20210921/Packages/bluez-5.52-4.el8.s390x.rpm",
+        "checksum": "sha256:27d99d453cd8c984f2aee19b4ee72aa7ccd398a985083031a16edebbd6f65dc1"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_84-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -734,6 +738,9 @@
                   },
                   {
                     "id": "sha256:78926ec2c75db8bcbdd4f4fbd8c06b373f85bd7ecce0e6aac8c75dda95fcae2c"
+                  },
+                  {
+                    "id": "sha256:d3218f1c28a58c6a7ae8440fd4946a84f22a885d87c3840732c8031e0f6922c2"
                   },
                   {
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
@@ -3710,6 +3717,9 @@
           "sha256:d31afc5532d581167003977d88771f22255923bf3a1aec4dabb5ac98ec910234": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/gettext-libs-0.19.8.1-17.el8.x86_64.rpm"
           },
+          "sha256:d3218f1c28a58c6a7ae8440fd4946a84f22a885d87c3840732c8031e0f6922c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/bluez-5.52-4.el8.x86_64.rpm"
+          },
           "sha256:d3481aac56cc315696cfc650347a139993af5c7837b2fb8a231ebea8dae96f00": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/glibc-all-langpacks-2.28-151.el8.x86_64.rpm"
           },
@@ -5781,6 +5791,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/biosdevname-0.7.3-2.el8.x86_64.rpm",
         "checksum": "sha256:78926ec2c75db8bcbdd4f4fbd8c06b373f85bd7ecce0e6aac8c75dda95fcae2c"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.52",
+        "release": "4.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/bluez-5.52-4.el8.x86_64.rpm",
+        "checksum": "sha256:d3218f1c28a58c6a7ae8440fd4946a84f22a885d87c3840732c8031e0f6922c2"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_85-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -718,6 +722,9 @@
                   },
                   {
                     "id": "sha256:61b05a9f1e7711d6efa379e5038cc0b8888f672f7b2797981972c238197b84bf"
+                  },
+                  {
+                    "id": "sha256:83ec68da01c42465248083ed7e699d789df66b5885cabd83a03b24bb31532f61"
                   },
                   {
                     "id": "sha256:14df7263bcc35cb6633321f36149ddadd479ca334798bb33544109a2c61a6213"
@@ -3356,6 +3363,9 @@
           "sha256:83be16b0b671433e3d838d270818827eec46649b09e3dbc32850c2a6c6b51c1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.5-20220504/Packages/python3-syspurpose-1.28.21-3.el8.aarch64.rpm"
           },
+          "sha256:83ec68da01c42465248083ed7e699d789df66b5885cabd83a03b24bb31532f61": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.5-20220504/Packages/bluez-5.56-2.el8.aarch64.rpm"
+          },
           "sha256:8450db29ac9604e8bd5ca8dfa2254138a933689bfb987f89d7faeeb5d49b22b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.5-20220504/Packages/yum-utils-4.0.21-3.el8.noarch.rpm"
           },
@@ -5847,6 +5857,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.5-20220504/Packages/bind-export-libs-9.11.26-6.el8.aarch64.rpm",
         "checksum": "sha256:61b05a9f1e7711d6efa379e5038cc0b8888f672f7b2797981972c238197b84bf"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "2.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.5-20220504/Packages/bluez-5.56-2.el8.aarch64.rpm",
+        "checksum": "sha256:83ec68da01c42465248083ed7e699d789df66b5885cabd83a03b24bb31532f61"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_85-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-ppc64le-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -763,6 +767,9 @@
                   },
                   {
                     "id": "sha256:ebeaad718be6041c7e4b510f84f6b12e7d8adeaaf3f53bf609e989bd021fc74f"
+                  },
+                  {
+                    "id": "sha256:83e836ca4ffa8ac074dba2c44b580434a0f62fac8f0a945e5a29598fe6bd5029"
                   },
                   {
                     "id": "sha256:e695072a3790e6c1229abfa1f703f081941be82064a9faab686cb7122838759f"
@@ -3607,6 +3614,9 @@
           "sha256:8373993533b0671cf77930fe3e685a648f1393acc2231a12ce84d8f8ef0216fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.5-20210326/Packages/openssh-clients-8.0p1-5.el8.ppc64le.rpm"
           },
+          "sha256:83e836ca4ffa8ac074dba2c44b580434a0f62fac8f0a945e5a29598fe6bd5029": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.5-20210326/Packages/bluez-5.52-4.el8.ppc64le.rpm"
+          },
           "sha256:848e59a9e9836ac1c7300da6958b25b64527078a4e6547e011f5ada16ce2fa4a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.5-20210326/Packages/libsysfs-2.1.0-24.el8.ppc64le.rpm"
           },
@@ -6233,6 +6243,15 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.5-20210326/Packages/bind-export-libs-9.11.26-3.el8.ppc64le.rpm",
         "checksum": "sha256:ebeaad718be6041c7e4b510f84f6b12e7d8adeaaf3f53bf609e989bd021fc74f"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.52",
+        "release": "4.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.5-20210326/Packages/bluez-5.52-4.el8.ppc64le.rpm",
+        "checksum": "sha256:83e836ca4ffa8ac074dba2c44b580434a0f62fac8f0a945e5a29598fe6bd5029"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_85-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-s390x-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -834,6 +838,9 @@
                   },
                   {
                     "id": "sha256:97b07bfd05de6fa982fd370fa1718b461fded2521c81220cf4a87739b881e619"
+                  },
+                  {
+                    "id": "sha256:27d99d453cd8c984f2aee19b4ee72aa7ccd398a985083031a16edebbd6f65dc1"
                   },
                   {
                     "id": "sha256:e134da086a66848af20f21dcebbeca19fde6a4af3016a09d5fde3984317e2c33"
@@ -3059,6 +3066,9 @@
           },
           "sha256:27978a24f19805d828fb29c6fd8306260484859bc234e86e42255ab716b1a169": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.5-20210326/Packages/bzip2-1.0.6-26.el8.s390x.rpm"
+          },
+          "sha256:27d99d453cd8c984f2aee19b4ee72aa7ccd398a985083031a16edebbd6f65dc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.5-20210326/Packages/bluez-5.52-4.el8.s390x.rpm"
           },
           "sha256:2829ee7cd506bfadd391e04c6281fec277f2681e6b360bdbfc0305c48d429c3c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-appstream-n8.5-20210326/Packages/abattis-cantarell-fonts-0.0.25-6.el8.noarch.rpm"
@@ -6427,6 +6437,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.5-20210326/Packages/bind-export-libs-9.11.26-3.el8.s390x.rpm",
         "checksum": "sha256:97b07bfd05de6fa982fd370fa1718b461fded2521c81220cf4a87739b881e619"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.52",
+        "release": "4.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.5-20210326/Packages/bluez-5.52-4.el8.s390x.rpm",
+        "checksum": "sha256:27d99d453cd8c984f2aee19b4ee72aa7ccd398a985083031a16edebbd6f65dc1"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_85-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -736,6 +740,9 @@
                   },
                   {
                     "id": "sha256:78926ec2c75db8bcbdd4f4fbd8c06b373f85bd7ecce0e6aac8c75dda95fcae2c"
+                  },
+                  {
+                    "id": "sha256:f55ad3fefb28c7a504e4fa81c251cc95185f72167b9e700acaf5d149101b7693"
                   },
                   {
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
@@ -4136,6 +4143,9 @@
           "sha256:f5361f959d87ceb9c6fa101c443a20b28c769d5adcd0a0b6fd2bce871204183e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/selinux-policy-targeted-3.14.3-80.el8.noarch.rpm"
           },
+          "sha256:f55ad3fefb28c7a504e4fa81c251cc95185f72167b9e700acaf5d149101b7693": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/bluez-5.56-2.el8.x86_64.rpm"
+          },
           "sha256:f6f157776ee3fe21dd7af7a5af8dc55e25420cda37d01051d0e9746c68e508c0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/kexec-tools-2.0.20-57.el8.x86_64.rpm"
           },
@@ -5973,6 +5983,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/biosdevname-0.7.3-2.el8.x86_64.rpm",
         "checksum": "sha256:78926ec2c75db8bcbdd4f4fbd8c06b373f85bd7ecce0e6aac8c75dda95fcae2c"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "2.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/bluez-5.56-2.el8.x86_64.rpm",
+        "checksum": "sha256:f55ad3fefb28c7a504e4fa81c251cc95185f72167b9e700acaf5d149101b7693"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -713,6 +717,9 @@
                   },
                   {
                     "id": "sha256:bbc9877a2da7c38bb10a29c2c58dc15aa78bd661d53dbf8769c9d1c9bd43cc42"
+                  },
+                  {
+                    "id": "sha256:7f580a4d0ba2c9573edf7603e2fe15310503f7bc566931cb870790b9f79fac5f"
                   },
                   {
                     "id": "sha256:14df7263bcc35cb6633321f36149ddadd479ca334798bb33544109a2c61a6213"
@@ -3313,6 +3320,9 @@
           "sha256:7f2436df92ce3dacaf5a52d988e65b2cbfc6af8be917bdc14119940480efd7bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-slip-0.6.4-11.el8.noarch.rpm"
           },
+          "sha256:7f580a4d0ba2c9573edf7603e2fe15310503f7bc566931cb870790b9f79fac5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/bluez-5.56-3.el8.aarch64.rpm"
+          },
           "sha256:7fc33f147b99749fdbae420ed51277cb99d9b6418b7f739fe51c7563945bc0d7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/hostname-3.20-6.el8.aarch64.rpm"
           },
@@ -5816,6 +5826,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/bind-export-libs-9.11.36-2.el8.aarch64.rpm",
         "checksum": "sha256:bbc9877a2da7c38bb10a29c2c58dc15aa78bd661d53dbf8769c9d1c9bd43cc42"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/bluez-5.56-3.el8.aarch64.rpm",
+        "checksum": "sha256:7f580a4d0ba2c9573edf7603e2fe15310503f7bc566931cb870790b9f79fac5f"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -731,6 +735,9 @@
                   },
                   {
                     "id": "sha256:543d1030db390314d3d864c89ec0ffe1bb9694b62bed69b4ac6799d55f33f5ab"
+                  },
+                  {
+                    "id": "sha256:1e69e48be45b56c75b800d3a2059d0a563210346f8faac72586d5901d3fbc88e"
                   },
                   {
                     "id": "sha256:e695072a3790e6c1229abfa1f703f081941be82064a9faab686cb7122838759f"
@@ -2942,6 +2949,9 @@
           },
           "sha256:1d084e85f865a35f39067256c83f17a05632b531d9b6c5afb8cdecca1e594d62": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/bzip2-libs-1.0.6-26.el8.ppc64le.rpm"
+          },
+          "sha256:1e69e48be45b56c75b800d3a2059d0a563210346f8faac72586d5901d3fbc88e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/bluez-5.56-3.el8.ppc64le.rpm"
           },
           "sha256:1e791ea13ff9421f2218eacacf4a978429b9af0bcb70acb11ba58977b6ce5368": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/iptables-ebtables-1.8.4-22.el8.ppc64le.rpm"
@@ -6130,6 +6140,15 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/bind-export-libs-9.11.36-2.el8.ppc64le.rpm",
         "checksum": "sha256:543d1030db390314d3d864c89ec0ffe1bb9694b62bed69b4ac6799d55f33f5ab"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/bluez-5.56-3.el8.ppc64le.rpm",
+        "checksum": "sha256:1e69e48be45b56c75b800d3a2059d0a563210346f8faac72586d5901d3fbc88e"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -802,6 +806,9 @@
                   },
                   {
                     "id": "sha256:dcb0ab9dbdfad9661c88f3c227e7d7136aceda25ecab193501a68c80c6b28e7d"
+                  },
+                  {
+                    "id": "sha256:5df4160c50ae225413ae624f54ae486cf9eb035802f3f7167e78d251e8961d5b"
                   },
                   {
                     "id": "sha256:e134da086a66848af20f21dcebbeca19fde6a4af3016a09d5fde3984317e2c33"
@@ -3345,6 +3352,9 @@
           },
           "sha256:5db212cfd28de63c559db2a7bd8a1bdd3d1a9cb1b4f95254636f2062647b38bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/polkit-0.115-13.el8_5.1.s390x.rpm"
+          },
+          "sha256:5df4160c50ae225413ae624f54ae486cf9eb035802f3f7167e78d251e8961d5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/bluez-5.56-3.el8.s390x.rpm"
           },
           "sha256:5e6468f344c380e7ba83743a8a2aaa73a333595ea0a19a8388ead8753929909e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/libnl3-3.5.0-1.el8.s390x.rpm"
@@ -6299,6 +6309,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/bind-export-libs-9.11.36-2.el8.s390x.rpm",
         "checksum": "sha256:dcb0ab9dbdfad9661c88f3c227e7d7136aceda25ecab193501a68c80c6b28e7d"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/bluez-5.56-3.el8.s390x.rpm",
+        "checksum": "sha256:5df4160c50ae225413ae624f54ae486cf9eb035802f3f7167e78d251e8961d5b"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -731,6 +735,9 @@
                   },
                   {
                     "id": "sha256:78926ec2c75db8bcbdd4f4fbd8c06b373f85bd7ecce0e6aac8c75dda95fcae2c"
+                  },
+                  {
+                    "id": "sha256:2f2a7db8a9321af382d15722d8c2f17f149ee04932d969f6cb90fd87dcc0a081"
                   },
                   {
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
@@ -2943,6 +2950,9 @@
           },
           "sha256:2eba2dc51974271244bdeaaf17c6e8fac3c35b62914b680076bdc4a32272df01": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libpath_utils-0.2.1-39.el8.x86_64.rpm"
+          },
+          "sha256:2f2a7db8a9321af382d15722d8c2f17f149ee04932d969f6cb90fd87dcc0a081": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bluez-5.56-3.el8.x86_64.rpm"
           },
           "sha256:2f465049e10abac1680ed833f15b565ecdb5f3775a4e3c41510ccfbf4324d44a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-tools-2.02-106.el8.x86_64.rpm"
@@ -5942,6 +5952,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/biosdevname-0.7.3-2.el8.x86_64.rpm",
         "checksum": "sha256:78926ec2c75db8bcbdd4f4fbd8c06b373f85bd7ecce0e6aac8c75dda95fcae2c"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bluez-5.56-3.el8.x86_64.rpm",
+        "checksum": "sha256:2f2a7db8a9321af382d15722d8c2f17f149ee04932d969f6cb90fd87dcc0a081"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_87-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -713,6 +717,9 @@
                   },
                   {
                     "id": "sha256:21abf221b294dabd9f54246e990dc0294937ad3ab54c357167401f7bfb2e74bd"
+                  },
+                  {
+                    "id": "sha256:124aa6cddbdf52f1c60fdefd002b3a69532f07b5a4029be8b8424037589e4b73"
                   },
                   {
                     "id": "sha256:14df7263bcc35cb6633321f36149ddadd479ca334798bb33544109a2c61a6213"
@@ -2724,6 +2731,9 @@
           },
           "sha256:1143ac623a74d7feaaaf293c18d942d243248f6356628f87216670c10d11687b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/json-glib-1.4.4-1.el8.aarch64.rpm"
+          },
+          "sha256:124aa6cddbdf52f1c60fdefd002b3a69532f07b5a4029be8b8424037589e4b73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.aarch64.rpm"
           },
           "sha256:137a8ee6c1f8500fa0de50d6bf894e9aaeb04dd2fb4d6e347e2b4f7db89a948a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libX11-1.6.8-5.el8.aarch64.rpm"
@@ -5822,6 +5832,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bind-export-libs-9.11.36-5.el8.aarch64.rpm",
         "checksum": "sha256:21abf221b294dabd9f54246e990dc0294937ad3ab54c357167401f7bfb2e74bd"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.aarch64.rpm",
+        "checksum": "sha256:124aa6cddbdf52f1c60fdefd002b3a69532f07b5a4029be8b8424037589e4b73"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_87-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-ppc64le-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -731,6 +735,9 @@
                   },
                   {
                     "id": "sha256:93a2f00fd5ff983abf2923d2fe0cde54628302aa3e180ccec7e5686f74a62bfb"
+                  },
+                  {
+                    "id": "sha256:cede866e5700f9fce4664ef7731a6e208eb598f2391642b9aefd708d225f3ed1"
                   },
                   {
                     "id": "sha256:e695072a3790e6c1229abfa1f703f081941be82064a9faab686cb7122838759f"
@@ -4050,6 +4057,9 @@
           "sha256:ce4c3c1a7b545ba47da5993965acb341461487edd2f3f0f2eba662e85ac4ff24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.7-20221015/Packages/ncurses-libs-6.1-9.20180224.el8.ppc64le.rpm"
           },
+          "sha256:cede866e5700f9fce4664ef7731a6e208eb598f2391642b9aefd708d225f3ed1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.ppc64le.rpm"
+          },
           "sha256:cf726c1b70ee7c004e9fc03becd099ad6b3fede8efd8a99610e9a204b75a3cbb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-appstream-n8.7-20221015/Packages/insights-client-3.1.7-8.el8.noarch.rpm"
           },
@@ -6136,6 +6146,15 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.7-20221015/Packages/bind-export-libs-9.11.36-5.el8.ppc64le.rpm",
         "checksum": "sha256:93a2f00fd5ff983abf2923d2fe0cde54628302aa3e180ccec7e5686f74a62bfb"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.ppc64le.rpm",
+        "checksum": "sha256:cede866e5700f9fce4664ef7731a6e208eb598f2391642b9aefd708d225f3ed1"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_87-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-s390x-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -805,6 +809,9 @@
                   },
                   {
                     "id": "sha256:e22b5160fff19bdd88bc0d3097584970f476ca09397ae120e02022296b984f7a"
+                  },
+                  {
+                    "id": "sha256:ead363f014185dd1882513c5309f780104e0c52e6adf093d8a5ff0c3324bcdca"
                   },
                   {
                     "id": "sha256:e134da086a66848af20f21dcebbeca19fde6a4af3016a09d5fde3984317e2c33"
@@ -4216,6 +4223,9 @@
           "sha256:ea8e98525aaeb63aea1e85a98ea93207cb2a88c82e921047e56f50a13b74a4fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.7-20221015/Packages/prefixdevname-0.1.0-6.el8.s390x.rpm"
           },
+          "sha256:ead363f014185dd1882513c5309f780104e0c52e6adf093d8a5ff0c3324bcdca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.s390x.rpm"
+          },
           "sha256:eaea4907a76867e75875d14a5ec659f6a80dfca805a21d3d1d3f55b4329cd8f1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-appstream-n8.7-20221015/Packages/rhc-0.2.1-9.el8.s390x.rpm"
           },
@@ -6329,6 +6339,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.7-20221015/Packages/bind-export-libs-9.11.36-5.el8.s390x.rpm",
         "checksum": "sha256:e22b5160fff19bdd88bc0d3097584970f476ca09397ae120e02022296b984f7a"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.s390x.rpm",
+        "checksum": "sha256:ead363f014185dd1882513c5309f780104e0c52e6adf093d8a5ff0c3324bcdca"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_87-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -731,6 +735,9 @@
                   },
                   {
                     "id": "sha256:78926ec2c75db8bcbdd4f4fbd8c06b373f85bd7ecce0e6aac8c75dda95fcae2c"
+                  },
+                  {
+                    "id": "sha256:2c80c4561489a13cc092992d30639e3cebb7acd1e282eedf1df285c8640dc2e0"
                   },
                   {
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
@@ -2907,6 +2914,9 @@
           },
           "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dnf-plugins-core-4.0.21-14.1.el8.noarch.rpm"
+          },
+          "sha256:2c80c4561489a13cc092992d30639e3cebb7acd1e282eedf1df285c8640dc2e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.x86_64.rpm"
           },
           "sha256:2d3abde6a8de3e2b73933735daf067a57d627c43d90e65b7bb98cba4967bd2c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libX11-1.6.8-5.el8.x86_64.rpm"
@@ -5948,6 +5958,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/biosdevname-0.7.3-2.el8.x86_64.rpm",
         "checksum": "sha256:78926ec2c75db8bcbdd4f4fbd8c06b373f85bd7ecce0e6aac8c75dda95fcae2c"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bluez-5.63-1.el8.x86_64.rpm",
+        "checksum": "sha256:2c80c4561489a13cc092992d30639e3cebb7acd1e282eedf1df285c8640dc2e0"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_88-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -713,6 +717,9 @@
                   },
                   {
                     "id": "sha256:21abf221b294dabd9f54246e990dc0294937ad3ab54c357167401f7bfb2e74bd"
+                  },
+                  {
+                    "id": "sha256:124aa6cddbdf52f1c60fdefd002b3a69532f07b5a4029be8b8424037589e4b73"
                   },
                   {
                     "id": "sha256:14df7263bcc35cb6633321f36149ddadd479ca334798bb33544109a2c61a6213"
@@ -2721,6 +2728,9 @@
           },
           "sha256:1143ac623a74d7feaaaf293c18d942d243248f6356628f87216670c10d11687b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/json-glib-1.4.4-1.el8.aarch64.rpm"
+          },
+          "sha256:124aa6cddbdf52f1c60fdefd002b3a69532f07b5a4029be8b8424037589e4b73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/bluez-5.63-1.el8.aarch64.rpm"
           },
           "sha256:137a8ee6c1f8500fa0de50d6bf894e9aaeb04dd2fb4d6e347e2b4f7db89a948a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/libX11-1.6.8-5.el8.aarch64.rpm"
@@ -5822,6 +5832,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/bind-export-libs-9.11.36-5.el8.aarch64.rpm",
         "checksum": "sha256:21abf221b294dabd9f54246e990dc0294937ad3ab54c357167401f7bfb2e74bd"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/bluez-5.63-1.el8.aarch64.rpm",
+        "checksum": "sha256:124aa6cddbdf52f1c60fdefd002b3a69532f07b5a4029be8b8424037589e4b73"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_88-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_88-ppc64le-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -731,6 +735,9 @@
                   },
                   {
                     "id": "sha256:93a2f00fd5ff983abf2923d2fe0cde54628302aa3e180ccec7e5686f74a62bfb"
+                  },
+                  {
+                    "id": "sha256:cede866e5700f9fce4664ef7731a6e208eb598f2391642b9aefd708d225f3ed1"
                   },
                   {
                     "id": "sha256:e695072a3790e6c1229abfa1f703f081941be82064a9faab686cb7122838759f"
@@ -4044,6 +4051,9 @@
           "sha256:ce4c3c1a7b545ba47da5993965acb341461487edd2f3f0f2eba662e85ac4ff24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.8-20221025/Packages/ncurses-libs-6.1-9.20180224.el8.ppc64le.rpm"
           },
+          "sha256:cede866e5700f9fce4664ef7731a6e208eb598f2391642b9aefd708d225f3ed1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.8-20221025/Packages/bluez-5.63-1.el8.ppc64le.rpm"
+          },
           "sha256:cef90773f78323d7e827424b6f0926d4c167d397461a44a478df3a740a1ad63d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.8-20221025/Packages/teamd-1.31-3.el8.ppc64le.rpm"
           },
@@ -6136,6 +6146,15 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.8-20221025/Packages/bind-export-libs-9.11.36-5.el8.ppc64le.rpm",
         "checksum": "sha256:93a2f00fd5ff983abf2923d2fe0cde54628302aa3e180ccec7e5686f74a62bfb"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.8-20221025/Packages/bluez-5.63-1.el8.ppc64le.rpm",
+        "checksum": "sha256:cede866e5700f9fce4664ef7731a6e208eb598f2391642b9aefd708d225f3ed1"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_88-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_88-s390x-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -805,6 +809,9 @@
                   },
                   {
                     "id": "sha256:e22b5160fff19bdd88bc0d3097584970f476ca09397ae120e02022296b984f7a"
+                  },
+                  {
+                    "id": "sha256:ead363f014185dd1882513c5309f780104e0c52e6adf093d8a5ff0c3324bcdca"
                   },
                   {
                     "id": "sha256:e134da086a66848af20f21dcebbeca19fde6a4af3016a09d5fde3984317e2c33"
@@ -4213,6 +4220,9 @@
           "sha256:ea8e98525aaeb63aea1e85a98ea93207cb2a88c82e921047e56f50a13b74a4fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.8-20221025/Packages/prefixdevname-0.1.0-6.el8.s390x.rpm"
           },
+          "sha256:ead363f014185dd1882513c5309f780104e0c52e6adf093d8a5ff0c3324bcdca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.8-20221025/Packages/bluez-5.63-1.el8.s390x.rpm"
+          },
           "sha256:eaea4907a76867e75875d14a5ec659f6a80dfca805a21d3d1d3f55b4329cd8f1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-appstream-n8.8-20221025/Packages/rhc-0.2.1-9.el8.s390x.rpm"
           },
@@ -6329,6 +6339,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.8-20221025/Packages/bind-export-libs-9.11.36-5.el8.s390x.rpm",
         "checksum": "sha256:e22b5160fff19bdd88bc0d3097584970f476ca09397ae120e02022296b984f7a"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.8-20221025/Packages/bluez-5.63-1.el8.s390x.rpm",
+        "checksum": "sha256:ead363f014185dd1882513c5309f780104e0c52e6adf093d8a5ff0c3324bcdca"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_88-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -731,6 +735,9 @@
                   },
                   {
                     "id": "sha256:78926ec2c75db8bcbdd4f4fbd8c06b373f85bd7ecce0e6aac8c75dda95fcae2c"
+                  },
+                  {
+                    "id": "sha256:2c80c4561489a13cc092992d30639e3cebb7acd1e282eedf1df285c8640dc2e0"
                   },
                   {
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
@@ -2913,6 +2920,9 @@
           },
           "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dnf-plugins-core-4.0.21-14.1.el8.noarch.rpm"
+          },
+          "sha256:2c80c4561489a13cc092992d30639e3cebb7acd1e282eedf1df285c8640dc2e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bluez-5.63-1.el8.x86_64.rpm"
           },
           "sha256:2cd7f54b726250042483f37e513645c240beec147cbfa959cd689b306d36d103": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgcc-8.5.0-17.el8.x86_64.rpm"
@@ -5948,6 +5958,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/biosdevname-0.7.3-2.el8.x86_64.rpm",
         "checksum": "sha256:78926ec2c75db8bcbdd4f4fbd8c06b373f85bd7ecce0e6aac8c75dda95fcae2c"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bluez-5.63-1.el8.x86_64.rpm",
+        "checksum": "sha256:2c80c4561489a13cc092992d30639e3cebb7acd1e282eedf1df285c8640dc2e0"
       },
       {
         "name": "brotli",

--- a/test/data/manifests/rhel_9-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -1360,6 +1364,14 @@
                   },
                   {
                     "id": "sha256:683ea8f7db5b1c1c47eac605620968a5c20e93dc9cd4ad5a2c61adafe2d4d5ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a992e7d9c5424ed394b1a96cf2bd5066590cfe70b2dc0298da9cad1636b9e975",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6233,6 +6245,9 @@
           "sha256:a96e1ce52455d5b16a66fe359b864bd4454160e0bab514b7f0e1ce0bbfb04282": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/quota-nls-4.06-6.el9.noarch.rpm"
           },
+          "sha256:a992e7d9c5424ed394b1a96cf2bd5066590cfe70b2dc0298da9cad1636b9e975": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bluez-5.64-2.el9.aarch64.rpm"
+          },
           "sha256:a9c1db7c192f0b2abfbb24be2759eaf70ba216cd909a334faca01ee3bb056a65": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/numactl-libs-2.0.14-8.el9.aarch64.rpm"
           },
@@ -8218,6 +8233,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bash-5.1.8-5.el9.aarch64.rpm",
         "checksum": "sha256:683ea8f7db5b1c1c47eac605620968a5c20e93dc9cd4ad5a2c61adafe2d4d5ab",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bluez-5.64-2.el9.aarch64.rpm",
+        "checksum": "sha256:a992e7d9c5424ed394b1a96cf2bd5066590cfe70b2dc0298da9cad1636b9e975",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_9-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_9-ppc64le-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -1568,6 +1572,14 @@
                   },
                   {
                     "id": "sha256:2f2d050bb10a3dbfe20dcbd42bfa16344d9356c0ec004b517ff77f389247e304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce41c74a8ac332411b53ea63e1bb4c0e0755117b883485ee9f5b030bf8112add",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -7148,6 +7160,9 @@
           "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.1-20221015/Packages/python3-setuptools-wheel-53.0.0-10.el9.noarch.rpm"
           },
+          "sha256:ce41c74a8ac332411b53ea63e1bb4c0e0755117b883485ee9f5b030bf8112add": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.1-20221015/Packages/bluez-5.64-2.el9.ppc64le.rpm"
+          },
           "sha256:cfb5e8fddaed92b1b22c957183d0ea626a4468f42a46dae4e68a795cb8c20393": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-appstream-n9.1-20221015/Packages/adobe-source-code-pro-fonts-2.030.1.050-12.el9.1.noarch.rpm"
           },
@@ -9213,6 +9228,16 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.1-20221015/Packages/bc-1.07.1-14.el9.ppc64le.rpm",
         "checksum": "sha256:2f2d050bb10a3dbfe20dcbd42bfa16344d9356c0ec004b517ff77f389247e304",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "2.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.1-20221015/Packages/bluez-5.64-2.el9.ppc64le.rpm",
+        "checksum": "sha256:ce41c74a8ac332411b53ea63e1bb4c0e0755117b883485ee9f5b030bf8112add",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_9-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_9-s390x-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -1921,6 +1925,14 @@
                   },
                   {
                     "id": "sha256:19555c17f00ea716a1f36dbcf9b9a4ac5027737976933eedb0e00f225c9b0e5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65655b86f063c19b731fb5a9e543586556b717c116872b4aefd39ab3d8c06f18",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6764,6 +6776,9 @@
           "sha256:63a02be83e7635a5ce164231c739085244084d71170ed2c0b2f10662a5640608": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/coreutils-common-8.32-32.el9.s390x.rpm"
           },
+          "sha256:65655b86f063c19b731fb5a9e543586556b717c116872b4aefd39ab3d8c06f18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/bluez-5.64-2.el9.s390x.rpm"
+          },
           "sha256:65eacc7c9ec37e67564902c33c4181b98d0ea20f2c17e64e88f7c879eef594e0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/libnfsidmap-2.5.4-15.el9.s390x.rpm"
           },
@@ -9887,6 +9902,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/bash-5.1.8-5.el9.s390x.rpm",
         "checksum": "sha256:19555c17f00ea716a1f36dbcf9b9a4ac5027737976933eedb0e00f225c9b0e5a",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/bluez-5.64-2.el9.s390x.rpm",
+        "checksum": "sha256:65655b86f063c19b731fb5a9e543586556b717c116872b4aefd39ab3d8c06f18",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_9-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -1568,6 +1572,14 @@
                   },
                   {
                     "id": "sha256:ae2f785a5899abe5bd03cd293029d3b78a5841ad4bf1938ea64483ec77083108",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7aa32658694d0195e02fc6c6984ebb8177f015c5187ed3c130d88ecf5bb72da4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6428,6 +6440,9 @@
           "sha256:7a9f8a5107e8f7a6132dce9c6a23b5a0c8c4ca41fab4e130c466b632e19f862c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libksba-1.5.1-4.el9.x86_64.rpm"
           },
+          "sha256:7aa32658694d0195e02fc6c6984ebb8177f015c5187ed3c130d88ecf5bb72da4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bluez-5.64-2.el9.x86_64.rpm"
+          },
           "sha256:7ad3d7984e1c37cc17819e84e8b0e731836ca5a7a56108b0d8e8378028b581b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/userspace-rcu-0.12.1-6.el9.x86_64.rpm"
           },
@@ -8889,6 +8904,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bash-5.1.8-5.el9.x86_64.rpm",
         "checksum": "sha256:ae2f785a5899abe5bd03cd293029d3b78a5841ad4bf1938ea64483ec77083108",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bluez-5.64-2.el9.x86_64.rpm",
+        "checksum": "sha256:7aa32658694d0195e02fc6c6984ebb8177f015c5187ed3c130d88ecf5bb72da4",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -609,6 +613,9 @@
                   },
                   {
                     "id": "sha256:c5e0c6b47a2404b6dc82bde6bb7c2c21c45aa1c42197171f42d36e48bd16162f"
+                  },
+                  {
+                    "id": "sha256:e02f1c520b8bbcc3db959891b51ec1d1d922e6344e29a4dffaf5589ef28df992"
                   },
                   {
                     "id": "sha256:c56e979225e15d1ae3b49834ac4341b2e94dbf67d889a27de815b330ee864355"
@@ -3532,6 +3539,9 @@
           "sha256:df9b0d96477ad46504c896d7994731ab6b1dc1cd9cc091493ea83e29b4d1bda5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/tzdata-2021e-1.el9.noarch.rpm"
           },
+          "sha256:e02f1c520b8bbcc3db959891b51ec1d1d922e6344e29a4dffaf5589ef28df992": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/bluez-5.56-8.el9.aarch64.rpm"
+          },
           "sha256:e1dbd2c38a65b135427c7c8fe988ea70dc95f7e26c4c8177b7dcb23925020015": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/lz4-libs-1.9.3-5.el9.aarch64.rpm"
           },
@@ -5096,6 +5106,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/bash-5.1.8-2.el9.aarch64.rpm",
         "checksum": "sha256:c5e0c6b47a2404b6dc82bde6bb7c2c21c45aa1c42197171f42d36e48bd16162f"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/bluez-5.56-8.el9.aarch64.rpm",
+        "checksum": "sha256:e02f1c520b8bbcc3db959891b51ec1d1d922e6344e29a4dffaf5589ef28df992"
       },
       {
         "name": "bubblewrap",

--- a/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -687,6 +691,9 @@
                   },
                   {
                     "id": "sha256:2f2d050bb10a3dbfe20dcbd42bfa16344d9356c0ec004b517ff77f389247e304"
+                  },
+                  {
+                    "id": "sha256:4b6283ae331c7700c99dfb2036349783f88a0ec4bf94acbc61c73cd7c14f4901"
                   },
                   {
                     "id": "sha256:44dd2e683d1a912032da388fd0539ab2479b0f4dd670caf2ad261f289bcd187d"
@@ -2989,6 +2996,9 @@
           },
           "sha256:4a876e7ddd2d9b8879e2e6982654ea7e8119a8200f8885478e72e415b0282e8d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.0-20220208/Packages/pcre-8.44-3.el9.3.ppc64le.rpm"
+          },
+          "sha256:4b6283ae331c7700c99dfb2036349783f88a0ec4bf94acbc61c73cd7c14f4901": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.0-20220208/Packages/bluez-5.56-8.el9.ppc64le.rpm"
           },
           "sha256:4b92bfb55c4e356a7960b721ec7f16c191e0081f9cb1bae98b1411078a706e48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-appstream-n9.0-20220208/Packages/abattis-cantarell-fonts-0.301-4.el9.noarch.rpm"
@@ -5691,6 +5701,15 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.0-20220208/Packages/bc-1.07.1-14.el9.ppc64le.rpm",
         "checksum": "sha256:2f2d050bb10a3dbfe20dcbd42bfa16344d9356c0ec004b517ff77f389247e304"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "8.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.0-20220208/Packages/bluez-5.56-8.el9.ppc64le.rpm",
+        "checksum": "sha256:4b6283ae331c7700c99dfb2036349783f88a0ec4bf94acbc61c73cd7c14f4901"
       },
       {
         "name": "bzip2",

--- a/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -817,6 +821,9 @@
                   },
                   {
                     "id": "sha256:25d5d485f555c3eeba77efbd2d0e2f0963091942ecf0c3947f3747ae58c67a8a"
+                  },
+                  {
+                    "id": "sha256:09755d60e204218bd9b7ab2e4532200d9f98271e669a9b72f3ee3f6617b9eb25"
                   },
                   {
                     "id": "sha256:aafcf70d0bcfeebf5da0c21c2a828b0e780c9fcc7d92e0b23f0fd79580bc9ed2"
@@ -2740,6 +2747,9 @@
           },
           "sha256:094cad3adcdab274d2bd7327c0df337b142a4fec247ed6d5ec023a6609c1c300": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/iproute-5.15.0-2.el9.s390x.rpm"
+          },
+          "sha256:09755d60e204218bd9b7ab2e4532200d9f98271e669a9b72f3ee3f6617b9eb25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/bluez-5.56-8.el9.s390x.rpm"
           },
           "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm"
@@ -6147,6 +6157,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/bash-5.1.8-2.el9.s390x.rpm",
         "checksum": "sha256:25d5d485f555c3eeba77efbd2d0e2f0963091942ecf0c3947f3747ae58c67a8a"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "8.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/bluez-5.56-8.el9.s390x.rpm",
+        "checksum": "sha256:09755d60e204218bd9b7ab2e4532200d9f98271e669a9b72f3ee3f6617b9eb25"
       },
       {
         "name": "bzip2",

--- a/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
@@ -23,6 +23,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -687,6 +691,9 @@
                   },
                   {
                     "id": "sha256:f835cc738fa003147087d68427c407e17c08587156ae961d641b2dfcee1fe7af"
+                  },
+                  {
+                    "id": "sha256:a94d6b04e12c27423a13284939362035683099bc295e5b3aded531b7508639da"
                   },
                   {
                     "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
@@ -3442,6 +3449,9 @@
           "sha256:a891d5fb2fcfab640f66d16eb802eebf8ea9dcc5f14048937c52e3fb812032b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libfastjson-0.99.9-3.el9.x86_64.rpm"
           },
+          "sha256:a94d6b04e12c27423a13284939362035683099bc295e5b3aded531b7508639da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bluez-5.56-8.el9.x86_64.rpm"
+          },
           "sha256:a96e1ce52455d5b16a66fe359b864bd4454160e0bab514b7f0e1ce0bbfb04282": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/quota-nls-4.06-6.el9.noarch.rpm"
           },
@@ -5543,6 +5553,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bash-5.1.8-2.el9.x86_64.rpm",
         "checksum": "sha256:f835cc738fa003147087d68427c407e17c08587156ae961d641b2dfcee1fe7af"
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.56",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bluez-5.56-8.el9.x86_64.rpm",
+        "checksum": "sha256:a94d6b04e12c27423a13284939362035683099bc295e5b3aded531b7508639da"
       },
       {
         "name": "bubblewrap",

--- a/test/data/manifests/rhel_92-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -1352,6 +1356,14 @@
                   },
                   {
                     "id": "sha256:e3b5b62c6ab76438013789260cefe41f3ea409acb4257f6215da364566f56ad1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a992e7d9c5424ed394b1a96cf2bd5066590cfe70b2dc0298da9cad1636b9e975",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6188,6 +6200,9 @@
           "sha256:a96e1ce52455d5b16a66fe359b864bd4454160e0bab514b7f0e1ce0bbfb04282": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/quota-nls-4.06-6.el9.noarch.rpm"
           },
+          "sha256:a992e7d9c5424ed394b1a96cf2bd5066590cfe70b2dc0298da9cad1636b9e975": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/bluez-5.64-2.el9.aarch64.rpm"
+          },
           "sha256:ab46c2ef8d3084aa5fa37eea7306afd0253ccd43004e5e60c280edf9260782b0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/NetworkManager-team-1.41.7-2.el9.aarch64.rpm"
           },
@@ -8181,6 +8196,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/bash-5.1.8-6.el9_1.aarch64.rpm",
         "checksum": "sha256:e3b5b62c6ab76438013789260cefe41f3ea409acb4257f6215da364566f56ad1",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/bluez-5.64-2.el9.aarch64.rpm",
+        "checksum": "sha256:a992e7d9c5424ed394b1a96cf2bd5066590cfe70b2dc0298da9cad1636b9e975",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-ppc64le-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -1568,6 +1572,14 @@
                   },
                   {
                     "id": "sha256:2f2d050bb10a3dbfe20dcbd42bfa16344d9356c0ec004b517ff77f389247e304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce41c74a8ac332411b53ea63e1bb4c0e0755117b883485ee9f5b030bf8112add",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -7159,6 +7171,9 @@
           "sha256:ce140e68125c6dcd448acb01ec6c5523f1568b5270711f9d0cfdc4708babdcc0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.2-20221025/Packages/lzo-2.10-7.el9.ppc64le.rpm"
           },
+          "sha256:ce41c74a8ac332411b53ea63e1bb4c0e0755117b883485ee9f5b030bf8112add": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.2-20221025/Packages/bluez-5.64-2.el9.ppc64le.rpm"
+          },
           "sha256:cfb5e8fddaed92b1b22c957183d0ea626a4468f42a46dae4e68a795cb8c20393": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-appstream-n9.2-20221025/Packages/adobe-source-code-pro-fonts-2.030.1.050-12.el9.1.noarch.rpm"
           },
@@ -9224,6 +9239,16 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.2-20221025/Packages/bc-1.07.1-14.el9.ppc64le.rpm",
         "checksum": "sha256:2f2d050bb10a3dbfe20dcbd42bfa16344d9356c0ec004b517ff77f389247e304",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "2.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.2-20221025/Packages/bluez-5.64-2.el9.ppc64le.rpm",
+        "checksum": "sha256:ce41c74a8ac332411b53ea63e1bb4c0e0755117b883485ee9f5b030bf8112add",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-s390x-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -1921,6 +1925,14 @@
                   },
                   {
                     "id": "sha256:19555c17f00ea716a1f36dbcf9b9a4ac5027737976933eedb0e00f225c9b0e5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65655b86f063c19b731fb5a9e543586556b717c116872b4aefd39ab3d8c06f18",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6781,6 +6793,9 @@
           "sha256:6413e441382132fe8ade345ebd9f9679aa51c246cd97a34f787d57454196b460": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/lua-libs-5.4.2-4.el9_0.3.s390x.rpm"
           },
+          "sha256:65655b86f063c19b731fb5a9e543586556b717c116872b4aefd39ab3d8c06f18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/bluez-5.64-2.el9.s390x.rpm"
+          },
           "sha256:65eacc7c9ec37e67564902c33c4181b98d0ea20f2c17e64e88f7c879eef594e0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/libnfsidmap-2.5.4-15.el9.s390x.rpm"
           },
@@ -9898,6 +9913,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/bash-5.1.8-5.el9.s390x.rpm",
         "checksum": "sha256:19555c17f00ea716a1f36dbcf9b9a4ac5027737976933eedb0e00f225c9b0e5a",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/bluez-5.64-2.el9.s390x.rpm",
+        "checksum": "sha256:65655b86f063c19b731fb5a9e543586556b717c116872b4aefd39ab3d8c06f18",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-qcow2_customize-boot.json
@@ -25,6 +25,10 @@
         {
           "name": "bash",
           "version": "*"
+        },
+        {
+          "name": "bluez",
+          "version": "*"
         }
       ],
       "groups": [
@@ -1576,6 +1580,14 @@
                   },
                   {
                     "id": "sha256:90603777c369e7e4266971d06a7c0bc33f3493b7ddf6904a7d141abe2e7b287f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7aa32658694d0195e02fc6c6984ebb8177f015c5187ed3c130d88ecf5bb72da4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6374,6 +6386,9 @@
           "sha256:7a71da78ee5934cd5241f08837dda50556bdf5f11be546c6710a1281b63b7e4c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/pcre2-syntax-10.40-2.el9.noarch.rpm"
           },
+          "sha256:7aa32658694d0195e02fc6c6984ebb8177f015c5187ed3c130d88ecf5bb72da4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bluez-5.64-2.el9.x86_64.rpm"
+          },
           "sha256:7ad3d7984e1c37cc17819e84e8b0e731836ca5a7a56108b0d8e8378028b581b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/userspace-rcu-0.12.1-6.el9.x86_64.rpm"
           },
@@ -8899,6 +8914,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bash-5.1.8-6.el9_1.x86_64.rpm",
         "checksum": "sha256:90603777c369e7e4266971d06a7c0bc33f3493b7ddf6904a7d141abe2e7b287f",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bluez-5.64-2.el9.x86_64.rpm",
+        "checksum": "sha256:7aa32658694d0195e02fc6c6984ebb8177f015c5187ed3c130d88ecf5bb72da4",
         "check_gpg": true
       },
       {

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -705,6 +705,10 @@
           {
             "name": "bash",
             "version": "*"
+          },
+          {
+            "name": "bluez",
+            "version": "*"
           }
         ],
         "modules": [],
@@ -786,6 +790,10 @@
           "packages": [
             {
               "name": "bash",
+              "version": "*"
+            },
+            {
+              "name": "bluez",
               "version": "*"
             }
           ],
@@ -873,6 +881,10 @@
             {
               "name": "bash",
               "version": "*"
+            },
+            {
+              "name": "bluez",
+              "version": "*"
             }
           ],
           "modules": [],
@@ -947,6 +959,10 @@
           "packages": [
             {
               "name": "bash",
+              "version": "*"
+            },
+            {
+              "name": "bluez",
               "version": "*"
             }
           ],


### PR DESCRIPTION
Our 'customize' test manifests include an option to disable the bluetooth.service.  Originally this option was added for image types that included bluez in their default package set (Fedora IoT commit) but it was later copied to the qcow2 image type as a way of testing customizations.

Until recently, building these caused no issues.  On distros with more recent versions of systemd, disabling a non-existent service causes an error and these manifests fail to build.

Added the 'bluez' package to all manifests that include the 'disable bluetooth.service' customization and updated the manifests.  These should all be buildable now.

Reproduces the failure locally with the CS9 x86-64 qcow2-customize test manifest and tested the updated to verify the fix.