### PR TITLE
internal/distro/rhel9+8/edge: add sos package

### DIFF
--- a/internal/distro/rhel8/edge.go
+++ b/internal/distro/rhel8/edge.go
@@ -242,6 +242,7 @@ func edgeCommitPackageSet(t *imageType) rpmmd.PackageSet {
 				"fdo-client",
 				"fdo-owner-cli",
 				"greenboot-default-health-checks",
+				"sos",
 			},
 		})
 	}

--- a/internal/distro/rhel9/edge.go
+++ b/internal/distro/rhel9/edge.go
@@ -366,6 +366,7 @@ func edgeCommitPackageSet(t *imageType) rpmmd.PackageSet {
 			"greenboot-default-health-checks",
 			"fdo-client",
 			"fdo-owner-cli",
+			"sos",
 		},
 		Exclude: []string{
 			"rng-tools",

--- a/test/data/manifests/centos_8-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_commit-boot.json
@@ -1732,6 +1732,14 @@
                     }
                   },
                   {
+                    "id": "sha256:b18d9f23161d7d5de93fa72a56c645762deefbc0f3e5a095bb8d9e3cf09521e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a4451cae0e8a3307228ed8ac7dc9bab7de77fcbf2004141daa7f986f5dc9b381",
                     "options": {
                       "metadata": {
@@ -3652,6 +3660,14 @@
                     }
                   },
                   {
+                    "id": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:116c1d18b0bda6388cde56e4c93f28b2449dc496ea6a9c5e2d4b581065e2e6c4",
                     "options": {
                       "metadata": {
@@ -3684,6 +3700,14 @@
                     }
                   },
                   {
+                    "id": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:5c5cceb3bf66b2bd1c9cab3ae1f4c91efe4981caca30d6242c9227ce23f6b934",
                     "options": {
                       "metadata": {
@@ -3708,6 +3732,14 @@
                     }
                   },
                   {
+                    "id": "sha256:d0dc30fa9e0355e15c45196bf07d296f56eaccfb04eeabfc619a1d962baec895",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:37deb2a42ef88e7c084293aea18c8425daaa682cb69e72408c96c77cf21709ff",
                     "options": {
                       "metadata": {
@@ -3725,6 +3757,22 @@
                   },
                   {
                     "id": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3765,6 +3813,14 @@
                   },
                   {
                     "id": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3877,6 +3933,14 @@
                   },
                   {
                     "id": "sha256:6404c2bf11a3f1b5b8215807cb4a5c95d6b283dccfe2e5798ec51918337afdcb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4460,6 +4524,22 @@
                     }
                   },
                   {
+                    "id": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8ebf8b358bda84cdc7ede6e6088d6a6bafbb9ed1b4f1b6d08c43baec1d354574",
                     "options": {
                       "metadata": {
@@ -4675,6 +4755,9 @@
           "sha256:0022ec2580783f68e603e9d4751478c28f2b383c596b4e896469077748771bfe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libcroco-0.6.12-4.el8_2.1.aarch64.rpm"
           },
+          "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:00522e43ce63cf63468052e627a429ededac0815212c644f4eadda88b990c3ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libnftnl-1.1.5-5.el8.aarch64.rpm"
           },
@@ -4735,6 +4818,9 @@
           "sha256:0b0efd2a42aea6e33d588c5eb13e33afc312f284c4eac60246247f7a18f17ab3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/glibc-2.28-189.el8.aarch64.rpm"
           },
+          "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
+          },
           "sha256:0d6de2febd0e0ef4fa74eb8f3cffa1b194118e4b7bfe4d2010bf4903ce2c4096": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/hardlink-1.3-6.el8.aarch64.rpm"
           },
@@ -4776,6 +4862,9 @@
           },
           "sha256:176cbc82e2a94159d457a7444d05573636084c1900405450715df48ac3a822bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libpsl-0.20.2-6.el8.aarch64.rpm"
+          },
+          "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:1914ffd356506dd43b92fd943594f3216d4c6416aae71c3863937978effc5f80": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/traceroute-2.1.0-6.el8.aarch64.rpm"
@@ -5008,6 +5097,9 @@
           "sha256:498e52ac86e6131ef31c5dde72cf6f442695444f55da33ef9a99401bf3b353ff": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/audit-libs-3.0.7-1.el8.aarch64.rpm"
           },
+          "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
+          },
           "sha256:4b45c6c1afff8f23163f8cba67b29e469b4172896f994348b6b697c0d994ffcb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/libblockdev-loop-2.24-8.el8.aarch64.rpm"
           },
@@ -5200,6 +5292,9 @@
           "sha256:772093492e290af496c3c8d4cf1d83d3288af49c4f0eb550f9c2489f96ecd89d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-pip-wheel-9.0.3-22.el8.noarch.rpm"
           },
+          "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm"
+          },
           "sha256:793231cf0bbec25af1a279212cba993a27bfe826b117026f03eee911be7e749b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/openssh-server-8.0p1-12.el8.aarch64.rpm"
           },
@@ -5211,6 +5306,9 @@
           },
           "sha256:7d604604382cb1ec72fb7534cdff4371e5b8ceb84be26ebb3ea6cfbc613f82d9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/efibootmgr-16-1.el8.aarch64.rpm"
+          },
+          "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
           "sha256:7ffd6e95b0554466e97346b2f41fb5279aedcb29ae07828f63d06a8dedd7cd51": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/grep-3.1-6.el8.aarch64.rpm"
@@ -5416,6 +5514,9 @@
           "sha256:a8f80c18fec48fd84a0e573e3698f36184c489814a2e2c9a944a5361d99a0a9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-1.02.181-3.el8.aarch64.rpm"
           },
+          "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
+          },
           "sha256:aa4f5049c476ade3c8a7dd6f8b7b43d1db7b3c69a5a7d030b550278950862ba2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/initscripts-10.00.17-1.el8.aarch64.rpm"
           },
@@ -5454,6 +5555,9 @@
           },
           "sha256:b16a98262f089dba44738a4a3a9b0033ef13ed61b6d000eb7d389f766018bb6d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/cryptsetup-2.3.7-1.el8.aarch64.rpm"
+          },
+          "sha256:b18d9f23161d7d5de93fa72a56c645762deefbc0f3e5a095bb8d9e3cf09521e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
           },
           "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm"
@@ -5574,6 +5678,9 @@
           },
           "sha256:d04772c994bb24a6465f78c1e0b70a5453b6dfa062b00ac030f58e6bf4382b9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/rpm-ostree-libs-2022.1-1.el8.aarch64.rpm"
+          },
+          "sha256:d0dc30fa9e0355e15c45196bf07d296f56eaccfb04eeabfc619a1d962baec895": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.aarch64.rpm"
           },
           "sha256:d1b96b4e5da6bd14ac8354c9ff70e910108313dc46fcad406e63695a956eec3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libbpf-0.4.0-3.el8.aarch64.rpm"
@@ -5754,6 +5861,9 @@
           },
           "sha256:f97d55f7bdf6fe126e7a1446563af7ee4c1bb7ee3a2a9b12b6df1cdd344da47e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/gnutls-3.6.16-4.el8.aarch64.rpm"
+          },
+          "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm"
           },
           "sha256:fa5060e3e3771a2545b353861057bd5e9e900c0452cf477077aa93efe62ec954": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/policycoreutils-python-utils-2.9-18.el8.noarch.rpm"
@@ -7868,6 +7978,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/bubblewrap-0.4.0-1.el8.aarch64.rpm",
         "checksum": "sha256:a445b27920d4bf9e6944a289c3e9cf69cb4396fe5f7f3383aab7dbe53ad6b39f",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:b18d9f23161d7d5de93fa72a56c645762deefbc0f3e5a095bb8d9e3cf09521e6",
         "check_gpg": true
       },
       {
@@ -10271,6 +10391,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -10311,6 +10441,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -10341,6 +10481,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.aarch64.rpm",
+        "checksum": "sha256:d0dc30fa9e0355e15c45196bf07d296f56eaccfb04eeabfc619a1d962baec895",
+        "check_gpg": true
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -10368,6 +10518,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
         "checksum": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
         "check_gpg": true
       },
       {
@@ -10418,6 +10588,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
         "checksum": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
         "check_gpg": true
       },
       {
@@ -10558,6 +10738,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/shim-aa64-15-15.el8_2.aarch64.rpm",
         "checksum": "sha256:6404c2bf11a3f1b5b8215807cb4a5c95d6b283dccfe2e5798ec51918337afdcb",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
         "check_gpg": true
       },
       {
@@ -11278,6 +11468,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/protobuf-3.5.0-13.el8.aarch64.rpm",
         "checksum": "sha256:99b7f78ebf248671fbc96a7cbe1d5373ca77ed911adf2be3beebaaf0983d3924",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_commit_with_container-boot.json
@@ -1962,6 +1962,14 @@
                     }
                   },
                   {
+                    "id": "sha256:b18d9f23161d7d5de93fa72a56c645762deefbc0f3e5a095bb8d9e3cf09521e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a4451cae0e8a3307228ed8ac7dc9bab7de77fcbf2004141daa7f986f5dc9b381",
                     "options": {
                       "metadata": {
@@ -3882,6 +3890,14 @@
                     }
                   },
                   {
+                    "id": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:116c1d18b0bda6388cde56e4c93f28b2449dc496ea6a9c5e2d4b581065e2e6c4",
                     "options": {
                       "metadata": {
@@ -3914,6 +3930,14 @@
                     }
                   },
                   {
+                    "id": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:5c5cceb3bf66b2bd1c9cab3ae1f4c91efe4981caca30d6242c9227ce23f6b934",
                     "options": {
                       "metadata": {
@@ -3938,6 +3962,14 @@
                     }
                   },
                   {
+                    "id": "sha256:d0dc30fa9e0355e15c45196bf07d296f56eaccfb04eeabfc619a1d962baec895",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:37deb2a42ef88e7c084293aea18c8425daaa682cb69e72408c96c77cf21709ff",
                     "options": {
                       "metadata": {
@@ -3955,6 +3987,22 @@
                   },
                   {
                     "id": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3995,6 +4043,14 @@
                   },
                   {
                     "id": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4107,6 +4163,14 @@
                   },
                   {
                     "id": "sha256:6404c2bf11a3f1b5b8215807cb4a5c95d6b283dccfe2e5798ec51918337afdcb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4690,6 +4754,22 @@
                     }
                   },
                   {
+                    "id": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8ebf8b358bda84cdc7ede6e6088d6a6bafbb9ed1b4f1b6d08c43baec1d354574",
                     "options": {
                       "metadata": {
@@ -4940,6 +5020,9 @@
           "sha256:0022ec2580783f68e603e9d4751478c28f2b383c596b4e896469077748771bfe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libcroco-0.6.12-4.el8_2.1.aarch64.rpm"
           },
+          "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:00522e43ce63cf63468052e627a429ededac0815212c644f4eadda88b990c3ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libnftnl-1.1.5-5.el8.aarch64.rpm"
           },
@@ -5000,6 +5083,9 @@
           "sha256:0b0efd2a42aea6e33d588c5eb13e33afc312f284c4eac60246247f7a18f17ab3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/glibc-2.28-189.el8.aarch64.rpm"
           },
+          "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
+          },
           "sha256:0d6de2febd0e0ef4fa74eb8f3cffa1b194118e4b7bfe4d2010bf4903ce2c4096": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/hardlink-1.3-6.el8.aarch64.rpm"
           },
@@ -5041,6 +5127,9 @@
           },
           "sha256:176cbc82e2a94159d457a7444d05573636084c1900405450715df48ac3a822bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libpsl-0.20.2-6.el8.aarch64.rpm"
+          },
+          "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:1914ffd356506dd43b92fd943594f3216d4c6416aae71c3863937978effc5f80": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/traceroute-2.1.0-6.el8.aarch64.rpm"
@@ -5273,6 +5362,9 @@
           "sha256:498e52ac86e6131ef31c5dde72cf6f442695444f55da33ef9a99401bf3b353ff": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/audit-libs-3.0.7-1.el8.aarch64.rpm"
           },
+          "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
+          },
           "sha256:4b45c6c1afff8f23163f8cba67b29e469b4172896f994348b6b697c0d994ffcb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/libblockdev-loop-2.24-8.el8.aarch64.rpm"
           },
@@ -5465,6 +5557,9 @@
           "sha256:772093492e290af496c3c8d4cf1d83d3288af49c4f0eb550f9c2489f96ecd89d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-pip-wheel-9.0.3-22.el8.noarch.rpm"
           },
+          "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm"
+          },
           "sha256:793231cf0bbec25af1a279212cba993a27bfe826b117026f03eee911be7e749b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/openssh-server-8.0p1-12.el8.aarch64.rpm"
           },
@@ -5476,6 +5571,9 @@
           },
           "sha256:7d604604382cb1ec72fb7534cdff4371e5b8ceb84be26ebb3ea6cfbc613f82d9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/efibootmgr-16-1.el8.aarch64.rpm"
+          },
+          "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
           "sha256:7ffd6e95b0554466e97346b2f41fb5279aedcb29ae07828f63d06a8dedd7cd51": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/grep-3.1-6.el8.aarch64.rpm"
@@ -5681,6 +5779,9 @@
           "sha256:a8f80c18fec48fd84a0e573e3698f36184c489814a2e2c9a944a5361d99a0a9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-1.02.181-3.el8.aarch64.rpm"
           },
+          "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
+          },
           "sha256:aa4f5049c476ade3c8a7dd6f8b7b43d1db7b3c69a5a7d030b550278950862ba2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/initscripts-10.00.17-1.el8.aarch64.rpm"
           },
@@ -5719,6 +5820,9 @@
           },
           "sha256:b16a98262f089dba44738a4a3a9b0033ef13ed61b6d000eb7d389f766018bb6d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/cryptsetup-2.3.7-1.el8.aarch64.rpm"
+          },
+          "sha256:b18d9f23161d7d5de93fa72a56c645762deefbc0f3e5a095bb8d9e3cf09521e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
           },
           "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm"
@@ -5842,6 +5946,9 @@
           },
           "sha256:d04772c994bb24a6465f78c1e0b70a5453b6dfa062b00ac030f58e6bf4382b9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/rpm-ostree-libs-2022.1-1.el8.aarch64.rpm"
+          },
+          "sha256:d0dc30fa9e0355e15c45196bf07d296f56eaccfb04eeabfc619a1d962baec895": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.aarch64.rpm"
           },
           "sha256:d1b96b4e5da6bd14ac8354c9ff70e910108313dc46fcad406e63695a956eec3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libbpf-0.4.0-3.el8.aarch64.rpm"
@@ -6022,6 +6129,9 @@
           },
           "sha256:f97d55f7bdf6fe126e7a1446563af7ee4c1bb7ee3a2a9b12b6df1cdd344da47e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/gnutls-3.6.16-4.el8.aarch64.rpm"
+          },
+          "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm"
           },
           "sha256:fa5060e3e3771a2545b353861057bd5e9e900c0452cf477077aa93efe62ec954": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/policycoreutils-python-utils-2.9-18.el8.noarch.rpm"
@@ -8429,6 +8539,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:b18d9f23161d7d5de93fa72a56c645762deefbc0f3e5a095bb8d9e3cf09521e6",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -10829,6 +10949,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -10869,6 +10999,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -10899,6 +11039,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.aarch64.rpm",
+        "checksum": "sha256:d0dc30fa9e0355e15c45196bf07d296f56eaccfb04eeabfc619a1d962baec895",
+        "check_gpg": true
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -10926,6 +11076,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
         "checksum": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
         "check_gpg": true
       },
       {
@@ -10976,6 +11146,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
         "checksum": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
         "check_gpg": true
       },
       {
@@ -11116,6 +11296,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/shim-aa64-15-15.el8_2.aarch64.rpm",
         "checksum": "sha256:6404c2bf11a3f1b5b8215807cb4a5c95d6b283dccfe2e5798ec51918337afdcb",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
         "check_gpg": true
       },
       {
@@ -11836,6 +12026,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/protobuf-3.5.0-13.el8.aarch64.rpm",
         "checksum": "sha256:99b7f78ebf248671fbc96a7cbe1d5373ca77ed911adf2be3beebaaf0983d3924",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-aarch64-edge_container-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_container-boot.json
@@ -1732,6 +1732,14 @@
                     }
                   },
                   {
+                    "id": "sha256:b18d9f23161d7d5de93fa72a56c645762deefbc0f3e5a095bb8d9e3cf09521e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a4451cae0e8a3307228ed8ac7dc9bab7de77fcbf2004141daa7f986f5dc9b381",
                     "options": {
                       "metadata": {
@@ -3652,6 +3660,14 @@
                     }
                   },
                   {
+                    "id": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:116c1d18b0bda6388cde56e4c93f28b2449dc496ea6a9c5e2d4b581065e2e6c4",
                     "options": {
                       "metadata": {
@@ -3684,6 +3700,14 @@
                     }
                   },
                   {
+                    "id": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:5c5cceb3bf66b2bd1c9cab3ae1f4c91efe4981caca30d6242c9227ce23f6b934",
                     "options": {
                       "metadata": {
@@ -3708,6 +3732,14 @@
                     }
                   },
                   {
+                    "id": "sha256:d0dc30fa9e0355e15c45196bf07d296f56eaccfb04eeabfc619a1d962baec895",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:37deb2a42ef88e7c084293aea18c8425daaa682cb69e72408c96c77cf21709ff",
                     "options": {
                       "metadata": {
@@ -3725,6 +3757,22 @@
                   },
                   {
                     "id": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3765,6 +3813,14 @@
                   },
                   {
                     "id": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3877,6 +3933,14 @@
                   },
                   {
                     "id": "sha256:6404c2bf11a3f1b5b8215807cb4a5c95d6b283dccfe2e5798ec51918337afdcb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4453,6 +4517,22 @@
                   },
                   {
                     "id": "sha256:99b7f78ebf248671fbc96a7cbe1d5373ca77ed911adf2be3beebaaf0983d3924",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6596,6 +6676,9 @@
           "sha256:0022ec2580783f68e603e9d4751478c28f2b383c596b4e896469077748771bfe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libcroco-0.6.12-4.el8_2.1.aarch64.rpm"
           },
+          "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:00522e43ce63cf63468052e627a429ededac0815212c644f4eadda88b990c3ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libnftnl-1.1.5-5.el8.aarch64.rpm"
           },
@@ -6659,6 +6742,9 @@
           "sha256:0b0efd2a42aea6e33d588c5eb13e33afc312f284c4eac60246247f7a18f17ab3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/glibc-2.28-189.el8.aarch64.rpm"
           },
+          "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
+          },
           "sha256:0d5618af7bbb7fa3e5ac991ddb0fede801560bed21cfbb3c376f24627a0ce1bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/nginx-all-modules-1.14.1-9.module_el8.0.0+1060+3ab382d3.noarch.rpm"
           },
@@ -6706,6 +6792,9 @@
           },
           "sha256:176cbc82e2a94159d457a7444d05573636084c1900405450715df48ac3a822bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libpsl-0.20.2-6.el8.aarch64.rpm"
+          },
+          "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:1914ffd356506dd43b92fd943594f3216d4c6416aae71c3863937978effc5f80": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/traceroute-2.1.0-6.el8.aarch64.rpm"
@@ -6980,6 +7069,9 @@
           "sha256:498e52ac86e6131ef31c5dde72cf6f442695444f55da33ef9a99401bf3b353ff": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/audit-libs-3.0.7-1.el8.aarch64.rpm"
           },
+          "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
+          },
           "sha256:4b45c6c1afff8f23163f8cba67b29e469b4172896f994348b6b697c0d994ffcb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/libblockdev-loop-2.24-8.el8.aarch64.rpm"
           },
@@ -7217,6 +7309,9 @@
           "sha256:7775224319d430f62bb05c4777280167cde7a6fe7ac79421d238843864737665": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/nginx-mod-http-xslt-filter-1.14.1-9.module_el8.0.0+1060+3ab382d3.aarch64.rpm"
           },
+          "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm"
+          },
           "sha256:78d17ed089151e7fa3d1a3cdbbac8ca3b1b5c484fae5ba025642cc9107991037": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/perl-podlators-4.11-1.el8.noarch.rpm"
           },
@@ -7246,6 +7341,9 @@
           },
           "sha256:7edc503f5a919c489b651757095d8031982d530cc88088fdaeb743188364e9b0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/perl-Exporter-5.72-396.el8.noarch.rpm"
+          },
+          "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
           "sha256:7f6f173fb7e011d072bcbf78dea79ddf89c662b3087b92320f1bf512a956fa32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/nginx-mod-stream-1.14.1-9.module_el8.0.0+1060+3ab382d3.aarch64.rpm"
@@ -7481,6 +7579,9 @@
           "sha256:a962371d12134f284540f5ca10186c248350a560814aeb94ddfb7b5d4503b6be": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/nginx-filesystem-1.14.1-9.module_el8.0.0+1060+3ab382d3.noarch.rpm"
           },
+          "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
+          },
           "sha256:aa4f5049c476ade3c8a7dd6f8b7b43d1db7b3c69a5a7d030b550278950862ba2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/initscripts-10.00.17-1.el8.aarch64.rpm"
           },
@@ -7522,6 +7623,9 @@
           },
           "sha256:b16a98262f089dba44738a4a3a9b0033ef13ed61b6d000eb7d389f766018bb6d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/cryptsetup-2.3.7-1.el8.aarch64.rpm"
+          },
+          "sha256:b18d9f23161d7d5de93fa72a56c645762deefbc0f3e5a095bb8d9e3cf09521e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
           },
           "sha256:b19bd4f106ce301ee21c860183cc1c2ef9c09bdf495059bdf16e8d8ccc71bbe8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm"
@@ -7657,6 +7761,9 @@
           },
           "sha256:d04772c994bb24a6465f78c1e0b70a5453b6dfa062b00ac030f58e6bf4382b9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/rpm-ostree-libs-2022.1-1.el8.aarch64.rpm"
+          },
+          "sha256:d0dc30fa9e0355e15c45196bf07d296f56eaccfb04eeabfc619a1d962baec895": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.aarch64.rpm"
           },
           "sha256:d1b96b4e5da6bd14ac8354c9ff70e910108313dc46fcad406e63695a956eec3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libbpf-0.4.0-3.el8.aarch64.rpm"
@@ -7870,6 +7977,9 @@
           },
           "sha256:f97d55f7bdf6fe126e7a1446563af7ee4c1bb7ee3a2a9b12b6df1cdd344da47e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/gnutls-3.6.16-4.el8.aarch64.rpm"
+          },
+          "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm"
           },
           "sha256:fa5060e3e3771a2545b353861057bd5e9e900c0452cf477077aa93efe62ec954": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/policycoreutils-python-utils-2.9-18.el8.noarch.rpm"
@@ -12269,6 +12379,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:b18d9f23161d7d5de93fa72a56c645762deefbc0f3e5a095bb8d9e3cf09521e6",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -14669,6 +14789,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -14709,6 +14839,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -14739,6 +14879,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.aarch64.rpm",
+        "checksum": "sha256:d0dc30fa9e0355e15c45196bf07d296f56eaccfb04eeabfc619a1d962baec895",
+        "check_gpg": true
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -14766,6 +14916,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
         "checksum": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
         "check_gpg": true
       },
       {
@@ -14816,6 +14986,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
         "checksum": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
         "check_gpg": true
       },
       {
@@ -14956,6 +15136,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/shim-aa64-15-15.el8_2.aarch64.rpm",
         "checksum": "sha256:6404c2bf11a3f1b5b8215807cb4a5c95d6b283dccfe2e5798ec51918337afdcb",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
         "check_gpg": true
       },
       {
@@ -15676,6 +15866,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/protobuf-3.5.0-13.el8.aarch64.rpm",
         "checksum": "sha256:99b7f78ebf248671fbc96a7cbe1d5373ca77ed911adf2be3beebaaf0983d3924",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit-boot.json
@@ -1772,6 +1772,14 @@
                     }
                   },
                   {
+                    "id": "sha256:78596f457c3d737a97a4edfe9a03a01f593606379c281701ab7f7eba13ecaf18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:19d66d152b745dbd49cea9d21c52aec0ec4d4321edef97a342acd3542404fa31",
                     "options": {
                       "metadata": {
@@ -3812,6 +3820,14 @@
                     }
                   },
                   {
+                    "id": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:066f254f9ac7712b44214816de907a87eb8dfd0d2ea9570a7513db9a6617ba26",
                     "options": {
                       "metadata": {
@@ -3844,6 +3860,14 @@
                     }
                   },
                   {
+                    "id": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:603aad60c3d0e7134a2dbbfe85ddb672441d87ae4469e4f1497125b671a7b13e",
                     "options": {
                       "metadata": {
@@ -3868,6 +3892,14 @@
                     }
                   },
                   {
+                    "id": "sha256:cd67bee728093239e123eb0851a0ec6cc185911d9fb979421a34530d3e5e6f59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:56e3aaed4790949f4ae57e61b02f97f2e8d9da24eb75b847c1609ceab18efe1f",
                     "options": {
                       "metadata": {
@@ -3885,6 +3917,22 @@
                   },
                   {
                     "id": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3925,6 +3973,14 @@
                   },
                   {
                     "id": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4037,6 +4093,14 @@
                   },
                   {
                     "id": "sha256:f0346c485da9a7e8c8d93624f335cbb25790a7f37c6c03e43232517bb73bbacb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4620,6 +4684,22 @@
                     }
                   },
                   {
+                    "id": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:b9425df26e0072317dfd994f0a95b6eb0c5a477f00b01317a5b2651730821955",
                     "options": {
                       "metadata": {
@@ -4835,6 +4915,9 @@
           "sha256:002b3672de2744c3f97ad8776d012952c058f9213a0cf8e01f7f9b8651b3e6af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python36-3.6.8-38.module_el8.5.0+895+a459eca8.x86_64.rpm"
           },
+          "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libyaml-0.1.7-5.el8.x86_64.rpm"
           },
@@ -4895,6 +4978,9 @@
           "sha256:0ba4d2ab0e7f3e339baf86e9bf5c78dcf918126ddff38c2e277ea29a51c2384d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/librepo-1.14.2-1.el8.x86_64.rpm"
           },
+          "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
+          },
           "sha256:0bd547870e69b6a2f48779eb78560a2c3c97b006ed2ca5d76d3c24f04f0d0892": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libfdisk-2.32.1-32.el8.x86_64.rpm"
           },
@@ -4951,6 +5037,9 @@
           },
           "sha256:168ab5dbc86b836b8742b2e63eee51d074f1d790728e3d30b0c59fff93cf1d8d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/npth-1.5-4.el8.x86_64.rpm"
+          },
+          "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:17cebd5c2e6ad0cf05850096d2d54d667c0d2af7407dad68e35b4745abd1d4bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libblockdev-2.24-8.el8.x86_64.rpm"
@@ -5174,6 +5263,9 @@
           "sha256:4973664648b7ed9278bf29074ec6a60a9f660aa97c23a283750483f64429d5bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libacl-2.2.53-1.el8.x86_64.rpm"
           },
+          "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
+          },
           "sha256:49a09debb380abe15df4d8becccb40d1fe42fa662099c3007bd5501ef6e722f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/setools-console-4.3.0-3.el8.x86_64.rpm"
           },
@@ -5393,11 +5485,17 @@
           "sha256:7834014af304d81ed3fecf37c0bdd981b817220c6dda003e7c007c7818d6a2e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/iwl105-firmware-18.168.6.1-105.el8.1.noarch.rpm"
           },
+          "sha256:78596f457c3d737a97a4edfe9a03a01f593606379c281701ab7f7eba13ecaf18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
+          },
           "sha256:7875ef88b689e6249a87ebbbed865b31fe78f31091de39e89869ff369e61bb38": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/initscripts-10.00.17-1.el8.x86_64.rpm"
           },
           "sha256:787e580211e6b205a0a6e1fd6341cd220722778f15e10f30ffcea11fb42b681c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libqb-1.0.3-12.el8.x86_64.rpm"
+          },
+          "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:7927147168e4f74efd126d2156bfcb841e251b4f960726476feecd17e1710fbe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/xfsprogs-5.0.0-10.el8.x86_64.rpm"
@@ -5437,6 +5535,9 @@
           },
           "sha256:7f429477c26b4650a3eca4a27b3972ff0857c843bdb4d8fcb02086da111ce5fd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libpcap-1.9.1-5.el8.x86_64.rpm"
+          },
+          "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
           "sha256:80ffd3c1ca47e469c9d69b9e88d5b385ba081e55412238ced56fecd996afdf8e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libkcapi-hmaccalc-1.2.0-2.el8.x86_64.rpm"
@@ -5612,6 +5713,9 @@
           "sha256:a913dec09e866e860fb5d67cbcab73ae861ec44a0758ec4c0810f975dfebdfd5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/elfutils-libs-0.186-1.el8.x86_64.rpm"
           },
+          "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
+          },
           "sha256:ab7bc1a828168006b88934bea949ab2b29b837b0a431f7da1a12147f64f6ddb5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
@@ -5752,6 +5856,9 @@
           },
           "sha256:ccba794a7e11afe4b02ca0de1d5131ae6f0fb75836a39c2567b99cd9ab01e2b4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/systemd-pam-239-56.el8.x86_64.rpm"
+          },
+          "sha256:cd67bee728093239e123eb0851a0ec6cc185911d9fb979421a34530d3e5e6f59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.x86_64.rpm"
           },
           "sha256:cd873179894c7fc92ca30493f11bc00ca3505111bba32be0c54f0d4a49d5100d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/polkit-0.115-13.el8_5.1.x86_64.rpm"
@@ -5959,6 +6066,9 @@
           },
           "sha256:f95f673fc9236dc712270a343807cdac06297d847001e78cd707482c751b2d0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libverto-0.3.0-5.el8.x86_64.rpm"
+          },
+          "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm"
           },
           "sha256:fa5060e3e3771a2545b353861057bd5e9e900c0452cf477077aa93efe62ec954": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/policycoreutils-python-utils-2.9-18.el8.noarch.rpm"
@@ -8123,6 +8233,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:9e78ec1230b9ec69ef8e3ad0484cbe3b5c36cfc214d90f890a49093b22df2948",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:78596f457c3d737a97a4edfe9a03a01f593606379c281701ab7f7eba13ecaf18",
         "check_gpg": true
       },
       {
@@ -10676,6 +10796,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -10716,6 +10846,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -10746,6 +10886,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.x86_64.rpm",
+        "checksum": "sha256:cd67bee728093239e123eb0851a0ec6cc185911d9fb979421a34530d3e5e6f59",
+        "check_gpg": true
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -10773,6 +10923,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
         "checksum": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
         "check_gpg": true
       },
       {
@@ -10823,6 +10993,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
         "checksum": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
         "check_gpg": true
       },
       {
@@ -10963,6 +11143,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/shim-x64-15-15.el8_2.x86_64.rpm",
         "checksum": "sha256:f0346c485da9a7e8c8d93624f335cbb25790a7f37c6c03e43232517bb73bbacb",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
         "check_gpg": true
       },
       {
@@ -11683,6 +11873,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/protobuf-3.5.0-13.el8.x86_64.rpm",
         "checksum": "sha256:3d22f213a58b2a2d1424e2a91baa9a6d894e1ae37348b04a6ab2e2aa989961d2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit_rt-boot.json
@@ -1779,6 +1779,14 @@
                     }
                   },
                   {
+                    "id": "sha256:78596f457c3d737a97a4edfe9a03a01f593606379c281701ab7f7eba13ecaf18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:19d66d152b745dbd49cea9d21c52aec0ec4d4321edef97a342acd3542404fa31",
                     "options": {
                       "metadata": {
@@ -3803,6 +3811,14 @@
                     }
                   },
                   {
+                    "id": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:066f254f9ac7712b44214816de907a87eb8dfd0d2ea9570a7513db9a6617ba26",
                     "options": {
                       "metadata": {
@@ -3835,6 +3851,14 @@
                     }
                   },
                   {
+                    "id": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:603aad60c3d0e7134a2dbbfe85ddb672441d87ae4469e4f1497125b671a7b13e",
                     "options": {
                       "metadata": {
@@ -3859,6 +3883,14 @@
                     }
                   },
                   {
+                    "id": "sha256:cd67bee728093239e123eb0851a0ec6cc185911d9fb979421a34530d3e5e6f59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:56e3aaed4790949f4ae57e61b02f97f2e8d9da24eb75b847c1609ceab18efe1f",
                     "options": {
                       "metadata": {
@@ -3876,6 +3908,22 @@
                   },
                   {
                     "id": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3916,6 +3964,14 @@
                   },
                   {
                     "id": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4028,6 +4084,14 @@
                   },
                   {
                     "id": "sha256:f0346c485da9a7e8c8d93624f335cbb25790a7f37c6c03e43232517bb73bbacb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4611,6 +4675,22 @@
                     }
                   },
                   {
+                    "id": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:b9425df26e0072317dfd994f0a95b6eb0c5a477f00b01317a5b2651730821955",
                     "options": {
                       "metadata": {
@@ -4826,6 +4906,9 @@
           "sha256:002b3672de2744c3f97ad8776d012952c058f9213a0cf8e01f7f9b8651b3e6af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python36-3.6.8-38.module_el8.5.0+895+a459eca8.x86_64.rpm"
           },
+          "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libyaml-0.1.7-5.el8.x86_64.rpm"
           },
@@ -4886,6 +4969,9 @@
           "sha256:0ba4d2ab0e7f3e339baf86e9bf5c78dcf918126ddff38c2e277ea29a51c2384d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/librepo-1.14.2-1.el8.x86_64.rpm"
           },
+          "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
+          },
           "sha256:0bd547870e69b6a2f48779eb78560a2c3c97b006ed2ca5d76d3c24f04f0d0892": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libfdisk-2.32.1-32.el8.x86_64.rpm"
           },
@@ -4942,6 +5028,9 @@
           },
           "sha256:168ab5dbc86b836b8742b2e63eee51d074f1d790728e3d30b0c59fff93cf1d8d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/npth-1.5-4.el8.x86_64.rpm"
+          },
+          "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:17cebd5c2e6ad0cf05850096d2d54d667c0d2af7407dad68e35b4745abd1d4bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libblockdev-2.24-8.el8.x86_64.rpm"
@@ -5165,6 +5254,9 @@
           "sha256:4973664648b7ed9278bf29074ec6a60a9f660aa97c23a283750483f64429d5bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libacl-2.2.53-1.el8.x86_64.rpm"
           },
+          "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
+          },
           "sha256:49a09debb380abe15df4d8becccb40d1fe42fa662099c3007bd5501ef6e722f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/setools-console-4.3.0-3.el8.x86_64.rpm"
           },
@@ -5384,11 +5476,17 @@
           "sha256:7834014af304d81ed3fecf37c0bdd981b817220c6dda003e7c007c7818d6a2e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/iwl105-firmware-18.168.6.1-105.el8.1.noarch.rpm"
           },
+          "sha256:78596f457c3d737a97a4edfe9a03a01f593606379c281701ab7f7eba13ecaf18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
+          },
           "sha256:7875ef88b689e6249a87ebbbed865b31fe78f31091de39e89869ff369e61bb38": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/initscripts-10.00.17-1.el8.x86_64.rpm"
           },
           "sha256:787e580211e6b205a0a6e1fd6341cd220722778f15e10f30ffcea11fb42b681c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libqb-1.0.3-12.el8.x86_64.rpm"
+          },
+          "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:7927147168e4f74efd126d2156bfcb841e251b4f960726476feecd17e1710fbe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/xfsprogs-5.0.0-10.el8.x86_64.rpm"
@@ -5428,6 +5526,9 @@
           },
           "sha256:7f429477c26b4650a3eca4a27b3972ff0857c843bdb4d8fcb02086da111ce5fd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libpcap-1.9.1-5.el8.x86_64.rpm"
+          },
+          "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
           "sha256:80ffd3c1ca47e469c9d69b9e88d5b385ba081e55412238ced56fecd996afdf8e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libkcapi-hmaccalc-1.2.0-2.el8.x86_64.rpm"
@@ -5603,6 +5704,9 @@
           "sha256:a913dec09e866e860fb5d67cbcab73ae861ec44a0758ec4c0810f975dfebdfd5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/elfutils-libs-0.186-1.el8.x86_64.rpm"
           },
+          "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
+          },
           "sha256:ab7bc1a828168006b88934bea949ab2b29b837b0a431f7da1a12147f64f6ddb5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
@@ -5743,6 +5847,9 @@
           },
           "sha256:ccba794a7e11afe4b02ca0de1d5131ae6f0fb75836a39c2567b99cd9ab01e2b4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/systemd-pam-239-56.el8.x86_64.rpm"
+          },
+          "sha256:cd67bee728093239e123eb0851a0ec6cc185911d9fb979421a34530d3e5e6f59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.x86_64.rpm"
           },
           "sha256:cd873179894c7fc92ca30493f11bc00ca3505111bba32be0c54f0d4a49d5100d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/polkit-0.115-13.el8_5.1.x86_64.rpm"
@@ -5944,6 +6051,9 @@
           },
           "sha256:f95f673fc9236dc712270a343807cdac06297d847001e78cd707482c751b2d0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libverto-0.3.0-5.el8.x86_64.rpm"
+          },
+          "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm"
           },
           "sha256:fa5060e3e3771a2545b353861057bd5e9e900c0452cf477077aa93efe62ec954": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/policycoreutils-python-utils-2.9-18.el8.noarch.rpm"
@@ -8108,6 +8218,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:9e78ec1230b9ec69ef8e3ad0484cbe3b5c36cfc214d90f890a49093b22df2948",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:78596f457c3d737a97a4edfe9a03a01f593606379c281701ab7f7eba13ecaf18",
         "check_gpg": true
       },
       {
@@ -10641,6 +10761,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -10681,6 +10811,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -10711,6 +10851,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.x86_64.rpm",
+        "checksum": "sha256:cd67bee728093239e123eb0851a0ec6cc185911d9fb979421a34530d3e5e6f59",
+        "check_gpg": true
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -10738,6 +10888,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
         "checksum": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
         "check_gpg": true
       },
       {
@@ -10788,6 +10958,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
         "checksum": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
         "check_gpg": true
       },
       {
@@ -10928,6 +11108,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/shim-x64-15-15.el8_2.x86_64.rpm",
         "checksum": "sha256:f0346c485da9a7e8c8d93624f335cbb25790a7f37c6c03e43232517bb73bbacb",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
         "check_gpg": true
       },
       {
@@ -11648,6 +11838,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/protobuf-3.5.0-13.el8.x86_64.rpm",
         "checksum": "sha256:3d22f213a58b2a2d1424e2a91baa9a6d894e1ae37348b04a6ab2e2aa989961d2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit_with_container-boot.json
@@ -2002,6 +2002,14 @@
                     }
                   },
                   {
+                    "id": "sha256:78596f457c3d737a97a4edfe9a03a01f593606379c281701ab7f7eba13ecaf18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:19d66d152b745dbd49cea9d21c52aec0ec4d4321edef97a342acd3542404fa31",
                     "options": {
                       "metadata": {
@@ -4042,6 +4050,14 @@
                     }
                   },
                   {
+                    "id": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:066f254f9ac7712b44214816de907a87eb8dfd0d2ea9570a7513db9a6617ba26",
                     "options": {
                       "metadata": {
@@ -4074,6 +4090,14 @@
                     }
                   },
                   {
+                    "id": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:603aad60c3d0e7134a2dbbfe85ddb672441d87ae4469e4f1497125b671a7b13e",
                     "options": {
                       "metadata": {
@@ -4098,6 +4122,14 @@
                     }
                   },
                   {
+                    "id": "sha256:cd67bee728093239e123eb0851a0ec6cc185911d9fb979421a34530d3e5e6f59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:56e3aaed4790949f4ae57e61b02f97f2e8d9da24eb75b847c1609ceab18efe1f",
                     "options": {
                       "metadata": {
@@ -4115,6 +4147,22 @@
                   },
                   {
                     "id": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4155,6 +4203,14 @@
                   },
                   {
                     "id": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4267,6 +4323,14 @@
                   },
                   {
                     "id": "sha256:f0346c485da9a7e8c8d93624f335cbb25790a7f37c6c03e43232517bb73bbacb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4850,6 +4914,22 @@
                     }
                   },
                   {
+                    "id": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:b9425df26e0072317dfd994f0a95b6eb0c5a477f00b01317a5b2651730821955",
                     "options": {
                       "metadata": {
@@ -5100,6 +5180,9 @@
           "sha256:002b3672de2744c3f97ad8776d012952c058f9213a0cf8e01f7f9b8651b3e6af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python36-3.6.8-38.module_el8.5.0+895+a459eca8.x86_64.rpm"
           },
+          "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libyaml-0.1.7-5.el8.x86_64.rpm"
           },
@@ -5160,6 +5243,9 @@
           "sha256:0ba4d2ab0e7f3e339baf86e9bf5c78dcf918126ddff38c2e277ea29a51c2384d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/librepo-1.14.2-1.el8.x86_64.rpm"
           },
+          "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
+          },
           "sha256:0bd547870e69b6a2f48779eb78560a2c3c97b006ed2ca5d76d3c24f04f0d0892": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libfdisk-2.32.1-32.el8.x86_64.rpm"
           },
@@ -5216,6 +5302,9 @@
           },
           "sha256:168ab5dbc86b836b8742b2e63eee51d074f1d790728e3d30b0c59fff93cf1d8d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/npth-1.5-4.el8.x86_64.rpm"
+          },
+          "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:17cebd5c2e6ad0cf05850096d2d54d667c0d2af7407dad68e35b4745abd1d4bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libblockdev-2.24-8.el8.x86_64.rpm"
@@ -5439,6 +5528,9 @@
           "sha256:4973664648b7ed9278bf29074ec6a60a9f660aa97c23a283750483f64429d5bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libacl-2.2.53-1.el8.x86_64.rpm"
           },
+          "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
+          },
           "sha256:49a09debb380abe15df4d8becccb40d1fe42fa662099c3007bd5501ef6e722f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/setools-console-4.3.0-3.el8.x86_64.rpm"
           },
@@ -5658,11 +5750,17 @@
           "sha256:7834014af304d81ed3fecf37c0bdd981b817220c6dda003e7c007c7818d6a2e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/iwl105-firmware-18.168.6.1-105.el8.1.noarch.rpm"
           },
+          "sha256:78596f457c3d737a97a4edfe9a03a01f593606379c281701ab7f7eba13ecaf18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
+          },
           "sha256:7875ef88b689e6249a87ebbbed865b31fe78f31091de39e89869ff369e61bb38": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/initscripts-10.00.17-1.el8.x86_64.rpm"
           },
           "sha256:787e580211e6b205a0a6e1fd6341cd220722778f15e10f30ffcea11fb42b681c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libqb-1.0.3-12.el8.x86_64.rpm"
+          },
+          "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:7927147168e4f74efd126d2156bfcb841e251b4f960726476feecd17e1710fbe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/xfsprogs-5.0.0-10.el8.x86_64.rpm"
@@ -5702,6 +5800,9 @@
           },
           "sha256:7f429477c26b4650a3eca4a27b3972ff0857c843bdb4d8fcb02086da111ce5fd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libpcap-1.9.1-5.el8.x86_64.rpm"
+          },
+          "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
           "sha256:80ffd3c1ca47e469c9d69b9e88d5b385ba081e55412238ced56fecd996afdf8e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libkcapi-hmaccalc-1.2.0-2.el8.x86_64.rpm"
@@ -5877,6 +5978,9 @@
           "sha256:a913dec09e866e860fb5d67cbcab73ae861ec44a0758ec4c0810f975dfebdfd5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/elfutils-libs-0.186-1.el8.x86_64.rpm"
           },
+          "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
+          },
           "sha256:ab7bc1a828168006b88934bea949ab2b29b837b0a431f7da1a12147f64f6ddb5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
@@ -6020,6 +6124,9 @@
           },
           "sha256:ccba794a7e11afe4b02ca0de1d5131ae6f0fb75836a39c2567b99cd9ab01e2b4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/systemd-pam-239-56.el8.x86_64.rpm"
+          },
+          "sha256:cd67bee728093239e123eb0851a0ec6cc185911d9fb979421a34530d3e5e6f59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.x86_64.rpm"
           },
           "sha256:cd873179894c7fc92ca30493f11bc00ca3505111bba32be0c54f0d4a49d5100d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/polkit-0.115-13.el8_5.1.x86_64.rpm"
@@ -6227,6 +6334,9 @@
           },
           "sha256:f95f673fc9236dc712270a343807cdac06297d847001e78cd707482c751b2d0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libverto-0.3.0-5.el8.x86_64.rpm"
+          },
+          "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm"
           },
           "sha256:fa5060e3e3771a2545b353861057bd5e9e900c0452cf477077aa93efe62ec954": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/policycoreutils-python-utils-2.9-18.el8.noarch.rpm"
@@ -8681,6 +8791,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:9e78ec1230b9ec69ef8e3ad0484cbe3b5c36cfc214d90f890a49093b22df2948",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:78596f457c3d737a97a4edfe9a03a01f593606379c281701ab7f7eba13ecaf18",
         "check_gpg": true
       },
       {
@@ -11234,6 +11354,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -11274,6 +11404,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -11304,6 +11444,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.x86_64.rpm",
+        "checksum": "sha256:cd67bee728093239e123eb0851a0ec6cc185911d9fb979421a34530d3e5e6f59",
+        "check_gpg": true
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -11331,6 +11481,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
         "checksum": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
         "check_gpg": true
       },
       {
@@ -11381,6 +11551,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
         "checksum": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
         "check_gpg": true
       },
       {
@@ -11521,6 +11701,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/shim-x64-15-15.el8_2.x86_64.rpm",
         "checksum": "sha256:f0346c485da9a7e8c8d93624f335cbb25790a7f37c6c03e43232517bb73bbacb",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
         "check_gpg": true
       },
       {
@@ -12241,6 +12431,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/protobuf-3.5.0-13.el8.x86_64.rpm",
         "checksum": "sha256:3d22f213a58b2a2d1424e2a91baa9a6d894e1ae37348b04a6ab2e2aa989961d2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-edge_container-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_container-boot.json
@@ -1772,6 +1772,14 @@
                     }
                   },
                   {
+                    "id": "sha256:78596f457c3d737a97a4edfe9a03a01f593606379c281701ab7f7eba13ecaf18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:19d66d152b745dbd49cea9d21c52aec0ec4d4321edef97a342acd3542404fa31",
                     "options": {
                       "metadata": {
@@ -3812,6 +3820,14 @@
                     }
                   },
                   {
+                    "id": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:066f254f9ac7712b44214816de907a87eb8dfd0d2ea9570a7513db9a6617ba26",
                     "options": {
                       "metadata": {
@@ -3844,6 +3860,14 @@
                     }
                   },
                   {
+                    "id": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:603aad60c3d0e7134a2dbbfe85ddb672441d87ae4469e4f1497125b671a7b13e",
                     "options": {
                       "metadata": {
@@ -3868,6 +3892,14 @@
                     }
                   },
                   {
+                    "id": "sha256:cd67bee728093239e123eb0851a0ec6cc185911d9fb979421a34530d3e5e6f59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:56e3aaed4790949f4ae57e61b02f97f2e8d9da24eb75b847c1609ceab18efe1f",
                     "options": {
                       "metadata": {
@@ -3885,6 +3917,22 @@
                   },
                   {
                     "id": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3925,6 +3973,14 @@
                   },
                   {
                     "id": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4037,6 +4093,14 @@
                   },
                   {
                     "id": "sha256:f0346c485da9a7e8c8d93624f335cbb25790a7f37c6c03e43232517bb73bbacb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4613,6 +4677,22 @@
                   },
                   {
                     "id": "sha256:3d22f213a58b2a2d1424e2a91baa9a6d894e1ae37348b04a6ab2e2aa989961d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6756,6 +6836,9 @@
           "sha256:002b3672de2744c3f97ad8776d012952c058f9213a0cf8e01f7f9b8651b3e6af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python36-3.6.8-38.module_el8.5.0+895+a459eca8.x86_64.rpm"
           },
+          "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libyaml-0.1.7-5.el8.x86_64.rpm"
           },
@@ -6822,6 +6905,9 @@
           "sha256:0ba4d2ab0e7f3e339baf86e9bf5c78dcf918126ddff38c2e277ea29a51c2384d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/librepo-1.14.2-1.el8.x86_64.rpm"
           },
+          "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
+          },
           "sha256:0bd547870e69b6a2f48779eb78560a2c3c97b006ed2ca5d76d3c24f04f0d0892": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libfdisk-2.32.1-32.el8.x86_64.rpm"
           },
@@ -6887,6 +6973,9 @@
           },
           "sha256:168ab5dbc86b836b8742b2e63eee51d074f1d790728e3d30b0c59fff93cf1d8d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/npth-1.5-4.el8.x86_64.rpm"
+          },
+          "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:17cebd5c2e6ad0cf05850096d2d54d667c0d2af7407dad68e35b4745abd1d4bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libblockdev-2.24-8.el8.x86_64.rpm"
@@ -7146,6 +7235,9 @@
           "sha256:4973664648b7ed9278bf29074ec6a60a9f660aa97c23a283750483f64429d5bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libacl-2.2.53-1.el8.x86_64.rpm"
           },
+          "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
+          },
           "sha256:49a09debb380abe15df4d8becccb40d1fe42fa662099c3007bd5501ef6e722f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/setools-console-4.3.0-3.el8.x86_64.rpm"
           },
@@ -7398,11 +7490,17 @@
           "sha256:7834014af304d81ed3fecf37c0bdd981b817220c6dda003e7c007c7818d6a2e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/iwl105-firmware-18.168.6.1-105.el8.1.noarch.rpm"
           },
+          "sha256:78596f457c3d737a97a4edfe9a03a01f593606379c281701ab7f7eba13ecaf18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
+          },
           "sha256:7875ef88b689e6249a87ebbbed865b31fe78f31091de39e89869ff369e61bb38": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/initscripts-10.00.17-1.el8.x86_64.rpm"
           },
           "sha256:787e580211e6b205a0a6e1fd6341cd220722778f15e10f30ffcea11fb42b681c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libqb-1.0.3-12.el8.x86_64.rpm"
+          },
+          "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:78d17ed089151e7fa3d1a3cdbbac8ca3b1b5c484fae5ba025642cc9107991037": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/perl-podlators-4.11-1.el8.noarch.rpm"
@@ -7460,6 +7558,9 @@
           },
           "sha256:7f429477c26b4650a3eca4a27b3972ff0857c843bdb4d8fcb02086da111ce5fd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libpcap-1.9.1-5.el8.x86_64.rpm"
+          },
+          "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
           "sha256:7ff911df218c38953660d4a09f9864364e2433b9aaf8283db8b7d5214411e28a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/perl-IO-1.38-421.el8.x86_64.rpm"
@@ -7671,6 +7772,9 @@
           "sha256:a962371d12134f284540f5ca10186c248350a560814aeb94ddfb7b5d4503b6be": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/nginx-filesystem-1.14.1-9.module_el8.0.0+1060+3ab382d3.noarch.rpm"
           },
+          "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
+          },
           "sha256:ab7bc1a828168006b88934bea949ab2b29b837b0a431f7da1a12147f64f6ddb5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
@@ -7820,6 +7924,9 @@
           },
           "sha256:ccba794a7e11afe4b02ca0de1d5131ae6f0fb75836a39c2567b99cd9ab01e2b4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/systemd-pam-239-56.el8.x86_64.rpm"
+          },
+          "sha256:cd67bee728093239e123eb0851a0ec6cc185911d9fb979421a34530d3e5e6f59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.x86_64.rpm"
           },
           "sha256:cd873179894c7fc92ca30493f11bc00ca3505111bba32be0c54f0d4a49d5100d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/polkit-0.115-13.el8_5.1.x86_64.rpm"
@@ -8075,6 +8182,9 @@
           },
           "sha256:f95f673fc9236dc712270a343807cdac06297d847001e78cd707482c751b2d0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libverto-0.3.0-5.el8.x86_64.rpm"
+          },
+          "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm"
           },
           "sha256:fa5060e3e3771a2545b353861057bd5e9e900c0452cf477077aa93efe62ec954": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/policycoreutils-python-utils-2.9-18.el8.noarch.rpm"
@@ -12524,6 +12634,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:78596f457c3d737a97a4edfe9a03a01f593606379c281701ab7f7eba13ecaf18",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -15074,6 +15194,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -15114,6 +15244,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -15144,6 +15284,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "11.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-libxml2-2.9.7-11.el8.x86_64.rpm",
+        "checksum": "sha256:cd67bee728093239e123eb0851a0ec6cc185911d9fb979421a34530d3e5e6f59",
+        "check_gpg": true
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -15171,6 +15321,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
         "checksum": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
         "check_gpg": true
       },
       {
@@ -15221,6 +15391,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
         "checksum": "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
         "check_gpg": true
       },
       {
@@ -15361,6 +15541,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/shim-x64-15-15.el8_2.x86_64.rpm",
         "checksum": "sha256:f0346c485da9a7e8c8d93624f335cbb25790a7f37c6c03e43232517bb73bbacb",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:fa20e0ec81d1747d8a2e679c30a165dfbefc8185f0ba1ea5985c6316b30840d6",
         "check_gpg": true
       },
       {
@@ -16081,6 +16271,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/protobuf-3.5.0-13.el8.x86_64.rpm",
         "checksum": "sha256:3d22f213a58b2a2d1424e2a91baa9a6d894e1ae37348b04a6ab2e2aa989961d2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:0bc637f0d028043e8388b083cdd8d0a0acea7fdbc79c0bc9401dfb02c20fb817",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:499e48b35f3b5f5da45031fa78fba559fee6a480ecb106e6c300eb8344510958",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_commit-boot.json
@@ -2244,6 +2244,14 @@
                     }
                   },
                   {
+                    "id": "sha256:d89b742bc5327741c3ff26a7fb17a518552bbad74c0c299f147af57a0a208b93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:6c20f6f13c274fa2487f95f1e3dddcee9b931ce222abebd2f1d9b3f7eb69fcde",
                     "options": {
                       "metadata": {
@@ -4004,6 +4012,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:ce454fa8f9a2d015face9e9ae64f6730f2ba104d0556c91b93fca2006f132bf9",
                     "options": {
                       "metadata": {
@@ -4036,7 +4052,23 @@
                     }
                   },
                   {
+                    "id": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:5b3ca2504a39b4d0a54fe0dccf8b3860156dbe56f6af7af2e6e9f58dc9301fe4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eebaadcdf7e1a76b9c12a8429ac9b7256c84526729621ec9ca79a6142c954f40",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4052,7 +4084,39 @@
                     }
                   },
                   {
+                    "id": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4077,6 +4141,22 @@
                   },
                   {
                     "id": "sha256:b923161167a7bab6fc9f235ebe4ae0f0344df9db6f1879dc9a52fd2c1efe2af5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4197,6 +4277,14 @@
                   },
                   {
                     "id": "sha256:f7be56d036127a8c4d865ed71c300072c12f1340574dcb064ca9bfc169d972b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4588,6 +4676,9 @@
           "sha256:0d79c32f97191766d21e5279961ae482c6ebc3fed0c674fabac88a528d3c80f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20230101/Packages/fdo-owner-cli-0.4.5-1.el9.aarch64.rpm"
           },
+          "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:0f50b567d538990d025a59227768ecc8f5359cd747a1eddfcceaeab82bdc4064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/policycoreutils-3.4-4.el9.aarch64.rpm"
           },
@@ -4693,6 +4784,9 @@
           "sha256:26a21395b0bb4f7b60ab89bacaa8fc210c9921f1aba90ec950b91b3ee9e25dcc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/ncurses-libs-6.2-8.20210508.el9.aarch64.rpm"
           },
+          "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:27738cdaa184318017d5ce087fa026f73e7882a51bfce41fcd1ab9381b668170": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libmodulemd-2.13.0-2.el9.aarch64.rpm"
           },
@@ -4780,6 +4874,12 @@
           "sha256:3795bd49dbfa25b1e4bfc83fc9f3b4c71b3b712f243e7c813e0ac1311c0a7bb2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/cryptsetup-libs-2.6.0-1.el9.aarch64.rpm"
           },
+          "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm"
+          },
+          "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
+          },
           "sha256:38c811f2a986d7f36965e2ec0d0001768fedb25e9d78fc080952a0f7e9fb1f74": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20230101/Packages/fdo-client-0.4.5-1.el9.aarch64.rpm"
           },
@@ -4839,6 +4939,9 @@
           },
           "sha256:4975593414dfa1e822cd108e988d18453c2ff036b03e4cdbf38db0afb45e0c92": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libacl-2.3.1-3.el9.aarch64.rpm"
+          },
+          "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
           },
           "sha256:4aac0e04d11130bf2fe1b2e050397de8e0e655065eddcf4e8b62e927479a4917": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/iputils-20210202-8.el9.aarch64.rpm"
@@ -5020,6 +5123,9 @@
           "sha256:6ed96112059449aa37b99d4d4e3b5d089c34afefbd9b618691bed8c206c4d441": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libidn2-2.3.0-7.el9.aarch64.rpm"
           },
+          "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:6f82d810994199c4f6ad02d4df4b996044cbcf79bc4bf0319298d6d7cf42d3eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/grub2-tools-2.06-46.el9.aarch64.rpm"
           },
@@ -5133,6 +5239,9 @@
           },
           "sha256:8f15f31546ada628dc842c7ddde4ad209dfb1277425137e080c7379f49aa9210": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/file-libs-5.39-10.el9.aarch64.rpm"
+          },
+          "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:90c9cc8b6e9abd030ffb23d722067266502c46316e0c3398f9ec51affd405f75": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/gnupg2-2.3.3-2.el9.aarch64.rpm"
@@ -5455,6 +5564,9 @@
           "sha256:d82ebf3bcfe85eae2b34c4dbd507d8a0b0ac05d4df4c9ee16fee7555f36c7873": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/fuse-libs-2.9.9-15.el9.aarch64.rpm"
           },
+          "sha256:d89b742bc5327741c3ff26a7fb17a518552bbad74c0c299f147af57a0a208b93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:d89e3c54801e05424a23e60c39e06ea6409ca3305f7401dff5ca5fbfaec73740": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libndp-1.8-4.el9.aarch64.rpm"
           },
@@ -5484,6 +5596,9 @@
           },
           "sha256:db518be8ad99feee87bcbccbd5c1c740f8cbe610f3a1d59bd70637053c37fba8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libsmartcols-2.37.4-9.el9.aarch64.rpm"
+          },
+          "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm"
           },
           "sha256:de4946454f110a9b12ab50c9c3dfaa68633b4ae3cb4e5278b23d491eb3edc27a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/pkgconf-m4-1.7.3-10.el9.noarch.rpm"
@@ -5548,11 +5663,17 @@
           "sha256:ee31abd3d1325b05c5ba336158ba3b235a718a99ad5cec5e6ab498ca99b688b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libseccomp-2.5.2-2.el9.aarch64.rpm"
           },
+          "sha256:eebaadcdf7e1a76b9c12a8429ac9b7256c84526729621ec9ca79a6142c954f40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.aarch64.rpm"
+          },
           "sha256:ef2fae47d7af695381904f92bcfb70353305c2d5c6d057d5e4e270d8aaa99142": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libqmi-utils-1.32.2-1.el9.aarch64.rpm"
           },
           "sha256:efc31e2b3a79208457bafe9fc61f6bee935dd021216cfe18567936b95487fdd0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/e2fsprogs-libs-1.46.5-3.el9.aarch64.rpm"
+          },
+          "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
           },
           "sha256:f008b954b622f27dbc5b0c8f3633589c844b5428a1dfe84ca96d42a72dae707c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libusbx-1.0.26-1.el9.aarch64.rpm"
@@ -8337,6 +8458,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:d89b742bc5327741c3ff26a7fb17a518552bbad74c0c299f147af57a0a208b93",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -10537,6 +10668,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -10577,6 +10718,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.16",
@@ -10584,6 +10735,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-libs-3.9.16-1.el9.aarch64.rpm",
         "checksum": "sha256:5b3ca2504a39b4d0a54fe0dccf8b3860156dbe56f6af7af2e6e9f58dc9301fe4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.aarch64.rpm",
+        "checksum": "sha256:eebaadcdf7e1a76b9c12a8429ac9b7256c84526729621ec9ca79a6142c954f40",
         "check_gpg": true
       },
       {
@@ -10597,6 +10758,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -10604,6 +10775,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
         "check_gpg": true
       },
       {
@@ -10634,6 +10835,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-setuptools-wheel-53.0.0-11.el9.noarch.rpm",
         "checksum": "sha256:b923161167a7bab6fc9f235ebe4ae0f0344df9db6f1879dc9a52fd2c1efe2af5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
         "check_gpg": true
       },
       {
@@ -10784,6 +11005,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/shim-aa64-15-15.el8_2.aarch64.rpm",
         "checksum": "sha256:f7be56d036127a8c4d865ed71c300072c12f1340574dcb064ca9bfc169d972b7",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm",
+        "checksum": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
@@ -2258,6 +2258,14 @@
                     }
                   },
                   {
+                    "id": "sha256:d89b742bc5327741c3ff26a7fb17a518552bbad74c0c299f147af57a0a208b93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:6c20f6f13c274fa2487f95f1e3dddcee9b931ce222abebd2f1d9b3f7eb69fcde",
                     "options": {
                       "metadata": {
@@ -4018,6 +4026,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:ce454fa8f9a2d015face9e9ae64f6730f2ba104d0556c91b93fca2006f132bf9",
                     "options": {
                       "metadata": {
@@ -4050,7 +4066,23 @@
                     }
                   },
                   {
+                    "id": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:5b3ca2504a39b4d0a54fe0dccf8b3860156dbe56f6af7af2e6e9f58dc9301fe4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eebaadcdf7e1a76b9c12a8429ac9b7256c84526729621ec9ca79a6142c954f40",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4066,7 +4098,39 @@
                     }
                   },
                   {
+                    "id": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4091,6 +4155,22 @@
                   },
                   {
                     "id": "sha256:b923161167a7bab6fc9f235ebe4ae0f0344df9db6f1879dc9a52fd2c1efe2af5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4211,6 +4291,14 @@
                   },
                   {
                     "id": "sha256:f7be56d036127a8c4d865ed71c300072c12f1340574dcb064ca9bfc169d972b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4637,6 +4725,9 @@
           "sha256:0d79c32f97191766d21e5279961ae482c6ebc3fed0c674fabac88a528d3c80f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20230101/Packages/fdo-owner-cli-0.4.5-1.el9.aarch64.rpm"
           },
+          "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:0f50b567d538990d025a59227768ecc8f5359cd747a1eddfcceaeab82bdc4064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/policycoreutils-3.4-4.el9.aarch64.rpm"
           },
@@ -4742,6 +4833,9 @@
           "sha256:26a21395b0bb4f7b60ab89bacaa8fc210c9921f1aba90ec950b91b3ee9e25dcc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/ncurses-libs-6.2-8.20210508.el9.aarch64.rpm"
           },
+          "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:27738cdaa184318017d5ce087fa026f73e7882a51bfce41fcd1ab9381b668170": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libmodulemd-2.13.0-2.el9.aarch64.rpm"
           },
@@ -4829,6 +4923,12 @@
           "sha256:3795bd49dbfa25b1e4bfc83fc9f3b4c71b3b712f243e7c813e0ac1311c0a7bb2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/cryptsetup-libs-2.6.0-1.el9.aarch64.rpm"
           },
+          "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm"
+          },
+          "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
+          },
           "sha256:38c811f2a986d7f36965e2ec0d0001768fedb25e9d78fc080952a0f7e9fb1f74": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20230101/Packages/fdo-client-0.4.5-1.el9.aarch64.rpm"
           },
@@ -4888,6 +4988,9 @@
           },
           "sha256:4975593414dfa1e822cd108e988d18453c2ff036b03e4cdbf38db0afb45e0c92": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libacl-2.3.1-3.el9.aarch64.rpm"
+          },
+          "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
           },
           "sha256:4aac0e04d11130bf2fe1b2e050397de8e0e655065eddcf4e8b62e927479a4917": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/iputils-20210202-8.el9.aarch64.rpm"
@@ -5069,6 +5172,9 @@
           "sha256:6ed96112059449aa37b99d4d4e3b5d089c34afefbd9b618691bed8c206c4d441": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libidn2-2.3.0-7.el9.aarch64.rpm"
           },
+          "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:6f82d810994199c4f6ad02d4df4b996044cbcf79bc4bf0319298d6d7cf42d3eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/grub2-tools-2.06-46.el9.aarch64.rpm"
           },
@@ -5182,6 +5288,9 @@
           },
           "sha256:8f15f31546ada628dc842c7ddde4ad209dfb1277425137e080c7379f49aa9210": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/file-libs-5.39-10.el9.aarch64.rpm"
+          },
+          "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:90c9cc8b6e9abd030ffb23d722067266502c46316e0c3398f9ec51affd405f75": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/gnupg2-2.3.3-2.el9.aarch64.rpm"
@@ -5504,6 +5613,9 @@
           "sha256:d82ebf3bcfe85eae2b34c4dbd507d8a0b0ac05d4df4c9ee16fee7555f36c7873": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/fuse-libs-2.9.9-15.el9.aarch64.rpm"
           },
+          "sha256:d89b742bc5327741c3ff26a7fb17a518552bbad74c0c299f147af57a0a208b93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:d89e3c54801e05424a23e60c39e06ea6409ca3305f7401dff5ca5fbfaec73740": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libndp-1.8-4.el9.aarch64.rpm"
           },
@@ -5533,6 +5645,9 @@
           },
           "sha256:db518be8ad99feee87bcbccbd5c1c740f8cbe610f3a1d59bd70637053c37fba8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libsmartcols-2.37.4-9.el9.aarch64.rpm"
+          },
+          "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm"
           },
           "sha256:de4946454f110a9b12ab50c9c3dfaa68633b4ae3cb4e5278b23d491eb3edc27a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/pkgconf-m4-1.7.3-10.el9.noarch.rpm"
@@ -5597,11 +5712,17 @@
           "sha256:ee31abd3d1325b05c5ba336158ba3b235a718a99ad5cec5e6ab498ca99b688b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libseccomp-2.5.2-2.el9.aarch64.rpm"
           },
+          "sha256:eebaadcdf7e1a76b9c12a8429ac9b7256c84526729621ec9ca79a6142c954f40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.aarch64.rpm"
+          },
           "sha256:ef2fae47d7af695381904f92bcfb70353305c2d5c6d057d5e4e270d8aaa99142": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libqmi-utils-1.32.2-1.el9.aarch64.rpm"
           },
           "sha256:efc31e2b3a79208457bafe9fc61f6bee935dd021216cfe18567936b95487fdd0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/e2fsprogs-libs-1.46.5-3.el9.aarch64.rpm"
+          },
+          "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
           },
           "sha256:f008b954b622f27dbc5b0c8f3633589c844b5428a1dfe84ca96d42a72dae707c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libusbx-1.0.26-1.el9.aarch64.rpm"
@@ -8409,6 +8530,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:d89b742bc5327741c3ff26a7fb17a518552bbad74c0c299f147af57a0a208b93",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -10609,6 +10740,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -10649,6 +10790,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.16",
@@ -10656,6 +10807,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-libs-3.9.16-1.el9.aarch64.rpm",
         "checksum": "sha256:5b3ca2504a39b4d0a54fe0dccf8b3860156dbe56f6af7af2e6e9f58dc9301fe4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.aarch64.rpm",
+        "checksum": "sha256:eebaadcdf7e1a76b9c12a8429ac9b7256c84526729621ec9ca79a6142c954f40",
         "check_gpg": true
       },
       {
@@ -10669,6 +10830,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -10676,6 +10847,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
         "check_gpg": true
       },
       {
@@ -10706,6 +10907,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-setuptools-wheel-53.0.0-11.el9.noarch.rpm",
         "checksum": "sha256:b923161167a7bab6fc9f235ebe4ae0f0344df9db6f1879dc9a52fd2c1efe2af5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
         "check_gpg": true
       },
       {
@@ -10856,6 +11077,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/shim-aa64-15-15.el8_2.aarch64.rpm",
         "checksum": "sha256:f7be56d036127a8c4d865ed71c300072c12f1340574dcb064ca9bfc169d972b7",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm",
+        "checksum": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-aarch64-edge_container-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_container-boot.json
@@ -2244,6 +2244,14 @@
                     }
                   },
                   {
+                    "id": "sha256:d89b742bc5327741c3ff26a7fb17a518552bbad74c0c299f147af57a0a208b93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:6c20f6f13c274fa2487f95f1e3dddcee9b931ce222abebd2f1d9b3f7eb69fcde",
                     "options": {
                       "metadata": {
@@ -4004,6 +4012,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:ce454fa8f9a2d015face9e9ae64f6730f2ba104d0556c91b93fca2006f132bf9",
                     "options": {
                       "metadata": {
@@ -4036,7 +4052,23 @@
                     }
                   },
                   {
+                    "id": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:5b3ca2504a39b4d0a54fe0dccf8b3860156dbe56f6af7af2e6e9f58dc9301fe4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eebaadcdf7e1a76b9c12a8429ac9b7256c84526729621ec9ca79a6142c954f40",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4052,7 +4084,39 @@
                     }
                   },
                   {
+                    "id": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4077,6 +4141,22 @@
                   },
                   {
                     "id": "sha256:b923161167a7bab6fc9f235ebe4ae0f0344df9db6f1879dc9a52fd2c1efe2af5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4197,6 +4277,14 @@
                   },
                   {
                     "id": "sha256:f7be56d036127a8c4d865ed71c300072c12f1340574dcb064ca9bfc169d972b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5349,6 +5437,9 @@
           "sha256:0d79c32f97191766d21e5279961ae482c6ebc3fed0c674fabac88a528d3c80f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20230101/Packages/fdo-owner-cli-0.4.5-1.el9.aarch64.rpm"
           },
+          "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:0f50b567d538990d025a59227768ecc8f5359cd747a1eddfcceaeab82bdc4064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/policycoreutils-3.4-4.el9.aarch64.rpm"
           },
@@ -5454,6 +5545,9 @@
           "sha256:26a21395b0bb4f7b60ab89bacaa8fc210c9921f1aba90ec950b91b3ee9e25dcc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/ncurses-libs-6.2-8.20210508.el9.aarch64.rpm"
           },
+          "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:27738cdaa184318017d5ce087fa026f73e7882a51bfce41fcd1ab9381b668170": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libmodulemd-2.13.0-2.el9.aarch64.rpm"
           },
@@ -5541,6 +5635,12 @@
           "sha256:3795bd49dbfa25b1e4bfc83fc9f3b4c71b3b712f243e7c813e0ac1311c0a7bb2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/cryptsetup-libs-2.6.0-1.el9.aarch64.rpm"
           },
+          "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm"
+          },
+          "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
+          },
           "sha256:38c811f2a986d7f36965e2ec0d0001768fedb25e9d78fc080952a0f7e9fb1f74": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20230101/Packages/fdo-client-0.4.5-1.el9.aarch64.rpm"
           },
@@ -5600,6 +5700,9 @@
           },
           "sha256:4975593414dfa1e822cd108e988d18453c2ff036b03e4cdbf38db0afb45e0c92": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libacl-2.3.1-3.el9.aarch64.rpm"
+          },
+          "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
           },
           "sha256:4aac0e04d11130bf2fe1b2e050397de8e0e655065eddcf4e8b62e927479a4917": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/iputils-20210202-8.el9.aarch64.rpm"
@@ -5784,6 +5887,9 @@
           "sha256:6ed96112059449aa37b99d4d4e3b5d089c34afefbd9b618691bed8c206c4d441": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libidn2-2.3.0-7.el9.aarch64.rpm"
           },
+          "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:6f82d810994199c4f6ad02d4df4b996044cbcf79bc4bf0319298d6d7cf42d3eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/grub2-tools-2.06-46.el9.aarch64.rpm"
           },
@@ -5897,6 +6003,9 @@
           },
           "sha256:8f15f31546ada628dc842c7ddde4ad209dfb1277425137e080c7379f49aa9210": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/file-libs-5.39-10.el9.aarch64.rpm"
+          },
+          "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:90c9cc8b6e9abd030ffb23d722067266502c46316e0c3398f9ec51affd405f75": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/gnupg2-2.3.3-2.el9.aarch64.rpm"
@@ -6225,6 +6334,9 @@
           "sha256:d82ebf3bcfe85eae2b34c4dbd507d8a0b0ac05d4df4c9ee16fee7555f36c7873": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/fuse-libs-2.9.9-15.el9.aarch64.rpm"
           },
+          "sha256:d89b742bc5327741c3ff26a7fb17a518552bbad74c0c299f147af57a0a208b93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:d89e3c54801e05424a23e60c39e06ea6409ca3305f7401dff5ca5fbfaec73740": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libndp-1.8-4.el9.aarch64.rpm"
           },
@@ -6254,6 +6366,9 @@
           },
           "sha256:db518be8ad99feee87bcbccbd5c1c740f8cbe610f3a1d59bd70637053c37fba8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libsmartcols-2.37.4-9.el9.aarch64.rpm"
+          },
+          "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm"
           },
           "sha256:ddf5b914ca04ca25fb11d6c84268da5e02a5480499e8951255163fa79b94d977": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20230101/Packages/nginx-filesystem-1.20.1-13.el9.noarch.rpm"
@@ -6321,11 +6436,17 @@
           "sha256:ee31abd3d1325b05c5ba336158ba3b235a718a99ad5cec5e6ab498ca99b688b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libseccomp-2.5.2-2.el9.aarch64.rpm"
           },
+          "sha256:eebaadcdf7e1a76b9c12a8429ac9b7256c84526729621ec9ca79a6142c954f40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.aarch64.rpm"
+          },
           "sha256:ef2fae47d7af695381904f92bcfb70353305c2d5c6d057d5e4e270d8aaa99142": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libqmi-utils-1.32.2-1.el9.aarch64.rpm"
           },
           "sha256:efc31e2b3a79208457bafe9fc61f6bee935dd021216cfe18567936b95487fdd0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/e2fsprogs-libs-1.46.5-3.el9.aarch64.rpm"
+          },
+          "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
           },
           "sha256:f008b954b622f27dbc5b0c8f3633589c844b5428a1dfe84ca96d42a72dae707c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/libusbx-1.0.26-1.el9.aarch64.rpm"
@@ -9945,6 +10066,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:d89b742bc5327741c3ff26a7fb17a518552bbad74c0c299f147af57a0a208b93",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -12145,6 +12276,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -12185,6 +12326,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.16",
@@ -12192,6 +12343,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-libs-3.9.16-1.el9.aarch64.rpm",
         "checksum": "sha256:5b3ca2504a39b4d0a54fe0dccf8b3860156dbe56f6af7af2e6e9f58dc9301fe4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.aarch64.rpm",
+        "checksum": "sha256:eebaadcdf7e1a76b9c12a8429ac9b7256c84526729621ec9ca79a6142c954f40",
         "check_gpg": true
       },
       {
@@ -12205,6 +12366,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -12212,6 +12383,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
         "check_gpg": true
       },
       {
@@ -12242,6 +12443,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-setuptools-wheel-53.0.0-11.el9.noarch.rpm",
         "checksum": "sha256:b923161167a7bab6fc9f235ebe4ae0f0344df9db6f1879dc9a52fd2c1efe2af5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
         "check_gpg": true
       },
       {
@@ -12392,6 +12613,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/shim-aa64-15-15.el8_2.aarch64.rpm",
         "checksum": "sha256:f7be56d036127a8c4d865ed71c300072c12f1340574dcb064ca9bfc169d972b7",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm",
+        "checksum": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit-boot.json
@@ -2339,6 +2339,14 @@
                     }
                   },
                   {
+                    "id": "sha256:90aeb088fad0093b1ca531387d38e1c32ad64efd56f2306eacc0edbc4c37e205",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:fabd6b5c065c2b9d4a8d39a938ae577d801de2ddc73c8cdf6f7803db29c28d0a",
                     "options": {
                       "metadata": {
@@ -4203,6 +4211,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8e42f3e54292bfc76ab52ee3f91f850fb0cca63c9a49692938381ca93460a686",
                     "options": {
                       "metadata": {
@@ -4235,7 +4251,23 @@
                     }
                   },
                   {
+                    "id": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:21a7fe05e3c1a36b8242f5c783f7cdf636634b69bbd21428089b948f9c2433bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27945a54ed84a4e7d11454a1307711f14e1ad705b0f35a5886c4f5e109f45144",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4251,7 +4283,39 @@
                     }
                   },
                   {
+                    "id": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4276,6 +4340,22 @@
                   },
                   {
                     "id": "sha256:b923161167a7bab6fc9f235ebe4ae0f0344df9db6f1879dc9a52fd2c1efe2af5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4396,6 +4476,14 @@
                   },
                   {
                     "id": "sha256:3b69435ded0d7a1302bbb3dd521ec08dcbf7e0374c8bd892619e811f15c9cf3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4778,6 +4866,9 @@
           "sha256:09f700a94e187a74f6f4a5f750082732e193d41392a85f042bdeb0bcbabe0a1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bash-5.1.8-6.el9.x86_64.rpm"
           },
+          "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:0fd5ff205e232adb010ce204b2b8c0c5270f523a4905102657f9e7838a6bb82d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/libblockdev-loop-2.28-3.el9.x86_64.rpm"
           },
@@ -4904,8 +4995,14 @@
           "sha256:2698b610b549f02621a3d0a214d16e2f653c59ee49e3b9509fc7d5bb3e495e5c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/setools-console-4.4.0-5.el9.x86_64.rpm"
           },
+          "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:276ea59394e1bc5ad4b4e2fbac6fdc2d0e22a8a2eb70373804ded801d9e0966c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/sudo-1.9.5p2-7.el9.x86_64.rpm"
+          },
+          "sha256:27945a54ed84a4e7d11454a1307711f14e1ad705b0f35a5886c4f5e109f45144": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.x86_64.rpm"
           },
           "sha256:2a488ad20ae5f87bd33a20ef9cd8aee891a0df22738cfd50d62a3895a264d419": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/libqrtr-glib-1.2.2-1.el9.x86_64.rpm"
@@ -4948,6 +5045,12 @@
           },
           "sha256:338b836ec8f148c17242c5cd7122d3478c213dc0f2979d6e16b05b5e3e1ff4a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/protobuf-3.14.0-13.el9.x86_64.rpm"
+          },
+          "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm"
+          },
+          "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:386905ddacb2614d519ec5dbaf038d40dbc44307b0edaa0bd3e6a5baa405a7b8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/gettext-0.21-7.el9.x86_64.rpm"
@@ -5032,6 +5135,9 @@
           },
           "sha256:4a3cb61eb08c4f24e44756b6cb329812fe48d5c65c1fba546fadfa975045a8c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/pcre-8.44-3.el9.3.x86_64.rpm"
+          },
+          "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
           },
           "sha256:4c53176eafd8c449aef704b8fbc2d5401bb7d2ea0a67961956f318f2e9a2c7a4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/libarchive-3.5.3-4.el9.x86_64.rpm"
@@ -5177,6 +5283,9 @@
           "sha256:6e6d77b76b1e89fe6f012cdc16111bea35eb4ceedac5040e5d81b5a066429af8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/gawk-5.1.0-6.el9.x86_64.rpm"
           },
+          "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:7061ac070b69ba818387b1413ea7292d4ec0a92164a9c658aeebb24147083053": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/traceroute-2.1.0-16.el9.x86_64.rpm"
           },
@@ -5299,6 +5408,12 @@
           },
           "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm"
+          },
+          "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
+          },
+          "sha256:90aeb088fad0093b1ca531387d38e1c32ad64efd56f2306eacc0edbc4c37e205": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:91db0205d933da34eca8bc71f39fbbf7dcae9370ede8873edb4b49c7475e1277": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/nss-softokn-3.79.0-14.el9.x86_64.rpm"
@@ -5681,6 +5796,9 @@
           "sha256:da7d1d8133633f351813587c3a12c9299f51dd8a1436ad2d2fa17ab981edee43": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/ipset-7.11-7.el9.x86_64.rpm"
           },
+          "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm"
+          },
           "sha256:dd297a44aa4657986871e3497e655709babf87016b1c1f134d902543c79daf7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/nspr-4.34.0-14.el9.x86_64.rpm"
           },
@@ -5767,6 +5885,9 @@
           },
           "sha256:efa5bab6739f4d21f61a383f62851e5d193dc096d6e532592319b33101484575": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/libblockdev-2.28-3.el9.x86_64.rpm"
+          },
+          "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
           },
           "sha256:f0ac4b6454d4018833dd10e3f437d8271c7c6a628d99b37e75b83af890b86bc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/libffi-3.4.2-7.el9.x86_64.rpm"
@@ -8697,6 +8818,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:90aeb088fad0093b1ca531387d38e1c32ad64efd56f2306eacc0edbc4c37e205",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -11027,6 +11158,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -11067,6 +11208,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.16",
@@ -11074,6 +11225,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-libs-3.9.16-1.el9.x86_64.rpm",
         "checksum": "sha256:21a7fe05e3c1a36b8242f5c783f7cdf636634b69bbd21428089b948f9c2433bc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.x86_64.rpm",
+        "checksum": "sha256:27945a54ed84a4e7d11454a1307711f14e1ad705b0f35a5886c4f5e109f45144",
         "check_gpg": true
       },
       {
@@ -11087,6 +11248,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -11094,6 +11265,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
         "check_gpg": true
       },
       {
@@ -11124,6 +11325,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-setuptools-wheel-53.0.0-11.el9.noarch.rpm",
         "checksum": "sha256:b923161167a7bab6fc9f235ebe4ae0f0344df9db6f1879dc9a52fd2c1efe2af5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
         "check_gpg": true
       },
       {
@@ -11274,6 +11495,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/shim-x64-15-15.el8_2.x86_64.rpm",
         "checksum": "sha256:3b69435ded0d7a1302bbb3dd521ec08dcbf7e0374c8bd892619e811f15c9cf3b",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm",
+        "checksum": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit_rt-boot.json
@@ -2346,6 +2346,14 @@
                     }
                   },
                   {
+                    "id": "sha256:90aeb088fad0093b1ca531387d38e1c32ad64efd56f2306eacc0edbc4c37e205",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:fabd6b5c065c2b9d4a8d39a938ae577d801de2ddc73c8cdf6f7803db29c28d0a",
                     "options": {
                       "metadata": {
@@ -4266,6 +4274,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8e42f3e54292bfc76ab52ee3f91f850fb0cca63c9a49692938381ca93460a686",
                     "options": {
                       "metadata": {
@@ -4298,7 +4314,23 @@
                     }
                   },
                   {
+                    "id": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:21a7fe05e3c1a36b8242f5c783f7cdf636634b69bbd21428089b948f9c2433bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27945a54ed84a4e7d11454a1307711f14e1ad705b0f35a5886c4f5e109f45144",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4330,6 +4362,14 @@
                     }
                   },
                   {
+                    "id": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff",
                     "options": {
                       "metadata": {
@@ -4338,7 +4378,31 @@
                     }
                   },
                   {
+                    "id": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:db815d76afabb8dd7eca6ca5a5bf838304f82824c41e4f06b6d25b5eb63c65c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4371,6 +4435,14 @@
                   },
                   {
                     "id": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4499,6 +4571,14 @@
                   },
                   {
                     "id": "sha256:10facee86b64af91b06292ca9892fd94fe5fc08c068b0baed6a0927d6a64955a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4962,6 +5042,9 @@
           "sha256:0ddd7fbfab82a67977c91b4f19b96824c5abbe44c3d9142df622c42a84db43ac": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/squashfs-tools-4.4-8.git1.el9.x86_64.rpm"
           },
+          "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:0fd5ff205e232adb010ce204b2b8c0c5270f523a4905102657f9e7838a6bb82d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/libblockdev-loop-2.28-3.el9.x86_64.rpm"
           },
@@ -5094,8 +5177,14 @@
           "sha256:2698b610b549f02621a3d0a214d16e2f653c59ee49e3b9509fc7d5bb3e495e5c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/setools-console-4.4.0-5.el9.x86_64.rpm"
           },
+          "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:276ea59394e1bc5ad4b4e2fbac6fdc2d0e22a8a2eb70373804ded801d9e0966c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/sudo-1.9.5p2-7.el9.x86_64.rpm"
+          },
+          "sha256:27945a54ed84a4e7d11454a1307711f14e1ad705b0f35a5886c4f5e109f45144": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.x86_64.rpm"
           },
           "sha256:2a488ad20ae5f87bd33a20ef9cd8aee891a0df22738cfd50d62a3895a264d419": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/libqrtr-glib-1.2.2-1.el9.x86_64.rpm"
@@ -5138,6 +5227,12 @@
           },
           "sha256:338b836ec8f148c17242c5cd7122d3478c213dc0f2979d6e16b05b5e3e1ff4a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/protobuf-3.14.0-13.el9.x86_64.rpm"
+          },
+          "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm"
+          },
+          "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:386905ddacb2614d519ec5dbaf038d40dbc44307b0edaa0bd3e6a5baa405a7b8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/gettext-0.21-7.el9.x86_64.rpm"
@@ -5228,6 +5323,9 @@
           },
           "sha256:4a3cb61eb08c4f24e44756b6cb329812fe48d5c65c1fba546fadfa975045a8c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/pcre-8.44-3.el9.3.x86_64.rpm"
+          },
+          "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
           },
           "sha256:4c53176eafd8c449aef704b8fbc2d5401bb7d2ea0a67961956f318f2e9a2c7a4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/libarchive-3.5.3-4.el9.x86_64.rpm"
@@ -5379,6 +5477,9 @@
           "sha256:6e6d77b76b1e89fe6f012cdc16111bea35eb4ceedac5040e5d81b5a066429af8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/gawk-5.1.0-6.el9.x86_64.rpm"
           },
+          "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:7061ac070b69ba818387b1413ea7292d4ec0a92164a9c658aeebb24147083053": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/traceroute-2.1.0-16.el9.x86_64.rpm"
           },
@@ -5516,6 +5617,12 @@
           },
           "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm"
+          },
+          "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
+          },
+          "sha256:90aeb088fad0093b1ca531387d38e1c32ad64efd56f2306eacc0edbc4c37e205": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:91db0205d933da34eca8bc71f39fbbf7dcae9370ede8873edb4b49c7475e1277": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/nss-softokn-3.79.0-14.el9.x86_64.rpm"
@@ -5906,6 +6013,9 @@
           },
           "sha256:db815d76afabb8dd7eca6ca5a5bf838304f82824c41e4f06b6d25b5eb63c65c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pyudev-0.22.0-6.el9.noarch.rpm"
+          },
+          "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm"
           },
           "sha256:dd297a44aa4657986871e3497e655709babf87016b1c1f134d902543c79daf7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/nspr-4.34.0-14.el9.x86_64.rpm"
@@ -8935,6 +9045,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:90aeb088fad0093b1ca531387d38e1c32ad64efd56f2306eacc0edbc4c37e205",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -11335,6 +11455,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -11375,6 +11505,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.16",
@@ -11382,6 +11522,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-libs-3.9.16-1.el9.x86_64.rpm",
         "checksum": "sha256:21a7fe05e3c1a36b8242f5c783f7cdf636634b69bbd21428089b948f9c2433bc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.x86_64.rpm",
+        "checksum": "sha256:27945a54ed84a4e7d11454a1307711f14e1ad705b0f35a5886c4f5e109f45144",
         "check_gpg": true
       },
       {
@@ -11415,6 +11565,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -11425,6 +11585,26 @@
         "check_gpg": true
       },
       {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pyudev",
         "epoch": 0,
         "version": "0.22.0",
@@ -11432,6 +11612,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pyudev-0.22.0-6.el9.noarch.rpm",
         "checksum": "sha256:db815d76afabb8dd7eca6ca5a5bf838304f82824c41e4f06b6d25b5eb63c65c6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
         "check_gpg": true
       },
       {
@@ -11472,6 +11662,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
         "checksum": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
         "check_gpg": true
       },
       {
@@ -11632,6 +11832,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/snappy-1.1.8-8.el9.x86_64.rpm",
         "checksum": "sha256:10facee86b64af91b06292ca9892fd94fe5fc08c068b0baed6a0927d6a64955a",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm",
+        "checksum": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
@@ -2353,6 +2353,14 @@
                     }
                   },
                   {
+                    "id": "sha256:90aeb088fad0093b1ca531387d38e1c32ad64efd56f2306eacc0edbc4c37e205",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:fabd6b5c065c2b9d4a8d39a938ae577d801de2ddc73c8cdf6f7803db29c28d0a",
                     "options": {
                       "metadata": {
@@ -4217,6 +4225,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8e42f3e54292bfc76ab52ee3f91f850fb0cca63c9a49692938381ca93460a686",
                     "options": {
                       "metadata": {
@@ -4249,7 +4265,23 @@
                     }
                   },
                   {
+                    "id": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:21a7fe05e3c1a36b8242f5c783f7cdf636634b69bbd21428089b948f9c2433bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27945a54ed84a4e7d11454a1307711f14e1ad705b0f35a5886c4f5e109f45144",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4265,7 +4297,39 @@
                     }
                   },
                   {
+                    "id": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4290,6 +4354,22 @@
                   },
                   {
                     "id": "sha256:b923161167a7bab6fc9f235ebe4ae0f0344df9db6f1879dc9a52fd2c1efe2af5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4410,6 +4490,14 @@
                   },
                   {
                     "id": "sha256:3b69435ded0d7a1302bbb3dd521ec08dcbf7e0374c8bd892619e811f15c9cf3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4827,6 +4915,9 @@
           "sha256:09f700a94e187a74f6f4a5f750082732e193d41392a85f042bdeb0bcbabe0a1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bash-5.1.8-6.el9.x86_64.rpm"
           },
+          "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:0fd5ff205e232adb010ce204b2b8c0c5270f523a4905102657f9e7838a6bb82d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/libblockdev-loop-2.28-3.el9.x86_64.rpm"
           },
@@ -4953,8 +5044,14 @@
           "sha256:2698b610b549f02621a3d0a214d16e2f653c59ee49e3b9509fc7d5bb3e495e5c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/setools-console-4.4.0-5.el9.x86_64.rpm"
           },
+          "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:276ea59394e1bc5ad4b4e2fbac6fdc2d0e22a8a2eb70373804ded801d9e0966c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/sudo-1.9.5p2-7.el9.x86_64.rpm"
+          },
+          "sha256:27945a54ed84a4e7d11454a1307711f14e1ad705b0f35a5886c4f5e109f45144": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.x86_64.rpm"
           },
           "sha256:2a488ad20ae5f87bd33a20ef9cd8aee891a0df22738cfd50d62a3895a264d419": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/libqrtr-glib-1.2.2-1.el9.x86_64.rpm"
@@ -4997,6 +5094,12 @@
           },
           "sha256:338b836ec8f148c17242c5cd7122d3478c213dc0f2979d6e16b05b5e3e1ff4a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/protobuf-3.14.0-13.el9.x86_64.rpm"
+          },
+          "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm"
+          },
+          "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:386905ddacb2614d519ec5dbaf038d40dbc44307b0edaa0bd3e6a5baa405a7b8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/gettext-0.21-7.el9.x86_64.rpm"
@@ -5081,6 +5184,9 @@
           },
           "sha256:4a3cb61eb08c4f24e44756b6cb329812fe48d5c65c1fba546fadfa975045a8c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/pcre-8.44-3.el9.3.x86_64.rpm"
+          },
+          "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
           },
           "sha256:4c53176eafd8c449aef704b8fbc2d5401bb7d2ea0a67961956f318f2e9a2c7a4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/libarchive-3.5.3-4.el9.x86_64.rpm"
@@ -5226,6 +5332,9 @@
           "sha256:6e6d77b76b1e89fe6f012cdc16111bea35eb4ceedac5040e5d81b5a066429af8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/gawk-5.1.0-6.el9.x86_64.rpm"
           },
+          "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:7061ac070b69ba818387b1413ea7292d4ec0a92164a9c658aeebb24147083053": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/traceroute-2.1.0-16.el9.x86_64.rpm"
           },
@@ -5348,6 +5457,12 @@
           },
           "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm"
+          },
+          "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
+          },
+          "sha256:90aeb088fad0093b1ca531387d38e1c32ad64efd56f2306eacc0edbc4c37e205": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:91db0205d933da34eca8bc71f39fbbf7dcae9370ede8873edb4b49c7475e1277": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/nss-softokn-3.79.0-14.el9.x86_64.rpm"
@@ -5730,6 +5845,9 @@
           "sha256:da7d1d8133633f351813587c3a12c9299f51dd8a1436ad2d2fa17ab981edee43": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/ipset-7.11-7.el9.x86_64.rpm"
           },
+          "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm"
+          },
           "sha256:dd297a44aa4657986871e3497e655709babf87016b1c1f134d902543c79daf7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/nspr-4.34.0-14.el9.x86_64.rpm"
           },
@@ -5816,6 +5934,9 @@
           },
           "sha256:efa5bab6739f4d21f61a383f62851e5d193dc096d6e532592319b33101484575": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/libblockdev-2.28-3.el9.x86_64.rpm"
+          },
+          "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
           },
           "sha256:f0ac4b6454d4018833dd10e3f437d8271c7c6a628d99b37e75b83af890b86bc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/libffi-3.4.2-7.el9.x86_64.rpm"
@@ -8769,6 +8890,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:90aeb088fad0093b1ca531387d38e1c32ad64efd56f2306eacc0edbc4c37e205",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -11099,6 +11230,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -11139,6 +11280,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.16",
@@ -11146,6 +11297,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-libs-3.9.16-1.el9.x86_64.rpm",
         "checksum": "sha256:21a7fe05e3c1a36b8242f5c783f7cdf636634b69bbd21428089b948f9c2433bc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.x86_64.rpm",
+        "checksum": "sha256:27945a54ed84a4e7d11454a1307711f14e1ad705b0f35a5886c4f5e109f45144",
         "check_gpg": true
       },
       {
@@ -11159,6 +11320,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -11166,6 +11337,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
         "check_gpg": true
       },
       {
@@ -11196,6 +11397,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-setuptools-wheel-53.0.0-11.el9.noarch.rpm",
         "checksum": "sha256:b923161167a7bab6fc9f235ebe4ae0f0344df9db6f1879dc9a52fd2c1efe2af5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
         "check_gpg": true
       },
       {
@@ -11346,6 +11567,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/shim-x64-15-15.el8_2.x86_64.rpm",
         "checksum": "sha256:3b69435ded0d7a1302bbb3dd521ec08dcbf7e0374c8bd892619e811f15c9cf3b",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm",
+        "checksum": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-edge_container-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_container-boot.json
@@ -2339,6 +2339,14 @@
                     }
                   },
                   {
+                    "id": "sha256:90aeb088fad0093b1ca531387d38e1c32ad64efd56f2306eacc0edbc4c37e205",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:fabd6b5c065c2b9d4a8d39a938ae577d801de2ddc73c8cdf6f7803db29c28d0a",
                     "options": {
                       "metadata": {
@@ -4203,6 +4211,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8e42f3e54292bfc76ab52ee3f91f850fb0cca63c9a49692938381ca93460a686",
                     "options": {
                       "metadata": {
@@ -4235,7 +4251,23 @@
                     }
                   },
                   {
+                    "id": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:21a7fe05e3c1a36b8242f5c783f7cdf636634b69bbd21428089b948f9c2433bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27945a54ed84a4e7d11454a1307711f14e1ad705b0f35a5886c4f5e109f45144",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4251,7 +4283,39 @@
                     }
                   },
                   {
+                    "id": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4276,6 +4340,22 @@
                   },
                   {
                     "id": "sha256:b923161167a7bab6fc9f235ebe4ae0f0344df9db6f1879dc9a52fd2c1efe2af5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4396,6 +4476,14 @@
                   },
                   {
                     "id": "sha256:3b69435ded0d7a1302bbb3dd521ec08dcbf7e0374c8bd892619e811f15c9cf3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5540,6 +5628,9 @@
           "sha256:09f700a94e187a74f6f4a5f750082732e193d41392a85f042bdeb0bcbabe0a1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bash-5.1.8-6.el9.x86_64.rpm"
           },
+          "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:0fd5ff205e232adb010ce204b2b8c0c5270f523a4905102657f9e7838a6bb82d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/libblockdev-loop-2.28-3.el9.x86_64.rpm"
           },
@@ -5666,8 +5757,14 @@
           "sha256:2698b610b549f02621a3d0a214d16e2f653c59ee49e3b9509fc7d5bb3e495e5c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/setools-console-4.4.0-5.el9.x86_64.rpm"
           },
+          "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:276ea59394e1bc5ad4b4e2fbac6fdc2d0e22a8a2eb70373804ded801d9e0966c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/sudo-1.9.5p2-7.el9.x86_64.rpm"
+          },
+          "sha256:27945a54ed84a4e7d11454a1307711f14e1ad705b0f35a5886c4f5e109f45144": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.x86_64.rpm"
           },
           "sha256:2a488ad20ae5f87bd33a20ef9cd8aee891a0df22738cfd50d62a3895a264d419": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/libqrtr-glib-1.2.2-1.el9.x86_64.rpm"
@@ -5710,6 +5807,12 @@
           },
           "sha256:338b836ec8f148c17242c5cd7122d3478c213dc0f2979d6e16b05b5e3e1ff4a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/protobuf-3.14.0-13.el9.x86_64.rpm"
+          },
+          "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm"
+          },
+          "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:386905ddacb2614d519ec5dbaf038d40dbc44307b0edaa0bd3e6a5baa405a7b8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/gettext-0.21-7.el9.x86_64.rpm"
@@ -5794,6 +5897,9 @@
           },
           "sha256:4a3cb61eb08c4f24e44756b6cb329812fe48d5c65c1fba546fadfa975045a8c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/pcre-8.44-3.el9.3.x86_64.rpm"
+          },
+          "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
           },
           "sha256:4c53176eafd8c449aef704b8fbc2d5401bb7d2ea0a67961956f318f2e9a2c7a4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/libarchive-3.5.3-4.el9.x86_64.rpm"
@@ -5942,6 +6048,9 @@
           "sha256:6e6d77b76b1e89fe6f012cdc16111bea35eb4ceedac5040e5d81b5a066429af8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/gawk-5.1.0-6.el9.x86_64.rpm"
           },
+          "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:7061ac070b69ba818387b1413ea7292d4ec0a92164a9c658aeebb24147083053": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/traceroute-2.1.0-16.el9.x86_64.rpm"
           },
@@ -6064,6 +6173,12 @@
           },
           "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm"
+          },
+          "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
+          },
+          "sha256:90aeb088fad0093b1ca531387d38e1c32ad64efd56f2306eacc0edbc4c37e205": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:914154e6057274684a953fcf111cb8f6962673fd93b3f10a04b32b67eba133c7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/nginx-1.20.1-13.el9.x86_64.rpm"
@@ -6455,6 +6570,9 @@
           "sha256:da7d1d8133633f351813587c3a12c9299f51dd8a1436ad2d2fa17ab981edee43": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/ipset-7.11-7.el9.x86_64.rpm"
           },
+          "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm"
+          },
           "sha256:dd297a44aa4657986871e3497e655709babf87016b1c1f134d902543c79daf7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/nspr-4.34.0-14.el9.x86_64.rpm"
           },
@@ -6544,6 +6662,9 @@
           },
           "sha256:efa5bab6739f4d21f61a383f62851e5d193dc096d6e532592319b33101484575": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20230101/Packages/libblockdev-2.28-3.el9.x86_64.rpm"
+          },
+          "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
           },
           "sha256:f0ac4b6454d4018833dd10e3f437d8271c7c6a628d99b37e75b83af890b86bc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/libffi-3.4.2-7.el9.x86_64.rpm"
@@ -10306,6 +10427,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:90aeb088fad0093b1ca531387d38e1c32ad64efd56f2306eacc0edbc4c37e205",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -12636,6 +12767,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:0dfc3c1b6372cec4dc7f7291fe66770f1d147e58ad6f8458ed407db9cdf86e36",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -12676,6 +12817,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:37b6f3fde4fedbcd6f1e6ce0bc98e3a8897283d1e67db9d39dcb97494a14b733",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.16",
@@ -12683,6 +12834,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-libs-3.9.16-1.el9.x86_64.rpm",
         "checksum": "sha256:21a7fe05e3c1a36b8242f5c783f7cdf636634b69bbd21428089b948f9c2433bc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-libxml2-2.9.13-3.el9.x86_64.rpm",
+        "checksum": "sha256:27945a54ed84a4e7d11454a1307711f14e1ad705b0f35a5886c4f5e109f45144",
         "check_gpg": true
       },
       {
@@ -12696,6 +12857,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:4a41320a63bb3897ae43b4f5bf0ef167df08c4f3e8b4bb08e04050e5edbca456",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -12703,6 +12874,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:8e9e72535944204b48dbcb9cb34007b4991bdb4b5223e4c5874b07c6c122c1ff",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:8fcc1d7ec17d38a1cb2554e2b38da7462e84774ee864f6e35b410184ad5618c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:6f5340ce8603685539486d3fe9ce6a5aad1dd725cc6482dc15979eb0c3a1893c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:26be417b92737ab0b97d80d02f95b66cf94dbf25d346c28cf2d541af1a397deb",
         "check_gpg": true
       },
       {
@@ -12733,6 +12934,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-setuptools-wheel-53.0.0-11.el9.noarch.rpm",
         "checksum": "sha256:b923161167a7bab6fc9f235ebe4ae0f0344df9db6f1879dc9a52fd2c1efe2af5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:efecffed29602079a1ea1d41c819271ec705a97a68891b43e1d626b2fa0ea8a1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:384f5c3db81a0987137c889e74c078a8abde8a0c0e789b155def8f644919ae37",
         "check_gpg": true
       },
       {
@@ -12883,6 +13104,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/shim-x64-15-15.el8_2.x86_64.rpm",
         "checksum": "sha256:3b69435ded0d7a1302bbb3dd521ec08dcbf7e0374c8bd892619e811f15c9cf3b",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/sos-4.3-2.el9.noarch.rpm",
+        "checksum": "sha256:dc4f3bfdf4efd406a587a7c449df28a0063502bbabd7160ee06ce77d8b814a65",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_8-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_commit-boot.json
@@ -690,6 +690,9 @@
                     "id": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
                   },
                   {
+                    "id": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+                  },
+                  {
                     "id": "sha256:2d84f6765b1645f867527f493b6153470602a80c75f81545bf619aa92127e4da"
                   },
                   {
@@ -1404,6 +1407,9 @@
                     "id": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:8329bf1aedce9ef3a4d7513ef98d3931ad39b84d5c3e73e99936c7f9b87931c2"
                   },
                   {
@@ -1416,6 +1422,9 @@
                     "id": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:03be12262e36ab660619168fcadd6873d7c3b1aa2010e71e96ec9bb80df5c26a"
                   },
                   {
@@ -1425,6 +1434,9 @@
                     "id": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
                   },
                   {
+                    "id": "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741"
+                  },
+                  {
                     "id": "sha256:81d8d21fdf2b10f6ef63bfe5c623464382912c15fc852c575d435f7f6583a150"
                   },
                   {
@@ -1432,6 +1444,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f75e77a1746534f649a29ea02d4341ce3e266a34173ba4dbf654c9682c9787dc"
@@ -1447,6 +1465,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -1498,6 +1519,9 @@
                   },
                   {
                     "id": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:febcbcc4a7c110ec230246d3cf9b896a1d30bea6c36098023daf78189ee94c36"
@@ -1714,6 +1738,12 @@
                   },
                   {
                     "id": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:803145131d29a09c7ff7947ecb4df45b12f8f4bbdf2eff475fd11bd0f82a6177"
@@ -1961,6 +1991,9 @@
           "sha256:12ee21a949fde092444ac1177a22a5fc5bcdcc88292dce1a23347c60462c5a57": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libblockdev-utils-2.24-11.el8.aarch64.rpm"
           },
+          "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
+          },
           "sha256:14175dab807188a8261298dc3ba7b7cd19a9fbf36d0ee5b5c6cacc7e424998e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libssh-config-0.9.6-3.el8.noarch.rpm"
           },
@@ -2111,6 +2144,9 @@
           "sha256:30693df80fa5507a1dfd2b62c469ab391c74d953e3e37da6a6947325974d80c3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libmount-2.32.1-38.el8.aarch64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30c6bc05e2e1c144bb6dfab2f18ba3033c5b428709fde6261a95af734ba057e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/nss-util-3.79.0-10.el8_6.aarch64.rpm"
           },
@@ -2140,6 +2176,9 @@
           },
           "sha256:343c51ca38204f0244e1928ad6267eda7c48b3badcc5d22b09c084b5f0a8ada3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libseccomp-2.5.2-1.el8.aarch64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:383e8542b87c8033076f3197b7996ccbc0fe76521c115c127362a66f1afb79b0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/systemd-pam-239-68.el8.aarch64.rpm"
@@ -2615,6 +2654,9 @@
           "sha256:a136862804f237c8243194e85d6b15361aba8aeb90cf004e61bb8fb55052940a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/e2fsprogs-1.45.6-5.el8.aarch64.rpm"
           },
+          "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.aarch64.rpm"
+          },
           "sha256:a3c479a9afd17f2a92acab491af69de3b3f69850ab3f8fca5562c5f530530174": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/oniguruma-6.8.2-2.el8.aarch64.rpm"
           },
@@ -2635,6 +2677,9 @@
           },
           "sha256:a7551988b8c466f8759449f5cfb375173fe5aee67978fb3e1549a2a2bdeccf73": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/glib2-2.56.4-159.el8.aarch64.rpm"
+          },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
@@ -2683,6 +2728,9 @@
           },
           "sha256:b4f90cde4962b669ba8840d221dadc7c53c974aba1dc4b31ef31658eb6b3b116": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/device-mapper-libs-1.02.181-6.el8.aarch64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b6a865ea7596d521138f924a278ff5f859b4f56d2b69708d3befe476b5a9082d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/chrony-4.2-1.el8.aarch64.rpm"
@@ -2746,6 +2794,9 @@
           },
           "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/readline-7.0-10.el8.aarch64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c2f9ce9ba473dcb0b6a2e20b3362bfcc18762e26bcb1a0a871c2cd5724910c71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/redhat-release-8.7-0.3.el8.aarch64.rpm"
@@ -2843,6 +2894,9 @@
           "sha256:d895c769c757996bf32ec587297681122f5df371960db4e74f2c9e72c3b9f4f3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/elfutils-debuginfod-client-0.187-4.el8.aarch64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da104c59254b60f093034924e21a7aabdeb1515d4b39e29aae60937257f71398": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/protobuf-3.5.0-15.el8.aarch64.rpm"
           },
@@ -2863,6 +2917,9 @@
           },
           "sha256:dbc8445a77ef2921cc10b38c9ae21f434757df6e5e4f70b795297414afb6e609": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.aarch64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dcaaeb91089115d930cb254d06af1400edcc9fd8f93b53746c73d9485b7692d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/podman-4.2.0-1.module+el8.7.0+16772+33343656.aarch64.rpm"
@@ -2986,6 +3043,9 @@
           },
           "sha256:fd21565b47cb699188b18c636e9d155df0bd86942b3da9607ee6260d6d3abb3a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/lvm2-libs-2.03.14-6.el8.aarch64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
@@ -4878,6 +4938,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.aarch64.rpm",
         "checksum": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
       },
       {
         "name": "bzip2-libs",
@@ -7022,6 +7091,15 @@
         "checksum": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7058,6 +7136,15 @@
         "checksum": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7085,6 +7172,15 @@
         "checksum": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.aarch64.rpm",
+        "checksum": "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7110,6 +7206,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7155,6 +7269,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7308,6 +7431,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/shim-aa64-15.6-1.el8.aarch64.rpm",
         "checksum": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -7956,6 +8088,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.aarch64.rpm",
         "checksum": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
@@ -780,6 +780,9 @@
                     "id": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
                   },
                   {
+                    "id": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+                  },
+                  {
                     "id": "sha256:2d84f6765b1645f867527f493b6153470602a80c75f81545bf619aa92127e4da"
                   },
                   {
@@ -1494,6 +1497,9 @@
                     "id": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:8329bf1aedce9ef3a4d7513ef98d3931ad39b84d5c3e73e99936c7f9b87931c2"
                   },
                   {
@@ -1506,6 +1512,9 @@
                     "id": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:03be12262e36ab660619168fcadd6873d7c3b1aa2010e71e96ec9bb80df5c26a"
                   },
                   {
@@ -1515,6 +1524,9 @@
                     "id": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
                   },
                   {
+                    "id": "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741"
+                  },
+                  {
                     "id": "sha256:81d8d21fdf2b10f6ef63bfe5c623464382912c15fc852c575d435f7f6583a150"
                   },
                   {
@@ -1522,6 +1534,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f75e77a1746534f649a29ea02d4341ce3e266a34173ba4dbf654c9682c9787dc"
@@ -1537,6 +1555,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -1588,6 +1609,9 @@
                   },
                   {
                     "id": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:febcbcc4a7c110ec230246d3cf9b896a1d30bea6c36098023daf78189ee94c36"
@@ -1804,6 +1828,12 @@
                   },
                   {
                     "id": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:803145131d29a09c7ff7947ecb4df45b12f8f4bbdf2eff475fd11bd0f82a6177"
@@ -2086,6 +2116,9 @@
           "sha256:12ee21a949fde092444ac1177a22a5fc5bcdcc88292dce1a23347c60462c5a57": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libblockdev-utils-2.24-11.el8.aarch64.rpm"
           },
+          "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
+          },
           "sha256:14175dab807188a8261298dc3ba7b7cd19a9fbf36d0ee5b5c6cacc7e424998e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libssh-config-0.9.6-3.el8.noarch.rpm"
           },
@@ -2236,6 +2269,9 @@
           "sha256:30693df80fa5507a1dfd2b62c469ab391c74d953e3e37da6a6947325974d80c3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libmount-2.32.1-38.el8.aarch64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30c6bc05e2e1c144bb6dfab2f18ba3033c5b428709fde6261a95af734ba057e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/nss-util-3.79.0-10.el8_6.aarch64.rpm"
           },
@@ -2265,6 +2301,9 @@
           },
           "sha256:343c51ca38204f0244e1928ad6267eda7c48b3badcc5d22b09c084b5f0a8ada3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libseccomp-2.5.2-1.el8.aarch64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:383e8542b87c8033076f3197b7996ccbc0fe76521c115c127362a66f1afb79b0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/systemd-pam-239-68.el8.aarch64.rpm"
@@ -2743,6 +2782,9 @@
           "sha256:a136862804f237c8243194e85d6b15361aba8aeb90cf004e61bb8fb55052940a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/e2fsprogs-1.45.6-5.el8.aarch64.rpm"
           },
+          "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.aarch64.rpm"
+          },
           "sha256:a3c479a9afd17f2a92acab491af69de3b3f69850ab3f8fca5562c5f530530174": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/oniguruma-6.8.2-2.el8.aarch64.rpm"
           },
@@ -2763,6 +2805,9 @@
           },
           "sha256:a7551988b8c466f8759449f5cfb375173fe5aee67978fb3e1549a2a2bdeccf73": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/glib2-2.56.4-159.el8.aarch64.rpm"
+          },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
@@ -2811,6 +2856,9 @@
           },
           "sha256:b4f90cde4962b669ba8840d221dadc7c53c974aba1dc4b31ef31658eb6b3b116": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/device-mapper-libs-1.02.181-6.el8.aarch64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b6a865ea7596d521138f924a278ff5f859b4f56d2b69708d3befe476b5a9082d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/chrony-4.2-1.el8.aarch64.rpm"
@@ -2874,6 +2922,9 @@
           },
           "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/readline-7.0-10.el8.aarch64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c2f9ce9ba473dcb0b6a2e20b3362bfcc18762e26bcb1a0a871c2cd5724910c71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/redhat-release-8.7-0.3.el8.aarch64.rpm"
@@ -2971,6 +3022,9 @@
           "sha256:d895c769c757996bf32ec587297681122f5df371960db4e74f2c9e72c3b9f4f3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/elfutils-debuginfod-client-0.187-4.el8.aarch64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da104c59254b60f093034924e21a7aabdeb1515d4b39e29aae60937257f71398": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/protobuf-3.5.0-15.el8.aarch64.rpm"
           },
@@ -2991,6 +3045,9 @@
           },
           "sha256:dbc8445a77ef2921cc10b38c9ae21f434757df6e5e4f70b795297414afb6e609": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.aarch64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dcaaeb91089115d930cb254d06af1400edcc9fd8f93b53746c73d9485b7692d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/podman-4.2.0-1.module+el8.7.0+16772+33343656.aarch64.rpm"
@@ -3114,6 +3171,9 @@
           },
           "sha256:fd21565b47cb699188b18c636e9d155df0bd86942b3da9607ee6260d6d3abb3a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/lvm2-libs-2.03.14-6.el8.aarch64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
@@ -5270,6 +5330,15 @@
         "checksum": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -7412,6 +7481,15 @@
         "checksum": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7448,6 +7526,15 @@
         "checksum": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7475,6 +7562,15 @@
         "checksum": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.aarch64.rpm",
+        "checksum": "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7500,6 +7596,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7545,6 +7659,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7698,6 +7821,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/shim-aa64-15.6-1.el8.aarch64.rpm",
         "checksum": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -8346,6 +8478,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.aarch64.rpm",
         "checksum": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_8-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_container-boot.json
@@ -690,6 +690,9 @@
                     "id": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
                   },
                   {
+                    "id": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+                  },
+                  {
                     "id": "sha256:2d84f6765b1645f867527f493b6153470602a80c75f81545bf619aa92127e4da"
                   },
                   {
@@ -1404,6 +1407,9 @@
                     "id": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:8329bf1aedce9ef3a4d7513ef98d3931ad39b84d5c3e73e99936c7f9b87931c2"
                   },
                   {
@@ -1416,6 +1422,9 @@
                     "id": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:03be12262e36ab660619168fcadd6873d7c3b1aa2010e71e96ec9bb80df5c26a"
                   },
                   {
@@ -1425,6 +1434,9 @@
                     "id": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
                   },
                   {
+                    "id": "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741"
+                  },
+                  {
                     "id": "sha256:81d8d21fdf2b10f6ef63bfe5c623464382912c15fc852c575d435f7f6583a150"
                   },
                   {
@@ -1432,6 +1444,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f75e77a1746534f649a29ea02d4341ce3e266a34173ba4dbf654c9682c9787dc"
@@ -1447,6 +1465,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -1498,6 +1519,9 @@
                   },
                   {
                     "id": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:febcbcc4a7c110ec230246d3cf9b896a1d30bea6c36098023daf78189ee94c36"
@@ -1714,6 +1738,12 @@
                   },
                   {
                     "id": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:803145131d29a09c7ff7947ecb4df45b12f8f4bbdf2eff475fd11bd0f82a6177"
@@ -2745,6 +2775,9 @@
           "sha256:137a8ee6c1f8500fa0de50d6bf894e9aaeb04dd2fb4d6e347e2b4f7db89a948a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libX11-1.6.8-5.el8.aarch64.rpm"
           },
+          "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
+          },
           "sha256:14175dab807188a8261298dc3ba7b7cd19a9fbf36d0ee5b5c6cacc7e424998e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libssh-config-0.9.6-3.el8.noarch.rpm"
           },
@@ -2922,6 +2955,9 @@
           "sha256:30693df80fa5507a1dfd2b62c469ab391c74d953e3e37da6a6947325974d80c3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libmount-2.32.1-38.el8.aarch64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30c6bc05e2e1c144bb6dfab2f18ba3033c5b428709fde6261a95af734ba057e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/nss-util-3.79.0-10.el8_6.aarch64.rpm"
           },
@@ -2960,6 +2996,9 @@
           },
           "sha256:34f9dc2d00d389b5eb9fef46404f182c8e81f008bb13e0e4e397ebc6a704fc5d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libxslt-1.1.32-6.el8.aarch64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:36798d9e979c9976ed66e23b3c8bda6250c4e80e411afe55c3942291cb4cb4ce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/perl-constant-1.33-396.el8.noarch.rpm"
@@ -3537,6 +3576,9 @@
           "sha256:a1d320b27056062b54ff814b2db9e2c482c895c24c7228abfac607c36fee55cc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/perl-MIME-Base64-3.15-396.el8.aarch64.rpm"
           },
+          "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.aarch64.rpm"
+          },
           "sha256:a3c479a9afd17f2a92acab491af69de3b3f69850ab3f8fca5562c5f530530174": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/oniguruma-6.8.2-2.el8.aarch64.rpm"
           },
@@ -3563,6 +3605,9 @@
           },
           "sha256:a7551988b8c466f8759449f5cfb375173fe5aee67978fb3e1549a2a2bdeccf73": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/glib2-2.56.4-159.el8.aarch64.rpm"
+          },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
@@ -3614,6 +3659,9 @@
           },
           "sha256:b4f90cde4962b669ba8840d221dadc7c53c974aba1dc4b31ef31658eb6b3b116": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/device-mapper-libs-1.02.181-6.el8.aarch64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b5774cc6cf397117a0a9a5f7aad450385a2583bc055ee3aaf203e8e66660a5ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/perl-Digest-MD5-2.55-396.el8.aarch64.rpm"
@@ -3683,6 +3731,9 @@
           },
           "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/readline-7.0-10.el8.aarch64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c2f9ce9ba473dcb0b6a2e20b3362bfcc18762e26bcb1a0a871c2cd5724910c71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/redhat-release-8.7-0.3.el8.aarch64.rpm"
@@ -3789,6 +3840,9 @@
           "sha256:d906b13d5dd7a5595133e2a1af83ae17a1aae0c107579db723d21ec4371f3570": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/perl-File-Path-2.15-2.el8.noarch.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da104c59254b60f093034924e21a7aabdeb1515d4b39e29aae60937257f71398": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/protobuf-3.5.0-15.el8.aarch64.rpm"
           },
@@ -3812,6 +3866,9 @@
           },
           "sha256:dbc8445a77ef2921cc10b38c9ae21f434757df6e5e4f70b795297414afb6e609": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.aarch64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dcaaeb91089115d930cb254d06af1400edcc9fd8f93b53746c73d9485b7692d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/podman-4.2.0-1.module+el8.7.0+16772+33343656.aarch64.rpm"
@@ -3959,6 +4016,9 @@
           },
           "sha256:fd21565b47cb699188b18c636e9d155df0bd86942b3da9607ee6260d6d3abb3a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/lvm2-libs-2.03.14-6.el8.aarch64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
@@ -7898,6 +7958,15 @@
         "checksum": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -10040,6 +10109,15 @@
         "checksum": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -10076,6 +10154,15 @@
         "checksum": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -10103,6 +10190,15 @@
         "checksum": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.aarch64.rpm",
+        "checksum": "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -10128,6 +10224,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -10173,6 +10287,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -10326,6 +10449,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/shim-aa64-15.6-1.el8.aarch64.rpm",
         "checksum": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -10974,6 +11106,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.aarch64.rpm",
         "checksum": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_8-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit-boot.json
@@ -714,6 +714,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1473,6 +1476,9 @@
                     "id": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1485,6 +1491,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:496ad735717ce1ed9cde99894844f5f5b745475a28f52b67e3ee5b368e0f20f0"
                   },
                   {
@@ -1494,6 +1503,9 @@
                     "id": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
                   },
                   {
+                    "id": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
+                  },
+                  {
                     "id": "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed"
                   },
                   {
@@ -1501,6 +1513,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1516,6 +1534,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1567,6 +1588,9 @@
                   },
                   {
                     "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:b9cb64cbd8df172d478cd77d6dfa95309b5f3599dd4ce3423b0da7c93e25b6a4"
@@ -1783,6 +1807,12 @@
                   },
                   {
                     "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991"
@@ -2142,6 +2172,9 @@
           "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
@@ -2180,6 +2213,9 @@
           },
           "sha256:3445946e036e5c26e5163388e96566bb0e71159e0fe40a93016f51ff0a099d10": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-minimal-langpack-2.28-211.el8.x86_64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:35d2ce5cb5727a3703b83ffeb82b95c5ae2fb520e7a61a464425912e617294bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shadow-utils-4.6-17.el8.x86_64.rpm"
@@ -2387,6 +2423,9 @@
           },
           "sha256:644529740fa2e3655ab2aea0f5622958c34a591c0d08ee033ecbe2fb40dd437c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libbpf-0.5.0-1.el8.x86_64.rpm"
+          },
+          "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm"
           },
           "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-nftables-0.9.3-26.el8.x86_64.rpm"
@@ -2682,6 +2721,9 @@
           "sha256:a5a3efebdb4fd22edaa51a1ae737ef5801c8a8b6f87fb0891dd2ed93d55876f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/selinux-policy-targeted-3.14.3-108.el8.noarch.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a8233c195bb8b0a6b11b6e019d2a104bdfcdc07373d1d60c2b37723b19f97d0e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/NetworkManager-wifi-1.40.0-1.el8.x86_64.rpm"
           },
@@ -2699,6 +2741,9 @@
           },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ac99837d0568e37ab2b5dd8f10b17c3cc8b23d789199c93d79824bfab8f7f064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl6050-firmware-41.28.5.1-110.el8.1.noarch.rpm"
@@ -2750,6 +2795,9 @@
           },
           "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/rpm-ostree-2022.10.90.g4abaf4b4-4.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
@@ -2804,6 +2852,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm"
@@ -2946,8 +2997,14 @@
           "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da574dd0016840097a59070cc147ff60563ed7e314b97ae9ff9238188849956c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/clevis-15-11.el8.x86_64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:df82b0b9201f0d45f4a50a138d7592df71fde47bddbf9310fce62c2461cf0101": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl2030-firmware-18.168.6.1-110.el8.1.noarch.rpm"
@@ -3089,6 +3146,9 @@
           },
           "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -5038,6 +5098,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
       },
       {
         "name": "bzip2-libs",
@@ -7317,6 +7386,15 @@
         "checksum": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7353,6 +7431,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7380,6 +7467,15 @@
         "checksum": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm",
+        "checksum": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7405,6 +7501,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7450,6 +7564,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7603,6 +7726,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
         "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -8251,6 +8383,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
         "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_8-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit_rt-boot.json
@@ -721,6 +721,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1501,6 +1504,9 @@
                     "id": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1516,6 +1522,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:496ad735717ce1ed9cde99894844f5f5b745475a28f52b67e3ee5b368e0f20f0"
                   },
                   {
@@ -1523,6 +1532,9 @@
                   },
                   {
                     "id": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
+                  },
+                  {
+                    "id": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
                   },
                   {
                     "id": "sha256:c8653e199fdea0852a124ed24df2f7b3aa7e0aa6a1258147d89c39692a420c84"
@@ -1540,7 +1552,13 @@
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
                   },
                   {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
                     "id": "sha256:4ad66a3a1dd79384852669609567108dcc429607d40ca8adc5f1dbe6a9d6bdde"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1559,6 +1577,9 @@
                   },
                   {
                     "id": "sha256:7d9fc991404f6a6500385e328e231dd6b84a7722648e049ae9565fa31135f6a3"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1613,6 +1634,9 @@
                   },
                   {
                     "id": "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:b9cb64cbd8df172d478cd77d6dfa95309b5f3599dd4ce3423b0da7c93e25b6a4"
@@ -1841,6 +1865,12 @@
                   },
                   {
                     "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991"
@@ -2236,6 +2266,9 @@
           "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
@@ -2274,6 +2307,9 @@
           },
           "sha256:3445946e036e5c26e5163388e96566bb0e71159e0fe40a93016f51ff0a099d10": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-minimal-langpack-2.28-211.el8.x86_64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:35d2ce5cb5727a3703b83ffeb82b95c5ae2fb520e7a61a464425912e617294bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shadow-utils-4.6-17.el8.x86_64.rpm"
@@ -2484,6 +2520,9 @@
           },
           "sha256:644529740fa2e3655ab2aea0f5622958c34a591c0d08ee033ecbe2fb40dd437c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libbpf-0.5.0-1.el8.x86_64.rpm"
+          },
+          "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm"
           },
           "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-nftables-0.9.3-26.el8.x86_64.rpm"
@@ -2797,6 +2836,9 @@
           "sha256:a5a3efebdb4fd22edaa51a1ae737ef5801c8a8b6f87fb0891dd2ed93d55876f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/selinux-policy-targeted-3.14.3-108.el8.noarch.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a8233c195bb8b0a6b11b6e019d2a104bdfcdc07373d1d60c2b37723b19f97d0e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/NetworkManager-wifi-1.40.0-1.el8.x86_64.rpm"
           },
@@ -2814,6 +2856,9 @@
           },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ac99837d0568e37ab2b5dd8f10b17c3cc8b23d789199c93d79824bfab8f7f064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl6050-firmware-41.28.5.1-110.el8.1.noarch.rpm"
@@ -2868,6 +2913,9 @@
           },
           "sha256:b4babe48d93eccce4f0249ba34d592bfc306c3b14b40df7a5cc9eaec2eaae20f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/numactl-libs-2.0.12-13.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
@@ -2928,6 +2976,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm"
@@ -3076,8 +3127,14 @@
           "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da574dd0016840097a59070cc147ff60563ed7e314b97ae9ff9238188849956c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/clevis-15-11.el8.x86_64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:df82b0b9201f0d45f4a50a138d7592df71fde47bddbf9310fce62c2461cf0101": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl2030-firmware-18.168.6.1-110.el8.1.noarch.rpm"
@@ -3228,6 +3285,9 @@
           },
           "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -5177,6 +5237,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
       },
       {
         "name": "bzip2-libs",
@@ -7519,6 +7588,15 @@
         "checksum": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7564,6 +7642,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7589,6 +7676,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libsemanage-2.9-9.el8.x86_64.rpm",
         "checksum": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm",
+        "checksum": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
       },
       {
         "name": "python3-linux-procfs",
@@ -7636,6 +7732,15 @@
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
       },
       {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
         "name": "python3-pyudev",
         "epoch": 0,
         "version": "0.21.0",
@@ -7643,6 +7748,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pyudev-0.21.0-7.el8.noarch.rpm",
         "checksum": "sha256:4ad66a3a1dd79384852669609567108dcc429607d40ca8adc5f1dbe6a9d6bdde"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7697,6 +7811,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-syspurpose-1.28.32-1.el8.x86_64.rpm",
         "checksum": "sha256:7d9fc991404f6a6500385e328e231dd6b84a7722648e049ae9565fa31135f6a3"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7859,6 +7982,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/snappy-1.1.8-3.el8.x86_64.rpm",
         "checksum": "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -8543,6 +8675,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
         "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
@@ -804,6 +804,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1563,6 +1566,9 @@
                     "id": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1575,6 +1581,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:496ad735717ce1ed9cde99894844f5f5b745475a28f52b67e3ee5b368e0f20f0"
                   },
                   {
@@ -1584,6 +1593,9 @@
                     "id": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
                   },
                   {
+                    "id": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
+                  },
+                  {
                     "id": "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed"
                   },
                   {
@@ -1591,6 +1603,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1606,6 +1624,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1657,6 +1678,9 @@
                   },
                   {
                     "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:b9cb64cbd8df172d478cd77d6dfa95309b5f3599dd4ce3423b0da7c93e25b6a4"
@@ -1873,6 +1897,12 @@
                   },
                   {
                     "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991"
@@ -2267,6 +2297,9 @@
           "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
@@ -2305,6 +2338,9 @@
           },
           "sha256:3445946e036e5c26e5163388e96566bb0e71159e0fe40a93016f51ff0a099d10": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-minimal-langpack-2.28-211.el8.x86_64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:35d2ce5cb5727a3703b83ffeb82b95c5ae2fb520e7a61a464425912e617294bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shadow-utils-4.6-17.el8.x86_64.rpm"
@@ -2512,6 +2548,9 @@
           },
           "sha256:644529740fa2e3655ab2aea0f5622958c34a591c0d08ee033ecbe2fb40dd437c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libbpf-0.5.0-1.el8.x86_64.rpm"
+          },
+          "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm"
           },
           "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-nftables-0.9.3-26.el8.x86_64.rpm"
@@ -2810,6 +2849,9 @@
           "sha256:a5a3efebdb4fd22edaa51a1ae737ef5801c8a8b6f87fb0891dd2ed93d55876f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/selinux-policy-targeted-3.14.3-108.el8.noarch.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a8233c195bb8b0a6b11b6e019d2a104bdfcdc07373d1d60c2b37723b19f97d0e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/NetworkManager-wifi-1.40.0-1.el8.x86_64.rpm"
           },
@@ -2827,6 +2869,9 @@
           },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ac99837d0568e37ab2b5dd8f10b17c3cc8b23d789199c93d79824bfab8f7f064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl6050-firmware-41.28.5.1-110.el8.1.noarch.rpm"
@@ -2878,6 +2923,9 @@
           },
           "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/rpm-ostree-2022.10.90.g4abaf4b4-4.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
@@ -2932,6 +2980,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm"
@@ -3074,8 +3125,14 @@
           "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da574dd0016840097a59070cc147ff60563ed7e314b97ae9ff9238188849956c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/clevis-15-11.el8.x86_64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:df82b0b9201f0d45f4a50a138d7592df71fde47bddbf9310fce62c2461cf0101": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl2030-firmware-18.168.6.1-110.el8.1.noarch.rpm"
@@ -3217,6 +3274,9 @@
           },
           "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -5428,6 +5488,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
       },
       {
         "name": "bzip2-libs",
@@ -7707,6 +7776,15 @@
         "checksum": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7743,6 +7821,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7770,6 +7857,15 @@
         "checksum": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm",
+        "checksum": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7795,6 +7891,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7840,6 +7954,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7993,6 +8116,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
         "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -8641,6 +8773,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
         "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_8-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_container-boot.json
@@ -705,6 +705,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1464,6 +1467,9 @@
                     "id": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1476,6 +1482,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:496ad735717ce1ed9cde99894844f5f5b745475a28f52b67e3ee5b368e0f20f0"
                   },
                   {
@@ -1485,6 +1494,9 @@
                     "id": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
                   },
                   {
+                    "id": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
+                  },
+                  {
                     "id": "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed"
                   },
                   {
@@ -1492,6 +1504,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1507,6 +1525,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1558,6 +1579,9 @@
                   },
                   {
                     "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:b9cb64cbd8df172d478cd77d6dfa95309b5f3599dd4ce3423b0da7c93e25b6a4"
@@ -1774,6 +1798,12 @@
                   },
                   {
                     "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991"
@@ -2955,6 +2985,9 @@
           "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
@@ -2993,6 +3026,9 @@
           },
           "sha256:3445946e036e5c26e5163388e96566bb0e71159e0fe40a93016f51ff0a099d10": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-minimal-langpack-2.28-211.el8.x86_64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:35d2ce5cb5727a3703b83ffeb82b95c5ae2fb520e7a61a464425912e617294bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shadow-utils-4.6-17.el8.x86_64.rpm"
@@ -3236,6 +3272,9 @@
           },
           "sha256:644529740fa2e3655ab2aea0f5622958c34a591c0d08ee033ecbe2fb40dd437c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libbpf-0.5.0-1.el8.x86_64.rpm"
+          },
+          "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm"
           },
           "sha256:657efda777af4b0d63ab127a72f3373c0d8a18f3b81e912b24a5fbdc9927dc1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/perl-Term-ANSIColor-4.06-396.el8.noarch.rpm"
@@ -3591,6 +3630,9 @@
           "sha256:a660c78f704d3d22458c71d86605f51d62e3cc5306d22d66bb1df86c7274ad6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a8233c195bb8b0a6b11b6e019d2a104bdfcdc07373d1d60c2b37723b19f97d0e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/NetworkManager-wifi-1.40.0-1.el8.x86_64.rpm"
           },
@@ -3611,6 +3653,9 @@
           },
           "sha256:abe578c5dee7c306812e241c77ebc8ba4b54f90df8e65c56f8f202ba6e0d7183": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/perl-parent-0.237-1.el8.noarch.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ac99837d0568e37ab2b5dd8f10b17c3cc8b23d789199c93d79824bfab8f7f064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl6050-firmware-41.28.5.1-110.el8.1.noarch.rpm"
@@ -3666,6 +3711,9 @@
           "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/rpm-ostree-2022.10.90.g4abaf4b4-4.el8.x86_64.rpm"
           },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
+          },
           "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
           },
@@ -3719,6 +3767,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm"
@@ -3885,11 +3936,17 @@
           "sha256:d906b13d5dd7a5595133e2a1af83ae17a1aae0c107579db723d21ec4371f3570": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/perl-File-Path-2.15-2.el8.noarch.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da574dd0016840097a59070cc147ff60563ed7e314b97ae9ff9238188849956c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/clevis-15-11.el8.x86_64.rpm"
           },
           "sha256:db1fad3c2d8735e69084bd4b09ea963938e4dde2f2e096dc7a4ce146f18b7ab0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fontpackages-filesystem-1.44-22.el8.noarch.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dd6a948e5a656701156c618e202c0b6defd11ba6f162b6790cbb42cea15141ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/perl-URI-1.73-3.el8.noarch.rpm"
@@ -4052,6 +4109,9 @@
           },
           "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -8048,6 +8108,15 @@
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -10325,6 +10394,15 @@
         "checksum": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -10361,6 +10439,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -10388,6 +10475,15 @@
         "checksum": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm",
+        "checksum": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -10413,6 +10509,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -10458,6 +10572,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -10611,6 +10734,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
         "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -11259,6 +11391,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
         "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
@@ -687,6 +687,9 @@
                     "id": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
                   },
                   {
+                    "id": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+                  },
+                  {
                     "id": "sha256:2d84f6765b1645f867527f493b6153470602a80c75f81545bf619aa92127e4da"
                   },
                   {
@@ -1398,6 +1401,9 @@
                     "id": "sha256:cbcd24f6ecbc84656d72b146aa33dcbd5f8df79d55ccec1bf952b2dd8de972a6"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:8329bf1aedce9ef3a4d7513ef98d3931ad39b84d5c3e73e99936c7f9b87931c2"
                   },
                   {
@@ -1410,6 +1416,9 @@
                     "id": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:d5a9a87599b8aab3c5b878100398cf2159f26160ee6e809f74f93262f1d3ad78"
                   },
                   {
@@ -1419,6 +1428,9 @@
                     "id": "sha256:8db948c4e35bdc675cc942ef12296d8c9a3b652832e02f6c5147eaf026b5d161"
                   },
                   {
+                    "id": "sha256:3dec03926a2dcf9ec308c7eefc4e6a22da5aa40df758da25a925598e11fbffb9"
+                  },
+                  {
                     "id": "sha256:3750602e3fca7d1ddc3aa2f2ec1c373f257cc43895bc12fafd123dcb1400d6ea"
                   },
                   {
@@ -1426,6 +1438,12 @@
                   },
                   {
                     "id": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f75e77a1746534f649a29ea02d4341ce3e266a34173ba4dbf654c9682c9787dc"
@@ -1441,6 +1459,9 @@
                   },
                   {
                     "id": "sha256:96b090a6696ca4c8b3f701c3a7b95b91c892db389e023c4b2d500a5162e43e8d"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -1492,6 +1513,9 @@
                   },
                   {
                     "id": "sha256:b97af00f72ced6bb75ac2c5eb1100b4a39fea8867d68e6d633ea89f187689439"
+                  },
+                  {
+                    "id": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
                   },
                   {
                     "id": "sha256:432d9dd36116fce2b174d68c141f627919e4ac17b488ac5a035d7261a1070c22"
@@ -1708,6 +1732,12 @@
                   },
                   {
                     "id": "sha256:bf6a9ab5cdf3c0a71b634201fe260b1362d8eeb82fe33ccd220dc12c9396ec27"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:3953eb6443d651317e940d3328539d9ff0e93c251030385bd606d5b17ad22f3b"
@@ -1964,6 +1994,9 @@
           "sha256:12d6bfe52608f37a92a73b84330c66324ea981df4c6e940cc59fe835cbc4164e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/curl-7.61.1-22.el8.aarch64.rpm"
           },
+          "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
+          },
           "sha256:13ce9db75f06389171a5279b5cb389625f09522d06b5767ae827d5f18f79550e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/kernel-modules-4.18.0-361.el8.aarch64.rpm"
           },
@@ -2114,6 +2147,9 @@
           "sha256:343c51ca38204f0244e1928ad6267eda7c48b3badcc5d22b09c084b5f0a8ada3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libseccomp-2.5.2-1.el8.aarch64.rpm"
           },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
+          },
           "sha256:35a0ed6756beb693895afb57e01712f38ea20bcad54a92dc8cebf3f502cd05db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/iproute-5.15.0-2.el8.aarch64.rpm"
           },
@@ -2149,6 +2185,9 @@
           },
           "sha256:3d372ca16c46e471896f6cc4387142f49b5733e6649e7107929387be3117e9a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/zlib-1.2.11-17.el8.aarch64.rpm"
+          },
+          "sha256:3dec03926a2dcf9ec308c7eefc4e6a22da5aa40df758da25a925598e11fbffb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.aarch64.rpm"
           },
           "sha256:3f08b2a89e076a6826bfc793df6ea44e2ed1982187d1a02c2ebb631ba976b6d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/jq-1.6-3.el8.aarch64.rpm"
@@ -2525,6 +2564,9 @@
           "sha256:98f838a9775269a0f796151bd54d52c7ac91d4bf1365186772f243bfafbb136a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libaio-0.3.112-1.el8.aarch64.rpm"
           },
+          "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm"
+          },
           "sha256:9a1152654e67e7ef015a6ac39c6f53077e89aa5ec4e1c55ae204edfd298656b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/xfsprogs-5.0.0-10.el8.aarch64.rpm"
           },
@@ -2603,6 +2645,9 @@
           "sha256:a7a01029879d1966a822b028658b44f6cec885d2e25d77f67a5fdbb89fe4a860": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/audit-3.0.7-1.el8.aarch64.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a7c864ec250cae43189f249d99604f1d26f07e86abfba5195e9436425df8462c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/iptables-libs-1.8.4-22.el8.aarch64.rpm"
           },
@@ -2653,6 +2698,9 @@
           },
           "sha256:b3d72ac8eb91e5fcf3dcacc0d1bf1412b910ca4e1fe11cfa74d26b8f46eb1a9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/keyutils-1.5.10-9.el8.aarch64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b705e2abbce31768f9dde08b2e3bb4756f2512ad22ac94f4bb6761c530b66f71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/bash-completion-2.7-5.el8.noarch.rpm"
@@ -2728,6 +2776,9 @@
           },
           "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/readline-7.0-10.el8.aarch64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c321e3a0253fb2691035135b3d3740faa76b8e9c84a0378f480ff85ddd9f16bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/efibootmgr-16-1.el8.aarch64.rpm"
@@ -2834,6 +2885,9 @@
           "sha256:d92bfa56506bc755cc0e36943a1eb1d7c483c2b3e4d7bf6a306f1376a3f01ab6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/podman-3.4.5-0.5.module+el8.6.0+13916+cd3e3727.aarch64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:d96728282297bff3f25cb6e6f7c52e9a84d803c7e496e3d88f36445697ece9d9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libuuid-2.32.1-32.el8.aarch64.rpm"
           },
@@ -2854,6 +2908,9 @@
           },
           "sha256:dbc8445a77ef2921cc10b38c9ae21f434757df6e5e4f70b795297414afb6e609": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/libatasmart-0.19-14.el8.aarch64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dc532e65e53ebdcdf9e555c91a393869684b916ad463ec0919e6de5f001da930": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libbpf-0.4.0-3.el8.aarch64.rpm"
@@ -2977,6 +3034,9 @@
           },
           "sha256:fc51460213b3bf5b67f08f2695aae8d728f614adbbacb917a0825e4ebfbc3e68": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/hardlink-1.3-6.el8.aarch64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fdd5f73a53f3098a71a7ca7a869c14a0c63cf863224fbc54b88a7def54745ca9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/cryptsetup-libs-2.3.7-1.el8.aarch64.rpm"
@@ -4860,6 +4920,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/bubblewrap-0.4.0-1.el8.aarch64.rpm",
         "checksum": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
       },
       {
         "name": "bzip2-libs",
@@ -6995,6 +7064,15 @@
         "checksum": "sha256:cbcd24f6ecbc84656d72b146aa33dcbd5f8df79d55ccec1bf952b2dd8de972a6"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7031,6 +7109,15 @@
         "checksum": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7058,6 +7145,15 @@
         "checksum": "sha256:8db948c4e35bdc675cc942ef12296d8c9a3b652832e02f6c5147eaf026b5d161"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "9.el8_4.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.aarch64.rpm",
+        "checksum": "sha256:3dec03926a2dcf9ec308c7eefc4e6a22da5aa40df758da25a925598e11fbffb9"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7083,6 +7179,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
         "checksum": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7128,6 +7242,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
         "checksum": "sha256:96b090a6696ca4c8b3f701c3a7b95b91c892db389e023c4b2d500a5162e43e8d"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7281,6 +7404,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/shim-aa64-15.4-2.el8_1.aarch64.rpm",
         "checksum": "sha256:b97af00f72ced6bb75ac2c5eb1100b4a39fea8867d68e6d633ea89f187689439"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
       },
       {
         "name": "sqlite-libs",
@@ -7929,6 +8061,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/protobuf-3.5.0-13.el8.aarch64.rpm",
         "checksum": "sha256:bf6a9ab5cdf3c0a71b634201fe260b1362d8eeb82fe33ccd220dc12c9396ec27"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
@@ -777,6 +777,9 @@
                     "id": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
                   },
                   {
+                    "id": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+                  },
+                  {
                     "id": "sha256:2d84f6765b1645f867527f493b6153470602a80c75f81545bf619aa92127e4da"
                   },
                   {
@@ -1488,6 +1491,9 @@
                     "id": "sha256:cbcd24f6ecbc84656d72b146aa33dcbd5f8df79d55ccec1bf952b2dd8de972a6"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:8329bf1aedce9ef3a4d7513ef98d3931ad39b84d5c3e73e99936c7f9b87931c2"
                   },
                   {
@@ -1500,6 +1506,9 @@
                     "id": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:d5a9a87599b8aab3c5b878100398cf2159f26160ee6e809f74f93262f1d3ad78"
                   },
                   {
@@ -1509,6 +1518,9 @@
                     "id": "sha256:8db948c4e35bdc675cc942ef12296d8c9a3b652832e02f6c5147eaf026b5d161"
                   },
                   {
+                    "id": "sha256:3dec03926a2dcf9ec308c7eefc4e6a22da5aa40df758da25a925598e11fbffb9"
+                  },
+                  {
                     "id": "sha256:3750602e3fca7d1ddc3aa2f2ec1c373f257cc43895bc12fafd123dcb1400d6ea"
                   },
                   {
@@ -1516,6 +1528,12 @@
                   },
                   {
                     "id": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f75e77a1746534f649a29ea02d4341ce3e266a34173ba4dbf654c9682c9787dc"
@@ -1531,6 +1549,9 @@
                   },
                   {
                     "id": "sha256:96b090a6696ca4c8b3f701c3a7b95b91c892db389e023c4b2d500a5162e43e8d"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -1582,6 +1603,9 @@
                   },
                   {
                     "id": "sha256:b97af00f72ced6bb75ac2c5eb1100b4a39fea8867d68e6d633ea89f187689439"
+                  },
+                  {
+                    "id": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
                   },
                   {
                     "id": "sha256:432d9dd36116fce2b174d68c141f627919e4ac17b488ac5a035d7261a1070c22"
@@ -1798,6 +1822,12 @@
                   },
                   {
                     "id": "sha256:bf6a9ab5cdf3c0a71b634201fe260b1362d8eeb82fe33ccd220dc12c9396ec27"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:3953eb6443d651317e940d3328539d9ff0e93c251030385bd606d5b17ad22f3b"
@@ -2089,6 +2119,9 @@
           "sha256:12d6bfe52608f37a92a73b84330c66324ea981df4c6e940cc59fe835cbc4164e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/curl-7.61.1-22.el8.aarch64.rpm"
           },
+          "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
+          },
           "sha256:13ce9db75f06389171a5279b5cb389625f09522d06b5767ae827d5f18f79550e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/kernel-modules-4.18.0-361.el8.aarch64.rpm"
           },
@@ -2239,6 +2272,9 @@
           "sha256:343c51ca38204f0244e1928ad6267eda7c48b3badcc5d22b09c084b5f0a8ada3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libseccomp-2.5.2-1.el8.aarch64.rpm"
           },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
+          },
           "sha256:35a0ed6756beb693895afb57e01712f38ea20bcad54a92dc8cebf3f502cd05db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/iproute-5.15.0-2.el8.aarch64.rpm"
           },
@@ -2274,6 +2310,9 @@
           },
           "sha256:3d372ca16c46e471896f6cc4387142f49b5733e6649e7107929387be3117e9a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/zlib-1.2.11-17.el8.aarch64.rpm"
+          },
+          "sha256:3dec03926a2dcf9ec308c7eefc4e6a22da5aa40df758da25a925598e11fbffb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.aarch64.rpm"
           },
           "sha256:3f08b2a89e076a6826bfc793df6ea44e2ed1982187d1a02c2ebb631ba976b6d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/jq-1.6-3.el8.aarch64.rpm"
@@ -2653,6 +2692,9 @@
           "sha256:98f838a9775269a0f796151bd54d52c7ac91d4bf1365186772f243bfafbb136a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libaio-0.3.112-1.el8.aarch64.rpm"
           },
+          "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm"
+          },
           "sha256:9a1152654e67e7ef015a6ac39c6f53077e89aa5ec4e1c55ae204edfd298656b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/xfsprogs-5.0.0-10.el8.aarch64.rpm"
           },
@@ -2731,6 +2773,9 @@
           "sha256:a7a01029879d1966a822b028658b44f6cec885d2e25d77f67a5fdbb89fe4a860": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/audit-3.0.7-1.el8.aarch64.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a7c864ec250cae43189f249d99604f1d26f07e86abfba5195e9436425df8462c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/iptables-libs-1.8.4-22.el8.aarch64.rpm"
           },
@@ -2781,6 +2826,9 @@
           },
           "sha256:b3d72ac8eb91e5fcf3dcacc0d1bf1412b910ca4e1fe11cfa74d26b8f46eb1a9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/keyutils-1.5.10-9.el8.aarch64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b705e2abbce31768f9dde08b2e3bb4756f2512ad22ac94f4bb6761c530b66f71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/bash-completion-2.7-5.el8.noarch.rpm"
@@ -2856,6 +2904,9 @@
           },
           "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/readline-7.0-10.el8.aarch64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c321e3a0253fb2691035135b3d3740faa76b8e9c84a0378f480ff85ddd9f16bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/efibootmgr-16-1.el8.aarch64.rpm"
@@ -2962,6 +3013,9 @@
           "sha256:d92bfa56506bc755cc0e36943a1eb1d7c483c2b3e4d7bf6a306f1376a3f01ab6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/podman-3.4.5-0.5.module+el8.6.0+13916+cd3e3727.aarch64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:d96728282297bff3f25cb6e6f7c52e9a84d803c7e496e3d88f36445697ece9d9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libuuid-2.32.1-32.el8.aarch64.rpm"
           },
@@ -2982,6 +3036,9 @@
           },
           "sha256:dbc8445a77ef2921cc10b38c9ae21f434757df6e5e4f70b795297414afb6e609": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/libatasmart-0.19-14.el8.aarch64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dc532e65e53ebdcdf9e555c91a393869684b916ad463ec0919e6de5f001da930": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libbpf-0.4.0-3.el8.aarch64.rpm"
@@ -3105,6 +3162,9 @@
           },
           "sha256:fc51460213b3bf5b67f08f2695aae8d728f614adbbacb917a0825e4ebfbc3e68": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/hardlink-1.3-6.el8.aarch64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fdd5f73a53f3098a71a7ca7a869c14a0c63cf863224fbc54b88a7def54745ca9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/cryptsetup-libs-2.3.7-1.el8.aarch64.rpm"
@@ -5252,6 +5312,15 @@
         "checksum": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -7385,6 +7454,15 @@
         "checksum": "sha256:cbcd24f6ecbc84656d72b146aa33dcbd5f8df79d55ccec1bf952b2dd8de972a6"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7421,6 +7499,15 @@
         "checksum": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7448,6 +7535,15 @@
         "checksum": "sha256:8db948c4e35bdc675cc942ef12296d8c9a3b652832e02f6c5147eaf026b5d161"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "9.el8_4.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.aarch64.rpm",
+        "checksum": "sha256:3dec03926a2dcf9ec308c7eefc4e6a22da5aa40df758da25a925598e11fbffb9"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7473,6 +7569,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
         "checksum": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7518,6 +7632,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
         "checksum": "sha256:96b090a6696ca4c8b3f701c3a7b95b91c892db389e023c4b2d500a5162e43e8d"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7671,6 +7794,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/shim-aa64-15.4-2.el8_1.aarch64.rpm",
         "checksum": "sha256:b97af00f72ced6bb75ac2c5eb1100b4a39fea8867d68e6d633ea89f187689439"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
       },
       {
         "name": "sqlite-libs",
@@ -8319,6 +8451,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/protobuf-3.5.0-13.el8.aarch64.rpm",
         "checksum": "sha256:bf6a9ab5cdf3c0a71b634201fe260b1362d8eeb82fe33ccd220dc12c9396ec27"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_86-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_container-boot.json
@@ -687,6 +687,9 @@
                     "id": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
                   },
                   {
+                    "id": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+                  },
+                  {
                     "id": "sha256:2d84f6765b1645f867527f493b6153470602a80c75f81545bf619aa92127e4da"
                   },
                   {
@@ -1398,6 +1401,9 @@
                     "id": "sha256:cbcd24f6ecbc84656d72b146aa33dcbd5f8df79d55ccec1bf952b2dd8de972a6"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:8329bf1aedce9ef3a4d7513ef98d3931ad39b84d5c3e73e99936c7f9b87931c2"
                   },
                   {
@@ -1410,6 +1416,9 @@
                     "id": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:d5a9a87599b8aab3c5b878100398cf2159f26160ee6e809f74f93262f1d3ad78"
                   },
                   {
@@ -1419,6 +1428,9 @@
                     "id": "sha256:8db948c4e35bdc675cc942ef12296d8c9a3b652832e02f6c5147eaf026b5d161"
                   },
                   {
+                    "id": "sha256:3dec03926a2dcf9ec308c7eefc4e6a22da5aa40df758da25a925598e11fbffb9"
+                  },
+                  {
                     "id": "sha256:3750602e3fca7d1ddc3aa2f2ec1c373f257cc43895bc12fafd123dcb1400d6ea"
                   },
                   {
@@ -1426,6 +1438,12 @@
                   },
                   {
                     "id": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f75e77a1746534f649a29ea02d4341ce3e266a34173ba4dbf654c9682c9787dc"
@@ -1441,6 +1459,9 @@
                   },
                   {
                     "id": "sha256:96b090a6696ca4c8b3f701c3a7b95b91c892db389e023c4b2d500a5162e43e8d"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -1492,6 +1513,9 @@
                   },
                   {
                     "id": "sha256:b97af00f72ced6bb75ac2c5eb1100b4a39fea8867d68e6d633ea89f187689439"
+                  },
+                  {
+                    "id": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
                   },
                   {
                     "id": "sha256:432d9dd36116fce2b174d68c141f627919e4ac17b488ac5a035d7261a1070c22"
@@ -1708,6 +1732,12 @@
                   },
                   {
                     "id": "sha256:bf6a9ab5cdf3c0a71b634201fe260b1362d8eeb82fe33ccd220dc12c9396ec27"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:3953eb6443d651317e940d3328539d9ff0e93c251030385bd606d5b17ad22f3b"
@@ -2748,6 +2778,9 @@
           "sha256:137a8ee6c1f8500fa0de50d6bf894e9aaeb04dd2fb4d6e347e2b4f7db89a948a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/libX11-1.6.8-5.el8.aarch64.rpm"
           },
+          "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
+          },
           "sha256:13ce9db75f06389171a5279b5cb389625f09522d06b5767ae827d5f18f79550e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/kernel-modules-4.18.0-361.el8.aarch64.rpm"
           },
@@ -2931,6 +2964,9 @@
           "sha256:34f9dc2d00d389b5eb9fef46404f182c8e81f008bb13e0e4e397ebc6a704fc5d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libxslt-1.1.32-6.el8.aarch64.rpm"
           },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
+          },
           "sha256:35a0ed6756beb693895afb57e01712f38ea20bcad54a92dc8cebf3f502cd05db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/iproute-5.15.0-2.el8.aarch64.rpm"
           },
@@ -2975,6 +3011,9 @@
           },
           "sha256:3d372ca16c46e471896f6cc4387142f49b5733e6649e7107929387be3117e9a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/zlib-1.2.11-17.el8.aarch64.rpm"
+          },
+          "sha256:3dec03926a2dcf9ec308c7eefc4e6a22da5aa40df758da25a925598e11fbffb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.aarch64.rpm"
           },
           "sha256:3e570377bfb3946bbbbe32abfc92f800af7922d0a448e3f044ef75b18e97b924": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/libxcb-1.13.1-1.el8.aarch64.rpm"
@@ -3435,6 +3474,9 @@
           "sha256:98f838a9775269a0f796151bd54d52c7ac91d4bf1365186772f243bfafbb136a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libaio-0.3.112-1.el8.aarch64.rpm"
           },
+          "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm"
+          },
           "sha256:9a1152654e67e7ef015a6ac39c6f53077e89aa5ec4e1c55ae204edfd298656b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/xfsprogs-5.0.0-10.el8.aarch64.rpm"
           },
@@ -3528,6 +3570,9 @@
           "sha256:a7a01029879d1966a822b028658b44f6cec885d2e25d77f67a5fdbb89fe4a860": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/audit-3.0.7-1.el8.aarch64.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a7c864ec250cae43189f249d99604f1d26f07e86abfba5195e9436425df8462c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/iptables-libs-1.8.4-22.el8.aarch64.rpm"
           },
@@ -3581,6 +3626,9 @@
           },
           "sha256:b3d72ac8eb91e5fcf3dcacc0d1bf1412b910ca4e1fe11cfa74d26b8f46eb1a9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/keyutils-1.5.10-9.el8.aarch64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b5774cc6cf397117a0a9a5f7aad450385a2583bc055ee3aaf203e8e66660a5ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/perl-Digest-MD5-2.55-396.el8.aarch64.rpm"
@@ -3662,6 +3710,9 @@
           },
           "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/readline-7.0-10.el8.aarch64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c321e3a0253fb2691035135b3d3740faa76b8e9c84a0378f480ff85ddd9f16bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/efibootmgr-16-1.el8.aarch64.rpm"
@@ -3777,6 +3828,9 @@
           "sha256:d92bfa56506bc755cc0e36943a1eb1d7c483c2b3e4d7bf6a306f1376a3f01ab6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/podman-3.4.5-0.5.module+el8.6.0+13916+cd3e3727.aarch64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:d96728282297bff3f25cb6e6f7c52e9a84d803c7e496e3d88f36445697ece9d9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libuuid-2.32.1-32.el8.aarch64.rpm"
           },
@@ -3800,6 +3854,9 @@
           },
           "sha256:dbc8445a77ef2921cc10b38c9ae21f434757df6e5e4f70b795297414afb6e609": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/libatasmart-0.19-14.el8.aarch64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dc532e65e53ebdcdf9e555c91a393869684b916ad463ec0919e6de5f001da930": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libbpf-0.4.0-3.el8.aarch64.rpm"
@@ -3950,6 +4007,9 @@
           },
           "sha256:fc51460213b3bf5b67f08f2695aae8d728f614adbbacb917a0825e4ebfbc3e68": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/hardlink-1.3-6.el8.aarch64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fdd5f73a53f3098a71a7ca7a869c14a0c63cf863224fbc54b88a7def54745ca9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/cryptsetup-libs-2.3.7-1.el8.aarch64.rpm"
@@ -7880,6 +7940,15 @@
         "checksum": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -10013,6 +10082,15 @@
         "checksum": "sha256:cbcd24f6ecbc84656d72b146aa33dcbd5f8df79d55ccec1bf952b2dd8de972a6"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -10049,6 +10127,15 @@
         "checksum": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -10076,6 +10163,15 @@
         "checksum": "sha256:8db948c4e35bdc675cc942ef12296d8c9a3b652832e02f6c5147eaf026b5d161"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "9.el8_4.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.aarch64.rpm",
+        "checksum": "sha256:3dec03926a2dcf9ec308c7eefc4e6a22da5aa40df758da25a925598e11fbffb9"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -10101,6 +10197,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
         "checksum": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -10146,6 +10260,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
         "checksum": "sha256:96b090a6696ca4c8b3f701c3a7b95b91c892db389e023c4b2d500a5162e43e8d"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -10299,6 +10422,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/shim-aa64-15.4-2.el8_1.aarch64.rpm",
         "checksum": "sha256:b97af00f72ced6bb75ac2c5eb1100b4a39fea8867d68e6d633ea89f187689439"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
       },
       {
         "name": "sqlite-libs",
@@ -10947,6 +11079,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/protobuf-3.5.0-13.el8.aarch64.rpm",
         "checksum": "sha256:bf6a9ab5cdf3c0a71b634201fe260b1362d8eeb82fe33ccd220dc12c9396ec27"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
@@ -711,6 +711,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1467,6 +1470,9 @@
                     "id": "sha256:29ea55621defd44df6d0de87cb3a9727ac25fdf3179b63670e54cc7faa2996ee"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1479,6 +1485,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:5af8d36d62fb7633297da810e5ca7de0137ce72b98494028fd9672b66b6ed3fa"
                   },
                   {
@@ -1488,6 +1497,9 @@
                     "id": "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4"
                   },
                   {
+                    "id": "sha256:0fdeaf3c6214dd2c13aa75ef01198e7d792f9bb2fc447af013fc434cba94701d"
+                  },
+                  {
                     "id": "sha256:d759703d633257a88457c38d94b9a7836e0ec8eeb72df385df348423e668ae08"
                   },
                   {
@@ -1495,6 +1507,12 @@
                   },
                   {
                     "id": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1510,6 +1528,9 @@
                   },
                   {
                     "id": "sha256:96b090a6696ca4c8b3f701c3a7b95b91c892db389e023c4b2d500a5162e43e8d"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1561,6 +1582,9 @@
                   },
                   {
                     "id": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
+                  },
+                  {
+                    "id": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
                   },
                   {
                     "id": "sha256:645419874806713b904eed22d9e7dd2ba076452c733f47822d0c05723311a951"
@@ -1777,6 +1801,12 @@
                   },
                   {
                     "id": "sha256:eb0ed74444da940ab2a530776348362c5e2c07a0a30b2106dd4691bcbfa1e56a"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:2c29b07fd9ffb7977df80545bb36671b0fcf31d30d613330b3d3d1301694c5ae"
@@ -2034,6 +2064,9 @@
           "sha256:0fa57c508a0f2eda8a65460084e05e928773af89f1b44516f136a33f4b304bb7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/crypto-policies-20211116-1.gitae470d6.el8.noarch.rpm"
           },
+          "sha256:0fdeaf3c6214dd2c13aa75ef01198e7d792f9bb2fc447af013fc434cba94701d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.x86_64.rpm"
+          },
           "sha256:1065049dbd53849d35db269a23be54148cbe481122381ab71b72f62e83816b26": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/gobject-introspection-1.56.1-1.el8.x86_64.rpm"
           },
@@ -2219,6 +2252,9 @@
           },
           "sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/cracklib-dicts-2.9.6-15.el8.x86_64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:357cc78e20d4aea4ddb27f92d5126bfad570633542882a2f0d0c548f209f621f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shadow-utils-subid-4.6-16.el8.x86_64.rpm"
@@ -2652,6 +2688,9 @@
           "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm"
           },
+          "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm"
+          },
           "sha256:995831ad6397fbd6e91038c6889981a0b7c649c95192999dc184b98c26d48fea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/initscripts-10.00.15-1.el8.x86_64.rpm"
           },
@@ -2703,6 +2742,9 @@
           "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a8808c053ffb7ccf826d80fdd458b6521f2cc63e55eb90d79a504fbb66c36cb0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/checkpolicy-2.9-1.el8.x86_64.rpm"
           },
@@ -2717,6 +2759,9 @@
           },
           "sha256:abf7177d0911e70675875987ec0ef8d5f594da4cba4addf76ba9f5aff4a194d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/nftables-0.9.3-24.el8.x86_64.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/rootfiles-8.1-22.el8.noarch.rpm"
@@ -2762,6 +2807,9 @@
           },
           "sha256:b41c194ecf358e8e6cec46068c4fb6f34780ee2bd65200c367b94170103a8aa9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/ima-evm-utils-1.3.2-12.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b6050db00772299f827781e272f3b93f17687d164ded25cf795128567b539032": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mdadm-4.2-rc3.el8.x86_64.rpm"
@@ -2825,6 +2873,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c47289d6d7ee1e242b32ebaf0ef0e5f7aa3b95eced4b0753551254de92df7af6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/audit-libs-3.0.7-1.el8.x86_64.rpm"
@@ -2946,8 +2997,14 @@
           "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:daa11530884eae9f2ffdb112e99c2c7817ba4802a87b35a959d50bf5774126a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-tools-extra-2.02-106.el8.x86_64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dc28397f174b147917ff788379672663ebe4c89eff4bae329c32c88272d59c45": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-loop-2.24-8.el8.x86_64.rpm"
@@ -3092,6 +3149,9 @@
           },
           "sha256:fd5682d87d7ea52f094528cc0d7e6270a8e06cff411bda955a1e12fd48a708a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/kernel-core-4.18.0-361.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -5020,6 +5080,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
       },
       {
         "name": "bzip2-libs",
@@ -7290,6 +7359,15 @@
         "checksum": "sha256:29ea55621defd44df6d0de87cb3a9727ac25fdf3179b63670e54cc7faa2996ee"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7326,6 +7404,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7353,6 +7440,15 @@
         "checksum": "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "9.el8_4.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.x86_64.rpm",
+        "checksum": "sha256:0fdeaf3c6214dd2c13aa75ef01198e7d792f9bb2fc447af013fc434cba94701d"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7378,6 +7474,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
         "checksum": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7423,6 +7537,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
         "checksum": "sha256:96b090a6696ca4c8b3f701c3a7b95b91c892db389e023c4b2d500a5162e43e8d"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7576,6 +7699,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm",
         "checksum": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
       },
       {
         "name": "sqlite-libs",
@@ -8224,6 +8356,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/protobuf-3.5.0-13.el8.x86_64.rpm",
         "checksum": "sha256:eb0ed74444da940ab2a530776348362c5e2c07a0a30b2106dd4691bcbfa1e56a"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
@@ -718,6 +718,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1495,6 +1498,9 @@
                     "id": "sha256:29ea55621defd44df6d0de87cb3a9727ac25fdf3179b63670e54cc7faa2996ee"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367"
                   },
                   {
@@ -1513,6 +1519,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:5af8d36d62fb7633297da810e5ca7de0137ce72b98494028fd9672b66b6ed3fa"
                   },
                   {
@@ -1520,6 +1529,9 @@
                   },
                   {
                     "id": "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4"
+                  },
+                  {
+                    "id": "sha256:0fdeaf3c6214dd2c13aa75ef01198e7d792f9bb2fc447af013fc434cba94701d"
                   },
                   {
                     "id": "sha256:c8653e199fdea0852a124ed24df2f7b3aa7e0aa6a1258147d89c39692a420c84"
@@ -1537,7 +1549,13 @@
                     "id": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
                   },
                   {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
                     "id": "sha256:4ad66a3a1dd79384852669609567108dcc429607d40ca8adc5f1dbe6a9d6bdde"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1556,6 +1574,9 @@
                   },
                   {
                     "id": "sha256:5beed8560b5b56d6e6a6851451e7f6d2bbc7cf1790043873826a5adec89fde8a"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1610,6 +1631,9 @@
                   },
                   {
                     "id": "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1"
+                  },
+                  {
+                    "id": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
                   },
                   {
                     "id": "sha256:645419874806713b904eed22d9e7dd2ba076452c733f47822d0c05723311a951"
@@ -1838,6 +1862,12 @@
                   },
                   {
                     "id": "sha256:eb0ed74444da940ab2a530776348362c5e2c07a0a30b2106dd4691bcbfa1e56a"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:2c29b07fd9ffb7977df80545bb36671b0fcf31d30d613330b3d3d1301694c5ae"
@@ -2113,6 +2143,9 @@
           "sha256:0fa57c508a0f2eda8a65460084e05e928773af89f1b44516f136a33f4b304bb7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/crypto-policies-20211116-1.gitae470d6.el8.noarch.rpm"
           },
+          "sha256:0fdeaf3c6214dd2c13aa75ef01198e7d792f9bb2fc447af013fc434cba94701d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.x86_64.rpm"
+          },
           "sha256:1065049dbd53849d35db269a23be54148cbe481122381ab71b72f62e83816b26": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/gobject-introspection-1.56.1-1.el8.x86_64.rpm"
           },
@@ -2313,6 +2346,9 @@
           },
           "sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/cracklib-dicts-2.9.6-15.el8.x86_64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:357cc78e20d4aea4ddb27f92d5126bfad570633542882a2f0d0c548f209f621f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shadow-utils-subid-4.6-16.el8.x86_64.rpm"
@@ -2767,6 +2803,9 @@
           "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm"
           },
+          "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm"
+          },
           "sha256:995831ad6397fbd6e91038c6889981a0b7c649c95192999dc184b98c26d48fea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/initscripts-10.00.15-1.el8.x86_64.rpm"
           },
@@ -2830,6 +2869,9 @@
           "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a8808c053ffb7ccf826d80fdd458b6521f2cc63e55eb90d79a504fbb66c36cb0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/checkpolicy-2.9-1.el8.x86_64.rpm"
           },
@@ -2844,6 +2886,9 @@
           },
           "sha256:abf7177d0911e70675875987ec0ef8d5f594da4cba4addf76ba9f5aff4a194d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/nftables-0.9.3-24.el8.x86_64.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/rootfiles-8.1-22.el8.noarch.rpm"
@@ -2892,6 +2937,9 @@
           },
           "sha256:b4babe48d93eccce4f0249ba34d592bfc306c3b14b40df7a5cc9eaec2eaae20f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/numactl-libs-2.0.12-13.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b6050db00772299f827781e272f3b93f17687d164ded25cf795128567b539032": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mdadm-4.2-rc3.el8.x86_64.rpm"
@@ -2958,6 +3006,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c47289d6d7ee1e242b32ebaf0ef0e5f7aa3b95eced4b0753551254de92df7af6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/audit-libs-3.0.7-1.el8.x86_64.rpm"
@@ -3082,8 +3133,14 @@
           "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:daa11530884eae9f2ffdb112e99c2c7817ba4802a87b35a959d50bf5774126a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-tools-extra-2.02-106.el8.x86_64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dc28397f174b147917ff788379672663ebe4c89eff4bae329c32c88272d59c45": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-loop-2.24-8.el8.x86_64.rpm"
@@ -3234,6 +3291,9 @@
           },
           "sha256:fd52eb029e7c1379e6ba1bd414a518721f58505db8a3a8b1f67d545d46a79321": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/podman-catatonit-3.4.5-0.5.module+el8.6.0+13916+cd3e3727.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -5165,6 +5225,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
       },
       {
         "name": "bzip2-libs",
@@ -7498,6 +7567,15 @@
         "checksum": "sha256:29ea55621defd44df6d0de87cb3a9727ac25fdf3179b63670e54cc7faa2996ee"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-configobj",
         "epoch": 0,
         "version": "5.0.6",
@@ -7552,6 +7630,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7577,6 +7664,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libsemanage-2.9-6.el8.x86_64.rpm",
         "checksum": "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4"
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "9.el8_4.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.x86_64.rpm",
+        "checksum": "sha256:0fdeaf3c6214dd2c13aa75ef01198e7d792f9bb2fc447af013fc434cba94701d"
       },
       {
         "name": "python3-linux-procfs",
@@ -7624,6 +7720,15 @@
         "checksum": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
       },
       {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
         "name": "python3-pyudev",
         "epoch": 0,
         "version": "0.21.0",
@@ -7631,6 +7736,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pyudev-0.21.0-7.el8.noarch.rpm",
         "checksum": "sha256:4ad66a3a1dd79384852669609567108dcc429607d40ca8adc5f1dbe6a9d6bdde"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7685,6 +7799,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-syspurpose-1.28.25-1.el8.x86_64.rpm",
         "checksum": "sha256:5beed8560b5b56d6e6a6851451e7f6d2bbc7cf1790043873826a5adec89fde8a"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7847,6 +7970,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/snappy-1.1.8-3.el8.x86_64.rpm",
         "checksum": "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
       },
       {
         "name": "sqlite-libs",
@@ -8531,6 +8663,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/protobuf-3.5.0-13.el8.x86_64.rpm",
         "checksum": "sha256:eb0ed74444da940ab2a530776348362c5e2c07a0a30b2106dd4691bcbfa1e56a"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
@@ -801,6 +801,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1557,6 +1560,9 @@
                     "id": "sha256:29ea55621defd44df6d0de87cb3a9727ac25fdf3179b63670e54cc7faa2996ee"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1569,6 +1575,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:5af8d36d62fb7633297da810e5ca7de0137ce72b98494028fd9672b66b6ed3fa"
                   },
                   {
@@ -1578,6 +1587,9 @@
                     "id": "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4"
                   },
                   {
+                    "id": "sha256:0fdeaf3c6214dd2c13aa75ef01198e7d792f9bb2fc447af013fc434cba94701d"
+                  },
+                  {
                     "id": "sha256:d759703d633257a88457c38d94b9a7836e0ec8eeb72df385df348423e668ae08"
                   },
                   {
@@ -1585,6 +1597,12 @@
                   },
                   {
                     "id": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1600,6 +1618,9 @@
                   },
                   {
                     "id": "sha256:96b090a6696ca4c8b3f701c3a7b95b91c892db389e023c4b2d500a5162e43e8d"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1651,6 +1672,9 @@
                   },
                   {
                     "id": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
+                  },
+                  {
+                    "id": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
                   },
                   {
                     "id": "sha256:645419874806713b904eed22d9e7dd2ba076452c733f47822d0c05723311a951"
@@ -1867,6 +1891,12 @@
                   },
                   {
                     "id": "sha256:eb0ed74444da940ab2a530776348362c5e2c07a0a30b2106dd4691bcbfa1e56a"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:2c29b07fd9ffb7977df80545bb36671b0fcf31d30d613330b3d3d1301694c5ae"
@@ -2159,6 +2189,9 @@
           "sha256:0fa57c508a0f2eda8a65460084e05e928773af89f1b44516f136a33f4b304bb7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/crypto-policies-20211116-1.gitae470d6.el8.noarch.rpm"
           },
+          "sha256:0fdeaf3c6214dd2c13aa75ef01198e7d792f9bb2fc447af013fc434cba94701d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.x86_64.rpm"
+          },
           "sha256:1065049dbd53849d35db269a23be54148cbe481122381ab71b72f62e83816b26": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/gobject-introspection-1.56.1-1.el8.x86_64.rpm"
           },
@@ -2344,6 +2377,9 @@
           },
           "sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/cracklib-dicts-2.9.6-15.el8.x86_64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:357cc78e20d4aea4ddb27f92d5126bfad570633542882a2f0d0c548f209f621f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shadow-utils-subid-4.6-16.el8.x86_64.rpm"
@@ -2780,6 +2816,9 @@
           "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm"
           },
+          "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm"
+          },
           "sha256:995831ad6397fbd6e91038c6889981a0b7c649c95192999dc184b98c26d48fea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/initscripts-10.00.15-1.el8.x86_64.rpm"
           },
@@ -2831,6 +2870,9 @@
           "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a8808c053ffb7ccf826d80fdd458b6521f2cc63e55eb90d79a504fbb66c36cb0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/checkpolicy-2.9-1.el8.x86_64.rpm"
           },
@@ -2845,6 +2887,9 @@
           },
           "sha256:abf7177d0911e70675875987ec0ef8d5f594da4cba4addf76ba9f5aff4a194d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/nftables-0.9.3-24.el8.x86_64.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/rootfiles-8.1-22.el8.noarch.rpm"
@@ -2890,6 +2935,9 @@
           },
           "sha256:b41c194ecf358e8e6cec46068c4fb6f34780ee2bd65200c367b94170103a8aa9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/ima-evm-utils-1.3.2-12.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b6050db00772299f827781e272f3b93f17687d164ded25cf795128567b539032": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mdadm-4.2-rc3.el8.x86_64.rpm"
@@ -2953,6 +3001,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c47289d6d7ee1e242b32ebaf0ef0e5f7aa3b95eced4b0753551254de92df7af6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/audit-libs-3.0.7-1.el8.x86_64.rpm"
@@ -3074,8 +3125,14 @@
           "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:daa11530884eae9f2ffdb112e99c2c7817ba4802a87b35a959d50bf5774126a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-tools-extra-2.02-106.el8.x86_64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dc28397f174b147917ff788379672663ebe4c89eff4bae329c32c88272d59c45": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-loop-2.24-8.el8.x86_64.rpm"
@@ -3220,6 +3277,9 @@
           },
           "sha256:fd5682d87d7ea52f094528cc0d7e6270a8e06cff411bda955a1e12fd48a708a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/kernel-core-4.18.0-361.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -5410,6 +5470,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
       },
       {
         "name": "bzip2-libs",
@@ -7680,6 +7749,15 @@
         "checksum": "sha256:29ea55621defd44df6d0de87cb3a9727ac25fdf3179b63670e54cc7faa2996ee"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7716,6 +7794,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7743,6 +7830,15 @@
         "checksum": "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "9.el8_4.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.x86_64.rpm",
+        "checksum": "sha256:0fdeaf3c6214dd2c13aa75ef01198e7d792f9bb2fc447af013fc434cba94701d"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7768,6 +7864,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
         "checksum": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7813,6 +7927,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
         "checksum": "sha256:96b090a6696ca4c8b3f701c3a7b95b91c892db389e023c4b2d500a5162e43e8d"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7966,6 +8089,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm",
         "checksum": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
       },
       {
         "name": "sqlite-libs",
@@ -8614,6 +8746,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/protobuf-3.5.0-13.el8.x86_64.rpm",
         "checksum": "sha256:eb0ed74444da940ab2a530776348362c5e2c07a0a30b2106dd4691bcbfa1e56a"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_86-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_container-boot.json
@@ -702,6 +702,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1458,6 +1461,9 @@
                     "id": "sha256:29ea55621defd44df6d0de87cb3a9727ac25fdf3179b63670e54cc7faa2996ee"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1470,6 +1476,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:5af8d36d62fb7633297da810e5ca7de0137ce72b98494028fd9672b66b6ed3fa"
                   },
                   {
@@ -1479,6 +1488,9 @@
                     "id": "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4"
                   },
                   {
+                    "id": "sha256:0fdeaf3c6214dd2c13aa75ef01198e7d792f9bb2fc447af013fc434cba94701d"
+                  },
+                  {
                     "id": "sha256:d759703d633257a88457c38d94b9a7836e0ec8eeb72df385df348423e668ae08"
                   },
                   {
@@ -1486,6 +1498,12 @@
                   },
                   {
                     "id": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1501,6 +1519,9 @@
                   },
                   {
                     "id": "sha256:96b090a6696ca4c8b3f701c3a7b95b91c892db389e023c4b2d500a5162e43e8d"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1552,6 +1573,9 @@
                   },
                   {
                     "id": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
+                  },
+                  {
+                    "id": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
                   },
                   {
                     "id": "sha256:645419874806713b904eed22d9e7dd2ba076452c733f47822d0c05723311a951"
@@ -1768,6 +1792,12 @@
                   },
                   {
                     "id": "sha256:eb0ed74444da940ab2a530776348362c5e2c07a0a30b2106dd4691bcbfa1e56a"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:2c29b07fd9ffb7977df80545bb36671b0fcf31d30d613330b3d3d1301694c5ae"
@@ -2814,6 +2844,9 @@
           "sha256:0fa57c508a0f2eda8a65460084e05e928773af89f1b44516f136a33f4b304bb7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/crypto-policies-20211116-1.gitae470d6.el8.noarch.rpm"
           },
+          "sha256:0fdeaf3c6214dd2c13aa75ef01198e7d792f9bb2fc447af013fc434cba94701d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.x86_64.rpm"
+          },
           "sha256:0ffc4ad95bf26b5110f9a4b7c718cb0936f4de26c0e4a4bc368842324e10e79c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libwebp-1.0.0-5.el8.x86_64.rpm"
           },
@@ -3032,6 +3065,9 @@
           },
           "sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/cracklib-dicts-2.9.6-15.el8.x86_64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:357cc78e20d4aea4ddb27f92d5126bfad570633542882a2f0d0c548f209f621f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shadow-utils-subid-4.6-16.el8.x86_64.rpm"
@@ -3552,6 +3588,9 @@
           "sha256:98d459b974547e622dff185c1d5b51c20f0e4411eb7554ad2bf8857b3f503c5c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/nginx-all-modules-1.14.1-9.module+el8.0.0+4108+af250afe.noarch.rpm"
           },
+          "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm"
+          },
           "sha256:995831ad6397fbd6e91038c6889981a0b7c649c95192999dc184b98c26d48fea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/initscripts-10.00.15-1.el8.x86_64.rpm"
           },
@@ -3612,6 +3651,9 @@
           "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a8808c053ffb7ccf826d80fdd458b6521f2cc63e55eb90d79a504fbb66c36cb0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/checkpolicy-2.9-1.el8.x86_64.rpm"
           },
@@ -3629,6 +3671,9 @@
           },
           "sha256:abf7177d0911e70675875987ec0ef8d5f594da4cba4addf76ba9f5aff4a194d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/nftables-0.9.3-24.el8.x86_64.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/rootfiles-8.1-22.el8.noarch.rpm"
@@ -3677,6 +3722,9 @@
           },
           "sha256:b41c194ecf358e8e6cec46068c4fb6f34780ee2bd65200c367b94170103a8aa9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/ima-evm-utils-1.3.2-12.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b6050db00772299f827781e272f3b93f17687d164ded25cf795128567b539032": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mdadm-4.2-rc3.el8.x86_64.rpm"
@@ -3740,6 +3788,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c47289d6d7ee1e242b32ebaf0ef0e5f7aa3b95eced4b0753551254de92df7af6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/audit-libs-3.0.7-1.el8.x86_64.rpm"
@@ -3882,11 +3933,17 @@
           "sha256:d906b13d5dd7a5595133e2a1af83ae17a1aae0c107579db723d21ec4371f3570": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/perl-File-Path-2.15-2.el8.noarch.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:daa11530884eae9f2ffdb112e99c2c7817ba4802a87b35a959d50bf5774126a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-tools-extra-2.02-106.el8.x86_64.rpm"
           },
           "sha256:db1fad3c2d8735e69084bd4b09ea963938e4dde2f2e096dc7a4ce146f18b7ab0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/fontpackages-filesystem-1.44-22.el8.noarch.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dc28397f174b147917ff788379672663ebe4c89eff4bae329c32c88272d59c45": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-loop-2.24-8.el8.x86_64.rpm"
@@ -4055,6 +4112,9 @@
           },
           "sha256:fd5682d87d7ea52f094528cc0d7e6270a8e06cff411bda955a1e12fd48a708a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/kernel-core-4.18.0-361.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -8030,6 +8090,15 @@
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -10298,6 +10367,15 @@
         "checksum": "sha256:29ea55621defd44df6d0de87cb3a9727ac25fdf3179b63670e54cc7faa2996ee"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -10334,6 +10412,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -10361,6 +10448,15 @@
         "checksum": "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "9.el8_4.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libxml2-2.9.7-9.el8_4.2.x86_64.rpm",
+        "checksum": "sha256:0fdeaf3c6214dd2c13aa75ef01198e7d792f9bb2fc447af013fc434cba94701d"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -10386,6 +10482,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
         "checksum": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -10431,6 +10545,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm",
         "checksum": "sha256:96b090a6696ca4c8b3f701c3a7b95b91c892db389e023c4b2d500a5162e43e8d"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -10584,6 +10707,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm",
         "checksum": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/sos-4.2-13.el8.noarch.rpm",
+        "checksum": "sha256:9952db42b017b0cdb5ffc69f2a0b971ca2aea9ebf8b347ec9ece560e1e3a6c72"
       },
       {
         "name": "sqlite-libs",
@@ -11232,6 +11364,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/protobuf-3.5.0-13.el8.x86_64.rpm",
         "checksum": "sha256:eb0ed74444da940ab2a530776348362c5e2c07a0a30b2106dd4691bcbfa1e56a"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_87-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_commit-boot.json
@@ -690,6 +690,9 @@
                     "id": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
                   },
                   {
+                    "id": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+                  },
+                  {
                     "id": "sha256:2d84f6765b1645f867527f493b6153470602a80c75f81545bf619aa92127e4da"
                   },
                   {
@@ -1404,6 +1407,9 @@
                     "id": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:8329bf1aedce9ef3a4d7513ef98d3931ad39b84d5c3e73e99936c7f9b87931c2"
                   },
                   {
@@ -1416,6 +1422,9 @@
                     "id": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:03be12262e36ab660619168fcadd6873d7c3b1aa2010e71e96ec9bb80df5c26a"
                   },
                   {
@@ -1425,6 +1434,9 @@
                     "id": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
                   },
                   {
+                    "id": "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741"
+                  },
+                  {
                     "id": "sha256:81d8d21fdf2b10f6ef63bfe5c623464382912c15fc852c575d435f7f6583a150"
                   },
                   {
@@ -1432,6 +1444,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f75e77a1746534f649a29ea02d4341ce3e266a34173ba4dbf654c9682c9787dc"
@@ -1447,6 +1465,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -1498,6 +1519,9 @@
                   },
                   {
                     "id": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:febcbcc4a7c110ec230246d3cf9b896a1d30bea6c36098023daf78189ee94c36"
@@ -1714,6 +1738,12 @@
                   },
                   {
                     "id": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:803145131d29a09c7ff7947ecb4df45b12f8f4bbdf2eff475fd11bd0f82a6177"
@@ -1961,6 +1991,9 @@
           "sha256:12ee21a949fde092444ac1177a22a5fc5bcdcc88292dce1a23347c60462c5a57": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libblockdev-utils-2.24-11.el8.aarch64.rpm"
           },
+          "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
+          },
           "sha256:14175dab807188a8261298dc3ba7b7cd19a9fbf36d0ee5b5c6cacc7e424998e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libssh-config-0.9.6-3.el8.noarch.rpm"
           },
@@ -2111,6 +2144,9 @@
           "sha256:30693df80fa5507a1dfd2b62c469ab391c74d953e3e37da6a6947325974d80c3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libmount-2.32.1-38.el8.aarch64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30c6bc05e2e1c144bb6dfab2f18ba3033c5b428709fde6261a95af734ba057e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/nss-util-3.79.0-10.el8_6.aarch64.rpm"
           },
@@ -2140,6 +2176,9 @@
           },
           "sha256:343c51ca38204f0244e1928ad6267eda7c48b3badcc5d22b09c084b5f0a8ada3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libseccomp-2.5.2-1.el8.aarch64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:383e8542b87c8033076f3197b7996ccbc0fe76521c115c127362a66f1afb79b0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/systemd-pam-239-68.el8.aarch64.rpm"
@@ -2615,6 +2654,9 @@
           "sha256:a136862804f237c8243194e85d6b15361aba8aeb90cf004e61bb8fb55052940a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/e2fsprogs-1.45.6-5.el8.aarch64.rpm"
           },
+          "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.aarch64.rpm"
+          },
           "sha256:a3c479a9afd17f2a92acab491af69de3b3f69850ab3f8fca5562c5f530530174": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/oniguruma-6.8.2-2.el8.aarch64.rpm"
           },
@@ -2635,6 +2677,9 @@
           },
           "sha256:a7551988b8c466f8759449f5cfb375173fe5aee67978fb3e1549a2a2bdeccf73": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/glib2-2.56.4-159.el8.aarch64.rpm"
+          },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
@@ -2683,6 +2728,9 @@
           },
           "sha256:b4f90cde4962b669ba8840d221dadc7c53c974aba1dc4b31ef31658eb6b3b116": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/device-mapper-libs-1.02.181-6.el8.aarch64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b6a865ea7596d521138f924a278ff5f859b4f56d2b69708d3befe476b5a9082d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/chrony-4.2-1.el8.aarch64.rpm"
@@ -2746,6 +2794,9 @@
           },
           "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/readline-7.0-10.el8.aarch64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c2f9ce9ba473dcb0b6a2e20b3362bfcc18762e26bcb1a0a871c2cd5724910c71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/redhat-release-8.7-0.3.el8.aarch64.rpm"
@@ -2843,6 +2894,9 @@
           "sha256:d895c769c757996bf32ec587297681122f5df371960db4e74f2c9e72c3b9f4f3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/elfutils-debuginfod-client-0.187-4.el8.aarch64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da104c59254b60f093034924e21a7aabdeb1515d4b39e29aae60937257f71398": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/protobuf-3.5.0-15.el8.aarch64.rpm"
           },
@@ -2863,6 +2917,9 @@
           },
           "sha256:dbc8445a77ef2921cc10b38c9ae21f434757df6e5e4f70b795297414afb6e609": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.aarch64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dcaaeb91089115d930cb254d06af1400edcc9fd8f93b53746c73d9485b7692d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/podman-4.2.0-1.module+el8.7.0+16772+33343656.aarch64.rpm"
@@ -2986,6 +3043,9 @@
           },
           "sha256:fd21565b47cb699188b18c636e9d155df0bd86942b3da9607ee6260d6d3abb3a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/lvm2-libs-2.03.14-6.el8.aarch64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
@@ -4878,6 +4938,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.aarch64.rpm",
         "checksum": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
       },
       {
         "name": "bzip2-libs",
@@ -7022,6 +7091,15 @@
         "checksum": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7058,6 +7136,15 @@
         "checksum": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7085,6 +7172,15 @@
         "checksum": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.aarch64.rpm",
+        "checksum": "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7110,6 +7206,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7155,6 +7269,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7308,6 +7431,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/shim-aa64-15.6-1.el8.aarch64.rpm",
         "checksum": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -7956,6 +8088,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.aarch64.rpm",
         "checksum": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
@@ -780,6 +780,9 @@
                     "id": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
                   },
                   {
+                    "id": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+                  },
+                  {
                     "id": "sha256:2d84f6765b1645f867527f493b6153470602a80c75f81545bf619aa92127e4da"
                   },
                   {
@@ -1494,6 +1497,9 @@
                     "id": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:8329bf1aedce9ef3a4d7513ef98d3931ad39b84d5c3e73e99936c7f9b87931c2"
                   },
                   {
@@ -1506,6 +1512,9 @@
                     "id": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:03be12262e36ab660619168fcadd6873d7c3b1aa2010e71e96ec9bb80df5c26a"
                   },
                   {
@@ -1515,6 +1524,9 @@
                     "id": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
                   },
                   {
+                    "id": "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741"
+                  },
+                  {
                     "id": "sha256:81d8d21fdf2b10f6ef63bfe5c623464382912c15fc852c575d435f7f6583a150"
                   },
                   {
@@ -1522,6 +1534,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f75e77a1746534f649a29ea02d4341ce3e266a34173ba4dbf654c9682c9787dc"
@@ -1537,6 +1555,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -1588,6 +1609,9 @@
                   },
                   {
                     "id": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:febcbcc4a7c110ec230246d3cf9b896a1d30bea6c36098023daf78189ee94c36"
@@ -1804,6 +1828,12 @@
                   },
                   {
                     "id": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:803145131d29a09c7ff7947ecb4df45b12f8f4bbdf2eff475fd11bd0f82a6177"
@@ -2086,6 +2116,9 @@
           "sha256:12ee21a949fde092444ac1177a22a5fc5bcdcc88292dce1a23347c60462c5a57": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libblockdev-utils-2.24-11.el8.aarch64.rpm"
           },
+          "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
+          },
           "sha256:14175dab807188a8261298dc3ba7b7cd19a9fbf36d0ee5b5c6cacc7e424998e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libssh-config-0.9.6-3.el8.noarch.rpm"
           },
@@ -2236,6 +2269,9 @@
           "sha256:30693df80fa5507a1dfd2b62c469ab391c74d953e3e37da6a6947325974d80c3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libmount-2.32.1-38.el8.aarch64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30c6bc05e2e1c144bb6dfab2f18ba3033c5b428709fde6261a95af734ba057e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/nss-util-3.79.0-10.el8_6.aarch64.rpm"
           },
@@ -2265,6 +2301,9 @@
           },
           "sha256:343c51ca38204f0244e1928ad6267eda7c48b3badcc5d22b09c084b5f0a8ada3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libseccomp-2.5.2-1.el8.aarch64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:383e8542b87c8033076f3197b7996ccbc0fe76521c115c127362a66f1afb79b0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/systemd-pam-239-68.el8.aarch64.rpm"
@@ -2743,6 +2782,9 @@
           "sha256:a136862804f237c8243194e85d6b15361aba8aeb90cf004e61bb8fb55052940a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/e2fsprogs-1.45.6-5.el8.aarch64.rpm"
           },
+          "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.aarch64.rpm"
+          },
           "sha256:a3c479a9afd17f2a92acab491af69de3b3f69850ab3f8fca5562c5f530530174": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/oniguruma-6.8.2-2.el8.aarch64.rpm"
           },
@@ -2763,6 +2805,9 @@
           },
           "sha256:a7551988b8c466f8759449f5cfb375173fe5aee67978fb3e1549a2a2bdeccf73": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/glib2-2.56.4-159.el8.aarch64.rpm"
+          },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
@@ -2811,6 +2856,9 @@
           },
           "sha256:b4f90cde4962b669ba8840d221dadc7c53c974aba1dc4b31ef31658eb6b3b116": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/device-mapper-libs-1.02.181-6.el8.aarch64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b6a865ea7596d521138f924a278ff5f859b4f56d2b69708d3befe476b5a9082d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/chrony-4.2-1.el8.aarch64.rpm"
@@ -2874,6 +2922,9 @@
           },
           "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/readline-7.0-10.el8.aarch64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c2f9ce9ba473dcb0b6a2e20b3362bfcc18762e26bcb1a0a871c2cd5724910c71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/redhat-release-8.7-0.3.el8.aarch64.rpm"
@@ -2971,6 +3022,9 @@
           "sha256:d895c769c757996bf32ec587297681122f5df371960db4e74f2c9e72c3b9f4f3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/elfutils-debuginfod-client-0.187-4.el8.aarch64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da104c59254b60f093034924e21a7aabdeb1515d4b39e29aae60937257f71398": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/protobuf-3.5.0-15.el8.aarch64.rpm"
           },
@@ -2991,6 +3045,9 @@
           },
           "sha256:dbc8445a77ef2921cc10b38c9ae21f434757df6e5e4f70b795297414afb6e609": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.aarch64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dcaaeb91089115d930cb254d06af1400edcc9fd8f93b53746c73d9485b7692d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/podman-4.2.0-1.module+el8.7.0+16772+33343656.aarch64.rpm"
@@ -3114,6 +3171,9 @@
           },
           "sha256:fd21565b47cb699188b18c636e9d155df0bd86942b3da9607ee6260d6d3abb3a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/lvm2-libs-2.03.14-6.el8.aarch64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
@@ -5270,6 +5330,15 @@
         "checksum": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -7412,6 +7481,15 @@
         "checksum": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7448,6 +7526,15 @@
         "checksum": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7475,6 +7562,15 @@
         "checksum": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.aarch64.rpm",
+        "checksum": "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7500,6 +7596,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7545,6 +7659,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7698,6 +7821,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/shim-aa64-15.6-1.el8.aarch64.rpm",
         "checksum": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -8346,6 +8478,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.aarch64.rpm",
         "checksum": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_87-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_container-boot.json
@@ -690,6 +690,9 @@
                     "id": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
                   },
                   {
+                    "id": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+                  },
+                  {
                     "id": "sha256:2d84f6765b1645f867527f493b6153470602a80c75f81545bf619aa92127e4da"
                   },
                   {
@@ -1404,6 +1407,9 @@
                     "id": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:8329bf1aedce9ef3a4d7513ef98d3931ad39b84d5c3e73e99936c7f9b87931c2"
                   },
                   {
@@ -1416,6 +1422,9 @@
                     "id": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:03be12262e36ab660619168fcadd6873d7c3b1aa2010e71e96ec9bb80df5c26a"
                   },
                   {
@@ -1425,6 +1434,9 @@
                     "id": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
                   },
                   {
+                    "id": "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741"
+                  },
+                  {
                     "id": "sha256:81d8d21fdf2b10f6ef63bfe5c623464382912c15fc852c575d435f7f6583a150"
                   },
                   {
@@ -1432,6 +1444,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f75e77a1746534f649a29ea02d4341ce3e266a34173ba4dbf654c9682c9787dc"
@@ -1447,6 +1465,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -1498,6 +1519,9 @@
                   },
                   {
                     "id": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:febcbcc4a7c110ec230246d3cf9b896a1d30bea6c36098023daf78189ee94c36"
@@ -1714,6 +1738,12 @@
                   },
                   {
                     "id": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:803145131d29a09c7ff7947ecb4df45b12f8f4bbdf2eff475fd11bd0f82a6177"
@@ -2745,6 +2775,9 @@
           "sha256:137a8ee6c1f8500fa0de50d6bf894e9aaeb04dd2fb4d6e347e2b4f7db89a948a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libX11-1.6.8-5.el8.aarch64.rpm"
           },
+          "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
+          },
           "sha256:14175dab807188a8261298dc3ba7b7cd19a9fbf36d0ee5b5c6cacc7e424998e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libssh-config-0.9.6-3.el8.noarch.rpm"
           },
@@ -2922,6 +2955,9 @@
           "sha256:30693df80fa5507a1dfd2b62c469ab391c74d953e3e37da6a6947325974d80c3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libmount-2.32.1-38.el8.aarch64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30c6bc05e2e1c144bb6dfab2f18ba3033c5b428709fde6261a95af734ba057e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/nss-util-3.79.0-10.el8_6.aarch64.rpm"
           },
@@ -2960,6 +2996,9 @@
           },
           "sha256:34f9dc2d00d389b5eb9fef46404f182c8e81f008bb13e0e4e397ebc6a704fc5d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/libxslt-1.1.32-6.el8.aarch64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:36798d9e979c9976ed66e23b3c8bda6250c4e80e411afe55c3942291cb4cb4ce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/perl-constant-1.33-396.el8.noarch.rpm"
@@ -3537,6 +3576,9 @@
           "sha256:a1d320b27056062b54ff814b2db9e2c482c895c24c7228abfac607c36fee55cc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/perl-MIME-Base64-3.15-396.el8.aarch64.rpm"
           },
+          "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.aarch64.rpm"
+          },
           "sha256:a3c479a9afd17f2a92acab491af69de3b3f69850ab3f8fca5562c5f530530174": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/oniguruma-6.8.2-2.el8.aarch64.rpm"
           },
@@ -3563,6 +3605,9 @@
           },
           "sha256:a7551988b8c466f8759449f5cfb375173fe5aee67978fb3e1549a2a2bdeccf73": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/glib2-2.56.4-159.el8.aarch64.rpm"
+          },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
@@ -3614,6 +3659,9 @@
           },
           "sha256:b4f90cde4962b669ba8840d221dadc7c53c974aba1dc4b31ef31658eb6b3b116": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/device-mapper-libs-1.02.181-6.el8.aarch64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b5774cc6cf397117a0a9a5f7aad450385a2583bc055ee3aaf203e8e66660a5ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/perl-Digest-MD5-2.55-396.el8.aarch64.rpm"
@@ -3683,6 +3731,9 @@
           },
           "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/readline-7.0-10.el8.aarch64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c2f9ce9ba473dcb0b6a2e20b3362bfcc18762e26bcb1a0a871c2cd5724910c71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/redhat-release-8.7-0.3.el8.aarch64.rpm"
@@ -3789,6 +3840,9 @@
           "sha256:d906b13d5dd7a5595133e2a1af83ae17a1aae0c107579db723d21ec4371f3570": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/perl-File-Path-2.15-2.el8.noarch.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da104c59254b60f093034924e21a7aabdeb1515d4b39e29aae60937257f71398": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/protobuf-3.5.0-15.el8.aarch64.rpm"
           },
@@ -3812,6 +3866,9 @@
           },
           "sha256:dbc8445a77ef2921cc10b38c9ae21f434757df6e5e4f70b795297414afb6e609": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.aarch64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dcaaeb91089115d930cb254d06af1400edcc9fd8f93b53746c73d9485b7692d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/podman-4.2.0-1.module+el8.7.0+16772+33343656.aarch64.rpm"
@@ -3959,6 +4016,9 @@
           },
           "sha256:fd21565b47cb699188b18c636e9d155df0bd86942b3da9607ee6260d6d3abb3a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/lvm2-libs-2.03.14-6.el8.aarch64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
@@ -7898,6 +7958,15 @@
         "checksum": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -10040,6 +10109,15 @@
         "checksum": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -10076,6 +10154,15 @@
         "checksum": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -10103,6 +10190,15 @@
         "checksum": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.aarch64.rpm",
+        "checksum": "sha256:a22e3d5c1521526eafbab591f6349b59c3cb65c3e810ce86c09f496961c4c741"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -10128,6 +10224,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -10173,6 +10287,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -10326,6 +10449,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/shim-aa64-15.6-1.el8.aarch64.rpm",
         "checksum": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -10974,6 +11106,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.aarch64.rpm",
         "checksum": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_87-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit-boot.json
@@ -714,6 +714,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1473,6 +1476,9 @@
                     "id": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1485,6 +1491,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:496ad735717ce1ed9cde99894844f5f5b745475a28f52b67e3ee5b368e0f20f0"
                   },
                   {
@@ -1494,6 +1503,9 @@
                     "id": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
                   },
                   {
+                    "id": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
+                  },
+                  {
                     "id": "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed"
                   },
                   {
@@ -1501,6 +1513,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1516,6 +1534,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1567,6 +1588,9 @@
                   },
                   {
                     "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:b9cb64cbd8df172d478cd77d6dfa95309b5f3599dd4ce3423b0da7c93e25b6a4"
@@ -1783,6 +1807,12 @@
                   },
                   {
                     "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991"
@@ -2142,6 +2172,9 @@
           "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
@@ -2180,6 +2213,9 @@
           },
           "sha256:3445946e036e5c26e5163388e96566bb0e71159e0fe40a93016f51ff0a099d10": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-minimal-langpack-2.28-211.el8.x86_64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:35d2ce5cb5727a3703b83ffeb82b95c5ae2fb520e7a61a464425912e617294bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shadow-utils-4.6-17.el8.x86_64.rpm"
@@ -2387,6 +2423,9 @@
           },
           "sha256:644529740fa2e3655ab2aea0f5622958c34a591c0d08ee033ecbe2fb40dd437c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libbpf-0.5.0-1.el8.x86_64.rpm"
+          },
+          "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm"
           },
           "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-nftables-0.9.3-26.el8.x86_64.rpm"
@@ -2682,6 +2721,9 @@
           "sha256:a5a3efebdb4fd22edaa51a1ae737ef5801c8a8b6f87fb0891dd2ed93d55876f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/selinux-policy-targeted-3.14.3-108.el8.noarch.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a8233c195bb8b0a6b11b6e019d2a104bdfcdc07373d1d60c2b37723b19f97d0e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/NetworkManager-wifi-1.40.0-1.el8.x86_64.rpm"
           },
@@ -2699,6 +2741,9 @@
           },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ac99837d0568e37ab2b5dd8f10b17c3cc8b23d789199c93d79824bfab8f7f064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl6050-firmware-41.28.5.1-110.el8.1.noarch.rpm"
@@ -2750,6 +2795,9 @@
           },
           "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/rpm-ostree-2022.10.90.g4abaf4b4-4.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
@@ -2804,6 +2852,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm"
@@ -2946,8 +2997,14 @@
           "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da574dd0016840097a59070cc147ff60563ed7e314b97ae9ff9238188849956c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/clevis-15-11.el8.x86_64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:df82b0b9201f0d45f4a50a138d7592df71fde47bddbf9310fce62c2461cf0101": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl2030-firmware-18.168.6.1-110.el8.1.noarch.rpm"
@@ -3089,6 +3146,9 @@
           },
           "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -5038,6 +5098,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
       },
       {
         "name": "bzip2-libs",
@@ -7317,6 +7386,15 @@
         "checksum": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7353,6 +7431,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7380,6 +7467,15 @@
         "checksum": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm",
+        "checksum": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7405,6 +7501,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7450,6 +7564,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7603,6 +7726,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
         "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -8251,6 +8383,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
         "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_87-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit_rt-boot.json
@@ -721,6 +721,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1501,6 +1504,9 @@
                     "id": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1516,6 +1522,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:496ad735717ce1ed9cde99894844f5f5b745475a28f52b67e3ee5b368e0f20f0"
                   },
                   {
@@ -1523,6 +1532,9 @@
                   },
                   {
                     "id": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
+                  },
+                  {
+                    "id": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
                   },
                   {
                     "id": "sha256:c8653e199fdea0852a124ed24df2f7b3aa7e0aa6a1258147d89c39692a420c84"
@@ -1540,7 +1552,13 @@
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
                   },
                   {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
                     "id": "sha256:4ad66a3a1dd79384852669609567108dcc429607d40ca8adc5f1dbe6a9d6bdde"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1559,6 +1577,9 @@
                   },
                   {
                     "id": "sha256:7d9fc991404f6a6500385e328e231dd6b84a7722648e049ae9565fa31135f6a3"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1613,6 +1634,9 @@
                   },
                   {
                     "id": "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:b9cb64cbd8df172d478cd77d6dfa95309b5f3599dd4ce3423b0da7c93e25b6a4"
@@ -1841,6 +1865,12 @@
                   },
                   {
                     "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991"
@@ -2236,6 +2266,9 @@
           "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
@@ -2274,6 +2307,9 @@
           },
           "sha256:3445946e036e5c26e5163388e96566bb0e71159e0fe40a93016f51ff0a099d10": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-minimal-langpack-2.28-211.el8.x86_64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:35d2ce5cb5727a3703b83ffeb82b95c5ae2fb520e7a61a464425912e617294bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shadow-utils-4.6-17.el8.x86_64.rpm"
@@ -2484,6 +2520,9 @@
           },
           "sha256:644529740fa2e3655ab2aea0f5622958c34a591c0d08ee033ecbe2fb40dd437c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libbpf-0.5.0-1.el8.x86_64.rpm"
+          },
+          "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm"
           },
           "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-nftables-0.9.3-26.el8.x86_64.rpm"
@@ -2797,6 +2836,9 @@
           "sha256:a5a3efebdb4fd22edaa51a1ae737ef5801c8a8b6f87fb0891dd2ed93d55876f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/selinux-policy-targeted-3.14.3-108.el8.noarch.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a8233c195bb8b0a6b11b6e019d2a104bdfcdc07373d1d60c2b37723b19f97d0e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/NetworkManager-wifi-1.40.0-1.el8.x86_64.rpm"
           },
@@ -2814,6 +2856,9 @@
           },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ac99837d0568e37ab2b5dd8f10b17c3cc8b23d789199c93d79824bfab8f7f064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl6050-firmware-41.28.5.1-110.el8.1.noarch.rpm"
@@ -2868,6 +2913,9 @@
           },
           "sha256:b4babe48d93eccce4f0249ba34d592bfc306c3b14b40df7a5cc9eaec2eaae20f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/numactl-libs-2.0.12-13.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
@@ -2928,6 +2976,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm"
@@ -3076,8 +3127,14 @@
           "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da574dd0016840097a59070cc147ff60563ed7e314b97ae9ff9238188849956c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/clevis-15-11.el8.x86_64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:df82b0b9201f0d45f4a50a138d7592df71fde47bddbf9310fce62c2461cf0101": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl2030-firmware-18.168.6.1-110.el8.1.noarch.rpm"
@@ -3228,6 +3285,9 @@
           },
           "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -5177,6 +5237,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
       },
       {
         "name": "bzip2-libs",
@@ -7519,6 +7588,15 @@
         "checksum": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7564,6 +7642,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7589,6 +7676,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libsemanage-2.9-9.el8.x86_64.rpm",
         "checksum": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm",
+        "checksum": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
       },
       {
         "name": "python3-linux-procfs",
@@ -7636,6 +7732,15 @@
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
       },
       {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
         "name": "python3-pyudev",
         "epoch": 0,
         "version": "0.21.0",
@@ -7643,6 +7748,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pyudev-0.21.0-7.el8.noarch.rpm",
         "checksum": "sha256:4ad66a3a1dd79384852669609567108dcc429607d40ca8adc5f1dbe6a9d6bdde"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7697,6 +7811,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-syspurpose-1.28.32-1.el8.x86_64.rpm",
         "checksum": "sha256:7d9fc991404f6a6500385e328e231dd6b84a7722648e049ae9565fa31135f6a3"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7859,6 +7982,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/snappy-1.1.8-3.el8.x86_64.rpm",
         "checksum": "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -8543,6 +8675,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
         "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
@@ -804,6 +804,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1563,6 +1566,9 @@
                     "id": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1575,6 +1581,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:496ad735717ce1ed9cde99894844f5f5b745475a28f52b67e3ee5b368e0f20f0"
                   },
                   {
@@ -1584,6 +1593,9 @@
                     "id": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
                   },
                   {
+                    "id": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
+                  },
+                  {
                     "id": "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed"
                   },
                   {
@@ -1591,6 +1603,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1606,6 +1624,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1657,6 +1678,9 @@
                   },
                   {
                     "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:b9cb64cbd8df172d478cd77d6dfa95309b5f3599dd4ce3423b0da7c93e25b6a4"
@@ -1873,6 +1897,12 @@
                   },
                   {
                     "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991"
@@ -2267,6 +2297,9 @@
           "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
@@ -2305,6 +2338,9 @@
           },
           "sha256:3445946e036e5c26e5163388e96566bb0e71159e0fe40a93016f51ff0a099d10": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-minimal-langpack-2.28-211.el8.x86_64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:35d2ce5cb5727a3703b83ffeb82b95c5ae2fb520e7a61a464425912e617294bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shadow-utils-4.6-17.el8.x86_64.rpm"
@@ -2512,6 +2548,9 @@
           },
           "sha256:644529740fa2e3655ab2aea0f5622958c34a591c0d08ee033ecbe2fb40dd437c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libbpf-0.5.0-1.el8.x86_64.rpm"
+          },
+          "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm"
           },
           "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-nftables-0.9.3-26.el8.x86_64.rpm"
@@ -2810,6 +2849,9 @@
           "sha256:a5a3efebdb4fd22edaa51a1ae737ef5801c8a8b6f87fb0891dd2ed93d55876f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/selinux-policy-targeted-3.14.3-108.el8.noarch.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a8233c195bb8b0a6b11b6e019d2a104bdfcdc07373d1d60c2b37723b19f97d0e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/NetworkManager-wifi-1.40.0-1.el8.x86_64.rpm"
           },
@@ -2827,6 +2869,9 @@
           },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ac99837d0568e37ab2b5dd8f10b17c3cc8b23d789199c93d79824bfab8f7f064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl6050-firmware-41.28.5.1-110.el8.1.noarch.rpm"
@@ -2878,6 +2923,9 @@
           },
           "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/rpm-ostree-2022.10.90.g4abaf4b4-4.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
@@ -2932,6 +2980,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm"
@@ -3074,8 +3125,14 @@
           "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da574dd0016840097a59070cc147ff60563ed7e314b97ae9ff9238188849956c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/clevis-15-11.el8.x86_64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:df82b0b9201f0d45f4a50a138d7592df71fde47bddbf9310fce62c2461cf0101": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl2030-firmware-18.168.6.1-110.el8.1.noarch.rpm"
@@ -3217,6 +3274,9 @@
           },
           "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -5428,6 +5488,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
       },
       {
         "name": "bzip2-libs",
@@ -7707,6 +7776,15 @@
         "checksum": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7743,6 +7821,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7770,6 +7857,15 @@
         "checksum": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm",
+        "checksum": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7795,6 +7891,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7840,6 +7954,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7993,6 +8116,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
         "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -8641,6 +8773,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
         "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_87-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_container-boot.json
@@ -705,6 +705,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1464,6 +1467,9 @@
                     "id": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1476,6 +1482,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:496ad735717ce1ed9cde99894844f5f5b745475a28f52b67e3ee5b368e0f20f0"
                   },
                   {
@@ -1485,6 +1494,9 @@
                     "id": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
                   },
                   {
+                    "id": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
+                  },
+                  {
                     "id": "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed"
                   },
                   {
@@ -1492,6 +1504,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1507,6 +1525,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1558,6 +1579,9 @@
                   },
                   {
                     "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+                  },
+                  {
+                    "id": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
                   },
                   {
                     "id": "sha256:b9cb64cbd8df172d478cd77d6dfa95309b5f3599dd4ce3423b0da7c93e25b6a4"
@@ -1774,6 +1798,12 @@
                   },
                   {
                     "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991"
@@ -2955,6 +2985,9 @@
           "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
+          "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
+          },
           "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
@@ -2993,6 +3026,9 @@
           },
           "sha256:3445946e036e5c26e5163388e96566bb0e71159e0fe40a93016f51ff0a099d10": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-minimal-langpack-2.28-211.el8.x86_64.rpm"
+          },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
           "sha256:35d2ce5cb5727a3703b83ffeb82b95c5ae2fb520e7a61a464425912e617294bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shadow-utils-4.6-17.el8.x86_64.rpm"
@@ -3236,6 +3272,9 @@
           },
           "sha256:644529740fa2e3655ab2aea0f5622958c34a591c0d08ee033ecbe2fb40dd437c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libbpf-0.5.0-1.el8.x86_64.rpm"
+          },
+          "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm"
           },
           "sha256:657efda777af4b0d63ab127a72f3373c0d8a18f3b81e912b24a5fbdc9927dc1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/perl-Term-ANSIColor-4.06-396.el8.noarch.rpm"
@@ -3591,6 +3630,9 @@
           "sha256:a660c78f704d3d22458c71d86605f51d62e3cc5306d22d66bb1df86c7274ad6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a8233c195bb8b0a6b11b6e019d2a104bdfcdc07373d1d60c2b37723b19f97d0e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/NetworkManager-wifi-1.40.0-1.el8.x86_64.rpm"
           },
@@ -3611,6 +3653,9 @@
           },
           "sha256:abe578c5dee7c306812e241c77ebc8ba4b54f90df8e65c56f8f202ba6e0d7183": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/perl-parent-0.237-1.el8.noarch.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ac99837d0568e37ab2b5dd8f10b17c3cc8b23d789199c93d79824bfab8f7f064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iwl6050-firmware-41.28.5.1-110.el8.1.noarch.rpm"
@@ -3666,6 +3711,9 @@
           "sha256:b4257b248c03c38b331e4b7033ae10f11646bdb4f62b86c8bf834b351868d991": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/rpm-ostree-2022.10.90.g4abaf4b4-4.el8.x86_64.rpm"
           },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
+          },
           "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
           },
@@ -3719,6 +3767,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm"
@@ -3885,11 +3936,17 @@
           "sha256:d906b13d5dd7a5595133e2a1af83ae17a1aae0c107579db723d21ec4371f3570": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/perl-File-Path-2.15-2.el8.noarch.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da574dd0016840097a59070cc147ff60563ed7e314b97ae9ff9238188849956c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/clevis-15-11.el8.x86_64.rpm"
           },
           "sha256:db1fad3c2d8735e69084bd4b09ea963938e4dde2f2e096dc7a4ce146f18b7ab0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fontpackages-filesystem-1.44-22.el8.noarch.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dd6a948e5a656701156c618e202c0b6defd11ba6f162b6790cbb42cea15141ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/perl-URI-1.73-3.el8.noarch.rpm"
@@ -4052,6 +4109,9 @@
           },
           "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -8048,6 +8108,15 @@
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -10325,6 +10394,15 @@
         "checksum": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -10361,6 +10439,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -10388,6 +10475,15 @@
         "checksum": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "15.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libxml2-2.9.7-15.el8.x86_64.rpm",
+        "checksum": "sha256:647f876d995a658d94b6643067ee1e1c48d5059e3422eca34ba09f94c90ec785"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -10413,6 +10509,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -10458,6 +10572,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -10611,6 +10734,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
         "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm",
+        "checksum": "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434"
       },
       {
         "name": "sqlite-libs",
@@ -11259,6 +11391,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
         "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_88-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_commit-boot.json
@@ -690,6 +690,9 @@
                     "id": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
                   },
                   {
+                    "id": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+                  },
+                  {
                     "id": "sha256:2d84f6765b1645f867527f493b6153470602a80c75f81545bf619aa92127e4da"
                   },
                   {
@@ -1404,6 +1407,9 @@
                     "id": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:8329bf1aedce9ef3a4d7513ef98d3931ad39b84d5c3e73e99936c7f9b87931c2"
                   },
                   {
@@ -1416,6 +1422,9 @@
                     "id": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:03be12262e36ab660619168fcadd6873d7c3b1aa2010e71e96ec9bb80df5c26a"
                   },
                   {
@@ -1425,6 +1434,9 @@
                     "id": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
                   },
                   {
+                    "id": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+                  },
+                  {
                     "id": "sha256:81d8d21fdf2b10f6ef63bfe5c623464382912c15fc852c575d435f7f6583a150"
                   },
                   {
@@ -1432,6 +1444,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f75e77a1746534f649a29ea02d4341ce3e266a34173ba4dbf654c9682c9787dc"
@@ -1447,6 +1465,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -1498,6 +1519,9 @@
                   },
                   {
                     "id": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+                  },
+                  {
+                    "id": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
                   },
                   {
                     "id": "sha256:febcbcc4a7c110ec230246d3cf9b896a1d30bea6c36098023daf78189ee94c36"
@@ -1714,6 +1738,12 @@
                   },
                   {
                     "id": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:5992808ef26c57655540a90bd08ba303414650a724f9ceacfca0f25f896b3b64"
@@ -1955,6 +1985,9 @@
           "sha256:1143ac623a74d7feaaaf293c18d942d243248f6356628f87216670c10d11687b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/json-glib-1.4.4-1.el8.aarch64.rpm"
           },
+          "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
+          },
           "sha256:14175dab807188a8261298dc3ba7b7cd19a9fbf36d0ee5b5c6cacc7e424998e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/libssh-config-0.9.6-3.el8.noarch.rpm"
           },
@@ -2132,6 +2165,9 @@
           "sha256:343c51ca38204f0244e1928ad6267eda7c48b3badcc5d22b09c084b5f0a8ada3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/libseccomp-2.5.2-1.el8.aarch64.rpm"
           },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
+          },
           "sha256:3598c3aaaed7e91b8aeb67eb2232b111856b758f6e1a5bb1d166c0bbfd00f68f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/selinux-policy-3.14.3-109.el8.noarch.rpm"
           },
@@ -2245,6 +2281,9 @@
           },
           "sha256:4f894907d6731eab46984e45656405bd7550780c38caf1fae576710f2114f652": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/systemd-239-68.el8.aarch64.rpm"
+          },
+          "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm"
           },
           "sha256:5293624aaec9da3557c32d1c0792a4ec6b2db1a63b77ac2ef3cb283da15490e9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-slip-0.6.4-13.el8.noarch.rpm"
@@ -2627,6 +2666,9 @@
           "sha256:a7551988b8c466f8759449f5cfb375173fe5aee67978fb3e1549a2a2bdeccf73": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/glib2-2.56.4-159.el8.aarch64.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
           },
@@ -2675,8 +2717,14 @@
           "sha256:b3d72ac8eb91e5fcf3dcacc0d1bf1412b910ca4e1fe11cfa74d26b8f46eb1a9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/keyutils-1.5.10-9.el8.aarch64.rpm"
           },
+          "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm"
+          },
           "sha256:b4f90cde4962b669ba8840d221dadc7c53c974aba1dc4b31ef31658eb6b3b116": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/device-mapper-libs-1.02.181-6.el8.aarch64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b6a865ea7596d521138f924a278ff5f859b4f56d2b69708d3befe476b5a9082d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/chrony-4.2-1.el8.aarch64.rpm"
@@ -2740,6 +2788,9 @@
           },
           "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/readline-7.0-10.el8.aarch64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c321e3a0253fb2691035135b3d3740faa76b8e9c84a0378f480ff85ddd9f16bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/efibootmgr-16-1.el8.aarch64.rpm"
@@ -2831,6 +2882,9 @@
           "sha256:d8cdddd00be4bf516dd725f99b12f6799a467a48728fb843c1b92c18d59f432f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/NetworkManager-1.40.2-1.el8.aarch64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da104c59254b60f093034924e21a7aabdeb1515d4b39e29aae60937257f71398": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/protobuf-3.5.0-15.el8.aarch64.rpm"
           },
@@ -2851,6 +2905,9 @@
           },
           "sha256:dbc8445a77ef2921cc10b38c9ae21f434757df6e5e4f70b795297414afb6e609": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/libatasmart-0.19-14.el8.aarch64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dc55157bc7b9baccc810d3f056c736fb225679bc27b0c2b98c2d1a2366275c78": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/kernel-modules-4.18.0-431.el8.aarch64.rpm"
@@ -2983,6 +3040,9 @@
           },
           "sha256:fd21565b47cb699188b18c636e9d155df0bd86942b3da9607ee6260d6d3abb3a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/lvm2-libs-2.03.14-6.el8.aarch64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
@@ -4878,6 +4938,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/bubblewrap-0.4.0-1.el8.aarch64.rpm",
         "checksum": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
       },
       {
         "name": "bzip2-libs",
@@ -7022,6 +7091,15 @@
         "checksum": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7058,6 +7136,15 @@
         "checksum": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7085,6 +7172,15 @@
         "checksum": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
       },
       {
+        "name": "python3-magic",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "21.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm",
+        "checksum": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7110,6 +7206,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7155,6 +7269,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7308,6 +7431,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/shim-aa64-15.6-1.el8.aarch64.rpm",
         "checksum": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm",
+        "checksum": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
       },
       {
         "name": "sqlite-libs",
@@ -7956,6 +8088,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/protobuf-c-1.3.0-6.el8.aarch64.rpm",
         "checksum": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
@@ -780,6 +780,9 @@
                     "id": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
                   },
                   {
+                    "id": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+                  },
+                  {
                     "id": "sha256:2d84f6765b1645f867527f493b6153470602a80c75f81545bf619aa92127e4da"
                   },
                   {
@@ -1494,6 +1497,9 @@
                     "id": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:8329bf1aedce9ef3a4d7513ef98d3931ad39b84d5c3e73e99936c7f9b87931c2"
                   },
                   {
@@ -1506,6 +1512,9 @@
                     "id": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:03be12262e36ab660619168fcadd6873d7c3b1aa2010e71e96ec9bb80df5c26a"
                   },
                   {
@@ -1515,6 +1524,9 @@
                     "id": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
                   },
                   {
+                    "id": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+                  },
+                  {
                     "id": "sha256:81d8d21fdf2b10f6ef63bfe5c623464382912c15fc852c575d435f7f6583a150"
                   },
                   {
@@ -1522,6 +1534,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f75e77a1746534f649a29ea02d4341ce3e266a34173ba4dbf654c9682c9787dc"
@@ -1537,6 +1555,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -1588,6 +1609,9 @@
                   },
                   {
                     "id": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+                  },
+                  {
+                    "id": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
                   },
                   {
                     "id": "sha256:febcbcc4a7c110ec230246d3cf9b896a1d30bea6c36098023daf78189ee94c36"
@@ -1804,6 +1828,12 @@
                   },
                   {
                     "id": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:5992808ef26c57655540a90bd08ba303414650a724f9ceacfca0f25f896b3b64"
@@ -2080,6 +2110,9 @@
           "sha256:1143ac623a74d7feaaaf293c18d942d243248f6356628f87216670c10d11687b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/json-glib-1.4.4-1.el8.aarch64.rpm"
           },
+          "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
+          },
           "sha256:14175dab807188a8261298dc3ba7b7cd19a9fbf36d0ee5b5c6cacc7e424998e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/libssh-config-0.9.6-3.el8.noarch.rpm"
           },
@@ -2257,6 +2290,9 @@
           "sha256:343c51ca38204f0244e1928ad6267eda7c48b3badcc5d22b09c084b5f0a8ada3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/libseccomp-2.5.2-1.el8.aarch64.rpm"
           },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
+          },
           "sha256:3598c3aaaed7e91b8aeb67eb2232b111856b758f6e1a5bb1d166c0bbfd00f68f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/selinux-policy-3.14.3-109.el8.noarch.rpm"
           },
@@ -2370,6 +2406,9 @@
           },
           "sha256:4f894907d6731eab46984e45656405bd7550780c38caf1fae576710f2114f652": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/systemd-239-68.el8.aarch64.rpm"
+          },
+          "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm"
           },
           "sha256:5293624aaec9da3557c32d1c0792a4ec6b2db1a63b77ac2ef3cb283da15490e9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-slip-0.6.4-13.el8.noarch.rpm"
@@ -2755,6 +2794,9 @@
           "sha256:a7551988b8c466f8759449f5cfb375173fe5aee67978fb3e1549a2a2bdeccf73": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/glib2-2.56.4-159.el8.aarch64.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
           },
@@ -2803,8 +2845,14 @@
           "sha256:b3d72ac8eb91e5fcf3dcacc0d1bf1412b910ca4e1fe11cfa74d26b8f46eb1a9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/keyutils-1.5.10-9.el8.aarch64.rpm"
           },
+          "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm"
+          },
           "sha256:b4f90cde4962b669ba8840d221dadc7c53c974aba1dc4b31ef31658eb6b3b116": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/device-mapper-libs-1.02.181-6.el8.aarch64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b6a865ea7596d521138f924a278ff5f859b4f56d2b69708d3befe476b5a9082d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/chrony-4.2-1.el8.aarch64.rpm"
@@ -2868,6 +2916,9 @@
           },
           "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/readline-7.0-10.el8.aarch64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c321e3a0253fb2691035135b3d3740faa76b8e9c84a0378f480ff85ddd9f16bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/efibootmgr-16-1.el8.aarch64.rpm"
@@ -2959,6 +3010,9 @@
           "sha256:d8cdddd00be4bf516dd725f99b12f6799a467a48728fb843c1b92c18d59f432f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/NetworkManager-1.40.2-1.el8.aarch64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da104c59254b60f093034924e21a7aabdeb1515d4b39e29aae60937257f71398": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/protobuf-3.5.0-15.el8.aarch64.rpm"
           },
@@ -2979,6 +3033,9 @@
           },
           "sha256:dbc8445a77ef2921cc10b38c9ae21f434757df6e5e4f70b795297414afb6e609": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/libatasmart-0.19-14.el8.aarch64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dc55157bc7b9baccc810d3f056c736fb225679bc27b0c2b98c2d1a2366275c78": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/kernel-modules-4.18.0-431.el8.aarch64.rpm"
@@ -3111,6 +3168,9 @@
           },
           "sha256:fd21565b47cb699188b18c636e9d155df0bd86942b3da9607ee6260d6d3abb3a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/lvm2-libs-2.03.14-6.el8.aarch64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
@@ -5270,6 +5330,15 @@
         "checksum": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -7412,6 +7481,15 @@
         "checksum": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7448,6 +7526,15 @@
         "checksum": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7475,6 +7562,15 @@
         "checksum": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
       },
       {
+        "name": "python3-magic",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "21.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm",
+        "checksum": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7500,6 +7596,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7545,6 +7659,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7698,6 +7821,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/shim-aa64-15.6-1.el8.aarch64.rpm",
         "checksum": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm",
+        "checksum": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
       },
       {
         "name": "sqlite-libs",
@@ -8346,6 +8478,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/protobuf-c-1.3.0-6.el8.aarch64.rpm",
         "checksum": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_88-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_container-boot.json
@@ -690,6 +690,9 @@
                     "id": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
                   },
                   {
+                    "id": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+                  },
+                  {
                     "id": "sha256:2d84f6765b1645f867527f493b6153470602a80c75f81545bf619aa92127e4da"
                   },
                   {
@@ -1404,6 +1407,9 @@
                     "id": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:8329bf1aedce9ef3a4d7513ef98d3931ad39b84d5c3e73e99936c7f9b87931c2"
                   },
                   {
@@ -1416,6 +1422,9 @@
                     "id": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:03be12262e36ab660619168fcadd6873d7c3b1aa2010e71e96ec9bb80df5c26a"
                   },
                   {
@@ -1425,6 +1434,9 @@
                     "id": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
                   },
                   {
+                    "id": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+                  },
+                  {
                     "id": "sha256:81d8d21fdf2b10f6ef63bfe5c623464382912c15fc852c575d435f7f6583a150"
                   },
                   {
@@ -1432,6 +1444,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f75e77a1746534f649a29ea02d4341ce3e266a34173ba4dbf654c9682c9787dc"
@@ -1447,6 +1465,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e"
@@ -1498,6 +1519,9 @@
                   },
                   {
                     "id": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+                  },
+                  {
+                    "id": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
                   },
                   {
                     "id": "sha256:febcbcc4a7c110ec230246d3cf9b896a1d30bea6c36098023daf78189ee94c36"
@@ -1714,6 +1738,12 @@
                   },
                   {
                     "id": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:5992808ef26c57655540a90bd08ba303414650a724f9ceacfca0f25f896b3b64"
@@ -2739,6 +2769,9 @@
           "sha256:137a8ee6c1f8500fa0de50d6bf894e9aaeb04dd2fb4d6e347e2b4f7db89a948a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/libX11-1.6.8-5.el8.aarch64.rpm"
           },
+          "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.aarch64.rpm"
+          },
           "sha256:14175dab807188a8261298dc3ba7b7cd19a9fbf36d0ee5b5c6cacc7e424998e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/libssh-config-0.9.6-3.el8.noarch.rpm"
           },
@@ -2952,6 +2985,9 @@
           "sha256:34f9dc2d00d389b5eb9fef46404f182c8e81f008bb13e0e4e397ebc6a704fc5d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/libxslt-1.1.32-6.el8.aarch64.rpm"
           },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
+          },
           "sha256:3598c3aaaed7e91b8aeb67eb2232b111856b758f6e1a5bb1d166c0bbfd00f68f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/selinux-policy-3.14.3-109.el8.noarch.rpm"
           },
@@ -3101,6 +3137,9 @@
           },
           "sha256:4f894907d6731eab46984e45656405bd7550780c38caf1fae576710f2114f652": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/systemd-239-68.el8.aarch64.rpm"
+          },
+          "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm"
           },
           "sha256:5176881bae429bec5136195c73b402081184ae2a35519673031a075e855f75f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/libXau-1.0.9-3.el8.aarch64.rpm"
@@ -3555,6 +3594,9 @@
           "sha256:a7551988b8c466f8759449f5cfb375173fe5aee67978fb3e1549a2a2bdeccf73": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/glib2-2.56.4-159.el8.aarch64.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:aa45417d26f9cc35fff19c4d547e7c8eaabfbc72667d716d5b604982e2d704f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-firewall-0.9.3-13.el8.noarch.rpm"
           },
@@ -3606,8 +3648,14 @@
           "sha256:b3d72ac8eb91e5fcf3dcacc0d1bf1412b910ca4e1fe11cfa74d26b8f46eb1a9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/keyutils-1.5.10-9.el8.aarch64.rpm"
           },
+          "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm"
+          },
           "sha256:b4f90cde4962b669ba8840d221dadc7c53c974aba1dc4b31ef31658eb6b3b116": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/device-mapper-libs-1.02.181-6.el8.aarch64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b5774cc6cf397117a0a9a5f7aad450385a2583bc055ee3aaf203e8e66660a5ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/perl-Digest-MD5-2.55-396.el8.aarch64.rpm"
@@ -3677,6 +3725,9 @@
           },
           "sha256:c2f286f6b75caf1508829d748c35833ee5fba762e0175b1f5dbb23ab8ab2079e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/readline-7.0-10.el8.aarch64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c321e3a0253fb2691035135b3d3740faa76b8e9c84a0378f480ff85ddd9f16bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/efibootmgr-16-1.el8.aarch64.rpm"
@@ -3777,6 +3828,9 @@
           "sha256:d906b13d5dd7a5595133e2a1af83ae17a1aae0c107579db723d21ec4371f3570": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/perl-File-Path-2.15-2.el8.noarch.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da104c59254b60f093034924e21a7aabdeb1515d4b39e29aae60937257f71398": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/protobuf-3.5.0-15.el8.aarch64.rpm"
           },
@@ -3800,6 +3854,9 @@
           },
           "sha256:dbc8445a77ef2921cc10b38c9ae21f434757df6e5e4f70b795297414afb6e609": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/libatasmart-0.19-14.el8.aarch64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dc55157bc7b9baccc810d3f056c736fb225679bc27b0c2b98c2d1a2366275c78": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/kernel-modules-4.18.0-431.el8.aarch64.rpm"
@@ -3956,6 +4013,9 @@
           },
           "sha256:fd21565b47cb699188b18c636e9d155df0bd86942b3da9607ee6260d6d3abb3a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/lvm2-libs-2.03.14-6.el8.aarch64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
@@ -7898,6 +7958,15 @@
         "checksum": "sha256:40096d3516d115e83bc2aa2b5877708f4511961d524e03ce562f9f1872fa27ab"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.aarch64.rpm",
+        "checksum": "sha256:13cab1083eb51b9ab0dc3fdc567106454e28096a6ec32184ad509ec19214fdef"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -10040,6 +10109,15 @@
         "checksum": "sha256:80eb1cfd1c75402d145a147c15b0c111b7fe440e71035ad993a9033d522c5a45"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -10076,6 +10154,15 @@
         "checksum": "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -10103,6 +10190,15 @@
         "checksum": "sha256:79b6d77b301f53121f132b54652e6b671d7fcebd7eee9bdec0686494c3ae9918"
       },
       {
+        "name": "python3-magic",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "21.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm",
+        "checksum": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -10128,6 +10224,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -10173,6 +10287,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -10326,6 +10449,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/shim-aa64-15.6-1.el8.aarch64.rpm",
         "checksum": "sha256:fa746bdbe84370e415f826f411f032192108db5d58e3f752909face11aae2325"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm",
+        "checksum": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
       },
       {
         "name": "sqlite-libs",
@@ -10974,6 +11106,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/protobuf-c-1.3.0-6.el8.aarch64.rpm",
         "checksum": "sha256:0ef7b186d488320c8813db1a955d1f77635e9f5692ff5194bd29db140724afbe"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_88-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit-boot.json
@@ -714,6 +714,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1473,6 +1476,9 @@
                     "id": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1485,6 +1491,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:496ad735717ce1ed9cde99894844f5f5b745475a28f52b67e3ee5b368e0f20f0"
                   },
                   {
@@ -1494,6 +1503,9 @@
                     "id": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
                   },
                   {
+                    "id": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+                  },
+                  {
                     "id": "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed"
                   },
                   {
@@ -1501,6 +1513,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1516,6 +1534,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1567,6 +1588,9 @@
                   },
                   {
                     "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+                  },
+                  {
+                    "id": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
                   },
                   {
                     "id": "sha256:b9cb64cbd8df172d478cd77d6dfa95309b5f3599dd4ce3423b0da7c93e25b6a4"
@@ -1783,6 +1807,12 @@
                   },
                   {
                     "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:aa4e95a742f559e9cd02b5f19cbd4666a1da77e9f57311eed03810cc84d2c2a8"
@@ -2202,6 +2232,9 @@
           "sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/cracklib-dicts-2.9.6-15.el8.x86_64.rpm"
           },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
+          },
           "sha256:3598c3aaaed7e91b8aeb67eb2232b111856b758f6e1a5bb1d166c0bbfd00f68f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/selinux-policy-3.14.3-109.el8.noarch.rpm"
           },
@@ -2333,6 +2366,9 @@
           },
           "sha256:4ff48ee0aa97ca65082b5108bb2a2af036d32f99ea058a1eff0c33d7700c429a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/containers-common-1-42.module+el8.8.0+16760+2f749ab7.x86_64.rpm"
+          },
+          "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm"
           },
           "sha256:507c1a196520e4263a0581e70b669c352097d6bdc7a5409ae748ee3942e71f5c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-sysinit-3.79.0-10.el8_6.x86_64.rpm"
@@ -2700,6 +2736,9 @@
           "sha256:a506765865ee31210532f16af156f54ea9431ba1763269d3a39c9ebf0adf5163": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libqb-1.0.3-12.el8.x86_64.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a86f1309b026b7c6d2b3acc31f4829b838c46f11a981b20ee393f2a31d9d24a0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/protobuf-3.5.0-15.el8.x86_64.rpm"
           },
@@ -2720,6 +2759,9 @@
           },
           "sha256:aa4e95a742f559e9cd02b5f19cbd4666a1da77e9f57311eed03810cc84d2c2a8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/rpm-ostree-2022.10.97.gade6df33-2.el8.x86_64.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ac99837d0568e37ab2b5dd8f10b17c3cc8b23d789199c93d79824bfab8f7f064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/iwl6050-firmware-41.28.5.1-110.el8.1.noarch.rpm"
@@ -2766,8 +2808,14 @@
           "sha256:b2f076bf0b561c06b78adeb78be388d74606a8112530161073bf9c877eb1f744": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/cpio-2.12-11.el8.x86_64.rpm"
           },
+          "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm"
+          },
           "sha256:b41c194ecf358e8e6cec46068c4fb6f34780ee2bd65200c367b94170103a8aa9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/ima-evm-utils-1.3.2-12.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
@@ -2825,6 +2873,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm"
@@ -2964,8 +3015,14 @@
           "sha256:d9213f808784a7395a78e3b58351d21188bb5df23dd50dbc4432a49d682cd60b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libslirp-4.4.0-1.module+el8.8.0+16760+2f749ab7.x86_64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da574dd0016840097a59070cc147ff60563ed7e314b97ae9ff9238188849956c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/clevis-15-11.el8.x86_64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:df82b0b9201f0d45f4a50a138d7592df71fde47bddbf9310fce62c2461cf0101": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/iwl2030-firmware-18.168.6.1-110.el8.1.noarch.rpm"
@@ -3092,6 +3149,9 @@
           },
           "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -5038,6 +5098,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
       },
       {
         "name": "bzip2-libs",
@@ -7317,6 +7386,15 @@
         "checksum": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7353,6 +7431,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7380,6 +7467,15 @@
         "checksum": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
       },
       {
+        "name": "python3-magic",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "21.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm",
+        "checksum": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7405,6 +7501,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7450,6 +7564,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7603,6 +7726,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
         "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm",
+        "checksum": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
       },
       {
         "name": "sqlite-libs",
@@ -8251,6 +8383,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
         "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_88-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit_rt-boot.json
@@ -721,6 +721,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1501,6 +1504,9 @@
                     "id": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1511,6 +1517,9 @@
                   },
                   {
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
+                  },
+                  {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
                   },
                   {
                     "id": "sha256:496ad735717ce1ed9cde99894844f5f5b745475a28f52b67e3ee5b368e0f20f0"
@@ -1525,6 +1534,9 @@
                     "id": "sha256:c8653e199fdea0852a124ed24df2f7b3aa7e0aa6a1258147d89c39692a420c84"
                   },
                   {
+                    "id": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+                  },
+                  {
                     "id": "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed"
                   },
                   {
@@ -1537,7 +1549,13 @@
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
                   },
                   {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
                     "id": "sha256:4ad66a3a1dd79384852669609567108dcc429607d40ca8adc5f1dbe6a9d6bdde"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1556,6 +1574,9 @@
                   },
                   {
                     "id": "sha256:7d9fc991404f6a6500385e328e231dd6b84a7722648e049ae9565fa31135f6a3"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1610,6 +1631,9 @@
                   },
                   {
                     "id": "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1"
+                  },
+                  {
+                    "id": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
                   },
                   {
                     "id": "sha256:b9cb64cbd8df172d478cd77d6dfa95309b5f3599dd4ce3423b0da7c93e25b6a4"
@@ -1838,6 +1862,12 @@
                   },
                   {
                     "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:aa4e95a742f559e9cd02b5f19cbd4666a1da77e9f57311eed03810cc84d2c2a8"
@@ -2287,6 +2317,9 @@
           "sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/cracklib-dicts-2.9.6-15.el8.x86_64.rpm"
           },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
+          },
           "sha256:3598c3aaaed7e91b8aeb67eb2232b111856b758f6e1a5bb1d166c0bbfd00f68f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/selinux-policy-3.14.3-109.el8.noarch.rpm"
           },
@@ -2427,6 +2460,9 @@
           },
           "sha256:4ff48ee0aa97ca65082b5108bb2a2af036d32f99ea058a1eff0c33d7700c429a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/containers-common-1-42.module+el8.8.0+16760+2f749ab7.x86_64.rpm"
+          },
+          "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm"
           },
           "sha256:507c1a196520e4263a0581e70b669c352097d6bdc7a5409ae748ee3942e71f5c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-sysinit-3.79.0-10.el8_6.x86_64.rpm"
@@ -2818,6 +2854,9 @@
           "sha256:a506765865ee31210532f16af156f54ea9431ba1763269d3a39c9ebf0adf5163": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libqb-1.0.3-12.el8.x86_64.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a86f1309b026b7c6d2b3acc31f4829b838c46f11a981b20ee393f2a31d9d24a0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/protobuf-3.5.0-15.el8.x86_64.rpm"
           },
@@ -2835,6 +2874,9 @@
           },
           "sha256:aa4e95a742f559e9cd02b5f19cbd4666a1da77e9f57311eed03810cc84d2c2a8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/rpm-ostree-2022.10.97.gade6df33-2.el8.x86_64.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ac99837d0568e37ab2b5dd8f10b17c3cc8b23d789199c93d79824bfab8f7f064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/iwl6050-firmware-41.28.5.1-110.el8.1.noarch.rpm"
@@ -2881,11 +2923,17 @@
           "sha256:b2f076bf0b561c06b78adeb78be388d74606a8112530161073bf9c877eb1f744": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/cpio-2.12-11.el8.x86_64.rpm"
           },
+          "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm"
+          },
           "sha256:b41c194ecf358e8e6cec46068c4fb6f34780ee2bd65200c367b94170103a8aa9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/ima-evm-utils-1.3.2-12.el8.x86_64.rpm"
           },
           "sha256:b4babe48d93eccce4f0249ba34d592bfc306c3b14b40df7a5cc9eaec2eaae20f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/numactl-libs-2.0.12-13.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
@@ -2940,6 +2988,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm"
@@ -3085,8 +3136,14 @@
           "sha256:d9213f808784a7395a78e3b58351d21188bb5df23dd50dbc4432a49d682cd60b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libslirp-4.4.0-1.module+el8.8.0+16760+2f749ab7.x86_64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da574dd0016840097a59070cc147ff60563ed7e314b97ae9ff9238188849956c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/clevis-15-11.el8.x86_64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:df82b0b9201f0d45f4a50a138d7592df71fde47bddbf9310fce62c2461cf0101": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/iwl2030-firmware-18.168.6.1-110.el8.1.noarch.rpm"
@@ -3225,6 +3282,9 @@
           },
           "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -5171,6 +5231,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
       },
       {
         "name": "bzip2-libs",
@@ -7513,6 +7582,15 @@
         "checksum": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7547,6 +7625,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-gobject-base-3.28.3-2.el8.x86_64.rpm",
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
       },
       {
         "name": "python3-libs",
@@ -7585,6 +7672,15 @@
         "checksum": "sha256:c8653e199fdea0852a124ed24df2f7b3aa7e0aa6a1258147d89c39692a420c84"
       },
       {
+        "name": "python3-magic",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "21.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm",
+        "checksum": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7621,6 +7717,15 @@
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
       },
       {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
         "name": "python3-pyudev",
         "epoch": 0,
         "version": "0.21.0",
@@ -7628,6 +7733,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-pyudev-0.21.0-7.el8.noarch.rpm",
         "checksum": "sha256:4ad66a3a1dd79384852669609567108dcc429607d40ca8adc5f1dbe6a9d6bdde"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7682,6 +7796,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-syspurpose-1.28.32-1.el8.x86_64.rpm",
         "checksum": "sha256:7d9fc991404f6a6500385e328e231dd6b84a7722648e049ae9565fa31135f6a3"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7844,6 +7967,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/snappy-1.1.8-3.el8.x86_64.rpm",
         "checksum": "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm",
+        "checksum": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
       },
       {
         "name": "sqlite-libs",
@@ -8528,6 +8660,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
         "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
@@ -804,6 +804,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1563,6 +1566,9 @@
                     "id": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1575,6 +1581,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:496ad735717ce1ed9cde99894844f5f5b745475a28f52b67e3ee5b368e0f20f0"
                   },
                   {
@@ -1584,6 +1593,9 @@
                     "id": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
                   },
                   {
+                    "id": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+                  },
+                  {
                     "id": "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed"
                   },
                   {
@@ -1591,6 +1603,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1606,6 +1624,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1657,6 +1678,9 @@
                   },
                   {
                     "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+                  },
+                  {
+                    "id": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
                   },
                   {
                     "id": "sha256:b9cb64cbd8df172d478cd77d6dfa95309b5f3599dd4ce3423b0da7c93e25b6a4"
@@ -1873,6 +1897,12 @@
                   },
                   {
                     "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:aa4e95a742f559e9cd02b5f19cbd4666a1da77e9f57311eed03810cc84d2c2a8"
@@ -2327,6 +2357,9 @@
           "sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/cracklib-dicts-2.9.6-15.el8.x86_64.rpm"
           },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
+          },
           "sha256:3598c3aaaed7e91b8aeb67eb2232b111856b758f6e1a5bb1d166c0bbfd00f68f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/selinux-policy-3.14.3-109.el8.noarch.rpm"
           },
@@ -2458,6 +2491,9 @@
           },
           "sha256:4ff48ee0aa97ca65082b5108bb2a2af036d32f99ea058a1eff0c33d7700c429a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/containers-common-1-42.module+el8.8.0+16760+2f749ab7.x86_64.rpm"
+          },
+          "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm"
           },
           "sha256:507c1a196520e4263a0581e70b669c352097d6bdc7a5409ae748ee3942e71f5c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-sysinit-3.79.0-10.el8_6.x86_64.rpm"
@@ -2828,6 +2864,9 @@
           "sha256:a506765865ee31210532f16af156f54ea9431ba1763269d3a39c9ebf0adf5163": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libqb-1.0.3-12.el8.x86_64.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a86f1309b026b7c6d2b3acc31f4829b838c46f11a981b20ee393f2a31d9d24a0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/protobuf-3.5.0-15.el8.x86_64.rpm"
           },
@@ -2848,6 +2887,9 @@
           },
           "sha256:aa4e95a742f559e9cd02b5f19cbd4666a1da77e9f57311eed03810cc84d2c2a8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/rpm-ostree-2022.10.97.gade6df33-2.el8.x86_64.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ac99837d0568e37ab2b5dd8f10b17c3cc8b23d789199c93d79824bfab8f7f064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/iwl6050-firmware-41.28.5.1-110.el8.1.noarch.rpm"
@@ -2894,8 +2936,14 @@
           "sha256:b2f076bf0b561c06b78adeb78be388d74606a8112530161073bf9c877eb1f744": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/cpio-2.12-11.el8.x86_64.rpm"
           },
+          "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm"
+          },
           "sha256:b41c194ecf358e8e6cec46068c4fb6f34780ee2bd65200c367b94170103a8aa9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/ima-evm-utils-1.3.2-12.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
@@ -2953,6 +3001,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm"
@@ -3092,8 +3143,14 @@
           "sha256:d9213f808784a7395a78e3b58351d21188bb5df23dd50dbc4432a49d682cd60b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libslirp-4.4.0-1.module+el8.8.0+16760+2f749ab7.x86_64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da574dd0016840097a59070cc147ff60563ed7e314b97ae9ff9238188849956c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/clevis-15-11.el8.x86_64.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:df82b0b9201f0d45f4a50a138d7592df71fde47bddbf9310fce62c2461cf0101": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/iwl2030-firmware-18.168.6.1-110.el8.1.noarch.rpm"
@@ -3220,6 +3277,9 @@
           },
           "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -5428,6 +5488,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
       },
       {
         "name": "bzip2-libs",
@@ -7707,6 +7776,15 @@
         "checksum": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -7743,6 +7821,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -7770,6 +7857,15 @@
         "checksum": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
       },
       {
+        "name": "python3-magic",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "21.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm",
+        "checksum": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -7795,6 +7891,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -7840,6 +7954,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -7993,6 +8116,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
         "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm",
+        "checksum": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
       },
       {
         "name": "sqlite-libs",
@@ -8641,6 +8773,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
         "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_88-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_container-boot.json
@@ -705,6 +705,9 @@
                     "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
+                    "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+                  },
+                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -1464,6 +1467,9 @@
                     "id": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
                   },
                   {
+                    "id": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+                  },
+                  {
                     "id": "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86"
                   },
                   {
@@ -1476,6 +1482,9 @@
                     "id": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
                   },
                   {
+                    "id": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+                  },
+                  {
                     "id": "sha256:496ad735717ce1ed9cde99894844f5f5b745475a28f52b67e3ee5b368e0f20f0"
                   },
                   {
@@ -1485,6 +1494,9 @@
                     "id": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
                   },
                   {
+                    "id": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+                  },
+                  {
                     "id": "sha256:66ea1e3d0bfb3d08a0383cec05f9d51b598ad5fbc528fb980f38688bb7ede8ed"
                   },
                   {
@@ -1492,6 +1504,12 @@
                   },
                   {
                     "id": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+                  },
+                  {
+                    "id": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+                  },
+                  {
+                    "id": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
                   },
                   {
                     "id": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
@@ -1507,6 +1525,9 @@
                   },
                   {
                     "id": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+                  },
+                  {
+                    "id": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
                   },
                   {
                     "id": "sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9"
@@ -1558,6 +1579,9 @@
                   },
                   {
                     "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+                  },
+                  {
+                    "id": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
                   },
                   {
                     "id": "sha256:b9cb64cbd8df172d478cd77d6dfa95309b5f3599dd4ce3423b0da7c93e25b6a4"
@@ -1774,6 +1798,12 @@
                   },
                   {
                     "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+                  },
+                  {
+                    "id": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+                  },
+                  {
+                    "id": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
                   },
                   {
                     "id": "sha256:aa4e95a742f559e9cd02b5f19cbd4666a1da77e9f57311eed03810cc84d2c2a8"
@@ -3015,6 +3045,9 @@
           "sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/cracklib-dicts-2.9.6-15.el8.x86_64.rpm"
           },
+          "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
+          },
           "sha256:3598c3aaaed7e91b8aeb67eb2232b111856b758f6e1a5bb1d166c0bbfd00f68f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/selinux-policy-3.14.3-109.el8.noarch.rpm"
           },
@@ -3173,6 +3206,9 @@
           },
           "sha256:4ff48ee0aa97ca65082b5108bb2a2af036d32f99ea058a1eff0c33d7700c429a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/containers-common-1-42.module+el8.8.0+16760+2f749ab7.x86_64.rpm"
+          },
+          "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm"
           },
           "sha256:507c1a196520e4263a0581e70b669c352097d6bdc7a5409ae748ee3942e71f5c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-sysinit-3.79.0-10.el8_6.x86_64.rpm"
@@ -3609,6 +3645,9 @@
           "sha256:a660c78f704d3d22458c71d86605f51d62e3cc5306d22d66bb1df86c7274ad6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm"
           },
+          "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
           "sha256:a86f1309b026b7c6d2b3acc31f4829b838c46f11a981b20ee393f2a31d9d24a0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/protobuf-3.5.0-15.el8.x86_64.rpm"
           },
@@ -3632,6 +3671,9 @@
           },
           "sha256:abe578c5dee7c306812e241c77ebc8ba4b54f90df8e65c56f8f202ba6e0d7183": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/perl-parent-0.237-1.el8.noarch.rpm"
+          },
+          "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.x86_64.rpm"
           },
           "sha256:ac99837d0568e37ab2b5dd8f10b17c3cc8b23d789199c93d79824bfab8f7f064": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/iwl6050-firmware-41.28.5.1-110.el8.1.noarch.rpm"
@@ -3681,8 +3723,14 @@
           "sha256:b2f076bf0b561c06b78adeb78be388d74606a8112530161073bf9c877eb1f744": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/cpio-2.12-11.el8.x86_64.rpm"
           },
+          "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm"
+          },
           "sha256:b41c194ecf358e8e6cec46068c4fb6f34780ee2bd65200c367b94170103a8aa9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/ima-evm-utils-1.3.2-12.el8.x86_64.rpm"
+          },
+          "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
           "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
@@ -3740,6 +3788,9 @@
           },
           "sha256:c2ca16e84cca561fb94b13e4ef72b0c5ea2c463b8710d40aedce83a833c663e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm"
           },
           "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm"
@@ -3903,11 +3954,17 @@
           "sha256:d9213f808784a7395a78e3b58351d21188bb5df23dd50dbc4432a49d682cd60b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libslirp-4.4.0-1.module+el8.8.0+16760+2f749ab7.x86_64.rpm"
           },
+          "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
+          },
           "sha256:da574dd0016840097a59070cc147ff60563ed7e314b97ae9ff9238188849956c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/clevis-15-11.el8.x86_64.rpm"
           },
           "sha256:db1fad3c2d8735e69084bd4b09ea963938e4dde2f2e096dc7a4ce146f18b7ab0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fontpackages-filesystem-1.44-22.el8.noarch.rpm"
+          },
+          "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
           },
           "sha256:dd6a948e5a656701156c618e202c0b6defd11ba6f162b6790cbb42cea15141ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/perl-URI-1.73-3.el8.noarch.rpm"
@@ -4055,6 +4112,9 @@
           },
           "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
+          },
+          "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
           "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
@@ -8048,6 +8108,15 @@
         "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "26.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bzip2-1.0.6-26.el8.x86_64.rpm",
+        "checksum": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -10325,6 +10394,15 @@
         "checksum": "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.4",
@@ -10361,6 +10439,15 @@
         "checksum": "sha256:86d305a1466a596f8b436561d674f2510f268bed9e73f56c87da1dd120f99c18"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.6.8",
@@ -10388,6 +10475,15 @@
         "checksum": "sha256:fc1df6733519dc87a89fd355b1ed56c940d97d737427b72306723e8790dd35af"
       },
       {
+        "name": "python3-magic",
+        "epoch": 0,
+        "version": "5.33",
+        "release": "21.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-magic-5.33-21.el8.noarch.rpm",
+        "checksum": "sha256:b4169eded939e7c596da378f94776255a86790ded4cf749e3b62ce809040f183"
+      },
+      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "0.9.3",
@@ -10413,6 +10509,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm",
         "checksum": "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a"
       },
       {
         "name": "python3-setools",
@@ -10458,6 +10572,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-slip-dbus-0.6.4-13.el8.noarch.rpm",
         "checksum": "sha256:40c199fa3a31697ae9aa7a2ee1c37539faf7be0fbc81a6216332c77c99927b5c"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f"
       },
       {
         "name": "readline",
@@ -10611,6 +10734,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
         "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/sos-4.4-2.el8.noarch.rpm",
+        "checksum": "sha256:502435bab857028436bd33781bc49ea33f3d548eeebbcdb000e23ec61026f26d"
       },
       {
         "name": "sqlite-libs",
@@ -11259,6 +11391,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
         "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
+      },
+      {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.3.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm",
+        "checksum": "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.5.2",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm",
+        "checksum": "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b"
       },
       {
         "name": "rpm-ostree",

--- a/test/data/manifests/rhel_9-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_commit-boot.json
@@ -1668,6 +1668,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a06414786e5b316a6bc411b4827d45d0364817071f924fed85c395df0ecd9450",
                     "options": {
                       "metadata": {
@@ -3420,6 +3428,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:26f20dd590b09a8f418dc6c51ba734ca3714902ccde9ca3e91201481ed2728ba",
                     "options": {
                       "metadata": {
@@ -3452,7 +3468,23 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:cbdce6902501eef4192d765ee9b768a53cfee2fa2662e5abeefd597615ff2c04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3468,7 +3500,39 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3493,6 +3557,22 @@
                   },
                   {
                     "id": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3629,6 +3709,14 @@
                   },
                   {
                     "id": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4615,6 +4703,9 @@
           "sha256:09ff81634b9741b286b42e2067270b4f95141a5ea03886f0610e25e9d0f941a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/mpfr-4.1.0-7.el9.aarch64.rpm"
           },
+          "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:0bc4d57ac943f016fb716392828a7cfa4bfcb899c3ff7a61501bf7dd36228646": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libmbim-utils-1.26.0-2.el9.aarch64.rpm"
           },
@@ -4647,6 +4738,9 @@
           },
           "sha256:16b57cc1b34d4c44d9638d4f87527d7883baad76433b2d2210a5663907cd8e11": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/file-libs-5.39-10.el9.aarch64.rpm"
+          },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
           },
           "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
@@ -4696,11 +4790,17 @@
           "sha256:1e1ad4c81b343be9175db222ea845afcc622f5a9c38a1f4c55ecad90c83a23ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/dosfstools-4.2-3.el9.aarch64.rpm"
           },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:1eccd2b9ccbaa8a1c680c0e0fd4e1733d1abf1fe0bdff635e309cdc232492c1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/glibc-minimal-langpack-2.34-40.el9.aarch64.rpm"
           },
           "sha256:1f1518511e3dc9c199cc9215eb99e16cfc5b7cf4a474fc1d24bd46a7b51b06e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/gdisk-1.0.7-5.el9.aarch64.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:1f46937ea8b9af3010c90f75c0a0cde76348defb6604d35c670c77cb62f3640e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/NetworkManager-libnm-1.40.0-1.el9.aarch64.rpm"
@@ -4885,6 +4985,9 @@
           "sha256:496085a23af0a0fadb510bf3bbac631583a2b0268eb2b3deeeb1b4a31c9dd631": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/kpartx-0.8.7-12.el9.aarch64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:4a684a393f14704bf0bf74adc5943863334e8371d70fec6fc7667201b3c2fe9f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.aarch64.rpm"
           },
@@ -4941,6 +5044,9 @@
           },
           "sha256:55be6352c68f5245a31c09709a5b604038d9d373d69c226c49a5a5f6923eff46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/traceroute-2.1.0-16.el9.aarch64.rpm"
+          },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm"
           },
           "sha256:5684001de29ef187b78849729334c61ac7f77b4a56e0cdae0df196731777ec7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libacl-2.3.1-3.el9.aarch64.rpm"
@@ -5086,6 +5192,9 @@
           "sha256:767396019f392da9ce7d24d4f8e3178070c2594e984e7dbc019d103cca1e27e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/rsync-3.2.3-18.el9.aarch64.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:77719a7a94185255f23ff1e5c1e1292d8350a4d33b2b35d87fc273c337d771d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libtasn1-4.16.0-7.el9.aarch64.rpm"
           },
@@ -5184,6 +5293,9 @@
           },
           "sha256:85bbb36deb440290998a34782c92db155d399d00dee10c156810b5e50ca0baed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/greenboot-default-health-checks-0.14.0-3.el9.aarch64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:85dc4b0132dc60c0d2f1ff248bebf2c4f0146828db32617fa499f9280ab8af38": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/fdo-client-0.4.5-1.el9_0.aarch64.rpm"
@@ -5338,6 +5450,9 @@
           "sha256:b9e726b747cf8eaeaf1c7609196a02a9bb920720997dcc9ec1e6422620109fa5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/dbus-1.12.20-6.el9.aarch64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bb910836cb73b67aa169265375e372de221be156476575f3ee3ef9c81ca3a88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/libsecret-0.20.4-4.el9.aarch64.rpm"
           },
@@ -5400,6 +5515,9 @@
           },
           "sha256:c91fd1c5b88114d41d66611665c9ff27fbf53d97a3d41baf437af6d0f201e521": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/audit-libs-3.0.7-103.el9.aarch64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9930c540ae07e0375d4744f8ef541f2d3d8d2f6f715a85524c7ef5b8a93cff5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/file-5.39-10.el9.aarch64.rpm"
@@ -5496,6 +5614,9 @@
           },
           "sha256:dddae871bfa8a3d8d75415b7302940f8171b641ca2b894e527d84256f56b3df4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/glibc-2.34-40.el9.aarch64.rpm"
+          },
+          "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.aarch64.rpm"
           },
           "sha256:de499d867cc5e6069f2dcf6ffd48e56adad91b1358eeca80c86b8e9e9dc0b879": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/polkit-0.117-10.el9_0.aarch64.rpm"
@@ -7665,6 +7786,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.aarch64.rpm",
         "checksum": "sha256:c56e979225e15d1ae3b49834ac4341b2e94dbf67d889a27de815b330ee864355",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
         "check_gpg": true
       },
       {
@@ -9858,6 +9989,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -9898,6 +10039,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.14",
@@ -9905,6 +10056,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.aarch64.rpm",
         "checksum": "sha256:cbdce6902501eef4192d765ee9b768a53cfee2fa2662e5abeefd597615ff2c04",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.aarch64.rpm",
+        "checksum": "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03",
         "check_gpg": true
       },
       {
@@ -9918,6 +10079,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -9925,6 +10096,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -9955,6 +10156,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-setuptools-wheel-53.0.0-10.el9.noarch.rpm",
         "checksum": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -10125,6 +10346,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/shim-aa64-15.6-1.el9.aarch64.rpm",
         "checksum": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_9-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_commit_with_container-boot.json
@@ -1682,6 +1682,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a06414786e5b316a6bc411b4827d45d0364817071f924fed85c395df0ecd9450",
                     "options": {
                       "metadata": {
@@ -3434,6 +3442,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:26f20dd590b09a8f418dc6c51ba734ca3714902ccde9ca3e91201481ed2728ba",
                     "options": {
                       "metadata": {
@@ -3466,7 +3482,23 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:cbdce6902501eef4192d765ee9b768a53cfee2fa2662e5abeefd597615ff2c04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3482,7 +3514,39 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3507,6 +3571,22 @@
                   },
                   {
                     "id": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3643,6 +3723,14 @@
                   },
                   {
                     "id": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4664,6 +4752,9 @@
           "sha256:09ff81634b9741b286b42e2067270b4f95141a5ea03886f0610e25e9d0f941a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/mpfr-4.1.0-7.el9.aarch64.rpm"
           },
+          "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:0bc4d57ac943f016fb716392828a7cfa4bfcb899c3ff7a61501bf7dd36228646": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libmbim-utils-1.26.0-2.el9.aarch64.rpm"
           },
@@ -4696,6 +4787,9 @@
           },
           "sha256:16b57cc1b34d4c44d9638d4f87527d7883baad76433b2d2210a5663907cd8e11": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/file-libs-5.39-10.el9.aarch64.rpm"
+          },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
           },
           "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
@@ -4745,11 +4839,17 @@
           "sha256:1e1ad4c81b343be9175db222ea845afcc622f5a9c38a1f4c55ecad90c83a23ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/dosfstools-4.2-3.el9.aarch64.rpm"
           },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:1eccd2b9ccbaa8a1c680c0e0fd4e1733d1abf1fe0bdff635e309cdc232492c1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/glibc-minimal-langpack-2.34-40.el9.aarch64.rpm"
           },
           "sha256:1f1518511e3dc9c199cc9215eb99e16cfc5b7cf4a474fc1d24bd46a7b51b06e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/gdisk-1.0.7-5.el9.aarch64.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:1f46937ea8b9af3010c90f75c0a0cde76348defb6604d35c670c77cb62f3640e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/NetworkManager-libnm-1.40.0-1.el9.aarch64.rpm"
@@ -4934,6 +5034,9 @@
           "sha256:496085a23af0a0fadb510bf3bbac631583a2b0268eb2b3deeeb1b4a31c9dd631": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/kpartx-0.8.7-12.el9.aarch64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:4a684a393f14704bf0bf74adc5943863334e8371d70fec6fc7667201b3c2fe9f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.aarch64.rpm"
           },
@@ -4990,6 +5093,9 @@
           },
           "sha256:55be6352c68f5245a31c09709a5b604038d9d373d69c226c49a5a5f6923eff46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/traceroute-2.1.0-16.el9.aarch64.rpm"
+          },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm"
           },
           "sha256:5684001de29ef187b78849729334c61ac7f77b4a56e0cdae0df196731777ec7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libacl-2.3.1-3.el9.aarch64.rpm"
@@ -5135,6 +5241,9 @@
           "sha256:767396019f392da9ce7d24d4f8e3178070c2594e984e7dbc019d103cca1e27e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/rsync-3.2.3-18.el9.aarch64.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:77719a7a94185255f23ff1e5c1e1292d8350a4d33b2b35d87fc273c337d771d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libtasn1-4.16.0-7.el9.aarch64.rpm"
           },
@@ -5233,6 +5342,9 @@
           },
           "sha256:85bbb36deb440290998a34782c92db155d399d00dee10c156810b5e50ca0baed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/greenboot-default-health-checks-0.14.0-3.el9.aarch64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:85dc4b0132dc60c0d2f1ff248bebf2c4f0146828db32617fa499f9280ab8af38": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/fdo-client-0.4.5-1.el9_0.aarch64.rpm"
@@ -5390,6 +5502,9 @@
           "sha256:b9e726b747cf8eaeaf1c7609196a02a9bb920720997dcc9ec1e6422620109fa5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/dbus-1.12.20-6.el9.aarch64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bb910836cb73b67aa169265375e372de221be156476575f3ee3ef9c81ca3a88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/libsecret-0.20.4-4.el9.aarch64.rpm"
           },
@@ -5452,6 +5567,9 @@
           },
           "sha256:c91fd1c5b88114d41d66611665c9ff27fbf53d97a3d41baf437af6d0f201e521": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/audit-libs-3.0.7-103.el9.aarch64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9930c540ae07e0375d4744f8ef541f2d3d8d2f6f715a85524c7ef5b8a93cff5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/file-5.39-10.el9.aarch64.rpm"
@@ -5548,6 +5666,9 @@
           },
           "sha256:dddae871bfa8a3d8d75415b7302940f8171b641ca2b894e527d84256f56b3df4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/glibc-2.34-40.el9.aarch64.rpm"
+          },
+          "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.aarch64.rpm"
           },
           "sha256:de499d867cc5e6069f2dcf6ffd48e56adad91b1358eeca80c86b8e9e9dc0b879": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/polkit-0.117-10.el9_0.aarch64.rpm"
@@ -7737,6 +7858,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.aarch64.rpm",
         "checksum": "sha256:c56e979225e15d1ae3b49834ac4341b2e94dbf67d889a27de815b330ee864355",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
         "check_gpg": true
       },
       {
@@ -9930,6 +10061,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -9970,6 +10111,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.14",
@@ -9977,6 +10128,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.aarch64.rpm",
         "checksum": "sha256:cbdce6902501eef4192d765ee9b768a53cfee2fa2662e5abeefd597615ff2c04",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.aarch64.rpm",
+        "checksum": "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03",
         "check_gpg": true
       },
       {
@@ -9990,6 +10151,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -9997,6 +10168,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -10027,6 +10228,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-setuptools-wheel-53.0.0-10.el9.noarch.rpm",
         "checksum": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -10197,6 +10418,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/shim-aa64-15.6-1.el9.aarch64.rpm",
         "checksum": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_9-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_container-boot.json
@@ -1668,6 +1668,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a06414786e5b316a6bc411b4827d45d0364817071f924fed85c395df0ecd9450",
                     "options": {
                       "metadata": {
@@ -3420,6 +3428,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:26f20dd590b09a8f418dc6c51ba734ca3714902ccde9ca3e91201481ed2728ba",
                     "options": {
                       "metadata": {
@@ -3452,7 +3468,23 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:cbdce6902501eef4192d765ee9b768a53cfee2fa2662e5abeefd597615ff2c04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3468,7 +3500,39 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3493,6 +3557,22 @@
                   },
                   {
                     "id": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3629,6 +3709,14 @@
                   },
                   {
                     "id": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5408,6 +5496,9 @@
           "sha256:09ff81634b9741b286b42e2067270b4f95141a5ea03886f0610e25e9d0f941a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/mpfr-4.1.0-7.el9.aarch64.rpm"
           },
+          "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:0bc4d57ac943f016fb716392828a7cfa4bfcb899c3ff7a61501bf7dd36228646": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libmbim-utils-1.26.0-2.el9.aarch64.rpm"
           },
@@ -5440,6 +5531,9 @@
           },
           "sha256:16b57cc1b34d4c44d9638d4f87527d7883baad76433b2d2210a5663907cd8e11": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/file-libs-5.39-10.el9.aarch64.rpm"
+          },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
           },
           "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
@@ -5492,11 +5586,17 @@
           "sha256:1e1ad4c81b343be9175db222ea845afcc622f5a9c38a1f4c55ecad90c83a23ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/dosfstools-4.2-3.el9.aarch64.rpm"
           },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:1eccd2b9ccbaa8a1c680c0e0fd4e1733d1abf1fe0bdff635e309cdc232492c1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/glibc-minimal-langpack-2.34-40.el9.aarch64.rpm"
           },
           "sha256:1f1518511e3dc9c199cc9215eb99e16cfc5b7cf4a474fc1d24bd46a7b51b06e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/gdisk-1.0.7-5.el9.aarch64.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:1f46937ea8b9af3010c90f75c0a0cde76348defb6604d35c670c77cb62f3640e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/NetworkManager-libnm-1.40.0-1.el9.aarch64.rpm"
@@ -5684,6 +5784,9 @@
           "sha256:496085a23af0a0fadb510bf3bbac631583a2b0268eb2b3deeeb1b4a31c9dd631": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/kpartx-0.8.7-12.el9.aarch64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:4a684a393f14704bf0bf74adc5943863334e8371d70fec6fc7667201b3c2fe9f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.aarch64.rpm"
           },
@@ -5740,6 +5843,9 @@
           },
           "sha256:55be6352c68f5245a31c09709a5b604038d9d373d69c226c49a5a5f6923eff46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/traceroute-2.1.0-16.el9.aarch64.rpm"
+          },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm"
           },
           "sha256:5684001de29ef187b78849729334c61ac7f77b4a56e0cdae0df196731777ec7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libacl-2.3.1-3.el9.aarch64.rpm"
@@ -5885,6 +5991,9 @@
           "sha256:767396019f392da9ce7d24d4f8e3178070c2594e984e7dbc019d103cca1e27e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/rsync-3.2.3-18.el9.aarch64.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:77719a7a94185255f23ff1e5c1e1292d8350a4d33b2b35d87fc273c337d771d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libtasn1-4.16.0-7.el9.aarch64.rpm"
           },
@@ -5983,6 +6092,9 @@
           },
           "sha256:85bbb36deb440290998a34782c92db155d399d00dee10c156810b5e50ca0baed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/greenboot-default-health-checks-0.14.0-3.el9.aarch64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:85dc4b0132dc60c0d2f1ff248bebf2c4f0146828db32617fa499f9280ab8af38": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/fdo-client-0.4.5-1.el9_0.aarch64.rpm"
@@ -6140,6 +6252,9 @@
           "sha256:b9e726b747cf8eaeaf1c7609196a02a9bb920720997dcc9ec1e6422620109fa5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/dbus-1.12.20-6.el9.aarch64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bb910836cb73b67aa169265375e372de221be156476575f3ee3ef9c81ca3a88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/libsecret-0.20.4-4.el9.aarch64.rpm"
           },
@@ -6205,6 +6320,9 @@
           },
           "sha256:c91fd1c5b88114d41d66611665c9ff27fbf53d97a3d41baf437af6d0f201e521": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/audit-libs-3.0.7-103.el9.aarch64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9930c540ae07e0375d4744f8ef541f2d3d8d2f6f715a85524c7ef5b8a93cff5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/file-5.39-10.el9.aarch64.rpm"
@@ -6301,6 +6419,9 @@
           },
           "sha256:dddae871bfa8a3d8d75415b7302940f8171b641ca2b894e527d84256f56b3df4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/glibc-2.34-40.el9.aarch64.rpm"
+          },
+          "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.aarch64.rpm"
           },
           "sha256:de499d867cc5e6069f2dcf6ffd48e56adad91b1358eeca80c86b8e9e9dc0b879": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/polkit-0.117-10.el9_0.aarch64.rpm"
@@ -9348,6 +9469,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -11538,6 +11669,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -11578,6 +11719,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.14",
@@ -11585,6 +11736,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.aarch64.rpm",
         "checksum": "sha256:cbdce6902501eef4192d765ee9b768a53cfee2fa2662e5abeefd597615ff2c04",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.aarch64.rpm",
+        "checksum": "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03",
         "check_gpg": true
       },
       {
@@ -11598,6 +11759,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -11605,6 +11776,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -11635,6 +11836,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-setuptools-wheel-53.0.0-10.el9.noarch.rpm",
         "checksum": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -11805,6 +12026,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/shim-aa64-15.6-1.el9.aarch64.rpm",
         "checksum": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_9-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_commit-boot.json
@@ -1766,6 +1766,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -3622,6 +3630,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:adf8aafd3b5a7c590e2350c52e172e4b373158d76925c89db59ad201ec68bd27",
                     "options": {
                       "metadata": {
@@ -3654,7 +3670,23 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3670,7 +3702,39 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3695,6 +3759,22 @@
                   },
                   {
                     "id": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3831,6 +3911,14 @@
                   },
                   {
                     "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4889,6 +4977,9 @@
           "sha256:16538cb048aa28d39f92f83b3defbf9303c47a69eea40e08be6289c794d2ebad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/selinux-policy-targeted-34.1.43-1.el9.noarch.rpm"
           },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
           },
@@ -4915,6 +5006,12 @@
           },
           "sha256:1c1dc9948dd4203ff4804d94c9cd30b9cc0faab5e5641b2b04b795c408fb4b1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/tpm2-tools-5.2-1.el9.x86_64.rpm"
+          },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:20a5a375bd1a12950ba6ca5e4ca9f6af11020214da304317070803be37afd27c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libaio-0.3.111-13.el9.x86_64.rpm"
@@ -5102,6 +5199,9 @@
           "sha256:49163f6eb4683b4efaccbf47f07d5a038c36b5dae7bed665ca3b163a9b9c95ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/polkit-libs-0.117-10.el9_0.x86_64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:49e741d9b810140ec1af639caf2b1b9ca0c77a0360ae084366d02cb0414f6bde": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-3.9.14-1.el9.x86_64.rpm"
           },
@@ -5165,6 +5265,9 @@
           "sha256:55b01380f5c1df8f1212fcd061351c0b6b0562e2cba57b323aac10cb6d5b9f32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/less-590-1.el9_0.x86_64.rpm"
           },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm"
+          },
           "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
           },
@@ -5212,6 +5315,9 @@
           },
           "sha256:62ef24e5a54b563e486dfaee8b251bd5f67e875aa9bf4949ff8e02cf6a90889c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openssh-server-8.7p1-24.el9_1.x86_64.rpm"
+          },
+          "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm"
           },
           "sha256:6364708019c7122540bacf985f3ce4c961ef5da623a52bd76cffd7c4225ea7f8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/vim-minimal-8.2.2637-16.el9_0.3.x86_64.rpm"
@@ -5315,6 +5421,9 @@
           "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/kbd-misc-2.4.0-8.el9.noarch.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:77a03b852369645ab754a8ed17e6cd01c36734ae7959264050289d7998003cad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/rpm-4.16.1.3-17.el9.x86_64.rpm"
           },
@@ -5389,6 +5498,9 @@
           },
           "sha256:85912dbd3c57a6b5186b911498a7e7528865e24376ce7b1b6c05751929f97f7e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-gobject-base-3.40.1-6.el9.x86_64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:8714d3513d5e61fbcf6bd357d40fc5c1ba1f64f9d6ca2908439f4fd13e32836d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/pinentry-1.1.1-8.el9.x86_64.rpm"
@@ -5612,8 +5724,14 @@
           "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libjose-11-3.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm"
@@ -5668,6 +5786,9 @@
           },
           "sha256:c916ffb29385ca487c759e5aedfecacfda5a8e151e00e7ef9a7bc40a52fb58c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libslirp-4.4.0-7.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm"
@@ -8031,6 +8152,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -10351,6 +10482,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -10391,6 +10532,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.14",
@@ -10398,6 +10549,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm",
         "checksum": "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm",
+        "checksum": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
         "check_gpg": true
       },
       {
@@ -10411,6 +10572,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -10418,6 +10589,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -10448,6 +10649,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-setuptools-wheel-53.0.0-10.el9.noarch.rpm",
         "checksum": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -10618,6 +10839,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
         "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_9-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_commit_rt-boot.json
@@ -1773,6 +1773,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -3885,6 +3893,14 @@
                     }
                   },
                   {
+                    "id": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac",
                     "options": {
                       "metadata": {
@@ -3909,7 +3925,23 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4150,6 +4182,14 @@
                   },
                   {
                     "id": "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5719,6 +5759,9 @@
           "sha256:62ef24e5a54b563e486dfaee8b251bd5f67e875aa9bf4949ff8e02cf6a90889c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openssh-server-8.7p1-24.el9_1.x86_64.rpm"
           },
+          "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm"
+          },
           "sha256:6364708019c7122540bacf985f3ce4c961ef5da623a52bd76cffd7c4225ea7f8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/vim-minimal-8.2.2637-16.el9_0.3.x86_64.rpm"
           },
@@ -5916,6 +5959,9 @@
           },
           "sha256:85912dbd3c57a6b5186b911498a7e7528865e24376ce7b1b6c05751929f97f7e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-gobject-base-3.40.1-6.el9.x86_64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:8714d3513d5e61fbcf6bd357d40fc5c1ba1f64f9d6ca2908439f4fd13e32836d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/pinentry-1.1.1-8.el9.x86_64.rpm"
@@ -6175,8 +6221,14 @@
           "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libjose-11-3.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm"
@@ -6234,6 +6286,9 @@
           },
           "sha256:c916ffb29385ca487c759e5aedfecacfda5a8e151e00e7ef9a7bc40a52fb58c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libslirp-4.4.0-7.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm"
@@ -8618,6 +8673,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
         "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
         "check_gpg": true
       },
       {
@@ -11261,6 +11326,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm",
+        "checksum": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
+        "check_gpg": true
+      },
+      {
         "name": "python3-linux-procfs",
         "epoch": 0,
         "version": "0.7.0",
@@ -11291,6 +11366,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -11298,6 +11383,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
         "check_gpg": true
       },
       {
@@ -11598,6 +11693,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/snappy-1.1.8-8.el9.x86_64.rpm",
         "checksum": "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_9-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_commit_with_container-boot.json
@@ -1780,6 +1780,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -3636,6 +3644,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:adf8aafd3b5a7c590e2350c52e172e4b373158d76925c89db59ad201ec68bd27",
                     "options": {
                       "metadata": {
@@ -3668,7 +3684,23 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3684,7 +3716,39 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3709,6 +3773,22 @@
                   },
                   {
                     "id": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3845,6 +3925,14 @@
                   },
                   {
                     "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4938,6 +5026,9 @@
           "sha256:16538cb048aa28d39f92f83b3defbf9303c47a69eea40e08be6289c794d2ebad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/selinux-policy-targeted-34.1.43-1.el9.noarch.rpm"
           },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
           },
@@ -4964,6 +5055,12 @@
           },
           "sha256:1c1dc9948dd4203ff4804d94c9cd30b9cc0faab5e5641b2b04b795c408fb4b1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/tpm2-tools-5.2-1.el9.x86_64.rpm"
+          },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:20a5a375bd1a12950ba6ca5e4ca9f6af11020214da304317070803be37afd27c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libaio-0.3.111-13.el9.x86_64.rpm"
@@ -5151,6 +5248,9 @@
           "sha256:49163f6eb4683b4efaccbf47f07d5a038c36b5dae7bed665ca3b163a9b9c95ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/polkit-libs-0.117-10.el9_0.x86_64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:49e741d9b810140ec1af639caf2b1b9ca0c77a0360ae084366d02cb0414f6bde": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-3.9.14-1.el9.x86_64.rpm"
           },
@@ -5214,6 +5314,9 @@
           "sha256:55b01380f5c1df8f1212fcd061351c0b6b0562e2cba57b323aac10cb6d5b9f32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/less-590-1.el9_0.x86_64.rpm"
           },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm"
+          },
           "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
           },
@@ -5261,6 +5364,9 @@
           },
           "sha256:62ef24e5a54b563e486dfaee8b251bd5f67e875aa9bf4949ff8e02cf6a90889c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openssh-server-8.7p1-24.el9_1.x86_64.rpm"
+          },
+          "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm"
           },
           "sha256:6364708019c7122540bacf985f3ce4c961ef5da623a52bd76cffd7c4225ea7f8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/vim-minimal-8.2.2637-16.el9_0.3.x86_64.rpm"
@@ -5364,6 +5470,9 @@
           "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/kbd-misc-2.4.0-8.el9.noarch.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:77a03b852369645ab754a8ed17e6cd01c36734ae7959264050289d7998003cad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/rpm-4.16.1.3-17.el9.x86_64.rpm"
           },
@@ -5438,6 +5547,9 @@
           },
           "sha256:85912dbd3c57a6b5186b911498a7e7528865e24376ce7b1b6c05751929f97f7e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-gobject-base-3.40.1-6.el9.x86_64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:8714d3513d5e61fbcf6bd357d40fc5c1ba1f64f9d6ca2908439f4fd13e32836d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/pinentry-1.1.1-8.el9.x86_64.rpm"
@@ -5664,8 +5776,14 @@
           "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libjose-11-3.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm"
@@ -5720,6 +5838,9 @@
           },
           "sha256:c916ffb29385ca487c759e5aedfecacfda5a8e151e00e7ef9a7bc40a52fb58c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libslirp-4.4.0-7.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm"
@@ -8103,6 +8224,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -10423,6 +10554,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -10463,6 +10604,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.14",
@@ -10470,6 +10621,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm",
         "checksum": "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm",
+        "checksum": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
         "check_gpg": true
       },
       {
@@ -10483,6 +10644,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -10490,6 +10661,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -10520,6 +10721,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-setuptools-wheel-53.0.0-10.el9.noarch.rpm",
         "checksum": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -10690,6 +10911,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
         "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_9-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_container-boot.json
@@ -1756,6 +1756,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -3612,6 +3620,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:adf8aafd3b5a7c590e2350c52e172e4b373158d76925c89db59ad201ec68bd27",
                     "options": {
                       "metadata": {
@@ -3644,7 +3660,23 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3660,7 +3692,39 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3685,6 +3749,22 @@
                   },
                   {
                     "id": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3821,6 +3901,14 @@
                   },
                   {
                     "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5671,6 +5759,9 @@
           "sha256:16538cb048aa28d39f92f83b3defbf9303c47a69eea40e08be6289c794d2ebad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/selinux-policy-targeted-34.1.43-1.el9.noarch.rpm"
           },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
           },
@@ -5697,6 +5788,12 @@
           },
           "sha256:1c1dc9948dd4203ff4804d94c9cd30b9cc0faab5e5641b2b04b795c408fb4b1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/tpm2-tools-5.2-1.el9.x86_64.rpm"
+          },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:20a5a375bd1a12950ba6ca5e4ca9f6af11020214da304317070803be37afd27c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libaio-0.3.111-13.el9.x86_64.rpm"
@@ -5893,6 +5990,9 @@
           "sha256:49163f6eb4683b4efaccbf47f07d5a038c36b5dae7bed665ca3b163a9b9c95ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/polkit-libs-0.117-10.el9_0.x86_64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:49e741d9b810140ec1af639caf2b1b9ca0c77a0360ae084366d02cb0414f6bde": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-3.9.14-1.el9.x86_64.rpm"
           },
@@ -5956,6 +6056,9 @@
           "sha256:55b01380f5c1df8f1212fcd061351c0b6b0562e2cba57b323aac10cb6d5b9f32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/less-590-1.el9_0.x86_64.rpm"
           },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm"
+          },
           "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
           },
@@ -6003,6 +6106,9 @@
           },
           "sha256:62ef24e5a54b563e486dfaee8b251bd5f67e875aa9bf4949ff8e02cf6a90889c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openssh-server-8.7p1-24.el9_1.x86_64.rpm"
+          },
+          "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm"
           },
           "sha256:6364708019c7122540bacf985f3ce4c961ef5da623a52bd76cffd7c4225ea7f8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/vim-minimal-8.2.2637-16.el9_0.3.x86_64.rpm"
@@ -6106,6 +6212,9 @@
           "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/kbd-misc-2.4.0-8.el9.noarch.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:77a03b852369645ab754a8ed17e6cd01c36734ae7959264050289d7998003cad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/rpm-4.16.1.3-17.el9.x86_64.rpm"
           },
@@ -6180,6 +6289,9 @@
           },
           "sha256:85912dbd3c57a6b5186b911498a7e7528865e24376ce7b1b6c05751929f97f7e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-gobject-base-3.40.1-6.el9.x86_64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:8714d3513d5e61fbcf6bd357d40fc5c1ba1f64f9d6ca2908439f4fd13e32836d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/pinentry-1.1.1-8.el9.x86_64.rpm"
@@ -6403,8 +6515,14 @@
           "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libjose-11-3.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm"
@@ -6462,6 +6580,9 @@
           },
           "sha256:c916ffb29385ca487c759e5aedfecacfda5a8e151e00e7ef9a7bc40a52fb58c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libslirp-4.4.0-7.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm"
@@ -9700,6 +9821,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -12020,6 +12151,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -12060,6 +12201,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.14",
@@ -12067,6 +12218,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm",
         "checksum": "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm",
+        "checksum": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
         "check_gpg": true
       },
       {
@@ -12080,6 +12241,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -12087,6 +12258,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -12117,6 +12318,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-setuptools-wheel-53.0.0-10.el9.noarch.rpm",
         "checksum": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -12287,6 +12508,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
         "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
@@ -597,6 +597,9 @@
                     "id": "sha256:c56e979225e15d1ae3b49834ac4341b2e94dbf67d889a27de815b330ee864355"
                   },
                   {
+                    "id": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95"
+                  },
+                  {
                     "id": "sha256:a06414786e5b316a6bc411b4827d45d0364817071f924fed85c395df0ecd9450"
                   },
                   {
@@ -1245,6 +1248,9 @@
                     "id": "sha256:6096bfc6f28920cc845b2d69c0af0a6d912b2a248706f69545e8cd48ba090e76"
                   },
                   {
+                    "id": "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297"
+                  },
+                  {
                     "id": "sha256:26f20dd590b09a8f418dc6c51ba734ca3714902ccde9ca3e91201481ed2728ba"
                   },
                   {
@@ -1254,13 +1260,31 @@
                     "id": "sha256:21b7229992b9cb9fcc8c90d638dcb2c83adb52dd0d9ab67941e892caf4d96016"
                   },
                   {
+                    "id": "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b"
+                  },
+                  {
                     "id": "sha256:6a7f253283b4bf35a8ca9c9a4c006005c38f69f2fda7ff401b6095804c2f054e"
+                  },
+                  {
+                    "id": "sha256:2eb48bbf588108e2f876f442d4f54312002dab5ca44d0d1c802296c52f305f83"
                   },
                   {
                     "id": "sha256:5406506cee1642c682f4cdd596e12fc0309a22a16691e82cae5231740d0a7b91"
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
+                  },
+                  {
+                    "id": "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4"
+                  },
+                  {
+                    "id": "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03"
                   },
                   {
                     "id": "sha256:06fbab10e385e6e5da48b7d8c8ed5a7d32bff1e471986acc5b5cceafb2160f5b"
@@ -1270,6 +1294,12 @@
                   },
                   {
                     "id": "sha256:e4ab6f11d394cb13a23494da17a8432ad248c4e4f16df79d1aff439d77202298"
+                  },
+                  {
+                    "id": "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34"
+                  },
+                  {
+                    "id": "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00"
                   },
                   {
                     "id": "sha256:2ae424b368c6747124b51b205b9e11d74aeaff56b3de90e8cbd36012e0d17707"
@@ -1321,6 +1351,9 @@
                   },
                   {
                     "id": "sha256:986ae6b9c75597a2705619d8a0ec5d2ec299c599f1633f480f9bf4931ec2ecd4"
+                  },
+                  {
+                    "id": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
                   },
                   {
                     "id": "sha256:0c31efd8b5766ab422622a6df1f6d4ce29e831e9ac7a2ed89ef6e6538bc8b44c"
@@ -1796,6 +1829,9 @@
           "sha256:048b917ccf11528a1d02b37e554eab23995eb49ab5f958b565e8bcc513637b53": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libqrtr-glib-1.0.0-4.el9.aarch64.rpm"
           },
+          "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-chardet-4.0.0-3.el9.noarch.rpm"
+          },
           "sha256:0593c85b96abb90a75d6bd4df88b5c38c53b68e51a8b0a6e52b56febe4b4da09": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/tar-1.34-3.el9.aarch64.rpm"
           },
@@ -1829,6 +1865,9 @@
           "sha256:09ff81634b9741b286b42e2067270b4f95141a5ea03886f0610e25e9d0f941a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/mpfr-4.1.0-7.el9.aarch64.rpm"
           },
+          "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:0aff62a3cac644b279baf297cddc0102166b3cb41acc4a1a52ea28556d3a9a4c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/firewalld-filesystem-1.0.0-4.el9.noarch.rpm"
           },
@@ -1856,6 +1895,9 @@
           "sha256:0ecd0a2dc724d867afffa4cae14dd6048316f2914cb0a119dbde5d067a2c69d1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/openssh-server-8.7p1-6.el9.aarch64.rpm"
           },
+          "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-urllib3-1.26.5-2.el9.noarch.rpm"
+          },
           "sha256:1115017958235ca1039d5d3e7c4c09be04ade7af7fa3b8fb47f994d45836bffb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libfdisk-2.37.2-1.el9.aarch64.rpm"
           },
@@ -1868,6 +1910,9 @@
           "sha256:11f09add0e88b7b17c30188b7715131b7b861723edd4d9d8dda06f27642afe56": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/python3-libselinux-3.3-2.el9.aarch64.rpm"
           },
+          "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm"
+          },
           "sha256:149abbe50fd335fd4031bdead143e5d768def9ff3842664b8fdb13173cb9215b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/lua-libs-5.4.2-4.el9.aarch64.rpm"
           },
@@ -1879,6 +1924,9 @@
           },
           "sha256:1657d94bbd79f93dc7a79d474316813bde681ce3a7f62f73314ec4d630e39349": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libpwquality-1.4.4-8.el9.aarch64.rpm"
+          },
+          "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-six-1.15.0-7.el9.noarch.rpm"
           },
           "sha256:17178258237e1691ce937f71ffe91a2e081ca2e0d3eeaf1cad566f77bd427621": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/file-libs-5.39-8.el9.aarch64.rpm"
@@ -1985,6 +2033,9 @@
           "sha256:2e3ff61abdeb18204081539e97dbc55797031e5bd58801b1f8154d368b69f1a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libuuid-2.37.2-1.el9.aarch64.rpm"
           },
+          "sha256:2eb48bbf588108e2f876f442d4f54312002dab5ca44d0d1c802296c52f305f83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.aarch64.rpm"
+          },
           "sha256:30f57fed2f2d5269a19453210c22b52b5fd13d4fd0a64de6da1e5de1ea0e74a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libblockdev-fs-2.25-11.el9.aarch64.rpm"
           },
@@ -2008,6 +2059,9 @@
           },
           "sha256:37a9eec32ea3fd69b2b15c04c7d2ecda5c42e5da8aba90e41b5cee4938229836": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libxmlb-0.3.3-1.el9.aarch64.rpm"
+          },
+          "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm"
           },
           "sha256:38b08ddd5d3e409e4434b2d895cc19a5bde8f749918bec84637c00b7600fd28c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libjcat-0.1.6-3.el9.aarch64.rpm"
@@ -2330,6 +2384,9 @@
           "sha256:85bbb36deb440290998a34782c92db155d399d00dee10c156810b5e50ca0baed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/greenboot-default-health-checks-0.14.0-3.el9.aarch64.rpm"
           },
+          "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm"
+          },
           "sha256:8789628a44512d90f9b06613be1f71284b08b19c29df331e63e8d64151b910bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/pkgconf-pkg-config-1.7.3-9.el9.aarch64.rpm"
           },
@@ -2416,6 +2473,9 @@
           },
           "sha256:9c4d7d365d08f8e94978117e4b0117d44ef063b18960cc1df744e296f615131a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libedit-3.1-37.20210216cvs.el9.aarch64.rpm"
+          },
+          "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-idna-2.10-5.el9.noarch.rpm"
           },
           "sha256:9d1e931f9588ae5d7afb9595a871038146ceea72fe03fbc4725ddf58a614d32b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libcurl-7.76.1-14.el9.aarch64.rpm"
@@ -2540,6 +2600,9 @@
           "sha256:bab068aa3a2fa92a85d49a7e0045342cfe164cdbf5dc1c71df254300cfff6378": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/NetworkManager-1.36.0-0.7.el9.aarch64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bb910836cb73b67aa169265375e372de221be156476575f3ee3ef9c81ca3a88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libsecret-0.20.4-4.el9.aarch64.rpm"
           },
@@ -2611,6 +2674,9 @@
           },
           "sha256:c8c8043e19b87e054984343b134dec26b7d7a00ba35a5a8bcb7360e4487f8e09": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libmodulemd-2.13.0-2.el9.aarch64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:ca992eec8e88e16a1ee05643f92e9c9e34ef25ba63af169dc4b413345a6b48a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libblockdev-mdraid-2.25-11.el9.aarch64.rpm"
@@ -4446,6 +4512,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/bubblewrap-0.4.1-6.el9.aarch64.rpm",
         "checksum": "sha256:c56e979225e15d1ae3b49834ac4341b2e94dbf67d889a27de815b330ee864355"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95"
       },
       {
         "name": "bzip2-libs",
@@ -6392,6 +6467,15 @@
         "checksum": "sha256:6096bfc6f28920cc845b2d69c0af0a6d912b2a248706f69545e8cd48ba090e76"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-chardet-4.0.0-3.el9.noarch.rpm",
+        "checksum": "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -6419,6 +6503,15 @@
         "checksum": "sha256:21b7229992b9cb9fcc8c90d638dcb2c83adb52dd0d9ab67941e892caf4d96016"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-idna-2.10-5.el9.noarch.rpm",
+        "checksum": "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.10",
@@ -6426,6 +6519,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-libs-3.9.10-1.el9.aarch64.rpm",
         "checksum": "sha256:6a7f253283b4bf35a8ca9c9a4c006005c38f69f2fda7ff401b6095804c2f054e"
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.aarch64.rpm",
+        "checksum": "sha256:2eb48bbf588108e2f876f442d4f54312002dab5ca44d0d1c802296c52f305f83"
       },
       {
         "name": "python3-nftables",
@@ -6437,6 +6539,15 @@
         "checksum": "sha256:5406506cee1642c682f4cdd596e12fc0309a22a16691e82cae5231740d0a7b91"
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -6444,6 +6555,33 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm",
+        "checksum": "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm",
+        "checksum": "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03"
       },
       {
         "name": "python3-setools",
@@ -6471,6 +6609,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-setuptools-wheel-53.0.0-9.el9.noarch.rpm",
         "checksum": "sha256:e4ab6f11d394cb13a23494da17a8432ad248c4e4f16df79d1aff439d77202298"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-six-1.15.0-7.el9.noarch.rpm",
+        "checksum": "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-urllib3-1.26.5-2.el9.noarch.rpm",
+        "checksum": "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00"
       },
       {
         "name": "readline",
@@ -6624,6 +6780,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/shim-aa64-15-16.el8.aarch64.rpm",
         "checksum": "sha256:986ae6b9c75597a2705619d8a0ec5d2ec299c599f1633f480f9bf4931ec2ecd4"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm",
+        "checksum": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
       },
       {
         "name": "sqlite-libs",

--- a/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
@@ -675,6 +675,9 @@
                     "id": "sha256:c56e979225e15d1ae3b49834ac4341b2e94dbf67d889a27de815b330ee864355"
                   },
                   {
+                    "id": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95"
+                  },
+                  {
                     "id": "sha256:a06414786e5b316a6bc411b4827d45d0364817071f924fed85c395df0ecd9450"
                   },
                   {
@@ -1323,6 +1326,9 @@
                     "id": "sha256:6096bfc6f28920cc845b2d69c0af0a6d912b2a248706f69545e8cd48ba090e76"
                   },
                   {
+                    "id": "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297"
+                  },
+                  {
                     "id": "sha256:26f20dd590b09a8f418dc6c51ba734ca3714902ccde9ca3e91201481ed2728ba"
                   },
                   {
@@ -1332,13 +1338,31 @@
                     "id": "sha256:21b7229992b9cb9fcc8c90d638dcb2c83adb52dd0d9ab67941e892caf4d96016"
                   },
                   {
+                    "id": "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b"
+                  },
+                  {
                     "id": "sha256:6a7f253283b4bf35a8ca9c9a4c006005c38f69f2fda7ff401b6095804c2f054e"
+                  },
+                  {
+                    "id": "sha256:2eb48bbf588108e2f876f442d4f54312002dab5ca44d0d1c802296c52f305f83"
                   },
                   {
                     "id": "sha256:5406506cee1642c682f4cdd596e12fc0309a22a16691e82cae5231740d0a7b91"
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
+                  },
+                  {
+                    "id": "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4"
+                  },
+                  {
+                    "id": "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03"
                   },
                   {
                     "id": "sha256:06fbab10e385e6e5da48b7d8c8ed5a7d32bff1e471986acc5b5cceafb2160f5b"
@@ -1348,6 +1372,12 @@
                   },
                   {
                     "id": "sha256:e4ab6f11d394cb13a23494da17a8432ad248c4e4f16df79d1aff439d77202298"
+                  },
+                  {
+                    "id": "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34"
+                  },
+                  {
+                    "id": "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00"
                   },
                   {
                     "id": "sha256:2ae424b368c6747124b51b205b9e11d74aeaff56b3de90e8cbd36012e0d17707"
@@ -1399,6 +1429,9 @@
                   },
                   {
                     "id": "sha256:986ae6b9c75597a2705619d8a0ec5d2ec299c599f1633f480f9bf4931ec2ecd4"
+                  },
+                  {
+                    "id": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
                   },
                   {
                     "id": "sha256:0c31efd8b5766ab422622a6df1f6d4ce29e831e9ac7a2ed89ef6e6538bc8b44c"
@@ -1909,6 +1942,9 @@
           "sha256:048b917ccf11528a1d02b37e554eab23995eb49ab5f958b565e8bcc513637b53": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libqrtr-glib-1.0.0-4.el9.aarch64.rpm"
           },
+          "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-chardet-4.0.0-3.el9.noarch.rpm"
+          },
           "sha256:0593c85b96abb90a75d6bd4df88b5c38c53b68e51a8b0a6e52b56febe4b4da09": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/tar-1.34-3.el9.aarch64.rpm"
           },
@@ -1942,6 +1978,9 @@
           "sha256:09ff81634b9741b286b42e2067270b4f95141a5ea03886f0610e25e9d0f941a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/mpfr-4.1.0-7.el9.aarch64.rpm"
           },
+          "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:0aff62a3cac644b279baf297cddc0102166b3cb41acc4a1a52ea28556d3a9a4c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/firewalld-filesystem-1.0.0-4.el9.noarch.rpm"
           },
@@ -1969,6 +2008,9 @@
           "sha256:0ecd0a2dc724d867afffa4cae14dd6048316f2914cb0a119dbde5d067a2c69d1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/openssh-server-8.7p1-6.el9.aarch64.rpm"
           },
+          "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-urllib3-1.26.5-2.el9.noarch.rpm"
+          },
           "sha256:1115017958235ca1039d5d3e7c4c09be04ade7af7fa3b8fb47f994d45836bffb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libfdisk-2.37.2-1.el9.aarch64.rpm"
           },
@@ -1981,6 +2023,9 @@
           "sha256:11f09add0e88b7b17c30188b7715131b7b861723edd4d9d8dda06f27642afe56": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/python3-libselinux-3.3-2.el9.aarch64.rpm"
           },
+          "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm"
+          },
           "sha256:149abbe50fd335fd4031bdead143e5d768def9ff3842664b8fdb13173cb9215b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/lua-libs-5.4.2-4.el9.aarch64.rpm"
           },
@@ -1992,6 +2037,9 @@
           },
           "sha256:1657d94bbd79f93dc7a79d474316813bde681ce3a7f62f73314ec4d630e39349": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libpwquality-1.4.4-8.el9.aarch64.rpm"
+          },
+          "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-six-1.15.0-7.el9.noarch.rpm"
           },
           "sha256:17178258237e1691ce937f71ffe91a2e081ca2e0d3eeaf1cad566f77bd427621": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/file-libs-5.39-8.el9.aarch64.rpm"
@@ -2098,6 +2146,9 @@
           "sha256:2e3ff61abdeb18204081539e97dbc55797031e5bd58801b1f8154d368b69f1a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libuuid-2.37.2-1.el9.aarch64.rpm"
           },
+          "sha256:2eb48bbf588108e2f876f442d4f54312002dab5ca44d0d1c802296c52f305f83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.aarch64.rpm"
+          },
           "sha256:30f57fed2f2d5269a19453210c22b52b5fd13d4fd0a64de6da1e5de1ea0e74a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libblockdev-fs-2.25-11.el9.aarch64.rpm"
           },
@@ -2121,6 +2172,9 @@
           },
           "sha256:37a9eec32ea3fd69b2b15c04c7d2ecda5c42e5da8aba90e41b5cee4938229836": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libxmlb-0.3.3-1.el9.aarch64.rpm"
+          },
+          "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm"
           },
           "sha256:38b08ddd5d3e409e4434b2d895cc19a5bde8f749918bec84637c00b7600fd28c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libjcat-0.1.6-3.el9.aarch64.rpm"
@@ -2443,6 +2497,9 @@
           "sha256:85bbb36deb440290998a34782c92db155d399d00dee10c156810b5e50ca0baed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/greenboot-default-health-checks-0.14.0-3.el9.aarch64.rpm"
           },
+          "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm"
+          },
           "sha256:8789628a44512d90f9b06613be1f71284b08b19c29df331e63e8d64151b910bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/pkgconf-pkg-config-1.7.3-9.el9.aarch64.rpm"
           },
@@ -2529,6 +2586,9 @@
           },
           "sha256:9c4d7d365d08f8e94978117e4b0117d44ef063b18960cc1df744e296f615131a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libedit-3.1-37.20210216cvs.el9.aarch64.rpm"
+          },
+          "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-idna-2.10-5.el9.noarch.rpm"
           },
           "sha256:9d1e931f9588ae5d7afb9595a871038146ceea72fe03fbc4725ddf58a614d32b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libcurl-7.76.1-14.el9.aarch64.rpm"
@@ -2653,6 +2713,9 @@
           "sha256:bab068aa3a2fa92a85d49a7e0045342cfe164cdbf5dc1c71df254300cfff6378": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/NetworkManager-1.36.0-0.7.el9.aarch64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bb910836cb73b67aa169265375e372de221be156476575f3ee3ef9c81ca3a88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libsecret-0.20.4-4.el9.aarch64.rpm"
           },
@@ -2724,6 +2787,9 @@
           },
           "sha256:c8c8043e19b87e054984343b134dec26b7d7a00ba35a5a8bcb7360e4487f8e09": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libmodulemd-2.13.0-2.el9.aarch64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:ca992eec8e88e16a1ee05643f92e9c9e34ef25ba63af169dc4b413345a6b48a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libblockdev-mdraid-2.25-11.el9.aarch64.rpm"
@@ -4790,6 +4856,15 @@
         "checksum": "sha256:c56e979225e15d1ae3b49834ac4341b2e94dbf67d889a27de815b330ee864355"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -6734,6 +6809,15 @@
         "checksum": "sha256:6096bfc6f28920cc845b2d69c0af0a6d912b2a248706f69545e8cd48ba090e76"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-chardet-4.0.0-3.el9.noarch.rpm",
+        "checksum": "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -6761,6 +6845,15 @@
         "checksum": "sha256:21b7229992b9cb9fcc8c90d638dcb2c83adb52dd0d9ab67941e892caf4d96016"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-idna-2.10-5.el9.noarch.rpm",
+        "checksum": "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.10",
@@ -6768,6 +6861,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-libs-3.9.10-1.el9.aarch64.rpm",
         "checksum": "sha256:6a7f253283b4bf35a8ca9c9a4c006005c38f69f2fda7ff401b6095804c2f054e"
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.aarch64.rpm",
+        "checksum": "sha256:2eb48bbf588108e2f876f442d4f54312002dab5ca44d0d1c802296c52f305f83"
       },
       {
         "name": "python3-nftables",
@@ -6779,6 +6881,15 @@
         "checksum": "sha256:5406506cee1642c682f4cdd596e12fc0309a22a16691e82cae5231740d0a7b91"
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -6786,6 +6897,33 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm",
+        "checksum": "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm",
+        "checksum": "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03"
       },
       {
         "name": "python3-setools",
@@ -6813,6 +6951,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-setuptools-wheel-53.0.0-9.el9.noarch.rpm",
         "checksum": "sha256:e4ab6f11d394cb13a23494da17a8432ad248c4e4f16df79d1aff439d77202298"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-six-1.15.0-7.el9.noarch.rpm",
+        "checksum": "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-urllib3-1.26.5-2.el9.noarch.rpm",
+        "checksum": "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00"
       },
       {
         "name": "readline",
@@ -6966,6 +7122,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/shim-aa64-15-16.el8.aarch64.rpm",
         "checksum": "sha256:986ae6b9c75597a2705619d8a0ec5d2ec299c599f1633f480f9bf4931ec2ecd4"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm",
+        "checksum": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
       },
       {
         "name": "sqlite-libs",

--- a/test/data/manifests/rhel_90-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_container-boot.json
@@ -597,6 +597,9 @@
                     "id": "sha256:c56e979225e15d1ae3b49834ac4341b2e94dbf67d889a27de815b330ee864355"
                   },
                   {
+                    "id": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95"
+                  },
+                  {
                     "id": "sha256:a06414786e5b316a6bc411b4827d45d0364817071f924fed85c395df0ecd9450"
                   },
                   {
@@ -1245,6 +1248,9 @@
                     "id": "sha256:6096bfc6f28920cc845b2d69c0af0a6d912b2a248706f69545e8cd48ba090e76"
                   },
                   {
+                    "id": "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297"
+                  },
+                  {
                     "id": "sha256:26f20dd590b09a8f418dc6c51ba734ca3714902ccde9ca3e91201481ed2728ba"
                   },
                   {
@@ -1254,13 +1260,31 @@
                     "id": "sha256:21b7229992b9cb9fcc8c90d638dcb2c83adb52dd0d9ab67941e892caf4d96016"
                   },
                   {
+                    "id": "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b"
+                  },
+                  {
                     "id": "sha256:6a7f253283b4bf35a8ca9c9a4c006005c38f69f2fda7ff401b6095804c2f054e"
+                  },
+                  {
+                    "id": "sha256:2eb48bbf588108e2f876f442d4f54312002dab5ca44d0d1c802296c52f305f83"
                   },
                   {
                     "id": "sha256:5406506cee1642c682f4cdd596e12fc0309a22a16691e82cae5231740d0a7b91"
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
+                  },
+                  {
+                    "id": "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4"
+                  },
+                  {
+                    "id": "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03"
                   },
                   {
                     "id": "sha256:06fbab10e385e6e5da48b7d8c8ed5a7d32bff1e471986acc5b5cceafb2160f5b"
@@ -1270,6 +1294,12 @@
                   },
                   {
                     "id": "sha256:e4ab6f11d394cb13a23494da17a8432ad248c4e4f16df79d1aff439d77202298"
+                  },
+                  {
+                    "id": "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34"
+                  },
+                  {
+                    "id": "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00"
                   },
                   {
                     "id": "sha256:2ae424b368c6747124b51b205b9e11d74aeaff56b3de90e8cbd36012e0d17707"
@@ -1321,6 +1351,9 @@
                   },
                   {
                     "id": "sha256:986ae6b9c75597a2705619d8a0ec5d2ec299c599f1633f480f9bf4931ec2ecd4"
+                  },
+                  {
+                    "id": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
                   },
                   {
                     "id": "sha256:0c31efd8b5766ab422622a6df1f6d4ce29e831e9ac7a2ed89ef6e6538bc8b44c"
@@ -2160,6 +2193,9 @@
           "sha256:048b917ccf11528a1d02b37e554eab23995eb49ab5f958b565e8bcc513637b53": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libqrtr-glib-1.0.0-4.el9.aarch64.rpm"
           },
+          "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-chardet-4.0.0-3.el9.noarch.rpm"
+          },
           "sha256:0593c85b96abb90a75d6bd4df88b5c38c53b68e51a8b0a6e52b56febe4b4da09": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/tar-1.34-3.el9.aarch64.rpm"
           },
@@ -2193,6 +2229,9 @@
           "sha256:09ff81634b9741b286b42e2067270b4f95141a5ea03886f0610e25e9d0f941a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/mpfr-4.1.0-7.el9.aarch64.rpm"
           },
+          "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:0ada384fcf60abfc52005d39c7b09652c35dce5e7651439830e36f6c1f17de49": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/nginx-1.20.1-10.el9.aarch64.rpm"
           },
@@ -2223,6 +2262,9 @@
           "sha256:0ecd0a2dc724d867afffa4cae14dd6048316f2914cb0a119dbde5d067a2c69d1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/openssh-server-8.7p1-6.el9.aarch64.rpm"
           },
+          "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-urllib3-1.26.5-2.el9.noarch.rpm"
+          },
           "sha256:1115017958235ca1039d5d3e7c4c09be04ade7af7fa3b8fb47f994d45836bffb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libfdisk-2.37.2-1.el9.aarch64.rpm"
           },
@@ -2235,6 +2277,9 @@
           "sha256:11f09add0e88b7b17c30188b7715131b7b861723edd4d9d8dda06f27642afe56": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/python3-libselinux-3.3-2.el9.aarch64.rpm"
           },
+          "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm"
+          },
           "sha256:149abbe50fd335fd4031bdead143e5d768def9ff3842664b8fdb13173cb9215b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/lua-libs-5.4.2-4.el9.aarch64.rpm"
           },
@@ -2246,6 +2291,9 @@
           },
           "sha256:1657d94bbd79f93dc7a79d474316813bde681ce3a7f62f73314ec4d630e39349": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libpwquality-1.4.4-8.el9.aarch64.rpm"
+          },
+          "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-six-1.15.0-7.el9.noarch.rpm"
           },
           "sha256:17178258237e1691ce937f71ffe91a2e081ca2e0d3eeaf1cad566f77bd427621": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/file-libs-5.39-8.el9.aarch64.rpm"
@@ -2355,6 +2403,9 @@
           "sha256:2e3ff61abdeb18204081539e97dbc55797031e5bd58801b1f8154d368b69f1a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libuuid-2.37.2-1.el9.aarch64.rpm"
           },
+          "sha256:2eb48bbf588108e2f876f442d4f54312002dab5ca44d0d1c802296c52f305f83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.aarch64.rpm"
+          },
           "sha256:30f57fed2f2d5269a19453210c22b52b5fd13d4fd0a64de6da1e5de1ea0e74a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libblockdev-fs-2.25-11.el9.aarch64.rpm"
           },
@@ -2378,6 +2429,9 @@
           },
           "sha256:37a9eec32ea3fd69b2b15c04c7d2ecda5c42e5da8aba90e41b5cee4938229836": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libxmlb-0.3.3-1.el9.aarch64.rpm"
+          },
+          "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm"
           },
           "sha256:38b08ddd5d3e409e4434b2d895cc19a5bde8f749918bec84637c00b7600fd28c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libjcat-0.1.6-3.el9.aarch64.rpm"
@@ -2700,6 +2754,9 @@
           "sha256:85bbb36deb440290998a34782c92db155d399d00dee10c156810b5e50ca0baed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/greenboot-default-health-checks-0.14.0-3.el9.aarch64.rpm"
           },
+          "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm"
+          },
           "sha256:8789628a44512d90f9b06613be1f71284b08b19c29df331e63e8d64151b910bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/pkgconf-pkg-config-1.7.3-9.el9.aarch64.rpm"
           },
@@ -2792,6 +2849,9 @@
           },
           "sha256:9c4d7d365d08f8e94978117e4b0117d44ef063b18960cc1df744e296f615131a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libedit-3.1-37.20210216cvs.el9.aarch64.rpm"
+          },
+          "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-idna-2.10-5.el9.noarch.rpm"
           },
           "sha256:9d1e931f9588ae5d7afb9595a871038146ceea72fe03fbc4725ddf58a614d32b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libcurl-7.76.1-14.el9.aarch64.rpm"
@@ -2916,6 +2976,9 @@
           "sha256:bab068aa3a2fa92a85d49a7e0045342cfe164cdbf5dc1c71df254300cfff6378": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/NetworkManager-1.36.0-0.7.el9.aarch64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bb910836cb73b67aa169265375e372de221be156476575f3ee3ef9c81ca3a88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libsecret-0.20.4-4.el9.aarch64.rpm"
           },
@@ -2987,6 +3050,9 @@
           },
           "sha256:c8c8043e19b87e054984343b134dec26b7d7a00ba35a5a8bcb7360e4487f8e09": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libmodulemd-2.13.0-2.el9.aarch64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:ca992eec8e88e16a1ee05643f92e9c9e34ef25ba63af169dc4b413345a6b48a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libblockdev-mdraid-2.25-11.el9.aarch64.rpm"
@@ -5627,6 +5693,15 @@
         "checksum": "sha256:c56e979225e15d1ae3b49834ac4341b2e94dbf67d889a27de815b330ee864355"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -7571,6 +7646,15 @@
         "checksum": "sha256:6096bfc6f28920cc845b2d69c0af0a6d912b2a248706f69545e8cd48ba090e76"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-chardet-4.0.0-3.el9.noarch.rpm",
+        "checksum": "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -7598,6 +7682,15 @@
         "checksum": "sha256:21b7229992b9cb9fcc8c90d638dcb2c83adb52dd0d9ab67941e892caf4d96016"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-idna-2.10-5.el9.noarch.rpm",
+        "checksum": "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.10",
@@ -7605,6 +7698,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-libs-3.9.10-1.el9.aarch64.rpm",
         "checksum": "sha256:6a7f253283b4bf35a8ca9c9a4c006005c38f69f2fda7ff401b6095804c2f054e"
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.aarch64.rpm",
+        "checksum": "sha256:2eb48bbf588108e2f876f442d4f54312002dab5ca44d0d1c802296c52f305f83"
       },
       {
         "name": "python3-nftables",
@@ -7616,6 +7718,15 @@
         "checksum": "sha256:5406506cee1642c682f4cdd596e12fc0309a22a16691e82cae5231740d0a7b91"
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -7623,6 +7734,33 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm",
+        "checksum": "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm",
+        "checksum": "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03"
       },
       {
         "name": "python3-setools",
@@ -7650,6 +7788,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-setuptools-wheel-53.0.0-9.el9.noarch.rpm",
         "checksum": "sha256:e4ab6f11d394cb13a23494da17a8432ad248c4e4f16df79d1aff439d77202298"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-six-1.15.0-7.el9.noarch.rpm",
+        "checksum": "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-urllib3-1.26.5-2.el9.noarch.rpm",
+        "checksum": "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00"
       },
       {
         "name": "readline",
@@ -7803,6 +7959,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/shim-aa64-15-16.el8.aarch64.rpm",
         "checksum": "sha256:986ae6b9c75597a2705619d8a0ec5d2ec299c599f1633f480f9bf4931ec2ecd4"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm",
+        "checksum": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
       },
       {
         "name": "sqlite-libs",

--- a/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
@@ -639,6 +639,9 @@
                     "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886"
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b"
                   },
                   {
@@ -1329,6 +1332,9 @@
                     "id": "sha256:c746c3e534fa6616b62525a89cc8ab1014e5acfac31b1012823b5f1e9031181c"
                   },
                   {
+                    "id": "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297"
+                  },
+                  {
                     "id": "sha256:adf8aafd3b5a7c590e2350c52e172e4b373158d76925c89db59ad201ec68bd27"
                   },
                   {
@@ -1338,13 +1344,31 @@
                     "id": "sha256:a6fd1db30750fefdb6b2ddb91731c4e59c25ca9ee1c18530ebfe41f7158a66b4"
                   },
                   {
+                    "id": "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b"
+                  },
+                  {
                     "id": "sha256:e9efb4a947b2a178c85aa20bc5283d11f0dc85404fe527c25153d2389085eb71"
+                  },
+                  {
+                    "id": "sha256:51d508ed30f9b74fbef756f2be64cca597de9e797b6f5f00f70e4ec88a7c4d3a"
                   },
                   {
                     "id": "sha256:c8ce8d404b24fc632a072349de3c2f132694798e58f06fc470360abb4c3c578b"
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
+                  },
+                  {
+                    "id": "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4"
+                  },
+                  {
+                    "id": "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03"
                   },
                   {
                     "id": "sha256:90c4477700695fae364b625f105e290f85c29dea86c871925042e57920a95b47"
@@ -1354,6 +1378,12 @@
                   },
                   {
                     "id": "sha256:e4ab6f11d394cb13a23494da17a8432ad248c4e4f16df79d1aff439d77202298"
+                  },
+                  {
+                    "id": "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34"
+                  },
+                  {
+                    "id": "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00"
                   },
                   {
                     "id": "sha256:01bf315b3bc44c28515c4d33d49173b23d7979d2a09b7b15f749d434b60851e6"
@@ -1405,6 +1435,9 @@
                   },
                   {
                     "id": "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021"
+                  },
+                  {
+                    "id": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
                   },
                   {
                     "id": "sha256:372a5cfa95d2edb67435b0386029501ff5254bca91430b6d6e8e446582ba258a"
@@ -1878,6 +1911,9 @@
           "sha256:055f4ce6b721be7138dc2e45a6586412c65508acea3fe385a2655c129fe264f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libidn2-2.3.0-7.el9.x86_64.rpm"
           },
+          "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-chardet-4.0.0-3.el9.noarch.rpm"
+          },
           "sha256:05d265635c89ebce03e3cfc7e293dfe90756c5cdc38a2e237dee5f0056349b84": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/dnsmasq-2.85-2.el9.x86_64.rpm"
           },
@@ -1920,6 +1956,9 @@
           "sha256:0f1df5e0d48c2ac9914bfffa7ed569cd58e42b17ba96bb3f7cf74d1e80de2597": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libutempter-1.2.1-6.el9.x86_64.rpm"
           },
+          "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-urllib3-1.26.5-2.el9.noarch.rpm"
+          },
           "sha256:0f97ae871b19c01313979bfc246d1d9aa6cc6bd9a8d3c9f496e6427a3ff50796": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/device-mapper-libs-1.02.181-3.el9.x86_64.rpm"
           },
@@ -1928,6 +1967,9 @@
           },
           "sha256:1289b71edf0faa3874c651c1b8ffc760017c6749748bbd6037e6aefbf6029cd8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-libselinux-3.3-2.el9.x86_64.rpm"
+          },
+          "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm"
           },
           "sha256:147e281881105acfb8aa184a1d59faff4e3c1249205a86abb900b8d7a02cacbe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libusbx-1.0.24-4.el9.x86_64.rpm"
@@ -1940,6 +1982,9 @@
           },
           "sha256:1649240d2a69e13d3b5ddc5c5e63c5d64a77930578a6bc4c3aca32f00423cd87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/popt-1.18-8.el9.x86_64.rpm"
+          },
+          "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-six-1.15.0-7.el9.noarch.rpm"
           },
           "sha256:1749334511ad1fdf2699bb0b231eebc9af72722d90786463d0eedff460a8a660": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/file-libs-5.39-8.el9.x86_64.rpm"
@@ -2067,6 +2112,9 @@
           "sha256:3758fbca43cabdf79e494cf859fc8aa3a57cd6813a961a25bebe96c013b085ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/p11-kit-trust-0.24.1-2.el9.x86_64.rpm"
           },
+          "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm"
+          },
           "sha256:39146b9a69e244c59a9a41cfaab20fedcf890c640e04ed0d993e4473e7443106": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libpkgconf-1.7.3-9.el9.x86_64.rpm"
           },
@@ -2174,6 +2222,9 @@
           },
           "sha256:5196f5f7d2387e9dcdf504c8534e3109cc84f7545240b6fbd18866217653b4fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-055-10.git20210824.el9.x86_64.rpm"
+          },
+          "sha256:51d508ed30f9b74fbef756f2be64cca597de9e797b6f5f00f70e4ec88a7c4d3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.x86_64.rpm"
           },
           "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm"
@@ -2409,6 +2460,9 @@
           "sha256:85b7fd0c3905329563d2301eb0e8acd7b82f47dbaeb2a7da388a432af8ae1910": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libslirp-4.4.0-4.el9.x86_64.rpm"
           },
+          "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm"
+          },
           "sha256:86f913b51ec66a03003d2a19e8a6195fdafa37d01bfd66e268d95b198d7779f6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libcap-ng-python3-0.8.2-6.el9.x86_64.rpm"
           },
@@ -2519,6 +2573,9 @@
           },
           "sha256:9c08d030b1c8542405943bcbfc91bdbf6e9d433716543a624a49afc20a0c8033": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/krb5-libs-1.19.1-13.el9.x86_64.rpm"
+          },
+          "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-idna-2.10-5.el9.noarch.rpm"
           },
           "sha256:9d541eca0f4ed87fbaab65a973f6b69ac0c64b2e652da809494b03d8104869b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgcrypt-1.10.0-1.el9.x86_64.rpm"
@@ -2646,11 +2703,17 @@
           "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc0f73fb262df04514d6ce8f4d970adefc7385be519e759c9d61bf7f715cc6e1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxml2-2.9.12-4.el9.x86_64.rpm"
           },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libjose-11-3.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:bd6a3956f8d84430d1e03ee2a4cf18629a3846ac4341cd49771a6f89271bdf78": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libblkid-2.37.2-1.el9.x86_64.rpm"
@@ -2720,6 +2783,9 @@
           },
           "sha256:c8ce8d404b24fc632a072349de3c2f132694798e58f06fc470360abb4c3c578b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-nftables-0.9.8-10.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:cb07b2cabae7305f5e4e5784530a75a8f91c57a79da1ae7ff7808ce23917ebd3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libedit-3.1-37.20210216cvs.el9.x86_64.rpm"
@@ -4678,6 +4744,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
         "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886"
       },
       {
         "name": "bzip2-libs",
@@ -6750,6 +6825,15 @@
         "checksum": "sha256:c746c3e534fa6616b62525a89cc8ab1014e5acfac31b1012823b5f1e9031181c"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-chardet-4.0.0-3.el9.noarch.rpm",
+        "checksum": "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -6777,6 +6861,15 @@
         "checksum": "sha256:a6fd1db30750fefdb6b2ddb91731c4e59c25ca9ee1c18530ebfe41f7158a66b4"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-idna-2.10-5.el9.noarch.rpm",
+        "checksum": "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.10",
@@ -6784,6 +6877,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-libs-3.9.10-1.el9.x86_64.rpm",
         "checksum": "sha256:e9efb4a947b2a178c85aa20bc5283d11f0dc85404fe527c25153d2389085eb71"
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.x86_64.rpm",
+        "checksum": "sha256:51d508ed30f9b74fbef756f2be64cca597de9e797b6f5f00f70e4ec88a7c4d3a"
       },
       {
         "name": "python3-nftables",
@@ -6795,6 +6897,15 @@
         "checksum": "sha256:c8ce8d404b24fc632a072349de3c2f132694798e58f06fc470360abb4c3c578b"
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -6802,6 +6913,33 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm",
+        "checksum": "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm",
+        "checksum": "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03"
       },
       {
         "name": "python3-setools",
@@ -6829,6 +6967,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-setuptools-wheel-53.0.0-9.el9.noarch.rpm",
         "checksum": "sha256:e4ab6f11d394cb13a23494da17a8432ad248c4e4f16df79d1aff439d77202298"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-six-1.15.0-7.el9.noarch.rpm",
+        "checksum": "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-urllib3-1.26.5-2.el9.noarch.rpm",
+        "checksum": "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00"
       },
       {
         "name": "readline",
@@ -6982,6 +7138,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/shim-x64-15-16.el8.x86_64.rpm",
         "checksum": "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm",
+        "checksum": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
       },
       {
         "name": "sqlite-libs",

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
@@ -646,6 +646,9 @@
                     "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886"
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b"
                   },
                   {
@@ -1441,7 +1444,13 @@
                     "id": "sha256:947cd909d714ac798e930dc3e3d268c3b9c98556c8d55d9af9a8ca7e0949145b"
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
                   },
                   {
                     "id": "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4"
@@ -1532,6 +1541,9 @@
                   },
                   {
                     "id": "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f"
+                  },
+                  {
+                    "id": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
                   },
                   {
                     "id": "sha256:372a5cfa95d2edb67435b0386029501ff5254bca91430b6d6e8e446582ba258a"
@@ -2293,6 +2305,9 @@
           "sha256:37b1d60e8acd198f6fd474326524c6467de01f42400ea57f8622861cc2ba34ef": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/hdparm-9.62-2.el9.x86_64.rpm"
           },
+          "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm"
+          },
           "sha256:39146b9a69e244c59a9a41cfaab20fedcf890c640e04ed0d993e4473e7443106": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libpkgconf-1.7.3-9.el9.x86_64.rpm"
           },
@@ -2944,6 +2959,9 @@
           "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bb871a469a9f26c097c92b959dec683a44b8fec6c66e7f869ecc6fc9b9ed7fdd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/subscription-manager-1.29.23-1.el9.x86_64.rpm"
           },
@@ -2952,6 +2970,9 @@
           },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libjose-11-3.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:bd6a3956f8d84430d1e03ee2a4cf18629a3846ac4341cd49771a6f89271bdf78": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libblkid-2.37.2-1.el9.x86_64.rpm"
@@ -3024,6 +3045,9 @@
           },
           "sha256:c8ce8d404b24fc632a072349de3c2f132694798e58f06fc470360abb4c3c578b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-nftables-0.9.8-10.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:cb07b2cabae7305f5e4e5784530a75a8f91c57a79da1ae7ff7808ce23917ebd3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libedit-3.1-37.20210216cvs.el9.x86_64.rpm"
@@ -5009,6 +5033,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
         "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886"
       },
       {
         "name": "bzip2-libs",
@@ -7396,6 +7429,15 @@
         "checksum": "sha256:947cd909d714ac798e930dc3e3d268c3b9c98556c8d55d9af9a8ca7e0949145b"
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -7403,6 +7445,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
       },
       {
         "name": "python3-pysocks",
@@ -7673,6 +7724,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/snappy-1.1.8-8.el9.x86_64.rpm",
         "checksum": "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm",
+        "checksum": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
       },
       {
         "name": "sqlite-libs",

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
@@ -717,6 +717,9 @@
                     "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886"
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b"
                   },
                   {
@@ -1407,6 +1410,9 @@
                     "id": "sha256:c746c3e534fa6616b62525a89cc8ab1014e5acfac31b1012823b5f1e9031181c"
                   },
                   {
+                    "id": "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297"
+                  },
+                  {
                     "id": "sha256:adf8aafd3b5a7c590e2350c52e172e4b373158d76925c89db59ad201ec68bd27"
                   },
                   {
@@ -1416,13 +1422,31 @@
                     "id": "sha256:a6fd1db30750fefdb6b2ddb91731c4e59c25ca9ee1c18530ebfe41f7158a66b4"
                   },
                   {
+                    "id": "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b"
+                  },
+                  {
                     "id": "sha256:e9efb4a947b2a178c85aa20bc5283d11f0dc85404fe527c25153d2389085eb71"
+                  },
+                  {
+                    "id": "sha256:51d508ed30f9b74fbef756f2be64cca597de9e797b6f5f00f70e4ec88a7c4d3a"
                   },
                   {
                     "id": "sha256:c8ce8d404b24fc632a072349de3c2f132694798e58f06fc470360abb4c3c578b"
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
+                  },
+                  {
+                    "id": "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4"
+                  },
+                  {
+                    "id": "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03"
                   },
                   {
                     "id": "sha256:90c4477700695fae364b625f105e290f85c29dea86c871925042e57920a95b47"
@@ -1432,6 +1456,12 @@
                   },
                   {
                     "id": "sha256:e4ab6f11d394cb13a23494da17a8432ad248c4e4f16df79d1aff439d77202298"
+                  },
+                  {
+                    "id": "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34"
+                  },
+                  {
+                    "id": "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00"
                   },
                   {
                     "id": "sha256:01bf315b3bc44c28515c4d33d49173b23d7979d2a09b7b15f749d434b60851e6"
@@ -1483,6 +1513,9 @@
                   },
                   {
                     "id": "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021"
+                  },
+                  {
+                    "id": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
                   },
                   {
                     "id": "sha256:372a5cfa95d2edb67435b0386029501ff5254bca91430b6d6e8e446582ba258a"
@@ -1991,6 +2024,9 @@
           "sha256:055f4ce6b721be7138dc2e45a6586412c65508acea3fe385a2655c129fe264f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libidn2-2.3.0-7.el9.x86_64.rpm"
           },
+          "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-chardet-4.0.0-3.el9.noarch.rpm"
+          },
           "sha256:05d265635c89ebce03e3cfc7e293dfe90756c5cdc38a2e237dee5f0056349b84": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/dnsmasq-2.85-2.el9.x86_64.rpm"
           },
@@ -2033,6 +2069,9 @@
           "sha256:0f1df5e0d48c2ac9914bfffa7ed569cd58e42b17ba96bb3f7cf74d1e80de2597": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libutempter-1.2.1-6.el9.x86_64.rpm"
           },
+          "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-urllib3-1.26.5-2.el9.noarch.rpm"
+          },
           "sha256:0f97ae871b19c01313979bfc246d1d9aa6cc6bd9a8d3c9f496e6427a3ff50796": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/device-mapper-libs-1.02.181-3.el9.x86_64.rpm"
           },
@@ -2041,6 +2080,9 @@
           },
           "sha256:1289b71edf0faa3874c651c1b8ffc760017c6749748bbd6037e6aefbf6029cd8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-libselinux-3.3-2.el9.x86_64.rpm"
+          },
+          "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm"
           },
           "sha256:147e281881105acfb8aa184a1d59faff4e3c1249205a86abb900b8d7a02cacbe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libusbx-1.0.24-4.el9.x86_64.rpm"
@@ -2053,6 +2095,9 @@
           },
           "sha256:1649240d2a69e13d3b5ddc5c5e63c5d64a77930578a6bc4c3aca32f00423cd87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/popt-1.18-8.el9.x86_64.rpm"
+          },
+          "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-six-1.15.0-7.el9.noarch.rpm"
           },
           "sha256:1749334511ad1fdf2699bb0b231eebc9af72722d90786463d0eedff460a8a660": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/file-libs-5.39-8.el9.x86_64.rpm"
@@ -2180,6 +2225,9 @@
           "sha256:3758fbca43cabdf79e494cf859fc8aa3a57cd6813a961a25bebe96c013b085ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/p11-kit-trust-0.24.1-2.el9.x86_64.rpm"
           },
+          "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm"
+          },
           "sha256:39146b9a69e244c59a9a41cfaab20fedcf890c640e04ed0d993e4473e7443106": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libpkgconf-1.7.3-9.el9.x86_64.rpm"
           },
@@ -2287,6 +2335,9 @@
           },
           "sha256:5196f5f7d2387e9dcdf504c8534e3109cc84f7545240b6fbd18866217653b4fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-055-10.git20210824.el9.x86_64.rpm"
+          },
+          "sha256:51d508ed30f9b74fbef756f2be64cca597de9e797b6f5f00f70e4ec88a7c4d3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.x86_64.rpm"
           },
           "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm"
@@ -2522,6 +2573,9 @@
           "sha256:85b7fd0c3905329563d2301eb0e8acd7b82f47dbaeb2a7da388a432af8ae1910": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libslirp-4.4.0-4.el9.x86_64.rpm"
           },
+          "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm"
+          },
           "sha256:86f913b51ec66a03003d2a19e8a6195fdafa37d01bfd66e268d95b198d7779f6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libcap-ng-python3-0.8.2-6.el9.x86_64.rpm"
           },
@@ -2632,6 +2686,9 @@
           },
           "sha256:9c08d030b1c8542405943bcbfc91bdbf6e9d433716543a624a49afc20a0c8033": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/krb5-libs-1.19.1-13.el9.x86_64.rpm"
+          },
+          "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-idna-2.10-5.el9.noarch.rpm"
           },
           "sha256:9d541eca0f4ed87fbaab65a973f6b69ac0c64b2e652da809494b03d8104869b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgcrypt-1.10.0-1.el9.x86_64.rpm"
@@ -2759,11 +2816,17 @@
           "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc0f73fb262df04514d6ce8f4d970adefc7385be519e759c9d61bf7f715cc6e1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxml2-2.9.12-4.el9.x86_64.rpm"
           },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libjose-11-3.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:bd6a3956f8d84430d1e03ee2a4cf18629a3846ac4341cd49771a6f89271bdf78": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libblkid-2.37.2-1.el9.x86_64.rpm"
@@ -2833,6 +2896,9 @@
           },
           "sha256:c8ce8d404b24fc632a072349de3c2f132694798e58f06fc470360abb4c3c578b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-nftables-0.9.8-10.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:cb07b2cabae7305f5e4e5784530a75a8f91c57a79da1ae7ff7808ce23917ebd3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libedit-3.1-37.20210216cvs.el9.x86_64.rpm"
@@ -5022,6 +5088,15 @@
         "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -7092,6 +7167,15 @@
         "checksum": "sha256:c746c3e534fa6616b62525a89cc8ab1014e5acfac31b1012823b5f1e9031181c"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-chardet-4.0.0-3.el9.noarch.rpm",
+        "checksum": "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -7119,6 +7203,15 @@
         "checksum": "sha256:a6fd1db30750fefdb6b2ddb91731c4e59c25ca9ee1c18530ebfe41f7158a66b4"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-idna-2.10-5.el9.noarch.rpm",
+        "checksum": "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.10",
@@ -7126,6 +7219,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-libs-3.9.10-1.el9.x86_64.rpm",
         "checksum": "sha256:e9efb4a947b2a178c85aa20bc5283d11f0dc85404fe527c25153d2389085eb71"
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.x86_64.rpm",
+        "checksum": "sha256:51d508ed30f9b74fbef756f2be64cca597de9e797b6f5f00f70e4ec88a7c4d3a"
       },
       {
         "name": "python3-nftables",
@@ -7137,6 +7239,15 @@
         "checksum": "sha256:c8ce8d404b24fc632a072349de3c2f132694798e58f06fc470360abb4c3c578b"
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -7144,6 +7255,33 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm",
+        "checksum": "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm",
+        "checksum": "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03"
       },
       {
         "name": "python3-setools",
@@ -7171,6 +7309,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-setuptools-wheel-53.0.0-9.el9.noarch.rpm",
         "checksum": "sha256:e4ab6f11d394cb13a23494da17a8432ad248c4e4f16df79d1aff439d77202298"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-six-1.15.0-7.el9.noarch.rpm",
+        "checksum": "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-urllib3-1.26.5-2.el9.noarch.rpm",
+        "checksum": "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00"
       },
       {
         "name": "readline",
@@ -7324,6 +7480,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/shim-x64-15-16.el8.x86_64.rpm",
         "checksum": "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm",
+        "checksum": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
       },
       {
         "name": "sqlite-libs",

--- a/test/data/manifests/rhel_90-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_container-boot.json
@@ -630,6 +630,9 @@
                     "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886"
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b"
                   },
                   {
@@ -1320,6 +1323,9 @@
                     "id": "sha256:c746c3e534fa6616b62525a89cc8ab1014e5acfac31b1012823b5f1e9031181c"
                   },
                   {
+                    "id": "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297"
+                  },
+                  {
                     "id": "sha256:adf8aafd3b5a7c590e2350c52e172e4b373158d76925c89db59ad201ec68bd27"
                   },
                   {
@@ -1329,13 +1335,31 @@
                     "id": "sha256:a6fd1db30750fefdb6b2ddb91731c4e59c25ca9ee1c18530ebfe41f7158a66b4"
                   },
                   {
+                    "id": "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b"
+                  },
+                  {
                     "id": "sha256:e9efb4a947b2a178c85aa20bc5283d11f0dc85404fe527c25153d2389085eb71"
+                  },
+                  {
+                    "id": "sha256:51d508ed30f9b74fbef756f2be64cca597de9e797b6f5f00f70e4ec88a7c4d3a"
                   },
                   {
                     "id": "sha256:c8ce8d404b24fc632a072349de3c2f132694798e58f06fc470360abb4c3c578b"
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
+                  },
+                  {
+                    "id": "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4"
+                  },
+                  {
+                    "id": "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03"
                   },
                   {
                     "id": "sha256:90c4477700695fae364b625f105e290f85c29dea86c871925042e57920a95b47"
@@ -1345,6 +1369,12 @@
                   },
                   {
                     "id": "sha256:e4ab6f11d394cb13a23494da17a8432ad248c4e4f16df79d1aff439d77202298"
+                  },
+                  {
+                    "id": "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34"
+                  },
+                  {
+                    "id": "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00"
                   },
                   {
                     "id": "sha256:01bf315b3bc44c28515c4d33d49173b23d7979d2a09b7b15f749d434b60851e6"
@@ -1396,6 +1426,9 @@
                   },
                   {
                     "id": "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021"
+                  },
+                  {
+                    "id": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
                   },
                   {
                     "id": "sha256:372a5cfa95d2edb67435b0386029501ff5254bca91430b6d6e8e446582ba258a"
@@ -2232,6 +2265,9 @@
           "sha256:055f4ce6b721be7138dc2e45a6586412c65508acea3fe385a2655c129fe264f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libidn2-2.3.0-7.el9.x86_64.rpm"
           },
+          "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-chardet-4.0.0-3.el9.noarch.rpm"
+          },
           "sha256:05d265635c89ebce03e3cfc7e293dfe90756c5cdc38a2e237dee5f0056349b84": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/dnsmasq-2.85-2.el9.x86_64.rpm"
           },
@@ -2274,6 +2310,9 @@
           "sha256:0f1df5e0d48c2ac9914bfffa7ed569cd58e42b17ba96bb3f7cf74d1e80de2597": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libutempter-1.2.1-6.el9.x86_64.rpm"
           },
+          "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-urllib3-1.26.5-2.el9.noarch.rpm"
+          },
           "sha256:0f97ae871b19c01313979bfc246d1d9aa6cc6bd9a8d3c9f496e6427a3ff50796": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/device-mapper-libs-1.02.181-3.el9.x86_64.rpm"
           },
@@ -2282,6 +2321,9 @@
           },
           "sha256:1289b71edf0faa3874c651c1b8ffc760017c6749748bbd6037e6aefbf6029cd8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-libselinux-3.3-2.el9.x86_64.rpm"
+          },
+          "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm"
           },
           "sha256:147e281881105acfb8aa184a1d59faff4e3c1249205a86abb900b8d7a02cacbe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libusbx-1.0.24-4.el9.x86_64.rpm"
@@ -2294,6 +2336,9 @@
           },
           "sha256:1649240d2a69e13d3b5ddc5c5e63c5d64a77930578a6bc4c3aca32f00423cd87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/popt-1.18-8.el9.x86_64.rpm"
+          },
+          "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-six-1.15.0-7.el9.noarch.rpm"
           },
           "sha256:1749334511ad1fdf2699bb0b231eebc9af72722d90786463d0eedff460a8a660": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/file-libs-5.39-8.el9.x86_64.rpm"
@@ -2427,6 +2472,9 @@
           "sha256:37b14094c9001b85a2e11b288b3ed08a5694501e0645b20f9ca613a5f7e0dd2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/nginx-1.20.1-10.el9.x86_64.rpm"
           },
+          "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm"
+          },
           "sha256:39146b9a69e244c59a9a41cfaab20fedcf890c640e04ed0d993e4473e7443106": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libpkgconf-1.7.3-9.el9.x86_64.rpm"
           },
@@ -2534,6 +2582,9 @@
           },
           "sha256:5196f5f7d2387e9dcdf504c8534e3109cc84f7545240b6fbd18866217653b4fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-055-10.git20210824.el9.x86_64.rpm"
+          },
+          "sha256:51d508ed30f9b74fbef756f2be64cca597de9e797b6f5f00f70e4ec88a7c4d3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.x86_64.rpm"
           },
           "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm"
@@ -2769,6 +2820,9 @@
           "sha256:85b7fd0c3905329563d2301eb0e8acd7b82f47dbaeb2a7da388a432af8ae1910": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libslirp-4.4.0-4.el9.x86_64.rpm"
           },
+          "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm"
+          },
           "sha256:86f913b51ec66a03003d2a19e8a6195fdafa37d01bfd66e268d95b198d7779f6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libcap-ng-python3-0.8.2-6.el9.x86_64.rpm"
           },
@@ -2882,6 +2936,9 @@
           },
           "sha256:9c08d030b1c8542405943bcbfc91bdbf6e9d433716543a624a49afc20a0c8033": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/krb5-libs-1.19.1-13.el9.x86_64.rpm"
+          },
+          "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-idna-2.10-5.el9.noarch.rpm"
           },
           "sha256:9d541eca0f4ed87fbaab65a973f6b69ac0c64b2e652da809494b03d8104869b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgcrypt-1.10.0-1.el9.x86_64.rpm"
@@ -3009,11 +3066,17 @@
           "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc0f73fb262df04514d6ce8f4d970adefc7385be519e759c9d61bf7f715cc6e1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxml2-2.9.12-4.el9.x86_64.rpm"
           },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libjose-11-3.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:bd6a3956f8d84430d1e03ee2a4cf18629a3846ac4341cd49771a6f89271bdf78": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libblkid-2.37.2-1.el9.x86_64.rpm"
@@ -3083,6 +3146,9 @@
           },
           "sha256:c8ce8d404b24fc632a072349de3c2f132694798e58f06fc470360abb4c3c578b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-nftables-0.9.8-10.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:cb07b2cabae7305f5e4e5784530a75a8f91c57a79da1ae7ff7808ce23917ebd3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libedit-3.1-37.20210216cvs.el9.x86_64.rpm"
@@ -5849,6 +5915,15 @@
         "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886"
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -7919,6 +7994,15 @@
         "checksum": "sha256:c746c3e534fa6616b62525a89cc8ab1014e5acfac31b1012823b5f1e9031181c"
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-chardet-4.0.0-3.el9.noarch.rpm",
+        "checksum": "sha256:05904e53c832795f1d3e01cac91e3ca30984b91fa47f10873a1b325d5436c297"
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -7946,6 +8030,15 @@
         "checksum": "sha256:a6fd1db30750fefdb6b2ddb91731c4e59c25ca9ee1c18530ebfe41f7158a66b4"
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-idna-2.10-5.el9.noarch.rpm",
+        "checksum": "sha256:9caa68479e669c5e0e2149352fb748114e528a12408319de0a6f452bad52902b"
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.10",
@@ -7953,6 +8046,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-libs-3.9.10-1.el9.x86_64.rpm",
         "checksum": "sha256:e9efb4a947b2a178c85aa20bc5283d11f0dc85404fe527c25153d2389085eb71"
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.x86_64.rpm",
+        "checksum": "sha256:51d508ed30f9b74fbef756f2be64cca597de9e797b6f5f00f70e4ec88a7c4d3a"
       },
       {
         "name": "python3-nftables",
@@ -7964,6 +8066,15 @@
         "checksum": "sha256:c8ce8d404b24fc632a072349de3c2f132694798e58f06fc470360abb4c3c578b"
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93"
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -7971,6 +8082,33 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4"
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08"
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm",
+        "checksum": "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4"
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm",
+        "checksum": "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03"
       },
       {
         "name": "python3-setools",
@@ -7998,6 +8136,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-setuptools-wheel-53.0.0-9.el9.noarch.rpm",
         "checksum": "sha256:e4ab6f11d394cb13a23494da17a8432ad248c4e4f16df79d1aff439d77202298"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-six-1.15.0-7.el9.noarch.rpm",
+        "checksum": "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34"
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-urllib3-1.26.5-2.el9.noarch.rpm",
+        "checksum": "sha256:0f7eb2eddf9c8d10c554a67a68df0bca3bcd47186697d6c98d780b1d8d8cab00"
       },
       {
         "name": "readline",
@@ -8151,6 +8307,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/shim-x64-15-16.el8.x86_64.rpm",
         "checksum": "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "13.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sos-4.2-13.el9.noarch.rpm",
+        "checksum": "sha256:380655abda94b27902761d9865540dd59fb366d5e89fd9fcc6bb70cbc1fc922e"
       },
       {
         "name": "sqlite-libs",

--- a/test/data/manifests/rhel_91-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_commit-boot.json
@@ -1668,6 +1668,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a06414786e5b316a6bc411b4827d45d0364817071f924fed85c395df0ecd9450",
                     "options": {
                       "metadata": {
@@ -3420,6 +3428,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:26f20dd590b09a8f418dc6c51ba734ca3714902ccde9ca3e91201481ed2728ba",
                     "options": {
                       "metadata": {
@@ -3452,7 +3468,23 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:cbdce6902501eef4192d765ee9b768a53cfee2fa2662e5abeefd597615ff2c04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3468,7 +3500,39 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3493,6 +3557,22 @@
                   },
                   {
                     "id": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3629,6 +3709,14 @@
                   },
                   {
                     "id": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4615,6 +4703,9 @@
           "sha256:09ff81634b9741b286b42e2067270b4f95141a5ea03886f0610e25e9d0f941a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/mpfr-4.1.0-7.el9.aarch64.rpm"
           },
+          "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:0bc4d57ac943f016fb716392828a7cfa4bfcb899c3ff7a61501bf7dd36228646": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libmbim-utils-1.26.0-2.el9.aarch64.rpm"
           },
@@ -4647,6 +4738,9 @@
           },
           "sha256:16b57cc1b34d4c44d9638d4f87527d7883baad76433b2d2210a5663907cd8e11": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/file-libs-5.39-10.el9.aarch64.rpm"
+          },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
           },
           "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
@@ -4696,11 +4790,17 @@
           "sha256:1e1ad4c81b343be9175db222ea845afcc622f5a9c38a1f4c55ecad90c83a23ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/dosfstools-4.2-3.el9.aarch64.rpm"
           },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:1eccd2b9ccbaa8a1c680c0e0fd4e1733d1abf1fe0bdff635e309cdc232492c1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/glibc-minimal-langpack-2.34-40.el9.aarch64.rpm"
           },
           "sha256:1f1518511e3dc9c199cc9215eb99e16cfc5b7cf4a474fc1d24bd46a7b51b06e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/gdisk-1.0.7-5.el9.aarch64.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:1f46937ea8b9af3010c90f75c0a0cde76348defb6604d35c670c77cb62f3640e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/NetworkManager-libnm-1.40.0-1.el9.aarch64.rpm"
@@ -4885,6 +4985,9 @@
           "sha256:496085a23af0a0fadb510bf3bbac631583a2b0268eb2b3deeeb1b4a31c9dd631": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/kpartx-0.8.7-12.el9.aarch64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:4a684a393f14704bf0bf74adc5943863334e8371d70fec6fc7667201b3c2fe9f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.aarch64.rpm"
           },
@@ -4941,6 +5044,9 @@
           },
           "sha256:55be6352c68f5245a31c09709a5b604038d9d373d69c226c49a5a5f6923eff46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/traceroute-2.1.0-16.el9.aarch64.rpm"
+          },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm"
           },
           "sha256:5684001de29ef187b78849729334c61ac7f77b4a56e0cdae0df196731777ec7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libacl-2.3.1-3.el9.aarch64.rpm"
@@ -5086,6 +5192,9 @@
           "sha256:767396019f392da9ce7d24d4f8e3178070c2594e984e7dbc019d103cca1e27e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/rsync-3.2.3-18.el9.aarch64.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:77719a7a94185255f23ff1e5c1e1292d8350a4d33b2b35d87fc273c337d771d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libtasn1-4.16.0-7.el9.aarch64.rpm"
           },
@@ -5184,6 +5293,9 @@
           },
           "sha256:85bbb36deb440290998a34782c92db155d399d00dee10c156810b5e50ca0baed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/greenboot-default-health-checks-0.14.0-3.el9.aarch64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:85dc4b0132dc60c0d2f1ff248bebf2c4f0146828db32617fa499f9280ab8af38": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/fdo-client-0.4.5-1.el9_0.aarch64.rpm"
@@ -5338,6 +5450,9 @@
           "sha256:b9e726b747cf8eaeaf1c7609196a02a9bb920720997dcc9ec1e6422620109fa5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/dbus-1.12.20-6.el9.aarch64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bb910836cb73b67aa169265375e372de221be156476575f3ee3ef9c81ca3a88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/libsecret-0.20.4-4.el9.aarch64.rpm"
           },
@@ -5400,6 +5515,9 @@
           },
           "sha256:c91fd1c5b88114d41d66611665c9ff27fbf53d97a3d41baf437af6d0f201e521": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/audit-libs-3.0.7-103.el9.aarch64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9930c540ae07e0375d4744f8ef541f2d3d8d2f6f715a85524c7ef5b8a93cff5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/file-5.39-10.el9.aarch64.rpm"
@@ -5496,6 +5614,9 @@
           },
           "sha256:dddae871bfa8a3d8d75415b7302940f8171b641ca2b894e527d84256f56b3df4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/glibc-2.34-40.el9.aarch64.rpm"
+          },
+          "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.aarch64.rpm"
           },
           "sha256:de499d867cc5e6069f2dcf6ffd48e56adad91b1358eeca80c86b8e9e9dc0b879": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/polkit-0.117-10.el9_0.aarch64.rpm"
@@ -7665,6 +7786,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.aarch64.rpm",
         "checksum": "sha256:c56e979225e15d1ae3b49834ac4341b2e94dbf67d889a27de815b330ee864355",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
         "check_gpg": true
       },
       {
@@ -9858,6 +9989,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -9898,6 +10039,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.14",
@@ -9905,6 +10056,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.aarch64.rpm",
         "checksum": "sha256:cbdce6902501eef4192d765ee9b768a53cfee2fa2662e5abeefd597615ff2c04",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.aarch64.rpm",
+        "checksum": "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03",
         "check_gpg": true
       },
       {
@@ -9918,6 +10079,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -9925,6 +10096,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -9955,6 +10156,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-setuptools-wheel-53.0.0-10.el9.noarch.rpm",
         "checksum": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -10125,6 +10346,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/shim-aa64-15.6-1.el9.aarch64.rpm",
         "checksum": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
@@ -1682,6 +1682,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a06414786e5b316a6bc411b4827d45d0364817071f924fed85c395df0ecd9450",
                     "options": {
                       "metadata": {
@@ -3434,6 +3442,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:26f20dd590b09a8f418dc6c51ba734ca3714902ccde9ca3e91201481ed2728ba",
                     "options": {
                       "metadata": {
@@ -3466,7 +3482,23 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:cbdce6902501eef4192d765ee9b768a53cfee2fa2662e5abeefd597615ff2c04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3482,7 +3514,39 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3507,6 +3571,22 @@
                   },
                   {
                     "id": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3643,6 +3723,14 @@
                   },
                   {
                     "id": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4664,6 +4752,9 @@
           "sha256:09ff81634b9741b286b42e2067270b4f95141a5ea03886f0610e25e9d0f941a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/mpfr-4.1.0-7.el9.aarch64.rpm"
           },
+          "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:0bc4d57ac943f016fb716392828a7cfa4bfcb899c3ff7a61501bf7dd36228646": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libmbim-utils-1.26.0-2.el9.aarch64.rpm"
           },
@@ -4696,6 +4787,9 @@
           },
           "sha256:16b57cc1b34d4c44d9638d4f87527d7883baad76433b2d2210a5663907cd8e11": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/file-libs-5.39-10.el9.aarch64.rpm"
+          },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
           },
           "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
@@ -4745,11 +4839,17 @@
           "sha256:1e1ad4c81b343be9175db222ea845afcc622f5a9c38a1f4c55ecad90c83a23ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/dosfstools-4.2-3.el9.aarch64.rpm"
           },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:1eccd2b9ccbaa8a1c680c0e0fd4e1733d1abf1fe0bdff635e309cdc232492c1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/glibc-minimal-langpack-2.34-40.el9.aarch64.rpm"
           },
           "sha256:1f1518511e3dc9c199cc9215eb99e16cfc5b7cf4a474fc1d24bd46a7b51b06e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/gdisk-1.0.7-5.el9.aarch64.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:1f46937ea8b9af3010c90f75c0a0cde76348defb6604d35c670c77cb62f3640e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/NetworkManager-libnm-1.40.0-1.el9.aarch64.rpm"
@@ -4934,6 +5034,9 @@
           "sha256:496085a23af0a0fadb510bf3bbac631583a2b0268eb2b3deeeb1b4a31c9dd631": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/kpartx-0.8.7-12.el9.aarch64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:4a684a393f14704bf0bf74adc5943863334e8371d70fec6fc7667201b3c2fe9f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.aarch64.rpm"
           },
@@ -4990,6 +5093,9 @@
           },
           "sha256:55be6352c68f5245a31c09709a5b604038d9d373d69c226c49a5a5f6923eff46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/traceroute-2.1.0-16.el9.aarch64.rpm"
+          },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm"
           },
           "sha256:5684001de29ef187b78849729334c61ac7f77b4a56e0cdae0df196731777ec7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libacl-2.3.1-3.el9.aarch64.rpm"
@@ -5135,6 +5241,9 @@
           "sha256:767396019f392da9ce7d24d4f8e3178070c2594e984e7dbc019d103cca1e27e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/rsync-3.2.3-18.el9.aarch64.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:77719a7a94185255f23ff1e5c1e1292d8350a4d33b2b35d87fc273c337d771d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libtasn1-4.16.0-7.el9.aarch64.rpm"
           },
@@ -5233,6 +5342,9 @@
           },
           "sha256:85bbb36deb440290998a34782c92db155d399d00dee10c156810b5e50ca0baed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/greenboot-default-health-checks-0.14.0-3.el9.aarch64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:85dc4b0132dc60c0d2f1ff248bebf2c4f0146828db32617fa499f9280ab8af38": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/fdo-client-0.4.5-1.el9_0.aarch64.rpm"
@@ -5390,6 +5502,9 @@
           "sha256:b9e726b747cf8eaeaf1c7609196a02a9bb920720997dcc9ec1e6422620109fa5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/dbus-1.12.20-6.el9.aarch64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bb910836cb73b67aa169265375e372de221be156476575f3ee3ef9c81ca3a88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/libsecret-0.20.4-4.el9.aarch64.rpm"
           },
@@ -5452,6 +5567,9 @@
           },
           "sha256:c91fd1c5b88114d41d66611665c9ff27fbf53d97a3d41baf437af6d0f201e521": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/audit-libs-3.0.7-103.el9.aarch64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9930c540ae07e0375d4744f8ef541f2d3d8d2f6f715a85524c7ef5b8a93cff5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/file-5.39-10.el9.aarch64.rpm"
@@ -5548,6 +5666,9 @@
           },
           "sha256:dddae871bfa8a3d8d75415b7302940f8171b641ca2b894e527d84256f56b3df4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/glibc-2.34-40.el9.aarch64.rpm"
+          },
+          "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.aarch64.rpm"
           },
           "sha256:de499d867cc5e6069f2dcf6ffd48e56adad91b1358eeca80c86b8e9e9dc0b879": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/polkit-0.117-10.el9_0.aarch64.rpm"
@@ -7737,6 +7858,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.aarch64.rpm",
         "checksum": "sha256:c56e979225e15d1ae3b49834ac4341b2e94dbf67d889a27de815b330ee864355",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
         "check_gpg": true
       },
       {
@@ -9930,6 +10061,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -9970,6 +10111,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.14",
@@ -9977,6 +10128,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.aarch64.rpm",
         "checksum": "sha256:cbdce6902501eef4192d765ee9b768a53cfee2fa2662e5abeefd597615ff2c04",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.aarch64.rpm",
+        "checksum": "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03",
         "check_gpg": true
       },
       {
@@ -9990,6 +10151,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -9997,6 +10168,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -10027,6 +10228,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-setuptools-wheel-53.0.0-10.el9.noarch.rpm",
         "checksum": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -10197,6 +10418,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/shim-aa64-15.6-1.el9.aarch64.rpm",
         "checksum": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_container-boot.json
@@ -1668,6 +1668,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a06414786e5b316a6bc411b4827d45d0364817071f924fed85c395df0ecd9450",
                     "options": {
                       "metadata": {
@@ -3420,6 +3428,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:26f20dd590b09a8f418dc6c51ba734ca3714902ccde9ca3e91201481ed2728ba",
                     "options": {
                       "metadata": {
@@ -3452,7 +3468,23 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:cbdce6902501eef4192d765ee9b768a53cfee2fa2662e5abeefd597615ff2c04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3468,7 +3500,39 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3493,6 +3557,22 @@
                   },
                   {
                     "id": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3629,6 +3709,14 @@
                   },
                   {
                     "id": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5408,6 +5496,9 @@
           "sha256:09ff81634b9741b286b42e2067270b4f95141a5ea03886f0610e25e9d0f941a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/mpfr-4.1.0-7.el9.aarch64.rpm"
           },
+          "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:0bc4d57ac943f016fb716392828a7cfa4bfcb899c3ff7a61501bf7dd36228646": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libmbim-utils-1.26.0-2.el9.aarch64.rpm"
           },
@@ -5440,6 +5531,9 @@
           },
           "sha256:16b57cc1b34d4c44d9638d4f87527d7883baad76433b2d2210a5663907cd8e11": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/file-libs-5.39-10.el9.aarch64.rpm"
+          },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
           },
           "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
@@ -5492,11 +5586,17 @@
           "sha256:1e1ad4c81b343be9175db222ea845afcc622f5a9c38a1f4c55ecad90c83a23ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/dosfstools-4.2-3.el9.aarch64.rpm"
           },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:1eccd2b9ccbaa8a1c680c0e0fd4e1733d1abf1fe0bdff635e309cdc232492c1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/glibc-minimal-langpack-2.34-40.el9.aarch64.rpm"
           },
           "sha256:1f1518511e3dc9c199cc9215eb99e16cfc5b7cf4a474fc1d24bd46a7b51b06e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/gdisk-1.0.7-5.el9.aarch64.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:1f46937ea8b9af3010c90f75c0a0cde76348defb6604d35c670c77cb62f3640e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/NetworkManager-libnm-1.40.0-1.el9.aarch64.rpm"
@@ -5684,6 +5784,9 @@
           "sha256:496085a23af0a0fadb510bf3bbac631583a2b0268eb2b3deeeb1b4a31c9dd631": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/kpartx-0.8.7-12.el9.aarch64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:4a684a393f14704bf0bf74adc5943863334e8371d70fec6fc7667201b3c2fe9f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.aarch64.rpm"
           },
@@ -5740,6 +5843,9 @@
           },
           "sha256:55be6352c68f5245a31c09709a5b604038d9d373d69c226c49a5a5f6923eff46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/traceroute-2.1.0-16.el9.aarch64.rpm"
+          },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm"
           },
           "sha256:5684001de29ef187b78849729334c61ac7f77b4a56e0cdae0df196731777ec7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libacl-2.3.1-3.el9.aarch64.rpm"
@@ -5885,6 +5991,9 @@
           "sha256:767396019f392da9ce7d24d4f8e3178070c2594e984e7dbc019d103cca1e27e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/rsync-3.2.3-18.el9.aarch64.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:77719a7a94185255f23ff1e5c1e1292d8350a4d33b2b35d87fc273c337d771d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/libtasn1-4.16.0-7.el9.aarch64.rpm"
           },
@@ -5983,6 +6092,9 @@
           },
           "sha256:85bbb36deb440290998a34782c92db155d399d00dee10c156810b5e50ca0baed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/greenboot-default-health-checks-0.14.0-3.el9.aarch64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:85dc4b0132dc60c0d2f1ff248bebf2c4f0146828db32617fa499f9280ab8af38": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/fdo-client-0.4.5-1.el9_0.aarch64.rpm"
@@ -6140,6 +6252,9 @@
           "sha256:b9e726b747cf8eaeaf1c7609196a02a9bb920720997dcc9ec1e6422620109fa5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/dbus-1.12.20-6.el9.aarch64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bb910836cb73b67aa169265375e372de221be156476575f3ee3ef9c81ca3a88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/libsecret-0.20.4-4.el9.aarch64.rpm"
           },
@@ -6205,6 +6320,9 @@
           },
           "sha256:c91fd1c5b88114d41d66611665c9ff27fbf53d97a3d41baf437af6d0f201e521": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/audit-libs-3.0.7-103.el9.aarch64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9930c540ae07e0375d4744f8ef541f2d3d8d2f6f715a85524c7ef5b8a93cff5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/file-5.39-10.el9.aarch64.rpm"
@@ -6301,6 +6419,9 @@
           },
           "sha256:dddae871bfa8a3d8d75415b7302940f8171b641ca2b894e527d84256f56b3df4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/glibc-2.34-40.el9.aarch64.rpm"
+          },
+          "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.aarch64.rpm"
           },
           "sha256:de499d867cc5e6069f2dcf6ffd48e56adad91b1358eeca80c86b8e9e9dc0b879": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/polkit-0.117-10.el9_0.aarch64.rpm"
@@ -9348,6 +9469,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -11538,6 +11669,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -11578,6 +11719,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.14",
@@ -11585,6 +11736,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.aarch64.rpm",
         "checksum": "sha256:cbdce6902501eef4192d765ee9b768a53cfee2fa2662e5abeefd597615ff2c04",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.aarch64.rpm",
+        "checksum": "sha256:de33c426b2cb38294fa8340da3d069b388c7000d433f1ab16b98e7e4c06fce03",
         "check_gpg": true
       },
       {
@@ -11598,6 +11759,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -11605,6 +11776,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -11635,6 +11836,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-setuptools-wheel-53.0.0-10.el9.noarch.rpm",
         "checksum": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -11805,6 +12026,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/shim-aa64-15.6-1.el9.aarch64.rpm",
         "checksum": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit-boot.json
@@ -1766,6 +1766,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -3622,6 +3630,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:adf8aafd3b5a7c590e2350c52e172e4b373158d76925c89db59ad201ec68bd27",
                     "options": {
                       "metadata": {
@@ -3654,7 +3670,23 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3670,7 +3702,39 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3695,6 +3759,22 @@
                   },
                   {
                     "id": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3831,6 +3911,14 @@
                   },
                   {
                     "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4889,6 +4977,9 @@
           "sha256:16538cb048aa28d39f92f83b3defbf9303c47a69eea40e08be6289c794d2ebad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/selinux-policy-targeted-34.1.43-1.el9.noarch.rpm"
           },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
           },
@@ -4915,6 +5006,12 @@
           },
           "sha256:1c1dc9948dd4203ff4804d94c9cd30b9cc0faab5e5641b2b04b795c408fb4b1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/tpm2-tools-5.2-1.el9.x86_64.rpm"
+          },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:20a5a375bd1a12950ba6ca5e4ca9f6af11020214da304317070803be37afd27c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libaio-0.3.111-13.el9.x86_64.rpm"
@@ -5102,6 +5199,9 @@
           "sha256:49163f6eb4683b4efaccbf47f07d5a038c36b5dae7bed665ca3b163a9b9c95ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/polkit-libs-0.117-10.el9_0.x86_64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:49e741d9b810140ec1af639caf2b1b9ca0c77a0360ae084366d02cb0414f6bde": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-3.9.14-1.el9.x86_64.rpm"
           },
@@ -5165,6 +5265,9 @@
           "sha256:55b01380f5c1df8f1212fcd061351c0b6b0562e2cba57b323aac10cb6d5b9f32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/less-590-1.el9_0.x86_64.rpm"
           },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm"
+          },
           "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
           },
@@ -5212,6 +5315,9 @@
           },
           "sha256:62ef24e5a54b563e486dfaee8b251bd5f67e875aa9bf4949ff8e02cf6a90889c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openssh-server-8.7p1-24.el9_1.x86_64.rpm"
+          },
+          "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm"
           },
           "sha256:6364708019c7122540bacf985f3ce4c961ef5da623a52bd76cffd7c4225ea7f8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/vim-minimal-8.2.2637-16.el9_0.3.x86_64.rpm"
@@ -5315,6 +5421,9 @@
           "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/kbd-misc-2.4.0-8.el9.noarch.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:77a03b852369645ab754a8ed17e6cd01c36734ae7959264050289d7998003cad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/rpm-4.16.1.3-17.el9.x86_64.rpm"
           },
@@ -5389,6 +5498,9 @@
           },
           "sha256:85912dbd3c57a6b5186b911498a7e7528865e24376ce7b1b6c05751929f97f7e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-gobject-base-3.40.1-6.el9.x86_64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:8714d3513d5e61fbcf6bd357d40fc5c1ba1f64f9d6ca2908439f4fd13e32836d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/pinentry-1.1.1-8.el9.x86_64.rpm"
@@ -5612,8 +5724,14 @@
           "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libjose-11-3.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm"
@@ -5668,6 +5786,9 @@
           },
           "sha256:c916ffb29385ca487c759e5aedfecacfda5a8e151e00e7ef9a7bc40a52fb58c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libslirp-4.4.0-7.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm"
@@ -8031,6 +8152,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -10351,6 +10482,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -10391,6 +10532,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.14",
@@ -10398,6 +10549,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm",
         "checksum": "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm",
+        "checksum": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
         "check_gpg": true
       },
       {
@@ -10411,6 +10572,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -10418,6 +10589,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -10448,6 +10649,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-setuptools-wheel-53.0.0-10.el9.noarch.rpm",
         "checksum": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -10618,6 +10839,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
         "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit_rt-boot.json
@@ -1773,6 +1773,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -3885,6 +3893,14 @@
                     }
                   },
                   {
+                    "id": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac",
                     "options": {
                       "metadata": {
@@ -3909,7 +3925,23 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4150,6 +4182,14 @@
                   },
                   {
                     "id": "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5719,6 +5759,9 @@
           "sha256:62ef24e5a54b563e486dfaee8b251bd5f67e875aa9bf4949ff8e02cf6a90889c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openssh-server-8.7p1-24.el9_1.x86_64.rpm"
           },
+          "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm"
+          },
           "sha256:6364708019c7122540bacf985f3ce4c961ef5da623a52bd76cffd7c4225ea7f8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/vim-minimal-8.2.2637-16.el9_0.3.x86_64.rpm"
           },
@@ -5916,6 +5959,9 @@
           },
           "sha256:85912dbd3c57a6b5186b911498a7e7528865e24376ce7b1b6c05751929f97f7e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-gobject-base-3.40.1-6.el9.x86_64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:8714d3513d5e61fbcf6bd357d40fc5c1ba1f64f9d6ca2908439f4fd13e32836d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/pinentry-1.1.1-8.el9.x86_64.rpm"
@@ -6175,8 +6221,14 @@
           "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libjose-11-3.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm"
@@ -6234,6 +6286,9 @@
           },
           "sha256:c916ffb29385ca487c759e5aedfecacfda5a8e151e00e7ef9a7bc40a52fb58c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libslirp-4.4.0-7.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm"
@@ -8618,6 +8673,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
         "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
         "check_gpg": true
       },
       {
@@ -11261,6 +11326,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm",
+        "checksum": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
+        "check_gpg": true
+      },
+      {
         "name": "python3-linux-procfs",
         "epoch": 0,
         "version": "0.7.0",
@@ -11291,6 +11366,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -11298,6 +11383,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
         "check_gpg": true
       },
       {
@@ -11598,6 +11693,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/snappy-1.1.8-8.el9.x86_64.rpm",
         "checksum": "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
@@ -1780,6 +1780,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -3636,6 +3644,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:adf8aafd3b5a7c590e2350c52e172e4b373158d76925c89db59ad201ec68bd27",
                     "options": {
                       "metadata": {
@@ -3668,7 +3684,23 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3684,7 +3716,39 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3709,6 +3773,22 @@
                   },
                   {
                     "id": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3845,6 +3925,14 @@
                   },
                   {
                     "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4938,6 +5026,9 @@
           "sha256:16538cb048aa28d39f92f83b3defbf9303c47a69eea40e08be6289c794d2ebad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/selinux-policy-targeted-34.1.43-1.el9.noarch.rpm"
           },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
           },
@@ -4964,6 +5055,12 @@
           },
           "sha256:1c1dc9948dd4203ff4804d94c9cd30b9cc0faab5e5641b2b04b795c408fb4b1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/tpm2-tools-5.2-1.el9.x86_64.rpm"
+          },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:20a5a375bd1a12950ba6ca5e4ca9f6af11020214da304317070803be37afd27c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libaio-0.3.111-13.el9.x86_64.rpm"
@@ -5151,6 +5248,9 @@
           "sha256:49163f6eb4683b4efaccbf47f07d5a038c36b5dae7bed665ca3b163a9b9c95ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/polkit-libs-0.117-10.el9_0.x86_64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:49e741d9b810140ec1af639caf2b1b9ca0c77a0360ae084366d02cb0414f6bde": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-3.9.14-1.el9.x86_64.rpm"
           },
@@ -5214,6 +5314,9 @@
           "sha256:55b01380f5c1df8f1212fcd061351c0b6b0562e2cba57b323aac10cb6d5b9f32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/less-590-1.el9_0.x86_64.rpm"
           },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm"
+          },
           "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
           },
@@ -5261,6 +5364,9 @@
           },
           "sha256:62ef24e5a54b563e486dfaee8b251bd5f67e875aa9bf4949ff8e02cf6a90889c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openssh-server-8.7p1-24.el9_1.x86_64.rpm"
+          },
+          "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm"
           },
           "sha256:6364708019c7122540bacf985f3ce4c961ef5da623a52bd76cffd7c4225ea7f8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/vim-minimal-8.2.2637-16.el9_0.3.x86_64.rpm"
@@ -5364,6 +5470,9 @@
           "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/kbd-misc-2.4.0-8.el9.noarch.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:77a03b852369645ab754a8ed17e6cd01c36734ae7959264050289d7998003cad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/rpm-4.16.1.3-17.el9.x86_64.rpm"
           },
@@ -5438,6 +5547,9 @@
           },
           "sha256:85912dbd3c57a6b5186b911498a7e7528865e24376ce7b1b6c05751929f97f7e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-gobject-base-3.40.1-6.el9.x86_64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:8714d3513d5e61fbcf6bd357d40fc5c1ba1f64f9d6ca2908439f4fd13e32836d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/pinentry-1.1.1-8.el9.x86_64.rpm"
@@ -5664,8 +5776,14 @@
           "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libjose-11-3.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm"
@@ -5720,6 +5838,9 @@
           },
           "sha256:c916ffb29385ca487c759e5aedfecacfda5a8e151e00e7ef9a7bc40a52fb58c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libslirp-4.4.0-7.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm"
@@ -8103,6 +8224,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -10423,6 +10554,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -10463,6 +10604,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.14",
@@ -10470,6 +10621,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm",
         "checksum": "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm",
+        "checksum": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
         "check_gpg": true
       },
       {
@@ -10483,6 +10644,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -10490,6 +10661,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -10520,6 +10721,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-setuptools-wheel-53.0.0-10.el9.noarch.rpm",
         "checksum": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -10690,6 +10911,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
         "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_container-boot.json
@@ -1756,6 +1756,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -3612,6 +3620,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:adf8aafd3b5a7c590e2350c52e172e4b373158d76925c89db59ad201ec68bd27",
                     "options": {
                       "metadata": {
@@ -3644,7 +3660,23 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3660,7 +3692,39 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3685,6 +3749,22 @@
                   },
                   {
                     "id": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3821,6 +3901,14 @@
                   },
                   {
                     "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5671,6 +5759,9 @@
           "sha256:16538cb048aa28d39f92f83b3defbf9303c47a69eea40e08be6289c794d2ebad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/selinux-policy-targeted-34.1.43-1.el9.noarch.rpm"
           },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
           },
@@ -5697,6 +5788,12 @@
           },
           "sha256:1c1dc9948dd4203ff4804d94c9cd30b9cc0faab5e5641b2b04b795c408fb4b1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/tpm2-tools-5.2-1.el9.x86_64.rpm"
+          },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:20a5a375bd1a12950ba6ca5e4ca9f6af11020214da304317070803be37afd27c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libaio-0.3.111-13.el9.x86_64.rpm"
@@ -5893,6 +5990,9 @@
           "sha256:49163f6eb4683b4efaccbf47f07d5a038c36b5dae7bed665ca3b163a9b9c95ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/polkit-libs-0.117-10.el9_0.x86_64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:49e741d9b810140ec1af639caf2b1b9ca0c77a0360ae084366d02cb0414f6bde": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-3.9.14-1.el9.x86_64.rpm"
           },
@@ -5956,6 +6056,9 @@
           "sha256:55b01380f5c1df8f1212fcd061351c0b6b0562e2cba57b323aac10cb6d5b9f32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/less-590-1.el9_0.x86_64.rpm"
           },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm"
+          },
           "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
           },
@@ -6003,6 +6106,9 @@
           },
           "sha256:62ef24e5a54b563e486dfaee8b251bd5f67e875aa9bf4949ff8e02cf6a90889c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openssh-server-8.7p1-24.el9_1.x86_64.rpm"
+          },
+          "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm"
           },
           "sha256:6364708019c7122540bacf985f3ce4c961ef5da623a52bd76cffd7c4225ea7f8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/vim-minimal-8.2.2637-16.el9_0.3.x86_64.rpm"
@@ -6106,6 +6212,9 @@
           "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/kbd-misc-2.4.0-8.el9.noarch.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:77a03b852369645ab754a8ed17e6cd01c36734ae7959264050289d7998003cad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/rpm-4.16.1.3-17.el9.x86_64.rpm"
           },
@@ -6180,6 +6289,9 @@
           },
           "sha256:85912dbd3c57a6b5186b911498a7e7528865e24376ce7b1b6c05751929f97f7e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-gobject-base-3.40.1-6.el9.x86_64.rpm"
+          },
+          "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm"
           },
           "sha256:8714d3513d5e61fbcf6bd357d40fc5c1ba1f64f9d6ca2908439f4fd13e32836d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/pinentry-1.1.1-8.el9.x86_64.rpm"
@@ -6403,8 +6515,14 @@
           "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libjose-11-3.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm"
@@ -6462,6 +6580,9 @@
           },
           "sha256:c916ffb29385ca487c759e5aedfecacfda5a8e151e00e7ef9a7bc40a52fb58c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libslirp-4.4.0-7.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm"
@@ -9700,6 +9821,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -12020,6 +12151,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -12060,6 +12201,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.14",
@@ -12067,6 +12218,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libs-3.9.14-1.el9.x86_64.rpm",
         "checksum": "sha256:be196d529957404a012f21419140e1cb000e3363649d55f91e66ffc58f970a7a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libxml2",
+        "epoch": 0,
+        "version": "2.9.13",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libxml2-2.9.13-2.el9.x86_64.rpm",
+        "checksum": "sha256:632805fcf1e9cd8f794c01a505a1eb8351d30f358a193dfb45aa6185ae257547",
         "check_gpg": true
       },
       {
@@ -12080,6 +12241,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -12087,6 +12258,36 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -12117,6 +12318,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-setuptools-wheel-53.0.0-10.el9.noarch.rpm",
         "checksum": "sha256:ce24b4e32532777baafc2493bd27f42ad599a065e945723d6983785f6470ae7e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -12287,6 +12508,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
         "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "5.el9_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sos-4.3-5.el9_1.noarch.rpm",
+        "checksum": "sha256:85cd9b2851f762735ab5148a8ce59ad6e5704e71f9fcc411c31d254cdcce218a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_commit-boot.json
@@ -1620,6 +1620,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a06414786e5b316a6bc411b4827d45d0364817071f924fed85c395df0ecd9450",
                     "options": {
                       "metadata": {
@@ -3364,6 +3372,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:26f20dd590b09a8f418dc6c51ba734ca3714902ccde9ca3e91201481ed2728ba",
                     "options": {
                       "metadata": {
@@ -3396,6 +3412,14 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:d105af42e9c3dd0318d589b6f82fa7016482bf635985780a217a5547a2521d93",
                     "options": {
                       "metadata": {
@@ -3412,7 +3436,47 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90863eabe86d0d90467e4f2e24cd3b1b7c4605ad815cb926ec859d059154c5e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3437,6 +3501,22 @@
                   },
                   {
                     "id": "sha256:2af5b02a214f10e894f33dfa7554db0edd458328ae4dda31fc078a503fe0f376",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3573,6 +3653,14 @@
                   },
                   {
                     "id": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4284,6 +4372,14 @@
                     }
                   },
                   {
+                    "id": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:1bbcf1d4babed32f60dc70ffc7b00e6f673a50a7cf11e0e71712cf98391f3c82",
                     "options": {
                       "metadata": {
@@ -4565,6 +4661,9 @@
           "sha256:09ff81634b9741b286b42e2067270b4f95141a5ea03886f0610e25e9d0f941a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/mpfr-4.1.0-7.el9.aarch64.rpm"
           },
+          "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:0f809593a75d8a797e1aece00038435b856277f42a8db495b0b4037857db4ef4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/lvm2-2.03.17-3.el9.aarch64.rpm"
           },
@@ -4588,6 +4687,9 @@
           },
           "sha256:16c5217cbdf7b28612b7559e8b7d952ef291878c60290d13abfee6251536fec6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/krb5-libs-1.19.1-24.el9_1.aarch64.rpm"
+          },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
           },
           "sha256:180a6a50d74a38446cb62d1eb76aa7fedb869d4cfa3c53d3e962da0fbe866b2c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/libcap-ng-python3-0.8.2-7.el9.aarch64.rpm"
@@ -4628,8 +4730,14 @@
           "sha256:1e1b0e3bb3f5394bffde0aa49ce56a6c558f7eed92fe3261c656a04f97afd654": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/podman-catatonit-4.3.1-3.el9.aarch64.rpm"
           },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:1f1518511e3dc9c199cc9215eb99e16cfc5b7cf4a474fc1d24bd46a7b51b06e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/gdisk-1.0.7-5.el9.aarch64.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:1f5919c99e0ac581767e37f5e395e1e054399bbee5af0362159536ef0669b9d5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libbpf-0.8.0-1.el9.aarch64.rpm"
@@ -4714,6 +4822,9 @@
           },
           "sha256:342af53fbf4254e34b5f19a6be6f22c67551c26dd0c49016edc93e806621b75d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/dbus-broker-28-7.el9.aarch64.rpm"
+          },
+          "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm"
           },
           "sha256:367feabc4a99da45c00043f50a9fc1ce7f6bf1af683418786c6bc8f9558869e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/e2fsprogs-1.46.5-3.el9.aarch64.rpm"
@@ -4805,6 +4916,9 @@
           "sha256:48f40ca9883c6833ffc184367ebd189bba69bdcf4f0ffd576ce730388cf41197": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/grubby-8.40-61.el9.aarch64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:4a0086421c49fc76e18afbc5a6c1829bd371abf2461615febfefd8eb6e0f8aae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libuser-0.63-12.el9.aarch64.rpm"
           },
@@ -4864,6 +4978,9 @@
           },
           "sha256:55be6352c68f5245a31c09709a5b604038d9d373d69c226c49a5a5f6923eff46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/traceroute-2.1.0-16.el9.aarch64.rpm"
+          },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm"
           },
           "sha256:5684001de29ef187b78849729334c61ac7f77b4a56e0cdae0df196731777ec7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libacl-2.3.1-3.el9.aarch64.rpm"
@@ -5003,6 +5120,9 @@
           "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/kbd-misc-2.4.0-8.el9.noarch.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:76d779c0bf9a635c10eca6c0f48cc19904401015d06bf216cedbd0af7b01c123": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/lua-libs-5.4.2-4.el9_0.3.aarch64.rpm"
           },
@@ -5122,6 +5242,9 @@
           },
           "sha256:9021b3a1b936270df00f6e22999797620eb7ac056388f2efceaa11852b7ff975": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/dbus-common-1.12.20-7.el9_1.noarch.rpm"
+          },
+          "sha256:90863eabe86d0d90467e4f2e24cd3b1b7c4605ad815cb926ec859d059154c5e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.aarch64.rpm"
           },
           "sha256:91270c2edee5fe2cd30eab7547cad388210847f753a1dddafe69a34e34d1862e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/shadow-utils-4.9-6.el9.aarch64.rpm"
@@ -5285,6 +5408,9 @@
           "sha256:bb0a8a551c096d8ad994666ad25745e7aa261b1874384bdd95752a4c0932e8bf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libatomic-11.3.1-4.3.el9.aarch64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bb910836cb73b67aa169265375e372de221be156476575f3ee3ef9c81ca3a88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/libsecret-0.20.4-4.el9.aarch64.rpm"
           },
@@ -5362,6 +5488,9 @@
           },
           "sha256:c932dae4ab1aa044e1ecb377f5ea5a1fd41c16046a70ad6c8939ec468e28e5a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/libblockdev-2.28-3.el9.aarch64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9930c540ae07e0375d4744f8ef541f2d3d8d2f6f715a85524c7ef5b8a93cff5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/file-5.39-10.el9.aarch64.rpm"
@@ -5536,6 +5665,9 @@
           },
           "sha256:ef6eb3e28612b850c9ae97b260d6a38a7fa77e8b9170516079baaa0f1154c09a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/ca-certificates-2022.2.54-90.2.el9_0.noarch.rpm"
+          },
+          "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm"
           },
           "sha256:f05030123425a5033bcca3f260313cafc199bc7bca57e9fb13c335bd087c35a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libxcrypt-4.4.18-3.el9.aarch64.rpm"
@@ -7570,6 +7702,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/bubblewrap-0.4.1-6.el9.aarch64.rpm",
         "checksum": "sha256:c56e979225e15d1ae3b49834ac4341b2e94dbf67d889a27de815b330ee864355",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
         "check_gpg": true
       },
       {
@@ -9753,6 +9895,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -9793,6 +9945,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.16",
@@ -9813,6 +9975,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -9820,6 +9992,46 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "6.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.aarch64.rpm",
+        "checksum": "sha256:90863eabe86d0d90467e4f2e24cd3b1b7c4605ad815cb926ec859d059154c5e0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -9850,6 +10062,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-setuptools-wheel-53.0.0-11.el9.noarch.rpm",
         "checksum": "sha256:2af5b02a214f10e894f33dfa7554db0edd458328ae4dda31fc078a503fe0f376",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -10020,6 +10252,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/shim-aa64-15.6-1.el9.aarch64.rpm",
         "checksum": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm",
+        "checksum": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
         "check_gpg": true
       },
       {
@@ -10900,6 +11142,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/python3-audit-3.0.7-103.el9.aarch64.rpm",
         "checksum": "sha256:ce53394ea50d0a12afd13d8c2afec2f4f6992dd8af2406956d9c8579ed06a1aa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-file-magic",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm",
+        "checksum": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
@@ -1634,6 +1634,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a06414786e5b316a6bc411b4827d45d0364817071f924fed85c395df0ecd9450",
                     "options": {
                       "metadata": {
@@ -3378,6 +3386,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:26f20dd590b09a8f418dc6c51ba734ca3714902ccde9ca3e91201481ed2728ba",
                     "options": {
                       "metadata": {
@@ -3410,6 +3426,14 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:d105af42e9c3dd0318d589b6f82fa7016482bf635985780a217a5547a2521d93",
                     "options": {
                       "metadata": {
@@ -3426,7 +3450,47 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90863eabe86d0d90467e4f2e24cd3b1b7c4605ad815cb926ec859d059154c5e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3451,6 +3515,22 @@
                   },
                   {
                     "id": "sha256:2af5b02a214f10e894f33dfa7554db0edd458328ae4dda31fc078a503fe0f376",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3587,6 +3667,14 @@
                   },
                   {
                     "id": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4298,6 +4386,14 @@
                     }
                   },
                   {
+                    "id": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:1bbcf1d4babed32f60dc70ffc7b00e6f673a50a7cf11e0e71712cf98391f3c82",
                     "options": {
                       "metadata": {
@@ -4614,6 +4710,9 @@
           "sha256:09ff81634b9741b286b42e2067270b4f95141a5ea03886f0610e25e9d0f941a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/mpfr-4.1.0-7.el9.aarch64.rpm"
           },
+          "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:0f809593a75d8a797e1aece00038435b856277f42a8db495b0b4037857db4ef4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/lvm2-2.03.17-3.el9.aarch64.rpm"
           },
@@ -4637,6 +4736,9 @@
           },
           "sha256:16c5217cbdf7b28612b7559e8b7d952ef291878c60290d13abfee6251536fec6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/krb5-libs-1.19.1-24.el9_1.aarch64.rpm"
+          },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
           },
           "sha256:180a6a50d74a38446cb62d1eb76aa7fedb869d4cfa3c53d3e962da0fbe866b2c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/libcap-ng-python3-0.8.2-7.el9.aarch64.rpm"
@@ -4677,8 +4779,14 @@
           "sha256:1e1b0e3bb3f5394bffde0aa49ce56a6c558f7eed92fe3261c656a04f97afd654": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/podman-catatonit-4.3.1-3.el9.aarch64.rpm"
           },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:1f1518511e3dc9c199cc9215eb99e16cfc5b7cf4a474fc1d24bd46a7b51b06e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/gdisk-1.0.7-5.el9.aarch64.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:1f5919c99e0ac581767e37f5e395e1e054399bbee5af0362159536ef0669b9d5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libbpf-0.8.0-1.el9.aarch64.rpm"
@@ -4763,6 +4871,9 @@
           },
           "sha256:342af53fbf4254e34b5f19a6be6f22c67551c26dd0c49016edc93e806621b75d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/dbus-broker-28-7.el9.aarch64.rpm"
+          },
+          "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm"
           },
           "sha256:367feabc4a99da45c00043f50a9fc1ce7f6bf1af683418786c6bc8f9558869e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/e2fsprogs-1.46.5-3.el9.aarch64.rpm"
@@ -4854,6 +4965,9 @@
           "sha256:48f40ca9883c6833ffc184367ebd189bba69bdcf4f0ffd576ce730388cf41197": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/grubby-8.40-61.el9.aarch64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:4a0086421c49fc76e18afbc5a6c1829bd371abf2461615febfefd8eb6e0f8aae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libuser-0.63-12.el9.aarch64.rpm"
           },
@@ -4913,6 +5027,9 @@
           },
           "sha256:55be6352c68f5245a31c09709a5b604038d9d373d69c226c49a5a5f6923eff46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/traceroute-2.1.0-16.el9.aarch64.rpm"
+          },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm"
           },
           "sha256:5684001de29ef187b78849729334c61ac7f77b4a56e0cdae0df196731777ec7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libacl-2.3.1-3.el9.aarch64.rpm"
@@ -5052,6 +5169,9 @@
           "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/kbd-misc-2.4.0-8.el9.noarch.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:76d779c0bf9a635c10eca6c0f48cc19904401015d06bf216cedbd0af7b01c123": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/lua-libs-5.4.2-4.el9_0.3.aarch64.rpm"
           },
@@ -5171,6 +5291,9 @@
           },
           "sha256:9021b3a1b936270df00f6e22999797620eb7ac056388f2efceaa11852b7ff975": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/dbus-common-1.12.20-7.el9_1.noarch.rpm"
+          },
+          "sha256:90863eabe86d0d90467e4f2e24cd3b1b7c4605ad815cb926ec859d059154c5e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.aarch64.rpm"
           },
           "sha256:91270c2edee5fe2cd30eab7547cad388210847f753a1dddafe69a34e34d1862e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/shadow-utils-4.9-6.el9.aarch64.rpm"
@@ -5337,6 +5460,9 @@
           "sha256:bb0a8a551c096d8ad994666ad25745e7aa261b1874384bdd95752a4c0932e8bf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libatomic-11.3.1-4.3.el9.aarch64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bb910836cb73b67aa169265375e372de221be156476575f3ee3ef9c81ca3a88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/libsecret-0.20.4-4.el9.aarch64.rpm"
           },
@@ -5414,6 +5540,9 @@
           },
           "sha256:c932dae4ab1aa044e1ecb377f5ea5a1fd41c16046a70ad6c8939ec468e28e5a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/libblockdev-2.28-3.el9.aarch64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9930c540ae07e0375d4744f8ef541f2d3d8d2f6f715a85524c7ef5b8a93cff5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/file-5.39-10.el9.aarch64.rpm"
@@ -5588,6 +5717,9 @@
           },
           "sha256:ef6eb3e28612b850c9ae97b260d6a38a7fa77e8b9170516079baaa0f1154c09a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/ca-certificates-2022.2.54-90.2.el9_0.noarch.rpm"
+          },
+          "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm"
           },
           "sha256:f05030123425a5033bcca3f260313cafc199bc7bca57e9fb13c335bd087c35a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libxcrypt-4.4.18-3.el9.aarch64.rpm"
@@ -7642,6 +7774,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/bubblewrap-0.4.1-6.el9.aarch64.rpm",
         "checksum": "sha256:c56e979225e15d1ae3b49834ac4341b2e94dbf67d889a27de815b330ee864355",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
         "check_gpg": true
       },
       {
@@ -9825,6 +9967,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -9865,6 +10017,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.16",
@@ -9885,6 +10047,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -9892,6 +10064,46 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "6.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.aarch64.rpm",
+        "checksum": "sha256:90863eabe86d0d90467e4f2e24cd3b1b7c4605ad815cb926ec859d059154c5e0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -9922,6 +10134,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-setuptools-wheel-53.0.0-11.el9.noarch.rpm",
         "checksum": "sha256:2af5b02a214f10e894f33dfa7554db0edd458328ae4dda31fc078a503fe0f376",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -10092,6 +10324,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/shim-aa64-15.6-1.el9.aarch64.rpm",
         "checksum": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm",
+        "checksum": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
         "check_gpg": true
       },
       {
@@ -10972,6 +11214,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/python3-audit-3.0.7-103.el9.aarch64.rpm",
         "checksum": "sha256:ce53394ea50d0a12afd13d8c2afec2f4f6992dd8af2406956d9c8579ed06a1aa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-file-magic",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm",
+        "checksum": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_container-boot.json
@@ -1620,6 +1620,14 @@
                     }
                   },
                   {
+                    "id": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a06414786e5b316a6bc411b4827d45d0364817071f924fed85c395df0ecd9450",
                     "options": {
                       "metadata": {
@@ -3364,6 +3372,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:26f20dd590b09a8f418dc6c51ba734ca3714902ccde9ca3e91201481ed2728ba",
                     "options": {
                       "metadata": {
@@ -3396,6 +3412,14 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:d105af42e9c3dd0318d589b6f82fa7016482bf635985780a217a5547a2521d93",
                     "options": {
                       "metadata": {
@@ -3412,7 +3436,47 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90863eabe86d0d90467e4f2e24cd3b1b7c4605ad815cb926ec859d059154c5e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3437,6 +3501,22 @@
                   },
                   {
                     "id": "sha256:2af5b02a214f10e894f33dfa7554db0edd458328ae4dda31fc078a503fe0f376",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3573,6 +3653,14 @@
                   },
                   {
                     "id": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4277,6 +4365,14 @@
                   },
                   {
                     "id": "sha256:ce53394ea50d0a12afd13d8c2afec2f4f6992dd8af2406956d9c8579ed06a1aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5318,6 +5414,9 @@
           "sha256:09ff81634b9741b286b42e2067270b4f95141a5ea03886f0610e25e9d0f941a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/mpfr-4.1.0-7.el9.aarch64.rpm"
           },
+          "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.aarch64.rpm"
+          },
           "sha256:0f809593a75d8a797e1aece00038435b856277f42a8db495b0b4037857db4ef4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/lvm2-2.03.17-3.el9.aarch64.rpm"
           },
@@ -5341,6 +5440,9 @@
           },
           "sha256:16c5217cbdf7b28612b7559e8b7d952ef291878c60290d13abfee6251536fec6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/krb5-libs-1.19.1-24.el9_1.aarch64.rpm"
+          },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
           },
           "sha256:180a6a50d74a38446cb62d1eb76aa7fedb869d4cfa3c53d3e962da0fbe866b2c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/libcap-ng-python3-0.8.2-7.el9.aarch64.rpm"
@@ -5384,8 +5486,14 @@
           "sha256:1e1b0e3bb3f5394bffde0aa49ce56a6c558f7eed92fe3261c656a04f97afd654": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/podman-catatonit-4.3.1-3.el9.aarch64.rpm"
           },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
           "sha256:1f1518511e3dc9c199cc9215eb99e16cfc5b7cf4a474fc1d24bd46a7b51b06e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/gdisk-1.0.7-5.el9.aarch64.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:1f5919c99e0ac581767e37f5e395e1e054399bbee5af0362159536ef0669b9d5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libbpf-0.8.0-1.el9.aarch64.rpm"
@@ -5473,6 +5581,9 @@
           },
           "sha256:342af53fbf4254e34b5f19a6be6f22c67551c26dd0c49016edc93e806621b75d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/dbus-broker-28-7.el9.aarch64.rpm"
+          },
+          "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm"
           },
           "sha256:367feabc4a99da45c00043f50a9fc1ce7f6bf1af683418786c6bc8f9558869e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/e2fsprogs-1.46.5-3.el9.aarch64.rpm"
@@ -5564,6 +5675,9 @@
           "sha256:48f40ca9883c6833ffc184367ebd189bba69bdcf4f0ffd576ce730388cf41197": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/grubby-8.40-61.el9.aarch64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:4a0086421c49fc76e18afbc5a6c1829bd371abf2461615febfefd8eb6e0f8aae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libuser-0.63-12.el9.aarch64.rpm"
           },
@@ -5623,6 +5737,9 @@
           },
           "sha256:55be6352c68f5245a31c09709a5b604038d9d373d69c226c49a5a5f6923eff46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/traceroute-2.1.0-16.el9.aarch64.rpm"
+          },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm"
           },
           "sha256:5684001de29ef187b78849729334c61ac7f77b4a56e0cdae0df196731777ec7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libacl-2.3.1-3.el9.aarch64.rpm"
@@ -5762,6 +5879,9 @@
           "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/kbd-misc-2.4.0-8.el9.noarch.rpm"
           },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
+          },
           "sha256:76d779c0bf9a635c10eca6c0f48cc19904401015d06bf216cedbd0af7b01c123": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/lua-libs-5.4.2-4.el9_0.3.aarch64.rpm"
           },
@@ -5881,6 +6001,9 @@
           },
           "sha256:9021b3a1b936270df00f6e22999797620eb7ac056388f2efceaa11852b7ff975": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/dbus-common-1.12.20-7.el9_1.noarch.rpm"
+          },
+          "sha256:90863eabe86d0d90467e4f2e24cd3b1b7c4605ad815cb926ec859d059154c5e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.aarch64.rpm"
           },
           "sha256:91270c2edee5fe2cd30eab7547cad388210847f753a1dddafe69a34e34d1862e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/shadow-utils-4.9-6.el9.aarch64.rpm"
@@ -6047,6 +6170,9 @@
           "sha256:bb0a8a551c096d8ad994666ad25745e7aa261b1874384bdd95752a4c0932e8bf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libatomic-11.3.1-4.3.el9.aarch64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bb910836cb73b67aa169265375e372de221be156476575f3ee3ef9c81ca3a88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/libsecret-0.20.4-4.el9.aarch64.rpm"
           },
@@ -6127,6 +6253,9 @@
           },
           "sha256:c932dae4ab1aa044e1ecb377f5ea5a1fd41c16046a70ad6c8939ec468e28e5a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/libblockdev-2.28-3.el9.aarch64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c9930c540ae07e0375d4744f8ef541f2d3d8d2f6f715a85524c7ef5b8a93cff5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/file-5.39-10.el9.aarch64.rpm"
@@ -6304,6 +6433,9 @@
           },
           "sha256:ef6eb3e28612b850c9ae97b260d6a38a7fa77e8b9170516079baaa0f1154c09a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/ca-certificates-2022.2.54-90.2.el9_0.noarch.rpm"
+          },
+          "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm"
           },
           "sha256:f05030123425a5033bcca3f260313cafc199bc7bca57e9fb13c335bd087c35a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/libxcrypt-4.4.18-3.el9.aarch64.rpm"
@@ -9163,6 +9295,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.aarch64.rpm",
+        "checksum": "sha256:0abb88448b0db4121cc37445fa8a02be577ec94d630798f5bab6b195e6dcad95",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -11343,6 +11485,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -11383,6 +11535,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.16",
@@ -11403,6 +11565,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -11410,6 +11582,46 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "6.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.aarch64.rpm",
+        "checksum": "sha256:90863eabe86d0d90467e4f2e24cd3b1b7c4605ad815cb926ec859d059154c5e0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -11440,6 +11652,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-setuptools-wheel-53.0.0-11.el9.noarch.rpm",
         "checksum": "sha256:2af5b02a214f10e894f33dfa7554db0edd458328ae4dda31fc078a503fe0f376",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -11610,6 +11842,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/shim-aa64-15.6-1.el9.aarch64.rpm",
         "checksum": "sha256:70d4a2e5581a417a5becc9f5dc5cf822e6a0d69a4100c9e6fb6c834fa6bd7e53",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm",
+        "checksum": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
         "check_gpg": true
       },
       {
@@ -12490,6 +12732,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/python3-audit-3.0.7-103.el9.aarch64.rpm",
         "checksum": "sha256:ce53394ea50d0a12afd13d8c2afec2f4f6992dd8af2406956d9c8579ed06a1aa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-file-magic",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm",
+        "checksum": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit-boot.json
@@ -1718,6 +1718,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -3566,6 +3574,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:adf8aafd3b5a7c590e2350c52e172e4b373158d76925c89db59ad201ec68bd27",
                     "options": {
                       "metadata": {
@@ -3598,6 +3614,14 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:669c5b4c69c401de1b801f8b0c55ec01eeec7e8d565be0c526643ee7ef463e07",
                     "options": {
                       "metadata": {
@@ -3614,7 +3638,47 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3639,6 +3703,22 @@
                   },
                   {
                     "id": "sha256:2af5b02a214f10e894f33dfa7554db0edd458328ae4dda31fc078a503fe0f376",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3775,6 +3855,14 @@
                   },
                   {
                     "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4502,6 +4590,14 @@
                     }
                   },
                   {
+                    "id": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3d13ea02ea785ebca614d09aeaa970b11f21b2822eba3e1d53517f896a596009",
                     "options": {
                       "metadata": {
@@ -4854,6 +4950,9 @@
           "sha256:1649240d2a69e13d3b5ddc5c5e63c5d64a77930578a6bc4c3aca32f00423cd87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/popt-1.18-8.el9.x86_64.rpm"
           },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:17aab3ef99a2590ca905c28421572ae2ea378a634a157b312ec9a9e83e405a54": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/udisks2-2.9.4-7.el9.x86_64.rpm"
           },
@@ -4868,6 +4967,12 @@
           },
           "sha256:1aa1d059f7696ae397f8746d8d4fe5ead73bac461f53cce01b92db73fbd2fa81": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/findutils-4.8.0-5.el9.x86_64.rpm"
+          },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:20670ac5d570fb9adf0d11000eb3e9b95f05ba580752cae912f3fa8347f18279": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libtasn1-4.16.0-8.el9_1.x86_64.rpm"
@@ -4953,6 +5058,9 @@
           "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/microcode_ctl-20220809-1.el9.noarch.rpm"
           },
+          "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm"
+          },
           "sha256:368bcb3a0f163bb50f9f4064389c0125c7444ef65f6f416daab0587ede8d92a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/glibc-minimal-langpack-2.34-54.el9.x86_64.rpm"
           },
@@ -5037,6 +5145,9 @@
           "sha256:49163f6eb4683b4efaccbf47f07d5a038c36b5dae7bed665ca3b163a9b9c95ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/polkit-libs-0.117-10.el9_0.x86_64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:49f7baeb53e07a4b9b5739e36932f17f014abb765b3fa6c0c0f8af6a8ebf4d9b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/attr-2.5.1-3.el9.x86_64.rpm"
           },
@@ -5085,11 +5196,17 @@
           "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efivar-libs-38-2.el9.x86_64.rpm"
           },
+          "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm"
+          },
           "sha256:55b01380f5c1df8f1212fcd061351c0b6b0562e2cba57b323aac10cb6d5b9f32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/less-590-1.el9_0.x86_64.rpm"
           },
           "sha256:55bc0e4502324e35377386e64c9b80b3ccbc1f546e627cc2ee0ae4d820c39bc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/dbus-1.12.20-7.el9_1.x86_64.rpm"
+          },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm"
           },
           "sha256:5689da007cb289f6f1e812b31a56abdb7ad3d932f2b09adf94897c8c0d50640d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/krb5-libs-1.19.1-24.el9_1.x86_64.rpm"
@@ -5255,6 +5372,9 @@
           },
           "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/kbd-misc-2.4.0-8.el9.noarch.rpm"
+          },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
           },
           "sha256:7800f0c2c1f7c82155779d172fece3c0db31c7ec7de1695ddc0b905868c9d429": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/skopeo-1.10.0-1.el9.x86_64.rpm"
@@ -5559,11 +5679,17 @@
           "sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/pkgconf-1.7.3-10.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libjose-11-3.el9.x86_64.rpm"
           },
           "sha256:bc460ff9b1b2a921c65cb931ce81c526dd8587bf3e8480a9b1910096ab0d5311": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/glib2-2.68.4-6.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:bd312362d5a1d9c60589509be149682b071f732caed0dd46d20911c20c1c0baf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/iwl1000-firmware-39.31.5.1-129.el9.noarch.rpm"
@@ -5618,6 +5744,9 @@
           },
           "sha256:c916ffb29385ca487c759e5aedfecacfda5a8e151e00e7ef9a7bc40a52fb58c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libslirp-4.4.0-7.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c960dc0746753f01f8037a3ba79462721a1ecdf612123b4acacf67f6b01124b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/ModemManager-1.20.2-1.el9.x86_64.rpm"
@@ -5795,6 +5924,9 @@
           },
           "sha256:ef6eb3e28612b850c9ae97b260d6a38a7fa77e8b9170516079baaa0f1154c09a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/ca-certificates-2022.2.54-90.2.el9_0.noarch.rpm"
+          },
+          "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm"
           },
           "sha256:f148b83396b3a3cc002058225447b4f6fd799eee2627c95e1b24138cf3a0b224": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libselinux-utils-3.4-3.el9.x86_64.rpm"
@@ -7933,6 +8065,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
         "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
         "check_gpg": true
       },
       {
@@ -10246,6 +10388,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -10286,6 +10438,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.16",
@@ -10306,6 +10468,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -10313,6 +10485,46 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "6.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm",
+        "checksum": "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -10343,6 +10555,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-setuptools-wheel-53.0.0-11.el9.noarch.rpm",
         "checksum": "sha256:2af5b02a214f10e894f33dfa7554db0edd458328ae4dda31fc078a503fe0f376",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -10513,6 +10745,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
         "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm",
+        "checksum": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
         "check_gpg": true
       },
       {
@@ -11413,6 +11655,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-audit-3.0.7-103.el9.x86_64.rpm",
         "checksum": "sha256:a99b796ebf0f883aa95dff39ed0c87e9ed9987e2808ac9188e52cbf8a9149b6c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-file-magic",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm",
+        "checksum": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit_rt-boot.json
@@ -1725,6 +1725,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -3861,7 +3869,23 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3878,6 +3902,14 @@
                   },
                   {
                     "id": "sha256:3c3ada58a1436a70257fba2b11a51595382c21fa992ca7ba679821a92694914f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4110,6 +4142,14 @@
                   },
                   {
                     "id": "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4893,6 +4933,14 @@
                     }
                   },
                   {
+                    "id": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3d13ea02ea785ebca614d09aeaa970b11f21b2822eba3e1d53517f896a596009",
                     "options": {
                       "metadata": {
@@ -5437,6 +5485,9 @@
           "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/microcode_ctl-20220809-1.el9.noarch.rpm"
           },
+          "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm"
+          },
           "sha256:368bcb3a0f163bb50f9f4064389c0125c7444ef65f6f416daab0587ede8d92a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/glibc-minimal-langpack-2.34-54.el9.x86_64.rpm"
           },
@@ -5598,6 +5649,9 @@
           },
           "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efivar-libs-38-2.el9.x86_64.rpm"
+          },
+          "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm"
           },
           "sha256:55b01380f5c1df8f1212fcd061351c0b6b0562e2cba57b323aac10cb6d5b9f32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/less-590-1.el9_0.x86_64.rpm"
@@ -6139,11 +6193,17 @@
           "sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/pkgconf-1.7.3-10.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libjose-11-3.el9.x86_64.rpm"
           },
           "sha256:bc460ff9b1b2a921c65cb931ce81c526dd8587bf3e8480a9b1910096ab0d5311": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/glib2-2.68.4-6.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:bd312362d5a1d9c60589509be149682b071f732caed0dd46d20911c20c1c0baf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/iwl1000-firmware-39.31.5.1-129.el9.noarch.rpm"
@@ -6204,6 +6264,9 @@
           },
           "sha256:c916ffb29385ca487c759e5aedfecacfda5a8e151e00e7ef9a7bc40a52fb58c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libslirp-4.4.0-7.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c960dc0746753f01f8037a3ba79462721a1ecdf612123b4acacf67f6b01124b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/ModemManager-1.20.2-1.el9.x86_64.rpm"
@@ -6396,6 +6459,9 @@
           },
           "sha256:ef6eb3e28612b850c9ae97b260d6a38a7fa77e8b9170516079baaa0f1154c09a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/ca-certificates-2022.2.54-90.2.el9_0.noarch.rpm"
+          },
+          "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm"
           },
           "sha256:f148b83396b3a3cc002058225447b4f6fd799eee2627c95e1b24138cf3a0b224": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libselinux-utils-3.4-3.el9.x86_64.rpm"
@@ -8534,6 +8600,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
         "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
         "check_gpg": true
       },
       {
@@ -11207,6 +11283,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -11214,6 +11300,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
         "check_gpg": true
       },
       {
@@ -11234,6 +11330,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pyudev-0.22.0-6.el9.noarch.rpm",
         "checksum": "sha256:3c3ada58a1436a70257fba2b11a51595382c21fa992ca7ba679821a92694914f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "6.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm",
+        "checksum": "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e",
         "check_gpg": true
       },
       {
@@ -11524,6 +11630,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/snappy-1.1.8-8.el9.x86_64.rpm",
         "checksum": "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm",
+        "checksum": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
         "check_gpg": true
       },
       {
@@ -12494,6 +12610,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-audit-3.0.7-103.el9.x86_64.rpm",
         "checksum": "sha256:a99b796ebf0f883aa95dff39ed0c87e9ed9987e2808ac9188e52cbf8a9149b6c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-file-magic",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm",
+        "checksum": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
@@ -1732,6 +1732,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -3580,6 +3588,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:adf8aafd3b5a7c590e2350c52e172e4b373158d76925c89db59ad201ec68bd27",
                     "options": {
                       "metadata": {
@@ -3612,6 +3628,14 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:669c5b4c69c401de1b801f8b0c55ec01eeec7e8d565be0c526643ee7ef463e07",
                     "options": {
                       "metadata": {
@@ -3628,7 +3652,47 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3653,6 +3717,22 @@
                   },
                   {
                     "id": "sha256:2af5b02a214f10e894f33dfa7554db0edd458328ae4dda31fc078a503fe0f376",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3789,6 +3869,14 @@
                   },
                   {
                     "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4516,6 +4604,14 @@
                     }
                   },
                   {
+                    "id": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3d13ea02ea785ebca614d09aeaa970b11f21b2822eba3e1d53517f896a596009",
                     "options": {
                       "metadata": {
@@ -4903,6 +4999,9 @@
           "sha256:1649240d2a69e13d3b5ddc5c5e63c5d64a77930578a6bc4c3aca32f00423cd87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/popt-1.18-8.el9.x86_64.rpm"
           },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:17aab3ef99a2590ca905c28421572ae2ea378a634a157b312ec9a9e83e405a54": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/udisks2-2.9.4-7.el9.x86_64.rpm"
           },
@@ -4917,6 +5016,12 @@
           },
           "sha256:1aa1d059f7696ae397f8746d8d4fe5ead73bac461f53cce01b92db73fbd2fa81": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/findutils-4.8.0-5.el9.x86_64.rpm"
+          },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:20670ac5d570fb9adf0d11000eb3e9b95f05ba580752cae912f3fa8347f18279": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libtasn1-4.16.0-8.el9_1.x86_64.rpm"
@@ -5002,6 +5107,9 @@
           "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/microcode_ctl-20220809-1.el9.noarch.rpm"
           },
+          "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm"
+          },
           "sha256:368bcb3a0f163bb50f9f4064389c0125c7444ef65f6f416daab0587ede8d92a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/glibc-minimal-langpack-2.34-54.el9.x86_64.rpm"
           },
@@ -5086,6 +5194,9 @@
           "sha256:49163f6eb4683b4efaccbf47f07d5a038c36b5dae7bed665ca3b163a9b9c95ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/polkit-libs-0.117-10.el9_0.x86_64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:49f7baeb53e07a4b9b5739e36932f17f014abb765b3fa6c0c0f8af6a8ebf4d9b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/attr-2.5.1-3.el9.x86_64.rpm"
           },
@@ -5134,11 +5245,17 @@
           "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efivar-libs-38-2.el9.x86_64.rpm"
           },
+          "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm"
+          },
           "sha256:55b01380f5c1df8f1212fcd061351c0b6b0562e2cba57b323aac10cb6d5b9f32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/less-590-1.el9_0.x86_64.rpm"
           },
           "sha256:55bc0e4502324e35377386e64c9b80b3ccbc1f546e627cc2ee0ae4d820c39bc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/dbus-1.12.20-7.el9_1.x86_64.rpm"
+          },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm"
           },
           "sha256:5689da007cb289f6f1e812b31a56abdb7ad3d932f2b09adf94897c8c0d50640d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/krb5-libs-1.19.1-24.el9_1.x86_64.rpm"
@@ -5304,6 +5421,9 @@
           },
           "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/kbd-misc-2.4.0-8.el9.noarch.rpm"
+          },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
           },
           "sha256:7800f0c2c1f7c82155779d172fece3c0db31c7ec7de1695ddc0b905868c9d429": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/skopeo-1.10.0-1.el9.x86_64.rpm"
@@ -5611,11 +5731,17 @@
           "sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/pkgconf-1.7.3-10.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libjose-11-3.el9.x86_64.rpm"
           },
           "sha256:bc460ff9b1b2a921c65cb931ce81c526dd8587bf3e8480a9b1910096ab0d5311": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/glib2-2.68.4-6.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:bd312362d5a1d9c60589509be149682b071f732caed0dd46d20911c20c1c0baf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/iwl1000-firmware-39.31.5.1-129.el9.noarch.rpm"
@@ -5670,6 +5796,9 @@
           },
           "sha256:c916ffb29385ca487c759e5aedfecacfda5a8e151e00e7ef9a7bc40a52fb58c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libslirp-4.4.0-7.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c960dc0746753f01f8037a3ba79462721a1ecdf612123b4acacf67f6b01124b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/ModemManager-1.20.2-1.el9.x86_64.rpm"
@@ -5847,6 +5976,9 @@
           },
           "sha256:ef6eb3e28612b850c9ae97b260d6a38a7fa77e8b9170516079baaa0f1154c09a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/ca-certificates-2022.2.54-90.2.el9_0.noarch.rpm"
+          },
+          "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm"
           },
           "sha256:f148b83396b3a3cc002058225447b4f6fd799eee2627c95e1b24138cf3a0b224": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libselinux-utils-3.4-3.el9.x86_64.rpm"
@@ -8005,6 +8137,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
         "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
         "check_gpg": true
       },
       {
@@ -10318,6 +10460,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -10358,6 +10510,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.16",
@@ -10378,6 +10540,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -10385,6 +10557,46 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "6.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm",
+        "checksum": "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -10415,6 +10627,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-setuptools-wheel-53.0.0-11.el9.noarch.rpm",
         "checksum": "sha256:2af5b02a214f10e894f33dfa7554db0edd458328ae4dda31fc078a503fe0f376",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -10585,6 +10817,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
         "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm",
+        "checksum": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
         "check_gpg": true
       },
       {
@@ -11485,6 +11727,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-audit-3.0.7-103.el9.x86_64.rpm",
         "checksum": "sha256:a99b796ebf0f883aa95dff39ed0c87e9ed9987e2808ac9188e52cbf8a9149b6c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-file-magic",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm",
+        "checksum": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_container-boot.json
@@ -1708,6 +1708,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -3556,6 +3564,14 @@
                     }
                   },
                   {
+                    "id": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:adf8aafd3b5a7c590e2350c52e172e4b373158d76925c89db59ad201ec68bd27",
                     "options": {
                       "metadata": {
@@ -3588,6 +3604,14 @@
                     }
                   },
                   {
+                    "id": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:669c5b4c69c401de1b801f8b0c55ec01eeec7e8d565be0c526643ee7ef463e07",
                     "options": {
                       "metadata": {
@@ -3604,7 +3628,47 @@
                     }
                   },
                   {
+                    "id": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3629,6 +3693,22 @@
                   },
                   {
                     "id": "sha256:2af5b02a214f10e894f33dfa7554db0edd458328ae4dda31fc078a503fe0f376",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3765,6 +3845,14 @@
                   },
                   {
                     "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4485,6 +4573,14 @@
                   },
                   {
                     "id": "sha256:a99b796ebf0f883aa95dff39ed0c87e9ed9987e2808ac9188e52cbf8a9149b6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5596,6 +5692,9 @@
           "sha256:1649240d2a69e13d3b5ddc5c5e63c5d64a77930578a6bc4c3aca32f00423cd87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/popt-1.18-8.el9.x86_64.rpm"
           },
+          "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
+          },
           "sha256:17aab3ef99a2590ca905c28421572ae2ea378a634a157b312ec9a9e83e405a54": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/udisks2-2.9.4-7.el9.x86_64.rpm"
           },
@@ -5610,6 +5709,12 @@
           },
           "sha256:1aa1d059f7696ae397f8746d8d4fe5ead73bac461f53cce01b92db73fbd2fa81": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/findutils-4.8.0-5.el9.x86_64.rpm"
+          },
+          "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm"
+          },
+          "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm"
           },
           "sha256:20670ac5d570fb9adf0d11000eb3e9b95f05ba580752cae912f3fa8347f18279": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libtasn1-4.16.0-8.el9_1.x86_64.rpm"
@@ -5704,6 +5809,9 @@
           "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/microcode_ctl-20220809-1.el9.noarch.rpm"
           },
+          "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm"
+          },
           "sha256:368bcb3a0f163bb50f9f4064389c0125c7444ef65f6f416daab0587ede8d92a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/glibc-minimal-langpack-2.34-54.el9.x86_64.rpm"
           },
@@ -5788,6 +5896,9 @@
           "sha256:49163f6eb4683b4efaccbf47f07d5a038c36b5dae7bed665ca3b163a9b9c95ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/polkit-libs-0.117-10.el9_0.x86_64.rpm"
           },
+          "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm"
+          },
           "sha256:49f7baeb53e07a4b9b5739e36932f17f014abb765b3fa6c0c0f8af6a8ebf4d9b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/attr-2.5.1-3.el9.x86_64.rpm"
           },
@@ -5836,11 +5947,17 @@
           "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efivar-libs-38-2.el9.x86_64.rpm"
           },
+          "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm"
+          },
           "sha256:55b01380f5c1df8f1212fcd061351c0b6b0562e2cba57b323aac10cb6d5b9f32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/less-590-1.el9_0.x86_64.rpm"
           },
           "sha256:55bc0e4502324e35377386e64c9b80b3ccbc1f546e627cc2ee0ae4d820c39bc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/dbus-1.12.20-7.el9_1.x86_64.rpm"
+          },
+          "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm"
           },
           "sha256:5689da007cb289f6f1e812b31a56abdb7ad3d932f2b09adf94897c8c0d50640d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/krb5-libs-1.19.1-24.el9_1.x86_64.rpm"
@@ -6006,6 +6123,9 @@
           },
           "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/kbd-misc-2.4.0-8.el9.noarch.rpm"
+          },
+          "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm"
           },
           "sha256:7800f0c2c1f7c82155779d172fece3c0db31c7ec7de1695ddc0b905868c9d429": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/skopeo-1.10.0-1.el9.x86_64.rpm"
@@ -6310,11 +6430,17 @@
           "sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/pkgconf-1.7.3-10.el9.x86_64.rpm"
           },
+          "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm"
+          },
           "sha256:bc15b31ebd69900f5aac97e0e3506274c9704274c29bad90c7cbda95d87dc1fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libjose-11-3.el9.x86_64.rpm"
           },
           "sha256:bc460ff9b1b2a921c65cb931ce81c526dd8587bf3e8480a9b1910096ab0d5311": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/glib2-2.68.4-6.el9.x86_64.rpm"
+          },
+          "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm"
           },
           "sha256:bd312362d5a1d9c60589509be149682b071f732caed0dd46d20911c20c1c0baf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/iwl1000-firmware-39.31.5.1-129.el9.noarch.rpm"
@@ -6372,6 +6498,9 @@
           },
           "sha256:c916ffb29385ca487c759e5aedfecacfda5a8e151e00e7ef9a7bc40a52fb58c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libslirp-4.4.0-7.el9.x86_64.rpm"
+          },
+          "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
           },
           "sha256:c960dc0746753f01f8037a3ba79462721a1ecdf612123b4acacf67f6b01124b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/ModemManager-1.20.2-1.el9.x86_64.rpm"
@@ -6549,6 +6678,9 @@
           },
           "sha256:ef6eb3e28612b850c9ae97b260d6a38a7fa77e8b9170516079baaa0f1154c09a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/ca-certificates-2022.2.54-90.2.el9_0.noarch.rpm"
+          },
+          "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm"
           },
           "sha256:f148b83396b3a3cc002058225447b4f6fd799eee2627c95e1b24138cf3a0b224": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libselinux-utils-3.4-3.el9.x86_64.rpm"
@@ -9515,6 +9647,16 @@
         "check_gpg": true
       },
       {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "8.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bzip2-1.0.8-8.el9.x86_64.rpm",
+        "checksum": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -11825,6 +11967,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-chardet-4.0.0-5.el9.noarch.rpm",
+        "checksum": "sha256:49b0ab23d8436b6f0313cf69cd4992acd3b1ab3394753218cbd4d61dbbf5b2ae",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -11865,6 +12017,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-idna-2.10-7.el9.noarch.rpm",
+        "checksum": "sha256:563ca6d84346ef55208d0a1a8ddb13e1aec0276a666688761e148bd4c2232d6a",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.16",
@@ -11885,6 +12047,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pexpect",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pexpect-4.8.0-7.el9.noarch.rpm",
+        "checksum": "sha256:bb638732b15bd57733b78716d2263753c8956e078f1edc069c9b2e040e336c93",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pip-wheel",
         "epoch": 0,
         "version": "21.2.3",
@@ -11892,6 +12064,46 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm",
         "checksum": "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ptyprocess",
+        "epoch": 0,
+        "version": "0.6.0",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm",
+        "checksum": "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pysocks-1.7.1-12.el9.noarch.rpm",
+        "checksum": "sha256:1e7586cb9918e6c365105d452b9efedfaf5bb7c80309c5d0151043da847dc15f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "6.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm",
+        "checksum": "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm",
+        "checksum": "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d",
         "check_gpg": true
       },
       {
@@ -11922,6 +12134,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-setuptools-wheel-53.0.0-11.el9.noarch.rpm",
         "checksum": "sha256:2af5b02a214f10e894f33dfa7554db0edd458328ae4dda31fc078a503fe0f376",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-six-1.15.0-9.el9.noarch.rpm",
+        "checksum": "sha256:76c760f7e4ed054d158a31ef7927130baf917703c80eda92b0202b613aa81ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-urllib3-1.26.5-3.el9.noarch.rpm",
+        "checksum": "sha256:1f46676abf021b2240d9901ff272b337a9f51143a9435d0cba8bd8f01b174011",
         "check_gpg": true
       },
       {
@@ -12092,6 +12324,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
         "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
+        "check_gpg": true
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "4.4",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/sos-4.4-4.el9.noarch.rpm",
+        "checksum": "sha256:f0152383dc4a59d28bc0927cf17422ca88f2d65afb7f031969322ead09e2fc86",
         "check_gpg": true
       },
       {
@@ -12992,6 +13234,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-audit-3.0.7-103.el9.x86_64.rpm",
         "checksum": "sha256:a99b796ebf0f883aa95dff39ed0c87e9ed9987e2808ac9188e52cbf8a9149b6c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-file-magic",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-file-magic-5.39-10.el9.noarch.rpm",
+        "checksum": "sha256:35f53dd5d7fdcdf369c7c48106f35c7f85ba2f7eb228c4aa358355f963c9e784",
         "check_gpg": true
       },
       {


### PR DESCRIPTION
Adds the `sos` package to the edge commit package set so that users have built-in way to gather system logs and debug info.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
