### PR TITLE
Packer: workaround missing authselect-compat-1.2.5-2.el9_1 in RHUI repos

### DIFF
--- a/templates/packer/ansible/roles/common/tasks/packages.yml
+++ b/templates/packer/ansible/roles/common/tasks/packages.yml
@@ -24,6 +24,18 @@
   # if osbuild_commit is not defined, osbuild from distribution repositories is installed
   when: osbuild_commit is defined
 
+# Upgrading authselect without --allowerasing currently fails on RHEL 9.1 with RHUI repos
+# https://issues.redhat.com/browse/RHUIOPS-84
+# TODO: remove this once the issue is fixed
+- name: Upgrade authselect package
+  dnf:
+    name: authselect
+    state: latest
+    allowerasing: yes
+  register: result
+  retries: 5
+  until: result is success
+
 - name: Upgrade all packages
   package:
     name: "*"

--- a/tools/appsre-build-worker-packer.sh
+++ b/tools/appsre-build-worker-packer.sh
@@ -26,6 +26,9 @@ if [ "$ON_JENKINS" = false ]; then
     # see https://bugzilla.redhat.com/show_bug.cgi?id=2143282
     # TODO: Remove me when the bug is fixed or we switch to 9.1
     sudo dnf remove -y python-unversioned-command
+    # TODO: Remove once authselect-compat-1.2.5-2.el9_1.x86_64 is in el9 RHUI repos
+    # https://issues.redhat.com/browse/RHUIOPS-84
+    sudo dnf upgrade -y --allowerasing authselect
     sudo dnf upgrade -y
 
     sudo dnf install -y podman jq


### PR DESCRIPTION
`authselect-compat-1.2.5-2.el9_1` package is currently missing in AWS RHUI el9 AppStream repositories, which makes `dnf upgrade` fail on RHEL-9.1. This is a RHUI-specific issue, since the package is available in CDN repos.

In order to workaround the issue for now, `authselect-compat` needs to be removed as part of the upgrade in order for it to succeed. Use `--allowerasing` instead of just removing the issue, because this will ensure that `authselect-compat` will be upgraded just fine, once the issue is resolved.

Fix the issue in the CI script that builds the image using Packer, as well as the Ansible playbook used by Packer to build the image.

Signed-off-by: Tomáš Hozza <thozza@redhat.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
