### PR TITLE
osbuild-worker: annotate log statements used by splunk

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -184,7 +184,7 @@ func RequestAndRunJob(client *worker.Client, acceptedJobTypes []string, jobImpls
 		defer setProtection(false)
 	}
 
-	logrus.Infof("Running job '%s' (%s)\n", job.Id(), job.Type())
+	logrus.Infof("Running job '%s' (%s)\n", job.Id(), job.Type()) // DO NOT EDIT/REMOVE: used for Splunk dashboard
 
 	ctx, cancelWatcher := context.WithCancel(context.Background())
 	go WatchJob(ctx, job)
@@ -192,12 +192,12 @@ func RequestAndRunJob(client *worker.Client, acceptedJobTypes []string, jobImpls
 	err = impl.Run(job)
 	cancelWatcher()
 	if err != nil {
-		logrus.Warnf("Job '%s' (%s) failed: %v", job.Id(), job.Type(), err)
+		logrus.Warnf("Job '%s' (%s) failed: %v", job.Id(), job.Type(), err) // DO NOT EDIT/REMOVE: used for Splunk dashboard
 		// Don't return this error so the worker picks up the next job immediately
 		return nil
 	}
 
-	logrus.Infof("Job '%s' (%s) finished", job.Id(), job.Type())
+	logrus.Infof("Job '%s' (%s) finished", job.Id(), job.Type()) // DO NOT EDIT/REMOVE: used for Splunk dashboard
 	return nil
 }
 


### PR DESCRIPTION
So that they are not changed by mistake


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
