### PR TITLE
iot-installer: enable anaconda modules

### DIFF
--- a/internal/distro/fedora/images.go
+++ b/internal/distro/fedora/images.go
@@ -325,7 +325,11 @@ func iotInstallerImage(workload workload.Workload,
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
-	img.AdditionalAnacondaModules = []string{"org.fedoraproject.Anaconda.Modules.Users"}
+	img.AdditionalAnacondaModules = []string{
+		"org.fedoraproject.Anaconda.Modules.Timezone",
+		"org.fedoraproject.Anaconda.Modules.Localization",
+		"org.fedoraproject.Anaconda.Modules.Users",
+	}
 
 	img.SquashfsCompression = "lz4"
 

--- a/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
@@ -10430,6 +10430,8 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "org.fedoraproject.Anaconda.Modules.Localization",
                 "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }

--- a/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
@@ -10459,6 +10459,8 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "org.fedoraproject.Anaconda.Modules.Localization",
                 "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }

--- a/test/data/manifests/fedora_36-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_installer-boot.json
@@ -10614,6 +10614,8 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "org.fedoraproject.Anaconda.Modules.Localization",
                 "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }

--- a/test/data/manifests/fedora_36-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_installer_with_users-boot.json
@@ -10643,6 +10643,8 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "org.fedoraproject.Anaconda.Modules.Localization",
                 "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }

--- a/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
@@ -10556,6 +10556,8 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "org.fedoraproject.Anaconda.Modules.Localization",
                 "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }

--- a/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
@@ -10585,6 +10585,8 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "org.fedoraproject.Anaconda.Modules.Localization",
                 "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }

--- a/test/data/manifests/fedora_37-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_installer-boot.json
@@ -10748,6 +10748,8 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "org.fedoraproject.Anaconda.Modules.Localization",
                 "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }

--- a/test/data/manifests/fedora_37-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_installer_with_users-boot.json
@@ -10777,6 +10777,8 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "org.fedoraproject.Anaconda.Modules.Localization",
                 "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }

--- a/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
@@ -10195,6 +10195,8 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "org.fedoraproject.Anaconda.Modules.Localization",
                 "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }

--- a/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
@@ -10224,6 +10224,8 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "org.fedoraproject.Anaconda.Modules.Localization",
                 "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }

--- a/test/data/manifests/fedora_38-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_installer-boot.json
@@ -10371,6 +10371,8 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "org.fedoraproject.Anaconda.Modules.Localization",
                 "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }

--- a/test/data/manifests/fedora_38-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_installer_with_users-boot.json
@@ -10400,6 +10400,8 @@
                 "org.fedoraproject.Anaconda.Modules.Network",
                 "org.fedoraproject.Anaconda.Modules.Payloads",
                 "org.fedoraproject.Anaconda.Modules.Storage",
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "org.fedoraproject.Anaconda.Modules.Localization",
                 "org.fedoraproject.Anaconda.Modules.Users"
               ]
             }


### PR DESCRIPTION
As noted in #3141 I've enabled extra modules for Anaconda for the `iot-installer` image type.

![Screenshot_2023-01-25_16-16-41](https://user-images.githubusercontent.com/39536295/214602210-94fae2af-f929-4d72-b282-cb80a1dafe25.png)

