### PR TITLE
osbuild: unify implementations of files input 🧹

### DIFF
--- a/internal/manifest/coi_iso_tree.go
+++ b/internal/manifest/coi_iso_tree.go
@@ -64,7 +64,7 @@ func (p *CoreOSISOTree) serialize() osbuild.Pipeline {
 				},
 			},
 		},
-		osbuild.NewFilesInputs(osbuild.NewFilesInputReferencesPipeline(p.payloadPipeline.Name(), p.payloadPipeline.Filename)),
+		osbuild.NewFilesInputs(osbuild.NewFilesInputPipelineObjectRef(p.payloadPipeline.Name(), p.payloadPipeline.Filename, nil)),
 	))
 
 	if p.coiPipeline.Ignition != nil {

--- a/internal/manifest/coi_iso_tree.go
+++ b/internal/manifest/coi_iso_tree.go
@@ -64,7 +64,7 @@ func (p *CoreOSISOTree) serialize() osbuild.Pipeline {
 				},
 			},
 		},
-		osbuild.NewFilesInputs(osbuild.NewFilesInputPipelineObjectRef(p.payloadPipeline.Name(), p.payloadPipeline.Filename, nil)),
+		osbuild.NewXzStageInputs(osbuild.NewFilesInputPipelineObjectRef(p.payloadPipeline.Name(), p.payloadPipeline.Filename, nil)),
 	))
 
 	if p.coiPipeline.Ignition != nil {

--- a/internal/manifest/xz.go
+++ b/internal/manifest/xz.go
@@ -33,7 +33,7 @@ func (p *XZ) serialize() osbuild.Pipeline {
 
 	pipeline.AddStage(osbuild.NewXzStage(
 		osbuild.NewXzStageOptions(p.Filename),
-		osbuild.NewFilesInputs(osbuild.NewFilesInputReferencesPipeline(p.imgPipeline.Name(), p.imgPipeline.Export().Filename())),
+		osbuild.NewFilesInputs(osbuild.NewFilesInputPipelineObjectRef(p.imgPipeline.Name(), p.imgPipeline.Export().Filename(), nil)),
 	))
 
 	return pipeline

--- a/internal/manifest/xz.go
+++ b/internal/manifest/xz.go
@@ -33,7 +33,7 @@ func (p *XZ) serialize() osbuild.Pipeline {
 
 	pipeline.AddStage(osbuild.NewXzStage(
 		osbuild.NewXzStageOptions(p.Filename),
-		osbuild.NewFilesInputs(osbuild.NewFilesInputPipelineObjectRef(p.imgPipeline.Name(), p.imgPipeline.Export().Filename(), nil)),
+		osbuild.NewXzStageInputs(osbuild.NewFilesInputPipelineObjectRef(p.imgPipeline.Name(), p.imgPipeline.Export().Filename(), nil)),
 	))
 
 	return pipeline

--- a/internal/osbuild/fdo_stage.go
+++ b/internal/osbuild/fdo_stage.go
@@ -5,33 +5,18 @@ import (
 	"fmt"
 )
 
-type FDOStageReferences []string
-
-func (FDOStageReferences) isReferences() {}
-
-type FDOStageInput struct {
-	inputCommon
-	References FDOStageReferences `json:"references"`
-}
-
-func (FDOStageInput) isStageInput() {}
-
 type FDOStageInputs struct {
-	RootCerts *FDOStageInput `json:"rootcerts"`
+	RootCerts *FilesInput `json:"rootcerts"`
 }
 
 func (FDOStageInputs) isStageInputs() {}
 
 // NewFDOStageForCert creates FDOStage
 func NewFDOStageForRootCerts(rootCertsData string) *Stage {
-
 	dataBytes := []byte(rootCertsData)
-	rootCertsInputHash := fmt.Sprintf("sha256:%x", sha256.Sum256(dataBytes))
-
-	input := new(FDOStageInput)
-	input.Type = "org.osbuild.files"
-	input.Origin = "org.osbuild.source"
-	input.References = FDOStageReferences{rootCertsInputHash}
+	input := NewFilesInput(NewFilesInputSourcePlainRef([]string{
+		fmt.Sprintf("%x", sha256.Sum256(dataBytes)),
+	}))
 
 	return &Stage{
 		Type:   "org.osbuild.fdo",

--- a/internal/osbuild/fdo_stage_test.go
+++ b/internal/osbuild/fdo_stage_test.go
@@ -23,9 +23,10 @@ func TestNewFDOStageForRootCerts(t *testing.T) {
 
 		inputs := stage.Inputs.(*FDOStageInputs)
 		certs := inputs.RootCerts
+		refs := certs.References.(*FilesInputSourcePlainRef)
 
-		assert.Len(certs.References, 1)
-		assert.Equal(certs.References[0], tt.hash)
+		assert.Len(*refs, 1)
+		assert.Equal((*refs)[0], tt.hash)
 
 	}
 }

--- a/internal/osbuild/files_input.go
+++ b/internal/osbuild/files_input.go
@@ -13,7 +13,7 @@ type FilesInputs struct {
 
 func (FilesInputs) isStageInputs() {}
 
-func NewFilesInputs(references FilesInputReferences) *FilesInputs {
+func NewFilesInputs(references FilesInputRef) *FilesInputs {
 	return &FilesInputs{
 		File: NewFilesInput(references),
 	}
@@ -28,18 +28,20 @@ func (FilesInputs) isXzStageInputs() {}
 
 type FilesInput struct {
 	inputCommon
-	References FilesInputReferences `json:"references"`
+	References FilesInputRef `json:"references"`
 }
 
 const InputTypeFiles string = "org.osbuild.files"
 
-func NewFilesInput(references FilesInputReferences) *FilesInput {
+func NewFilesInput(references FilesInputRef) *FilesInput {
 	input := new(FilesInput)
 	input.Type = InputTypeFiles
 
 	switch t := references.(type) {
-	case *FilesInputReferencesPipeline:
+	case *FilesInputPipelineArrayRef, *FilesInputPipelineObjectRef:
 		input.Origin = InputOriginPipeline
+	case *FilesInputSourcePlainRef, *FilesInputSourceArrayRef, *FilesInputSourceObjectRef:
+		input.Origin = InputOriginSource
 	default:
 		panic(fmt.Sprintf("unknown FilesInputReferences type: %v", t))
 	}
@@ -60,46 +62,236 @@ func (f *FilesInput) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	var ref FilesInputReferences
 	switch rawFilesInput.Origin {
 	case InputOriginPipeline:
-		ref = &FilesInputReferencesPipeline{}
+		possibleRefs := []FilesInputRef{
+			&FilesInputPipelineArrayRef{},
+			&FilesInputPipelineObjectRef{},
+		}
+		var err error
+		for _, ref := range possibleRefs {
+			if err = json.Unmarshal(rawFilesInput.References, ref); err == nil {
+				f.References = ref
+				break
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("FilesInput: failed to unmarshal pipeline references into any supported type")
+		}
+	case InputOriginSource:
+		possibleRefs := []FilesInputRef{
+			&FilesInputSourcePlainRef{},
+			&FilesInputSourceArrayRef{},
+			&FilesInputSourceObjectRef{},
+		}
+		var err error
+		for _, ref := range possibleRefs {
+			if err = json.Unmarshal(rawFilesInput.References, ref); err == nil {
+				f.References = ref
+				break
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("FilesInput: failed to unmarshal source references into any supported type")
+		}
 	default:
 		return fmt.Errorf("FilesInput: unknown input origin: %s", rawFilesInput.Origin)
 	}
 
-	if err := json.Unmarshal(rawFilesInput.References, ref); err != nil {
-		return err
-	}
-
 	f.Type = rawFilesInput.Type
 	f.Origin = rawFilesInput.Origin
-	f.References = ref
 
 	return nil
 }
 
 // SUPPORTED FILE INPUT REFERENCES
 
-type FilesInputReferences interface {
-	isFilesInputReferences()
+// FilesInputRef is an interface that is implemented by all types that can be
+// used as a reference in the files input.
+type FilesInputRef interface {
+	isFilesInputRef()
 }
 
+// Type to represent stage-specific metadata that can be passed via the files
+// input to the stage.
 // The expected JSON structure is:
-// `"name:<pipeline_name>": {"file": "<filename>"}`
-type FilesInputReferencesPipeline map[string]FileReference
-
-func (*FilesInputReferencesPipeline) isFilesInputReferences() {}
-
-type FileReference struct {
-	File string `json:"file"`
+//
+//	`{
+//		"<metadata.str1>": <anything_but_object_with_additional_properties>,
+//		"<metadata.str2>": <anything_but_object_with_additional_properties>,
+//		...
+//	}`
+type FilesInputRefMetadata interface {
+	isFilesInputRefMetadata()
 }
 
-func NewFilesInputReferencesPipeline(pipeline, filename string) FilesInputReferences {
-	ref := &FilesInputReferencesPipeline{
-		fmt.Sprintf("name:%s", pipeline): {File: filename},
+// Pipeline Object Reference
+// The expected JSON structure is:
+//
+//	`{
+//		"name:<pipeline_name>": {
+//			"metadata": {
+//				"<metadata.str1>": <anything_but_object_with_additional_properties>,
+//				"<metadata.str2>": <anything_but_object_with_additional_properties>,
+//				...
+//			},
+//			"file": "<filename>"
+//		},
+//		...
+//	}`
+type FilesInputPipelineObjectRef map[string]FilesInputPipelineOptions
+
+func (*FilesInputPipelineObjectRef) isFilesInputRef() {}
+
+type FilesInputPipelineOptions struct {
+	// File to access with in a pipeline
+	File string `json:"file,omitempty"`
+	// Additional metadata to forward to the stage
+	Metadata FilesInputRefMetadata `json:"metadata,omitempty"`
+}
+
+func NewFilesInputPipelineObjectRef(pipeline, filename string, metadata FilesInputRefMetadata) FilesInputRef {
+	// The files input schema allows for multiple pipelines to be specified, but we don't use it.
+	ref := &FilesInputPipelineObjectRef{
+		fmt.Sprintf("name:%s", pipeline): {
+			File:     filename,
+			Metadata: metadata,
+		},
 	}
 	return ref
 }
 
-// TODO: define FilesInputReferences for "sources"
+// Pipeline Array Reference
+// The expected JSON structure is:
+//
+//	`[
+//		{
+//			"id": "name:<pipeline_name>",
+//			"options": {
+//				"metadata": {
+//					"<metadata.str1>": <anything_but_object_with_additional_properties>,
+//					"<metadata.str2>": <anything_but_object_with_additional_properties>,
+//					...
+//				},
+//				"file": "<filename>"
+//			}
+//		},
+//		...
+//	]`
+type FilesInputPipelineArrayRef []FilesInputPipelineArrayRefEntry
+
+func (*FilesInputPipelineArrayRef) isFilesInputRef() {}
+
+type FilesInputPipelineArrayRefEntry struct {
+	ID      string                    `json:"id"`
+	Options FilesInputPipelineOptions `json:"options,omitempty"`
+}
+
+func NewFilesInputPipelineArrayRef(pipeline, filename string, metadata FilesInputRefMetadata) FilesInputRef {
+	// The files input schema allows for multiple pipelines to be specified, but we don't use it.
+	ref := &FilesInputPipelineArrayRef{
+		{
+			ID: fmt.Sprintf("name:%s", pipeline),
+			Options: FilesInputPipelineOptions{
+				File:     filename,
+				Metadata: metadata,
+			},
+		},
+	}
+	return ref
+}
+
+// Source Plain Reference
+// The expected JSON structure is:
+//
+//	`[
+//		"sha256:<sha256sum>",
+//		...
+//	]`
+type FilesInputSourcePlainRef []string
+
+func (*FilesInputSourcePlainRef) isFilesInputRef() {}
+
+// NewFilesInputSourcePlainRef creates a FilesInputSourcePlainRef from a list of sha256sums.
+// The slice items are the SHA256 checksums of files as a hexadecimal string without any prefix (e.g. "sha256:").
+func NewFilesInputSourcePlainRef(sha256Sums []string) FilesInputRef {
+	refs := FilesInputSourcePlainRef{}
+	for _, sha256Sum := range sha256Sums {
+		refs = append(refs, fmt.Sprintf("sha256:%s", sha256Sum))
+	}
+	return &refs
+}
+
+// Source Array Reference
+// The expected JSON structure is:
+//
+//	`[
+//		{
+//			"id": "sha256:<sha256sum>",
+//			"options": {
+//				"metadata": {
+//					"<metadata.str1>": <anything_but_object_with_additional_properties>,
+//					"<metadata.str2>": <anything_but_object_with_additional_properties>,
+//					...
+//				}
+//			}
+//		},
+//		...
+//	]`
+type FilesInputSourceArrayRef []FilesInputSourceArrayRefEntry
+
+func (*FilesInputSourceArrayRef) isFilesInputRef() {}
+
+type FilesInputSourceOptions struct {
+	// Additional metadata to forward to the stage
+	Metadata FilesInputRefMetadata `json:"metadata,omitempty"`
+}
+
+type FilesInputSourceArrayRefEntry struct {
+	ID      string                   `json:"id"`
+	Options *FilesInputSourceOptions `json:"options,omitempty"`
+}
+
+// NewFilesInputSourceArrayRefEntry creates a FilesInputSourceArrayRefEntry from a sha256sum and metadata.
+// The sha256sum is the SHA256 checksum of the file as a hexadecimal string without any prefix (e.g. "sha256:").
+func NewFilesInputSourceArrayRefEntry(sha256Sum string, metadata FilesInputRefMetadata) FilesInputSourceArrayRefEntry {
+	ref := FilesInputSourceArrayRefEntry{
+		ID: fmt.Sprintf("sha256:%s", sha256Sum),
+	}
+	if metadata != nil {
+		ref.Options = &FilesInputSourceOptions{Metadata: metadata}
+	}
+	return ref
+}
+
+func NewFilesInputSourceArrayRef(entries []FilesInputSourceArrayRefEntry) FilesInputRef {
+	ref := FilesInputSourceArrayRef(entries)
+	return &ref
+}
+
+// Source Object Reference
+// The expected JSON structure is:
+//
+//	`{
+//		"sha256:<sha256sum>": {
+//			"metadata": {
+//				"<metadata.str1>": <anything_but_object_with_additional_properties>,
+//				"<metadata.str2>": <anything_but_object_with_additional_properties>,
+//				...
+//			}
+//		},
+//		...
+//	}`
+type FilesInputSourceObjectRef map[string]FilesInputSourceOptions
+
+func (*FilesInputSourceObjectRef) isFilesInputRef() {}
+
+// NewFilesInputSourceObjectRef creates a FilesInputSourceObjectRef from a map of sha256sums to metadata
+// The key is the SHA256 checksum of the file as a hexadecimal string without any prefix (e.g. "sha256:").
+func NewFilesInputSourceObjectRef(entries map[string]FilesInputRefMetadata) FilesInputRef {
+	refs := FilesInputSourceObjectRef{}
+	for sha256Sum, metadata := range entries {
+		refs[fmt.Sprintf("sha256:%s", sha256Sum)] = FilesInputSourceOptions{Metadata: metadata}
+	}
+	return &refs
+}

--- a/internal/osbuild/files_input.go
+++ b/internal/osbuild/files_input.go
@@ -5,25 +5,6 @@ import (
 	"fmt"
 )
 
-// Inputs for individual files
-
-type FilesInputs struct {
-	File *FilesInput `json:"file"`
-}
-
-func (FilesInputs) isStageInputs() {}
-
-func NewFilesInputs(references FilesInputRef) *FilesInputs {
-	return &FilesInputs{
-		File: NewFilesInput(references),
-	}
-}
-
-// IMPLEMENTED INTERFACES OF STAGES ACCEPTING THIS INPUTS TYPE
-
-// inputs accepted by the XZ stage
-func (FilesInputs) isXzStageInputs() {}
-
 // SPECIFIC INPUT STRUCTURE
 
 type FilesInput struct {

--- a/internal/osbuild/files_input_test.go
+++ b/internal/osbuild/files_input_test.go
@@ -2,39 +2,10 @@ package osbuild
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-type fakeFilesInputRef struct{}
-
-func (f *fakeFilesInputRef) isFilesInputRef() {}
-
-func TestNewFilesInputs(t *testing.T) {
-	inputFilename := "image.raw"
-	pipeline := "os"
-
-	expectedInput := &FilesInputs{
-		File: &FilesInput{
-			inputCommon: inputCommon{
-				Type:   InputTypeFiles,
-				Origin: InputOriginPipeline,
-			},
-			References: &FilesInputPipelineObjectRef{
-				fmt.Sprintf("name:%s", pipeline): FilesInputPipelineOptions{File: inputFilename},
-			},
-		},
-	}
-
-	actualInput := NewFilesInputs(NewFilesInputPipelineObjectRef(pipeline, inputFilename, nil))
-	assert.Equal(t, expectedInput, actualInput)
-
-	assert.Panics(t, func() {
-		NewFilesInputs(&fakeFilesInputRef{})
-	})
-}
 
 func TestFilesInput_UnmarshalJSON(t *testing.T) {
 	testCases := []struct {

--- a/internal/osbuild/ignition_stage.go
+++ b/internal/osbuild/ignition_stage.go
@@ -18,24 +18,14 @@ func NewIgnitionStage(options *IgnitionStageOptions) *Stage {
 }
 
 type IgnitionStageInputInline struct {
-	InlineFile IgnitionStageInput `json:"inlinefile"`
+	InlineFile *FilesInput `json:"inlinefile"`
 }
 
 func (IgnitionStageInputInline) isStageInputs() {}
 
-type IgnitionStageInput struct {
-	inputCommon
-	References IgnitionStageReferences `json:"references"`
-}
-
-type IgnitionStageReferences []string
-
-func (IgnitionStageReferences) isReferences() {}
-
 func NewIgnitionInlineInput(embeddedData string) Inputs {
-	inputs := new(IgnitionStageInputInline)
-	inputs.InlineFile.Type = "org.osbuild.files"
-	inputs.InlineFile.Origin = "org.osbuild.source"
-	inputs.InlineFile.References = IgnitionStageReferences{fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(embeddedData)))}
-	return inputs
+	input := NewFilesInput(NewFilesInputSourcePlainRef([]string{
+		fmt.Sprintf("%x", sha256.Sum256([]byte(embeddedData))),
+	}))
+	return &IgnitionStageInputInline{InlineFile: input}
 }

--- a/internal/osbuild/qemu_stage.go
+++ b/internal/osbuild/qemu_stage.go
@@ -163,28 +163,10 @@ func (o VHDXOptions) formatType() QEMUFormat {
 }
 
 type QEMUStageInputs struct {
-	Image *QEMUStageInput `json:"image"`
+	Image *FilesInput `json:"image"`
 }
 
 func (QEMUStageInputs) isStageInputs() {}
-
-type QEMUStageInput struct {
-	inputCommon
-	References QEMUStageReferences `json:"references"`
-}
-
-func (QEMUStageInput) isStageInput() {}
-
-type QEMUStageReferences map[string]QEMUFile
-
-func (QEMUStageReferences) isReferences() {}
-
-type QEMUFile struct {
-	Metadata FileMetadata `json:"metadata,omitempty"`
-	File     string       `json:"file,omitempty"`
-}
-
-type FileMetadata map[string]interface{}
 
 // NewQEMUStage creates a new QEMU Stage object.
 func NewQEMUStage(options *QEMUStageOptions, inputs *QEMUStageInputs) *Stage {
@@ -271,16 +253,7 @@ func (options QEMUStageOptions) MarshalJSON() ([]byte, error) {
 	return json.Marshal(qemuStageOptions(options))
 }
 
-func NewQemuStagePipelineFilesInputs(stage, file string) *QEMUStageInputs {
-	stageKey := "name:" + stage
-	ref := map[string]QEMUFile{
-		stageKey: {
-			File: file,
-		},
-	}
-	input := new(QEMUStageInput)
-	input.Type = "org.osbuild.files"
-	input.Origin = "org.osbuild.pipeline"
-	input.References = ref
+func NewQemuStagePipelineFilesInputs(pipeline, file string) *QEMUStageInputs {
+	input := NewFilesInput(NewFilesInputPipelineObjectRef(pipeline, file, nil))
 	return &QEMUStageInputs{Image: input}
 }

--- a/internal/osbuild/qemu_stage_test.go
+++ b/internal/osbuild/qemu_stage_test.go
@@ -30,14 +30,7 @@ func TestNewQemuStage(t *testing.T) {
 		},
 	}
 
-	input := new(QEMUStageInput)
-	input.Type = "org.osbuild.files"
-	input.Origin = "org.osbuild.pipeline"
-	input.References = map[string]QEMUFile{
-		"name:stage": {
-			File: "img.raw",
-		},
-	}
+	input := NewFilesInput(NewFilesInputPipelineObjectRef("stage", "img.raw", nil))
 	inputs := QEMUStageInputs{Image: input}
 
 	for _, format := range formatOptionsList {

--- a/internal/osbuild/xz_stage.go
+++ b/internal/osbuild/xz_stage.go
@@ -13,15 +13,23 @@ func NewXzStageOptions(filename string) *XzStageOptions {
 	}
 }
 
-type XzStageInputs interface {
-	isXzStageInputs()
+type XzStageInputs struct {
+	File *FilesInput `json:"file"`
+}
+
+func (*XzStageInputs) isStageInputs() {}
+
+func NewXzStageInputs(references FilesInputRef) *XzStageInputs {
+	return &XzStageInputs{
+		File: NewFilesInput(references),
+	}
 }
 
 // Compresses a file into a xz archive.
-func NewXzStage(options *XzStageOptions, inputs XzStageInputs) *Stage {
+func NewXzStage(options *XzStageOptions, inputs *XzStageInputs) *Stage {
 	var stageInputs Inputs
 	if inputs != nil {
-		stageInputs = inputs.(Inputs)
+		stageInputs = inputs
 	}
 
 	return &Stage{

--- a/internal/osbuild/xz_stage_test.go
+++ b/internal/osbuild/xz_stage_test.go
@@ -25,11 +25,11 @@ func TestNewXzStage(t *testing.T) {
 	expectedStage := &Stage{
 		Type:    "org.osbuild.xz",
 		Options: NewXzStageOptions(filename),
-		Inputs:  NewFilesInputs(NewFilesInputReferencesPipeline(pipeline, inputFilename)),
+		Inputs:  NewFilesInputs(NewFilesInputPipelineObjectRef(pipeline, inputFilename, nil)),
 	}
 
 	actualStage := NewXzStage(NewXzStageOptions(filename),
-		NewFilesInputs(NewFilesInputReferencesPipeline(pipeline, inputFilename)))
+		NewFilesInputs(NewFilesInputPipelineObjectRef(pipeline, inputFilename, nil)))
 	assert.Equal(t, expectedStage, actualStage)
 }
 

--- a/internal/osbuild/xz_stage_test.go
+++ b/internal/osbuild/xz_stage_test.go
@@ -25,11 +25,11 @@ func TestNewXzStage(t *testing.T) {
 	expectedStage := &Stage{
 		Type:    "org.osbuild.xz",
 		Options: NewXzStageOptions(filename),
-		Inputs:  NewFilesInputs(NewFilesInputPipelineObjectRef(pipeline, inputFilename, nil)),
+		Inputs:  NewXzStageInputs(NewFilesInputPipelineObjectRef(pipeline, inputFilename, nil)),
 	}
 
 	actualStage := NewXzStage(NewXzStageOptions(filename),
-		NewFilesInputs(NewFilesInputPipelineObjectRef(pipeline, inputFilename, nil)))
+		NewXzStageInputs(NewFilesInputPipelineObjectRef(pipeline, inputFilename, nil)))
 	assert.Equal(t, expectedStage, actualStage)
 }
 


### PR DESCRIPTION
This PR is a pre-work to support custom files in `/etc`, because the copy stage implementation will need to be extended to support files input with origin source. Instead of implementing 6th version of it, I decided to rework files input implementation, which we wanted to do anyway (me and @achilleas-k).

Rework files input implementation to support all reference types supported by the input schema. Also implement helper functions to generate supported reference types. In some cases, the reference supports e.g. referencing multiple pipelines in the stage inputs, but this is currently not implemented, since no pipeline in composer uses it.

Rework the stage inputs implementation of the following stages to use the common files input:

- XZ stage
- FDO stage
- QEMU stage
- RPM stage
- Ignition stage

This rework should not have any effect on manifests produced by osbuild-composer.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
