### PR TITLE
image-installer: switch payload to minimal-rpm

### DIFF
--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -79,7 +79,7 @@ var (
 		filename:    "installer.iso",
 		mimeType:    "application/x-iso9660-image",
 		packageSets: map[string]packageSetFunc{
-			osPkgsKey:        bareMetalPackageSet,
+			osPkgsKey:        minimalrpmPackageSet,
 			installerPkgsKey: imageInstallerPackageSet,
 		},
 		bootable:         true,

--- a/internal/distro/fedora/package_sets.go
+++ b/internal/distro/fedora/package_sets.go
@@ -565,14 +565,6 @@ func containerPackageSet(t *imageType) rpmmd.PackageSet {
 	return ps
 }
 
-func bareMetalPackageSet(t *imageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"@core",
-		},
-	}
-}
-
 func minimalrpmPackageSet(t *imageType) rpmmd.PackageSet {
 	return rpmmd.PackageSet{
 		Include: []string{


### PR DESCRIPTION
With the addition of the minimal rpm package set and image type in #3181 the previously added bare metal package set is a duplicate. It's not used elsewhere within fedora and the minimal rpm package set is officially defined.