### PR TITLE
File resolver job

### DIFF
--- a/cmd/osbuild-worker/jobimpl-file-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-file-resolve.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/osbuild/osbuild-composer/internal/remotefile"
+	"github.com/osbuild/osbuild-composer/internal/worker"
+	"github.com/osbuild/osbuild-composer/internal/worker/clienterrors"
+)
+
+type FileResolveJobImpl struct{}
+
+func (impl *FileResolveJobImpl) Run(job worker.Job) error {
+	logWithId := logrus.WithField("jobId", job.Id())
+
+	var err error
+	result := worker.FileResolveJobResult{
+		Success: false,
+		Results: []worker.FileResolveJobResultItem{},
+	}
+
+	defer func() {
+		logWithId := logrus.WithField("jobId", job.Id().String())
+		if result.JobError != nil {
+			logWithId.Errorf("file content resolve job failed: %s", result.JobError.Reason)
+			if result.JobError.Details != nil {
+				logWithId.Errorf("failure details: %v", result.JobError.Details)
+			}
+		}
+
+		if result.Results == nil || len(result.Results) == 0 {
+			logWithId.Infof("Resolving file contents failed: %v", err)
+			result.JobError = clienterrors.WorkerClientError(
+				clienterrors.ErrorRemoteFileResolution,
+				"Error resolving file contents",
+				"All remote file contents returned empty",
+			)
+		}
+
+		err := job.Update(result)
+		if err != nil {
+			logWithId.Errorf("Error reporting job result: %v", err)
+		}
+	}()
+
+	var args worker.FileResolveJob
+	err = job.Args(&args)
+	if err != nil {
+		return err
+	}
+
+	logWithId.Infof("Resolving file contents (%d)", len(args.URLs))
+
+	resolver := remotefile.NewResolver()
+	for _, url := range args.URLs {
+		resolver.Add(url)
+	}
+
+	resultItems := resolver.Finish()
+
+	for idx := range resultItems {
+		result.Results = append(result.Results, worker.FileResolveJobResultItem{
+			URL:             resultItems[idx].URL,
+			Content:         resultItems[idx].Content,
+			ResolutionError: resultItems[idx].ResolutionError,
+		})
+	}
+
+	resolutionErrors := result.ResolutionErrors()
+	if len(resolutionErrors) == 0 {
+		result.Success = true
+	} else {
+		result.JobError = clienterrors.WorkerClientError(
+			clienterrors.ErrorRemoteFileResolution,
+			"at least one file resolution failed",
+			resolutionErrors,
+		)
+	}
+
+	return nil
+}

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -466,6 +466,7 @@ func main() {
 			AuthFilePath: containersAuthFilePath,
 		},
 		worker.JobTypeOSTreeResolve: &OSTreeResolveJobImpl{},
+		worker.JobTypeFileResolve:   &FileResolveJobImpl{},
 		worker.JobTypeAWSEC2Copy: &AWSEC2CopyJobImpl{
 			AWSCreds: awsCredentials,
 		},

--- a/internal/remotefile/client.go
+++ b/internal/remotefile/client.go
@@ -1,0 +1,60 @@
+package remotefile
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+type Client struct {
+	client *http.Client
+}
+
+func NewClient() *Client {
+	return &Client{
+		client: &http.Client{},
+	}
+}
+
+func (c *Client) makeRequest(u *url.URL) ([]byte, error) {
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	output, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+func (c *Client) validateURL(u string) (*url.URL, error) {
+	if u == "" {
+		return nil, fmt.Errorf("File resolver: url is required")
+	}
+	parsedURL, err := url.ParseRequestURI(u)
+	if err != nil {
+		return nil, fmt.Errorf("File resolver: invalid url %s", u)
+	}
+	return parsedURL, nil
+}
+
+// resolve and return the contents of a remote file
+// which can be used later, in the pipeline
+func (c *Client) Resolve(u string) ([]byte, error) {
+	parsedURL, err := c.validateURL(u)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.makeRequest(parsedURL)
+}

--- a/internal/remotefile/client_test.go
+++ b/internal/remotefile/client_test.go
@@ -1,0 +1,73 @@
+package remotefile
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func makeTestServer() *httptest.Server {
+	// use a simple mock server to test the client
+	// and file content resolver
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/key1" {
+			fmt.Fprintln(w, "key1")
+		}
+		if r.URL.Path == "/key2" {
+			fmt.Fprintln(w, "key2")
+		}
+	}))
+}
+
+func TestClientResolve(t *testing.T) {
+	server := makeTestServer()
+
+	url := server.URL + "/key1"
+
+	client := NewClient()
+
+	output, err := client.Resolve(url)
+	assert.NoError(t, err)
+
+	expectedOutput := "key1\n"
+
+	assert.Equal(t, expectedOutput, string(output))
+}
+
+func TestInputSpecValidation(t *testing.T) {
+	server := makeTestServer()
+
+	test := []struct {
+		name string
+		url  string
+		want error
+	}{
+		{
+			name: "valid input spec",
+			url:  server.URL + "/key1",
+			want: nil,
+		},
+		{
+			name: "missing url spec",
+			url:  "",
+			want: fmt.Errorf("File resolver: url is required"),
+		},
+	}
+
+	client := NewClient()
+
+	for _, tt := range test {
+		url, err := client.validateURL(tt.url)
+		if tt.want == nil {
+			assert.NoError(t, err)
+			assert.Equal(t, tt.url, url.String())
+		} else {
+			assert.EqualError(t, err, tt.want.Error())
+			assert.Nil(t, url)
+		}
+	}
+
+}

--- a/internal/remotefile/resolver.go
+++ b/internal/remotefile/resolver.go
@@ -1,0 +1,66 @@
+package remotefile
+
+import (
+	"context"
+
+	"github.com/osbuild/osbuild-composer/internal/worker/clienterrors"
+)
+
+type resolveResult struct {
+	url     string
+	content []byte
+	err     error
+}
+
+// TODO: could make this more generic
+// since this is shared with the container
+// resolver
+type Resolver struct {
+	jobs  int
+	queue chan resolveResult
+
+	ctx context.Context
+}
+
+func NewResolver() *Resolver {
+	return &Resolver{
+		ctx:   context.Background(),
+		queue: make(chan resolveResult, 2),
+	}
+}
+
+func (r *Resolver) Add(url string) {
+	client := NewClient()
+	r.jobs += 1
+
+	go func() {
+		content, err := client.Resolve(url)
+		r.queue <- resolveResult{url: url, content: content, err: err}
+	}()
+}
+
+func (r *Resolver) Finish() []Spec {
+
+	resultItems := make([]Spec, 0, r.jobs)
+	for r.jobs > 0 {
+		result := <-r.queue
+		r.jobs -= 1
+
+		var resultError *clienterrors.Error
+		if result.err != nil {
+			resultError = clienterrors.WorkerClientError(
+				clienterrors.ErrorRemoteFileResolution,
+				result.err.Error(),
+				result.url,
+			)
+		}
+
+		resultItems = append(resultItems, Spec{
+			URL:             result.url,
+			Content:         result.content,
+			ResolutionError: resultError,
+		})
+	}
+
+	return resultItems
+}

--- a/internal/remotefile/resolver_test.go
+++ b/internal/remotefile/resolver_test.go
@@ -1,0 +1,102 @@
+package remotefile
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSingleInputResolver(t *testing.T) {
+	server := makeTestServer()
+	url := server.URL + "/key1"
+
+	resolver := NewResolver()
+
+	expectedOutput := Spec{
+		URL:             url,
+		Content:         []byte("key1\n"),
+		ResolutionError: nil,
+	}
+
+	resolver.Add(url)
+
+	resultItems := resolver.Finish()
+	assert.Contains(t, resultItems, expectedOutput)
+
+	for _, item := range resultItems {
+		assert.Nil(t, item.ResolutionError)
+	}
+}
+
+func TestMultiInputResolver(t *testing.T) {
+	server := makeTestServer()
+
+	urlOne := server.URL + "/key1"
+	urlTwo := server.URL + "/key2"
+
+	expectedOutputOne := Spec{
+		URL:             urlOne,
+		Content:         []byte("key1\n"),
+		ResolutionError: nil,
+	}
+
+	expectedOutputTwo := Spec{
+		URL:             urlTwo,
+		Content:         []byte("key2\n"),
+		ResolutionError: nil,
+	}
+
+	resolver := NewResolver()
+
+	resolver.Add(urlOne)
+	resolver.Add(urlTwo)
+
+	resultItems := resolver.Finish()
+
+	assert.Contains(t, resultItems, expectedOutputOne)
+	assert.Contains(t, resultItems, expectedOutputTwo)
+
+	for _, item := range resultItems {
+		assert.Nil(t, item.ResolutionError)
+	}
+}
+
+func TestInvalidInputResolver(t *testing.T) {
+	url := ""
+
+	resolver := NewResolver()
+
+	resolver.Add(url)
+
+	expectedErr := fmt.Errorf("File resolver: url is required")
+
+	resultItems := resolver.Finish()
+
+	for _, item := range resultItems {
+		assert.Equal(t, item.ResolutionError.Reason, expectedErr.Error())
+	}
+}
+
+func TestMultiInvalidInputResolver(t *testing.T) {
+	urlOne := ""
+	urlTwo := "hello"
+
+	resolver := NewResolver()
+
+	resolver.Add(urlOne)
+	resolver.Add(urlTwo)
+
+	expectedErrMessageOne := "File resolver: url is required"
+	expectedErrMessageTwo := fmt.Sprintf("File resolver: invalid url %s", urlTwo)
+
+	resultItems := resolver.Finish()
+
+	errs := []string{}
+	for _, item := range resultItems {
+		errs = append(errs, item.ResolutionError.Reason)
+	}
+
+	assert.Contains(t, errs, expectedErrMessageOne)
+	assert.Contains(t, errs, expectedErrMessageTwo)
+}

--- a/internal/remotefile/spec.go
+++ b/internal/remotefile/spec.go
@@ -1,0 +1,9 @@
+package remotefile
+
+import "github.com/osbuild/osbuild-composer/internal/worker/clienterrors"
+
+type Spec struct {
+	URL             string
+	Content         []byte
+	ResolutionError *clienterrors.Error
+}

--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -40,6 +40,7 @@ const (
 	ErrorOSTreeRefResolution  ClientErrorCode = 33
 	ErrorOSTreeParamsInvalid  ClientErrorCode = 34
 	ErrorOSTreeDependency     ClientErrorCode = 35
+	ErrorRemoteFileResolution ClientErrorCode = 36
 )
 
 type ClientErrorCode int

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -89,6 +89,18 @@ func (j *OSBuildJobResult) TargetResultsByName(name target.TargetName) []*target
 	return targetResults
 }
 
+func (j *FileResolveJobResult) ResolutionErrors() []*clienterrors.Error {
+	resolutionErrors := []*clienterrors.Error{}
+
+	for _, result := range j.Results {
+		if result.ResolutionError != nil {
+			resolutionErrors = append(resolutionErrors, result.ResolutionError)
+		}
+	}
+
+	return resolutionErrors
+}
+
 type KojiInitJob struct {
 	Server  string `json:"server"`
 	Name    string `json:"name"`
@@ -253,6 +265,22 @@ type ContainerResolveJob struct {
 type ContainerResolveJobResult struct {
 	Specs []ContainerSpec `json:"specs"`
 
+	JobResult
+}
+
+type FileResolveJob struct {
+	URLs []string `json:"urls"`
+}
+
+type FileResolveJobResultItem struct {
+	URL             string              `json:"url"`
+	Content         []byte              `json:"content"`
+	ResolutionError *clienterrors.Error `json:"target_error,omitempty"`
+}
+
+type FileResolveJobResult struct {
+	Success bool                       `json:"success"`
+	Results []FileResolveJobResultItem `json:"results"`
 	JobResult
 }
 

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -382,7 +382,7 @@ func (s *Server) ContainerResolveJobInfo(id uuid.UUID, result *ContainerResolveJ
 	}
 
 	if jobInfo.JobType != JobTypeContainerResolve {
-		return nil, fmt.Errorf("expected %q, found %q job instead", JobTypeDepsolve, jobInfo.JobType)
+		return nil, fmt.Errorf("expected %q, found %q job instead", JobTypeContainerResolve, jobInfo.JobType)
 	}
 
 	return jobInfo, nil


### PR DESCRIPTION
This pull request includes:
- adding a file resolver to generate a checksum for the contents of a remote file.

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
