### PR TITLE
Check sos package has been included in the edge commit package set

### DIFF
--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -1091,6 +1091,30 @@
             failed_counter: "{{ failed_counter | int + 1 }}"
       when: test_custom_dirs_files == "true"
 
+    # case: check sos package
+    - name: Check SOS Package
+      block:
+        - name: Generate sos report
+          command: sos report --no-report --batch -o podman
+          become: "true"
+          register: result_sos_report
+
+        - assert:
+            that:
+              - result_sos_report is succeeded
+            fail_msg: "No usable sos package present"
+            success_msg: "sos package present and usable"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+
+      when: (ansible_facts['distribution'] == 'RedHat' and ansible_facts['distribution_version'] is version('8.4', '>')) or
+            (ansible_facts['distribution'] == 'CentOS')
+
     - name: Check if any test failed
       assert:
         that:


### PR DESCRIPTION
Since sos package has been included in the edge commit package set, we need to check this package is indeed present. This PR includes a playbook task that executes the sos and make sure command execution has been successful.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
