### PR TITLE
rhel: fix conditionals for sysroot.readonly enablement

### DIFF
--- a/internal/distro/rhel8/images.go
+++ b/internal/distro/rhel8/images.go
@@ -394,13 +394,10 @@ func edgeRawImage(workload workload.Workload,
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
-	// "rw" kernel option is required when /sysroot is mounted read-only to
-	// keep stateful parts of the filesystem writeable (/var/ and /etc)
-	img.KernelOptionsAppend = []string{"modprobe.blacklist=vc4", "rw"}
+	img.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
 	// TODO: move to image config
 	img.Keyboard = "us"
 	img.Locale = "C.UTF-8"
-	img.SysrootReadOnly = true
 
 	img.Platform = t.platform
 	img.Workload = workload
@@ -442,12 +439,9 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	rawImg.Users = users.UsersFromBP(customizations.GetUsers())
 	rawImg.Groups = users.GroupsFromBP(customizations.GetGroups())
 
-	// "rw" kernel option is required when /sysroot is mounted read-only to
-	// keep stateful parts of the filesystem writeable (/var/ and /etc)
-	rawImg.KernelOptionsAppend = []string{"modprobe.blacklist=vc4", "rw"}
+	rawImg.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
 	rawImg.Keyboard = "us"
 	rawImg.Locale = "C.UTF-8"
-	rawImg.SysrootReadOnly = true
 
 	rawImg.Platform = t.platform
 	rawImg.Workload = workload

--- a/internal/distro/rhel9/images.go
+++ b/internal/distro/rhel9/images.go
@@ -340,7 +340,6 @@ func edgeRawImage(workload workload.Workload,
 		Checksum:   options.OSTree.FetchChecksum,
 	}
 	img := image.NewOSTreeRawImage(commit)
-	// TODO: add Fedora once it's ready
 	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || t.arch.distro.osVersion == "9-stream" {
 		img.Ignition = true
 	}
@@ -350,10 +349,13 @@ func edgeRawImage(workload workload.Workload,
 
 	// "rw" kernel option is required when /sysroot is mounted read-only to
 	// keep stateful parts of the filesystem writeable (/var/ and /etc)
-	img.KernelOptionsAppend = []string{"modprobe.blacklist=vc4", "rw"}
+	img.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
 	img.Keyboard = "us"
 	img.Locale = "C.UTF-8"
-	img.SysrootReadOnly = true
+	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || t.arch.distro.osVersion == "9-stream" {
+		img.SysrootReadOnly = true
+		img.KernelOptionsAppend = append(img.KernelOptionsAppend, "rw")
+	}
 
 	img.Platform = t.platform
 	img.Workload = workload
@@ -400,7 +402,6 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 		Checksum:   options.OSTree.FetchChecksum,
 	}
 	rawImg := image.NewOSTreeRawImage(commit)
-	// TODO: add Fedora once it's ready
 	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || t.arch.distro.osVersion == "9-stream" {
 		rawImg.Ignition = true
 	}
@@ -410,10 +411,13 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 
 	// "rw" kernel option is required when /sysroot is mounted read-only to
 	// keep stateful parts of the filesystem writeable (/var/ and /etc)
-	rawImg.KernelOptionsAppend = []string{"modprobe.blacklist=vc4", "rw"}
+	rawImg.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
 	rawImg.Keyboard = "us"
 	rawImg.Locale = "C.UTF-8"
-	rawImg.SysrootReadOnly = true
+	if !common.VersionLessThan(t.arch.distro.osVersion, "9.2") || t.arch.distro.osVersion == "9-stream" {
+		rawImg.SysrootReadOnly = true
+		rawImg.KernelOptionsAppend = append(rawImg.KernelOptionsAppend, "rw")
+	}
 
 	rawImg.Platform = t.platform
 	rawImg.Workload = workload

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -259,7 +259,7 @@
     # There are three checks here for /sysroot permission based on pr https://github.com/osbuild/osbuild-composer/pull/3053
     # 1. for edge-commit and edge-installer, check ro when fedora >= 37
     # 2. for edge-commit and edge-installer, check rw for other os.
-    # 3. for edge-simplified-installer and edge-raw-image, check ro for all os.
+    # 3. for edge-simplified-installer and edge-raw-image, check ro for 9.2+ and F37+.
     - name: /sysroot should be mount with ro permission for edge-commit and edge-installer on Fedora >= 37
       block:
         - assert:
@@ -307,7 +307,26 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
-      when: edge_type == "edge-simplified-installer" or edge_type == "edge-raw-image"
+      when: (edge_type == "edge-simplified-installer" or edge_type == "edge-raw-image") and ((ansible_facts['distribution'] == 'Fedora' and ansible_facts['distribution_version'] is version('37', '>=')) or
+            (ansible_facts['distribution'] == 'CentOS' and ansible_facts['distribution_version'] is version('9', '>=')) or (ansible_facts['distribution'] == 'RedHat' and ansible_facts['distribution_version'] is version('9.2', '>=')))
+
+    - name: /sysroot should be mount with rw permission for edge-simplified-installer and edge-raw-image for <9.2 and <F37
+      block:
+        - assert:
+            that:
+              - result_sysroot_mount_status.stdout == "rw"
+            fail_msg: "/sysroot is not mounted with rw permission"
+            success_msg: "/sysroot is mounted with rw permission"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: (edge_type == "edge-simplified-installer" or edge_type == "edge-raw-image") and ((ansible_facts['distribution'] == 'Fedora' and ansible_facts['distribution_version'] is version('37', '<')) or
+            (ansible_facts['distribution'] == 'CentOS' and ansible_facts['distribution_version'] is version('9', '<')) or (ansible_facts['distribution'] == 'RedHat' and ansible_facts['distribution_version'] is version('9.2', '<')))
+
 
     # case: check /var mount point
     - name: check /var mount point

--- a/test/data/manifests/centos_8-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_raw_image-boot.json
@@ -2102,8 +2102,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -2134,7 +2133,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -2260,7 +2259,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "centos",
                 "install": true,

--- a/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
@@ -2454,8 +2454,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -2486,7 +2485,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -2612,7 +2611,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "centos",
                 "install": true,

--- a/test/data/manifests/centos_8-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_raw_image-boot.json
@@ -2214,8 +2214,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -2246,7 +2245,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -2372,7 +2371,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "centos",

--- a/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
@@ -2502,8 +2502,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -2534,7 +2533,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -2660,7 +2659,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "centos",
                 "install": true,

--- a/test/data/manifests/rhel_8-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_raw_image-boot.json
@@ -857,8 +857,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -889,7 +888,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1015,7 +1014,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_simplified_installer-boot.json
@@ -994,8 +994,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -1026,7 +1025,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1152,7 +1151,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_8-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_raw_image-boot.json
@@ -899,8 +899,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -931,7 +930,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1057,7 +1056,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_simplified_installer-boot.json
@@ -1012,8 +1012,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -1044,7 +1043,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1170,7 +1169,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_86-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_raw_image-boot.json
@@ -857,8 +857,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -889,7 +888,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1015,7 +1014,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
@@ -997,8 +997,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -1029,7 +1028,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1155,7 +1154,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_86-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_raw_image-boot.json
@@ -899,8 +899,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -931,7 +930,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1057,7 +1056,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
@@ -1015,8 +1015,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -1047,7 +1046,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1173,7 +1172,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_87-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_raw_image-boot.json
@@ -857,8 +857,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -889,7 +888,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1015,7 +1014,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_87-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_simplified_installer-boot.json
@@ -994,8 +994,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -1026,7 +1025,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1152,7 +1151,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_87-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_raw_image-boot.json
@@ -899,8 +899,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -931,7 +930,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1057,7 +1056,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_87-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_simplified_installer-boot.json
@@ -1012,8 +1012,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -1044,7 +1043,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1170,7 +1169,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_88-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_raw_image-boot.json
@@ -857,8 +857,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -889,7 +888,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1015,7 +1014,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_88-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_simplified_installer-boot.json
@@ -994,8 +994,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -1026,7 +1025,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1152,7 +1151,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_88-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_raw_image-boot.json
@@ -899,8 +899,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -931,7 +930,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1057,7 +1056,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_88-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_simplified_installer-boot.json
@@ -1012,8 +1012,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -1044,7 +1043,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1170,7 +1169,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_9-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_raw_image-boot.json
@@ -2231,8 +2231,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -2263,7 +2262,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -2389,7 +2388,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_9-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_simplified_installer-boot.json
@@ -2615,8 +2615,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -2647,7 +2646,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -2773,7 +2772,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_9-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_raw_image-boot.json
@@ -2351,8 +2351,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -2383,7 +2382,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -2509,7 +2508,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_9-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_simplified_installer-boot.json
@@ -2663,8 +2663,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -2695,7 +2694,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -2821,7 +2820,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_90-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_raw_image-boot.json
@@ -836,8 +836,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -868,7 +867,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -994,7 +993,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
@@ -985,8 +985,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -1017,7 +1016,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1143,7 +1142,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_90-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_raw_image-boot.json
@@ -884,8 +884,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -916,7 +915,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1042,7 +1041,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
@@ -1006,8 +1006,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -1038,7 +1037,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -1164,7 +1163,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_91-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_raw_image-boot.json
@@ -2231,8 +2231,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -2263,7 +2262,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -2389,7 +2388,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_91-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_simplified_installer-boot.json
@@ -2615,8 +2615,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -2647,7 +2646,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -2773,7 +2772,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_91-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_raw_image-boot.json
@@ -2351,8 +2351,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -2383,7 +2382,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -2509,7 +2508,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_91-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_simplified_installer-boot.json
@@ -2663,8 +2663,7 @@
               },
               "kernel_opts": [
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                "modprobe.blacklist=vc4",
-                "rw"
+                "modprobe.blacklist=vc4"
               ]
             }
           },
@@ -2695,7 +2694,7 @@
               "repo": "/ostree/repo",
               "config": {
                 "sysroot": {
-                  "readonly": true,
+                  "readonly": false,
                   "bootloader": "none"
                 }
               }
@@ -2821,7 +2820,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,


### PR DESCRIPTION
sysroot.readonly is an f37+,8.8,9.2 thing so we need these conditionals to avoid having users build 9.1/8.7 images with RO - those lower versions should continue building w/o RO and only on upgrade to 9.2 they get RO

Signed-off-by: Antonio Murdaca <antoniomurdaca@gmail.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
