### PR TITLE
internal/worker: add String to clienterrors.Error struct

### DIFF
--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -1,5 +1,9 @@
 package clienterrors
 
+import (
+	"fmt"
+)
+
 const (
 	ErrorNoDynamicArgs        ClientErrorCode = 1
 	ErrorInvalidTargetConfig  ClientErrorCode = 2
@@ -44,6 +48,10 @@ type Error struct {
 	ID      ClientErrorCode `json:"id"`
 	Reason  string          `json:"reason"`
 	Details interface{}     `json:"details,omitempty"`
+}
+
+func (e *Error) String() string {
+	return fmt.Sprintf("Code: %d, Reason: %s, Details: %v", e.ID, e.Reason, e.Details)
 }
 
 const (


### PR DESCRIPTION
This should make the logging better when errors have another error struct.

Fixes #3272

