### PR TITLE
Image info: Update from manifest-db

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-36": {
     "dependencies": {
       "osbuild": {
-        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
+        "commit": "5eefdc1e9a732a0315c360a3771f1f3ba68a5294"
       }
     },
     "repos": [
@@ -79,7 +79,7 @@
   "fedora-37": {
     "dependencies": {
       "osbuild": {
-        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
+        "commit": "5eefdc1e9a732a0315c360a3771f1f3ba68a5294"
       }
     },
     "repos": [
@@ -156,28 +156,28 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "ae563ff8962be0ae13e5becd0a3c2c646eeacc24"
+        "commit": "5eefdc1e9a732a0315c360a3771f1f3ba68a5294"
       }
     }
   },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {
-        "commit": "ae563ff8962be0ae13e5becd0a3c2c646eeacc24"
+        "commit": "5eefdc1e9a732a0315c360a3771f1f3ba68a5294"
       }
     }
   },
   "rhel-8.7": {
     "dependencies": {
       "osbuild": {
-        "commit": "ae563ff8962be0ae13e5becd0a3c2c646eeacc24"
+        "commit": "5eefdc1e9a732a0315c360a3771f1f3ba68a5294"
       }
     }
   },
   "rhel-8.8": {
     "dependencies": {
       "osbuild": {
-        "commit": "cb989f79b110b4b18d372deace94a7c6c7137b93"
+        "commit": "5eefdc1e9a732a0315c360a3771f1f3ba68a5294"
       }
     },
     "repos": [
@@ -223,21 +223,21 @@
   "rhel-9.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "ae563ff8962be0ae13e5becd0a3c2c646eeacc24"
+        "commit": "5eefdc1e9a732a0315c360a3771f1f3ba68a5294"
       }
     }
   },
   "rhel-9.1": {
     "dependencies": {
       "osbuild": {
-        "commit": "ae563ff8962be0ae13e5becd0a3c2c646eeacc24"
+        "commit": "5eefdc1e9a732a0315c360a3771f1f3ba68a5294"
       }
     }
   },
   "rhel-9.2": {
     "dependencies": {
       "osbuild": {
-        "commit": "cb989f79b110b4b18d372deace94a7c6c7137b93"
+        "commit": "5eefdc1e9a732a0315c360a3771f1f3ba68a5294"
       }
     },
     "repos": [
@@ -283,21 +283,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
+        "commit": "5eefdc1e9a732a0315c360a3771f1f3ba68a5294"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
+        "commit": "5eefdc1e9a732a0315c360a3771f1f3ba68a5294"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
+        "commit": "5eefdc1e9a732a0315c360a3771f1f3ba68a5294"
       }
     },
     "repos": [
@@ -343,7 +343,7 @@
   "centos-stream-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "fdf064b15a1ef42bd13abdfcb7e08f764f596a60"
+        "commit": "5eefdc1e9a732a0315c360a3771f1f3ba68a5294"
       }
     },
     "repos": [

--- a/tools/image-info
+++ b/tools/image-info
@@ -21,7 +21,7 @@ import xml.etree.ElementTree
 import yaml
 
 from collections import OrderedDict
-from typing import Dict
+from typing import Dict, Any, Generator
 
 from osbuild import loop
 
@@ -70,7 +70,7 @@ def loop_open(ctl, image, *, offset=None, size=None):
 
 
 @contextlib.contextmanager
-def convert_image(ctl, image, fmt):
+def convert_image(image, fmt):
     with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
         if fmt["type"] != "raw":
             target = os.path.join(tmp, "image.raw")
@@ -135,6 +135,8 @@ def parse_environment_vars(s):
 def parse_unit_files(s, expected_state):
     r = []
     for line in s.split("\n")[1:]:
+        state = ""
+        unit = ""
         try:
             unit, state, *_ = line.split()
         except ValueError:
@@ -146,7 +148,7 @@ def parse_unit_files(s, expected_state):
     return r
 
 
-def subprocess_check_output(argv, parse_fn=None):
+def subprocess_check_output(argv, parse_fn=None) -> Any:
     try:
         output = subprocess.check_output(argv, encoding="utf-8")
     except subprocess.CalledProcessError as e:
@@ -195,7 +197,7 @@ def read_container_images(tree):
     return images
 
 
-def read_image_format(device):
+def read_image_format(device) -> Dict[str, str]:
     """
     Read image format.
 
@@ -318,7 +320,7 @@ def read_partition_table(device):
     return info
 
 
-def read_bootloader_type(device):
+def read_bootloader_type(device) -> str:
     """
     Read bootloader type from the provided device.
 
@@ -416,16 +418,18 @@ def rpm_verify(tree):
 
     changed = {}
     missing = []
-    for line in rpm.stdout:
-        # format description in rpm(8), under `--verify`
-        attrs = line[:9]
-        if attrs == "missing  ":
-            missing.append(line[12:].rstrip())
-        else:
-            changed[line[13:].rstrip()] = attrs
 
-    # ignore return value, because it returns non-zero when it found changes
-    rpm.wait()
+    if rpm.stdout:
+        for line in rpm.stdout:
+            # format description in rpm(8), under `--verify`
+            attrs = line[:9]
+            if attrs == "missing  ":
+                missing.append(line[12:].rstrip())
+            else:
+                changed[line[13:].rstrip()] = attrs
+
+        # ignore return value, because it returns non-zero when it found changes
+        rpm.wait()
 
     return {
         "missing": sorted(missing),
@@ -433,7 +437,7 @@ def rpm_verify(tree):
     }
 
 
-def rpm_not_installed_docs(tree, is_ostree):
+def rpm_not_installed_docs(tree):
     """
     Gathers information on documentation, which is part of RPM packages,
     but was not installed.
@@ -467,7 +471,7 @@ def rpm_not_installed_docs(tree, is_ostree):
     return sorted(not_installed_docs)
 
 
-def rpm_packages(tree, is_ostree):
+def rpm_packages(tree):
     """
     Read NVRs of RPM packages installed on the system.
 
@@ -494,7 +498,7 @@ def rpm_packages(tree, is_ostree):
         cmd += ["--dbpath", "/usr/share/rpm"]
     elif os.path.exists(os.path.join(tree, "var/lib/rpm")):
         cmd += ["--dbpath", "/var/lib/rpm"]
-    output = subprocess_check_output(cmd)
+    subprocess_check_output(cmd)
     pkgs = subprocess_check_output(cmd, str.split)
     return list(sorted(pkgs))
 
@@ -2271,11 +2275,11 @@ def read_resolv_conf(tree):
 
 def append_filesystem(report, tree, *, is_ostree=False):
     if os.path.exists(f"{tree}/etc/os-release"):
-        report["packages"] = rpm_packages(tree, is_ostree)
+        report["packages"] = rpm_packages(tree)
         if not is_ostree:
             report["rpm-verify"] = rpm_verify(tree)
 
-        not_installed_docs = rpm_not_installed_docs(tree, is_ostree)
+        not_installed_docs = rpm_not_installed_docs(tree)
         if not_installed_docs:
             report["rpm_not_installed_docs"] = not_installed_docs
 
@@ -2485,7 +2489,7 @@ def ensure_device_file(path: str, major: int, minor: int):
 
 
 @contextlib.contextmanager
-def discover_lvm(dev) -> Dict:
+def discover_lvm(dev) -> Generator[Dict[str, Any], None, None]:
     # find the volume group name for the device file
     vg_name = volume_group_for_device(dev)
 
@@ -2532,13 +2536,11 @@ def discover_lvm(dev) -> Dict:
             volumes[name] = info
             if name.startswith("root"):
                 volumes.move_to_end(name, last=False)
-        res = {
+        yield {
             "lvm": True,
             "lvm.vg": vg_name,
             "lvm.volumes": volumes
         }
-
-        yield res
 
     finally:
         r = subprocess.run(["vgchange", "-an", vg_name],
@@ -2621,13 +2623,13 @@ def append_partitions(report, image, loctl):
         append_filesystem(report, root_tree)
 
 
-def analyse_image(image):
+def analyse_image(image) -> Dict[str, Any]:
     loctl = loop.LoopControl()
 
     imgfmt = read_image_format(image)
-    report = {"image-format": imgfmt}
+    report: Dict[str, Any] = {"image-format": imgfmt}
 
-    with convert_image(loctl, image, imgfmt) as target:
+    with convert_image(image, imgfmt) as target:
         size = os.stat(target).st_size
         with loop_open(loctl, target, offset=0, size=size) as device:
             report["bootloader"] = read_bootloader_type(device)
@@ -2650,7 +2652,7 @@ def append_directory(report, tree):
         # Make sure that the tools which analyse the directory in-place
         # can not modify its content (e.g. create additional files).
         # mount_at() always mounts the source as read-only!
-        with mount_at(tree, tree_ro, ["bind"]) as mountpoint:
+        with mount_at(tree, tree_ro, ["bind"]) as _:
             if os.path.lexists(f"{tree}/ostree"):
                 os.makedirs(f"{tree}/etc", exist_ok=True)
                 with mount_at(f"{tree}/usr/etc", f"{tree}/etc", extra=["--bind"]):
@@ -2700,7 +2702,7 @@ def analyse_directory(path):
 
 
 def is_tarball(path):
-    mtype, encoding = mimetypes.guess_type(path)
+    mtype, _ = mimetypes.guess_type(path)
     return mtype == "application/x-tar"
 
 

--- a/tools/image-info
+++ b/tools/image-info
@@ -2484,74 +2484,70 @@ def discover_lvm(dev:str, parent:devices.Device, devmgr:devices.DeviceManager):
     # activating LVM is done OSBuild side.
     # However we still have to get OSBuild the name of the VG to open
 
-    try:
-        # Find all logical volumes in the volume group
-        cmd = [
-            "lvdisplay", "-C", "--noheadings",
-            "-o", "lv_name,path,lv_kernel_major,lv_kernel_minor",
-            "--separator", ";",
-            vg_name
-        ]
+    # Find all logical volumes in the volume group
+    cmd = [
+        "lvdisplay", "-C", "--noheadings",
+        "-o", "lv_name,path,lv_kernel_major,lv_kernel_minor",
+        "--separator", ";",
+        vg_name
+    ]
 
-        res = subprocess.run(cmd,
-                             check=False,
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE,
-                             encoding="UTF-8")
+    res = subprocess.run(cmd,
+                         check=False,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         encoding="UTF-8")
 
-        if res.returncode != 0:
-            raise RuntimeError(res.stderr.strip())
+    if res.returncode != 0:
+        raise RuntimeError(res.stderr.strip())
 
-        data = res.stdout.strip()
-        parsed = list(map(lambda l: l.split(";"), data.split("\n")))
-        volumes = OrderedDict()
+    data = res.stdout.strip()
+    parsed = list(map(lambda l: l.split(";"), data.split("\n")))
+    volumes = OrderedDict()
 
-        # devices_map stores for each device path onto the system the corresponding
-        # OSBuild's Device object
-        devices_map = {}
+    # devices_map stores for each device path onto the system the corresponding
+    # OSBuild's Device object
+    devices_map = {}
 
-        for vol in parsed:
-            vol = list(map(lambda v: v.strip(), vol))
-            assert len(vol) == 4
-            name, _, _, _ = vol
+    for vol in parsed:
+        vol = list(map(lambda v: v.strip(), vol))
+        assert len(vol) == 4
+        name, _, _, _ = vol
 
-            options = {
-                "volume": name,
-            }
-
-            # Create an OSBuild device object for the LVM partition
-            device = devices.Device(
-                        name,
-                        index.get_module_info("Device", "org.osbuild.lvm2.lv"),
-                        parent,
-                        options)
-            reply = devmgr.open(device)
-            voldev = reply["path"] # get the path where is mounted the device
-            minor = reply["node"]["minor"]
-            major = reply["node"]["major"]
-
-            info = {
-                "device": voldev
-            }
-            ensure_device_file(voldev, int(major), int(minor))
-
-            read_partition(voldev, info)
-            volumes[name] = info
-            if name.startswith("root"):
-                volumes.move_to_end(name, last=False)
-
-            # associate the device path with the Device object, we will need it to
-            # mount later on.
-            devices_map[voldev] = device
-        # get back both the device map and the result that'll go in the JSON report
-        return devices_map, {
-            "lvm": True,
-            "lvm.vg": vg_name,
-            "lvm.volumes": volumes
+        options = {
+            "volume": name,
         }
 
-    finally:
-        pass
+        # Create an OSBuild device object for the LVM partition
+        device = devices.Device(
+                    name,
+                    index.get_module_info("Device", "org.osbuild.lvm2.lv"),
+                    parent,
+                    options)
+        reply = devmgr.open(device)
+        voldev = reply["path"] # get the path where is mounted the device
+        minor = reply["node"]["minor"]
+        major = reply["node"]["major"]
+
+        info = {
+            "device": voldev
+        }
+        ensure_device_file(voldev, int(major), int(minor))
+
+        read_partition(voldev, info)
+        volumes[name] = info
+        if name.startswith("root"):
+            volumes.move_to_end(name, last=False)
+
+        # associate the device path with the Device object, we will need it to
+        # mount later on.
+        devices_map[voldev] = device
+    # get back both the device map and the result that'll go in the JSON report
+    return devices_map, {
+        "lvm": True,
+        "lvm.vg": vg_name,
+        "lvm.volumes": volumes
+    }
 
 
 def partition_is_lvm(part: Dict) -> bool:

--- a/tools/image-info
+++ b/tools/image-info
@@ -286,7 +286,7 @@ def read_partition_table(device):
     ptable = sfdisk["partitiontable"]
     assert ptable["unit"] == "sectors"
     is_dos = ptable["label"] == "dos"
-    ssize = ptable.get("sectorsize", 512)
+    ssize = ptable.get("sectorsize", SECTOR_SIZE)
 
     for i, p in enumerate(ptable["partitions"]):
 
@@ -324,7 +324,7 @@ def read_bootloader_type(device) -> str:
     - 'unknown'
     """
     with open(device, "rb") as f:
-        if b"GRUB" in f.read(512):
+        if b"GRUB" in f.read(SECTOR_SIZE):
             return "grub"
         else:
             return "unknown"

--- a/tools/image-info
+++ b/tools/image-info
@@ -2632,8 +2632,13 @@ def append_partitions(report, image):
                 info = index.get_module_info("Mount", "org.osbuild.xfs")
             else:
                 raise RuntimeError("Unknown file system")
-            options = { "readonly":True }
-
+            options = {"readonly": True}
+            for option in part_options:
+                if "=" in option:
+                    parts = option.split("=")
+                    options[parts[0]] = parts[1]
+                else:
+                    options[option] = True
 
             # the first mount point should be root
             if n == 0:

--- a/tools/image-info
+++ b/tools/image-info
@@ -41,7 +41,7 @@ def run_ostree(*args, _input=None, _check=True, **kwargs):
     return res
 
 
-def loop_open(devmgr:devices.DeviceManager, name:str, image, size, offset=0):
+def loop_open(devmgr: devices.DeviceManager, name: str, image, size, offset=0):
     """
     Uses a DeviceManager to open the `name` at `offset`
     Retuns a Device object and the path onto wich the image was loopback mounted
@@ -63,6 +63,7 @@ def loop_open(devmgr:devices.DeviceManager, name:str, image, size, offset=0):
         "Device": dev,
         "path": os.path.join("/dev", reply["path"])
     }
+
 
 @contextlib.contextmanager
 def convert_image(image, fmt):
@@ -232,7 +233,7 @@ def read_partition(device, partition):
     else:
         blkid = {}
 
-    partition["label"] = blkid.get("LABEL") # doesn't exist for mbr
+    partition["label"] = blkid.get("LABEL")  # doesn't exist for mbr
     partition["uuid"] = blkid.get("UUID")
     partition["fstype"] = blkid.get("TYPE")
     return partition
@@ -409,7 +410,7 @@ def rpm_verify(tree):
     # verify user and group ownership:
     #   https://github.com/rpm-software-management/rpm/issues/882
     rpm = subprocess.Popen(["chroot", tree, "rpm", "--verify", "--all"],
-            stdout=subprocess.PIPE, encoding="utf-8")
+                           stdout=subprocess.PIPE, encoding="utf-8")
 
     changed = {}
     missing = []
@@ -528,7 +529,8 @@ def read_services(tree, state):
         "chrony-wait.service"
     ]
     """
-    services_state = subprocess_check_output(["systemctl", f"--root={tree}", "list-unit-files"], (lambda s: parse_unit_files(s, state)))
+    services_state = subprocess_check_output(
+        ["systemctl", f"--root={tree}", "list-unit-files"], (lambda s: parse_unit_files(s, state)))
 
     # Since systemd v246, some services previously reported as "enabled" /
     # "disabled" are now reported as "alias". There is no systemd command, that
@@ -538,7 +540,8 @@ def read_services(tree, state):
     # pre/post v246 systemd versions, check all "alias" units and append them
     # to the list, if their target is also listed in 'services_state'.
     if state != "alias":
-        services_alias = subprocess_check_output(["systemctl", f"--root={tree}", "list-unit-files"], (lambda s: parse_unit_files(s, "alias")))
+        services_alias = subprocess_check_output(
+            ["systemctl", f"--root={tree}", "list-unit-files"], (lambda s: parse_unit_files(s, "alias")))
 
         for alias in services_alias:
             # The service may be in one of the following places (output of
@@ -2467,7 +2470,7 @@ def volume_group_for_device(device: str) -> str:
             continue
 
         if res.returncode != 0:
-             raise RuntimeError(res.stderr.strip())
+            raise RuntimeError(res.stderr.strip())
 
         vg_name = res.stdout.strip()
         if vg_name:
@@ -2483,7 +2486,7 @@ def ensure_device_file(path: str, major: int, minor: int):
         os.mknod(path, 0o600 | stat.S_IFBLK, os.makedev(major, minor))
 
 
-def discover_lvm(dev:str, parent:devices.Device, devmgr:devices.DeviceManager):
+def discover_lvm(dev: str, parent: devices.Device, devmgr: devices.DeviceManager):
     # find the volume group name for the device file
     vg_name = volume_group_for_device(dev)
 
@@ -2535,7 +2538,7 @@ def discover_lvm(dev:str, parent:devices.Device, devmgr:devices.DeviceManager):
             raise RuntimeError("can't find org.osbuild.lvm2.lv")
         jsonschema.validate(options, info.get_schema())
         reply = devmgr.open(device)
-        voldev = reply["path"] # get the path where is mounted the device
+        voldev = reply["path"]  # get the path where is mounted the device
         minor = reply["node"]["minor"]
         major = reply["node"]["major"]
 
@@ -2579,11 +2582,11 @@ def append_partitions(report, image):
         for part in partitions:
             start, size = part["start"], part["size"]
             ret = loop_open(
-                    devmgr,
-                    part["partuuid"],
-                    image,
-                    size,
-                    offset=start)
+                devmgr,
+                part["partuuid"],
+                image,
+                size,
+                offset=start)
             dev = ret["path"]
             devices_map[dev] = ret["Device"]
             read_partition(dev, part)
@@ -2685,7 +2688,7 @@ def append_partitions(report, image):
             mmgr.mount(mounts.Mount(
                 part_device,
                 info,
-                devices_map[part_device], # retrieves the associated Device Object
+                devices_map[part_device],  # retrieves the associated Device Object
                 part_mountpoint,
                 options))
 
@@ -2703,11 +2706,11 @@ def analyse_image(image) -> Dict[str, Any]:
         size = os.stat(target).st_size
         with host.ServiceManager(monitor=monitor.NullMonitor(1)) as mgr:
             device = loop_open(
-                    devices.DeviceManager(mgr, "/dev", os.path.dirname(target)),
-                    os.path.basename(target),
-                    target,
-                    size,
-                    offset=0)["path"]
+                devices.DeviceManager(mgr, "/dev", os.path.dirname(target)),
+                os.path.basename(target),
+                target,
+                size,
+                offset=0)["path"]
             report["bootloader"] = read_bootloader_type(device)
             report.update(read_partition_table(device))
             if not report["partition-table"]:
@@ -2835,6 +2838,7 @@ def analyse_compressed(path):
         assert len(files) == 1
         image = os.path.join(tmpdir, files[0])
         return analyse_image(image)
+
 
 def is_iso(path):
     return "iso" in pathlib.Path(path).suffix

--- a/tools/image-info
+++ b/tools/image-info
@@ -2569,133 +2569,133 @@ def partition_is_lvm(part: Dict) -> bool:
 
 def append_partitions(report, image):
     partitions = report["partitions"]
-    with (tempfile.TemporaryDirectory() as mountpoint,
-          host.ServiceManager(monitor=monitor.NullMonitor(1)) as mgr):
+    with tempfile.TemporaryDirectory() as mountpoint:
+        with host.ServiceManager(monitor=monitor.NullMonitor(1)) as mgr:
 
-        devmgr = devices.DeviceManager(mgr, "/dev", os.path.dirname(image))
+            devmgr = devices.DeviceManager(mgr, "/dev", os.path.dirname(image))
 
-        # Device map associate a path onto where the device is mounted with its
-        # corresponding Device object. Mount will require both the path and the
-        # Device object in order to do its job.
-        devices_map = {}
-        filesystems = {}
-        for part in partitions:
-            start, size = part["start"], part["size"]
-            ret = loop_open(
-                devmgr,
-                part["partuuid"],
-                image,
-                size,
-                offset=start)
-            dev = ret["path"]
-            devices_map[dev] = ret["Device"]
-            read_partition(dev, part)
-            if partition_is_lvm(part):
-                dmap, lvm = discover_lvm(dev, ret["Device"], devmgr)
-                devices_map.update(dmap)
-                for vol in lvm["lvm.volumes"].values():
-                    if vol["fstype"]:
-                        mntopts = []
-                        # we cannot recover since the underlying loopback device is mounted
-                        # read-only but since we are using the it through the device mapper
-                        # the fact might not be communicated and the kernel attempt a to
-                        # a recovery of the filesystem, which will lead to a kernel panic
-                        if vol["fstype"] in ("ext4", "ext3", "xfs"):
-                            mntopts = ["norecovery"]
-                        filesystems[vol["uuid"].upper()] = {
-                            "device": vol["device"],
-                            "mntops": mntopts
-                        }
-                    del vol["device"]
-                part.update(lvm)
-            elif part["uuid"] and part["fstype"]:
-                filesystems[part["uuid"].upper()] = {
-                    "device": dev
-                }
+            # Device map associate a path onto where the device is mounted with its
+            # corresponding Device object. Mount will require both the path and the
+            # Device object in order to do its job.
+            devices_map = {}
+            filesystems = {}
+            for part in partitions:
+                start, size = part["start"], part["size"]
+                ret = loop_open(
+                    devmgr,
+                    part["partuuid"],
+                    image,
+                    size,
+                    offset=start)
+                dev = ret["path"]
+                devices_map[dev] = ret["Device"]
+                read_partition(dev, part)
+                if partition_is_lvm(part):
+                    dmap, lvm = discover_lvm(dev, ret["Device"], devmgr)
+                    devices_map.update(dmap)
+                    for vol in lvm["lvm.volumes"].values():
+                        if vol["fstype"]:
+                            mntopts = []
+                            # we cannot recover since the underlying loopback device is mounted
+                            # read-only but since we are using the it through the device mapper
+                            # the fact might not be communicated and the kernel attempt a to
+                            # a recovery of the filesystem, which will lead to a kernel panic
+                            if vol["fstype"] in ("ext4", "ext3", "xfs"):
+                                mntopts = ["norecovery"]
+                            filesystems[vol["uuid"].upper()] = {
+                                "device": vol["device"],
+                                "mntops": mntopts
+                            }
+                        del vol["device"]
+                    part.update(lvm)
+                elif part["uuid"] and part["fstype"]:
+                    filesystems[part["uuid"].upper()] = {
+                        "device": dev
+                    }
 
-        # find partition with fstab and read it
-        fstab = []
-        for fs in filesystems.values():
-            dev, opts = fs["device"], fs.get("mntops")
-            with mount(dev, opts) as tree:
-                if os.path.exists(f"{tree}/etc/fstab"):
-                    fstab.extend(read_fstab(tree))
-                    break
-        # sort the fstab entries by the mountpoint
-        fstab = sorted(fstab, key=operator.itemgetter(1))
+            # find partition with fstab and read it
+            fstab = []
+            for fs in filesystems.values():
+                dev, opts = fs["device"], fs.get("mntops")
+                with mount(dev, opts) as tree:
+                    if os.path.exists(f"{tree}/etc/fstab"):
+                        fstab.extend(read_fstab(tree))
+                        break
+            # sort the fstab entries by the mountpoint
+            fstab = sorted(fstab, key=operator.itemgetter(1))
 
-        # mount all partitions to ther respective mount points
-        root_tree = ""
-        mmgr = mounts.MountManager(devmgr, mountpoint)
-        for n, fstab_entry in enumerate(fstab):
-            part_uuid = fstab_entry[0].split("=")[1].upper()
-            part_device = filesystems[part_uuid]["device"]
-            part_mountpoint = fstab_entry[1]
-            part_fstype = fstab_entry[2]
-            part_options = fstab_entry[3].split(",")
-            part_options += filesystems[part_uuid].get("mntops", [])
+            # mount all partitions to ther respective mount points
+            root_tree = ""
+            mmgr = mounts.MountManager(devmgr, mountpoint)
+            for n, fstab_entry in enumerate(fstab):
+                part_uuid = fstab_entry[0].split("=")[1].upper()
+                part_device = filesystems[part_uuid]["device"]
+                part_mountpoint = fstab_entry[1]
+                part_fstype = fstab_entry[2]
+                part_options = fstab_entry[3].split(",")
+                part_options += filesystems[part_uuid].get("mntops", [])
 
-            if "ext4" in part_fstype:
-                info = index.get_module_info("Mount", "org.osbuild.ext4")
-            elif "vfat" in part_fstype:
-                info = index.get_module_info("Mount", "org.osbuild.fat")
-            elif "btrfs" in part_fstype:
-                info = index.get_module_info("Mount", "org.osbuild.btrfs")
-            elif "xfs" in part_fstype:
-                info = index.get_module_info("Mount", "org.osbuild.xfs")
-            else:
-                raise RuntimeError("Unknown file system")
-            if not info:
-                raise RuntimeError(f"Can't find org.osbuild.{part_fstype}")
-
-            # the first mount point should be root
-            if n == 0:
-                if part_mountpoint != "/":
-                    raise RuntimeError("The first mountpoint in sorted fstab entries is not '/'")
-                root_tree = mountpoint
-
-            # prepare the options to mount the partition
-            options = {}
-            for option in part_options:
-                if option == "defaults":  # defaults is not a supported option
-                    continue
-
-                if "=" in option:
-                    parts = option.split("=")
-                    key = parts[0]
-                    val = parts[1]
-
-                    # uid and gid must be integers
-                    if key == "uid" or key == "gid":
-                        val = int(val)
-
-                    options[key] = val
+                if "ext4" in part_fstype:
+                    info = index.get_module_info("Mount", "org.osbuild.ext4")
+                elif "vfat" in part_fstype:
+                    info = index.get_module_info("Mount", "org.osbuild.fat")
+                elif "btrfs" in part_fstype:
+                    info = index.get_module_info("Mount", "org.osbuild.btrfs")
+                elif "xfs" in part_fstype:
+                    info = index.get_module_info("Mount", "org.osbuild.xfs")
                 else:
-                    options[option] = True
+                    raise RuntimeError("Unknown file system")
+                if not info:
+                    raise RuntimeError(f"Can't find org.osbuild.{part_fstype}")
 
-            options["readonly"] = True
+                # the first mount point should be root
+                if n == 0:
+                    if part_mountpoint != "/":
+                        raise RuntimeError("The first mountpoint in sorted fstab entries is not '/'")
+                    root_tree = mountpoint
 
-            # Validate the options
-            #
-            # The mount manager is taking care of opening the file system for us
-            # so we don't have access to the json objects that'll be used to
-            # invoke the mounter. However we're only interested at validating the
-            # options. We can extract these from the schame to validate them
-            # only.
-            jsonschema.validate(options, info.get_schema()["properties"]["options"])
+                # prepare the options to mount the partition
+                options = {}
+                for option in part_options:
+                    if option == "defaults":  # defaults is not a supported option
+                        continue
 
-            # Finally mount
-            mmgr.mount(mounts.Mount(
-                part_device,
-                info,
-                devices_map[part_device],  # retrieves the associated Device Object
-                part_mountpoint,
-                options))
+                    if "=" in option:
+                        parts = option.split("=")
+                        key = parts[0]
+                        val = parts[1]
 
-        if not root_tree:
-            raise RuntimeError("The root filesystem tree is not mounted")
+                        # uid and gid must be integers
+                        if key == "uid" or key == "gid":
+                            val = int(val)
 
-        append_filesystem(report, root_tree)
+                        options[key] = val
+                    else:
+                        options[option] = True
+
+                options["readonly"] = True
+
+                # Validate the options
+                #
+                # The mount manager is taking care of opening the file system for us
+                # so we don't have access to the json objects that'll be used to
+                # invoke the mounter. However we're only interested at validating the
+                # options. We can extract these from the schame to validate them
+                # only.
+                jsonschema.validate(options, info.get_schema()["properties"]["options"])
+
+                # Finally mount
+                mmgr.mount(mounts.Mount(
+                    part_device,
+                    info,
+                    devices_map[part_device],  # retrieves the associated Device Object
+                    part_mountpoint,
+                    options))
+
+            if not root_tree:
+                raise RuntimeError("The root filesystem tree is not mounted")
+
+            append_filesystem(report, root_tree)
 
 
 def analyse_image(image) -> Dict[str, Any]:

--- a/tools/image-info
+++ b/tools/image-info
@@ -18,6 +18,7 @@ import time
 import tempfile
 import xml.etree.ElementTree
 import yaml
+import pathlib
 import jsonschema
 
 from collections import OrderedDict
@@ -2835,6 +2836,21 @@ def analyse_compressed(path):
         image = os.path.join(tmpdir, files[0])
         return analyse_image(image)
 
+def is_iso(path):
+    return "iso" in pathlib.Path(path).suffix
+
+
+def analyse_iso(path):
+    with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
+        report = None
+        subprocess.run(["mount", "-o", "loop", path, tmp], check=True)
+        try:
+            report = analyse_tarball(os.path.join(tmp, "liveimg.tar.gz"))
+        except Exception as e:
+            print(f"{e}", file=sys.stderr)
+        subprocess.run(["umount", tmp], check=True)
+        return report
+
 
 def main():
     parser = argparse.ArgumentParser(description="Inspect an image")
@@ -2851,6 +2867,8 @@ def main():
         report = analyse_tarball(target)
     elif is_compressed(target):
         report = analyse_compressed(target)
+    elif is_iso(target):
+        report = analyse_iso(target)
     else:
         report = analyse_image(target)
 

--- a/tools/image-info
+++ b/tools/image-info
@@ -18,6 +18,7 @@ import time
 import tempfile
 import xml.etree.ElementTree
 import yaml
+import jsonschema
 
 from collections import OrderedDict
 from typing import Dict, Any
@@ -51,6 +52,10 @@ def loop_open(devmgr:devices.DeviceManager, name:str, image, size, offset=0):
         "start": offset // SECTOR_SIZE,
         "size": size // SECTOR_SIZE
     }
+    if not info:
+        raise RuntimeError("Can't load org.osbuild.loopback")
+
+    jsonschema.validate(options, info.get_schema())
     dev = devices.Device(name, info, None, options)
     reply = devmgr.open(dev)
     return {
@@ -2519,11 +2524,15 @@ def discover_lvm(dev:str, parent:devices.Device, devmgr:devices.DeviceManager):
         }
 
         # Create an OSBuild device object for the LVM partition
+        info = index.get_module_info("Device", "org.osbuild.lvm2.lv")
         device = devices.Device(
-                    name,
-                    index.get_module_info("Device", "org.osbuild.lvm2.lv"),
-                    parent,
-                    options)
+            name,
+            info,
+            parent,
+            options)
+        if not info:
+            raise RuntimeError("can't find org.osbuild.lvm2.lv")
+        jsonschema.validate(options, info.get_schema())
         reply = devmgr.open(device)
         voldev = reply["path"] # get the path where is mounted the device
         minor = reply["node"]["minor"]
@@ -2632,13 +2641,8 @@ def append_partitions(report, image):
                 info = index.get_module_info("Mount", "org.osbuild.xfs")
             else:
                 raise RuntimeError("Unknown file system")
-            options = {"readonly": True}
-            for option in part_options:
-                if "=" in option:
-                    parts = option.split("=")
-                    options[parts[0]] = parts[1]
-                else:
-                    options[option] = True
+            if not info:
+                raise RuntimeError(f"Can't find org.osbuild.{part_fstype}")
 
             # the first mount point should be root
             if n == 0:
@@ -2646,6 +2650,37 @@ def append_partitions(report, image):
                     raise RuntimeError("The first mountpoint in sorted fstab entries is not '/'")
                 root_tree = mountpoint
 
+            # prepare the options to mount the partition
+            options = {}
+            for option in part_options:
+                if option == "defaults":  # defaults is not a supported option
+                    continue
+
+                if "=" in option:
+                    parts = option.split("=")
+                    key = parts[0]
+                    val = parts[1]
+
+                    # uid and gid must be integers
+                    if key == "uid" or key == "gid":
+                        val = int(val)
+
+                    options[key] = val
+                else:
+                    options[option] = True
+
+            options["readonly"] = True
+
+            # Validate the options
+            #
+            # The mount manager is taking care of opening the file system for us
+            # so we don't have access to the json objects that'll be used to
+            # invoke the mounter. However we're only interested at validating the
+            # options. We can extract these from the schame to validate them
+            # only.
+            jsonschema.validate(options, info.get_schema()["properties"]["options"])
+
+            # Finally mount
             mmgr.mount(mounts.Mount(
                 part_device,
                 info,

--- a/tools/image-info
+++ b/tools/image-info
@@ -3,7 +3,6 @@
 import argparse
 import configparser
 import contextlib
-import errno
 import functools
 import glob
 import mimetypes
@@ -21,9 +20,12 @@ import xml.etree.ElementTree
 import yaml
 
 from collections import OrderedDict
-from typing import Dict, Any, Generator
+from typing import Dict, Any
 
-from osbuild import loop
+from osbuild import devices, host, mounts, meta, monitor
+
+index = meta.Index("/usr/lib/osbuild/")
+SECTOR_SIZE = 512
 
 
 def run_ostree(*args, _input=None, _check=True, **kwargs):
@@ -37,37 +39,24 @@ def run_ostree(*args, _input=None, _check=True, **kwargs):
     return res
 
 
-@contextlib.contextmanager
-def loop_create_device(ctl, fd, offset=None, sizelimit=None):
-    while True:
-        lo = loop.Loop(ctl.get_unbound())
-        try:
-            lo.set_fd(fd)
-        except OSError as e:
-            lo.close()
-            if e.errno == errno.EBUSY:
-                continue
-            raise e
-        try:
-            lo.set_status(offset=offset, sizelimit=sizelimit, autoclear=True)
-        except BlockingIOError:
-            lo.clear_fd()
-            lo.close()
-            continue
-        break
-    try:
-        yield lo
-    finally:
-        lo.close()
-
-
-@contextlib.contextmanager
-def loop_open(ctl, image, *, offset=None, size=None):
-    with open(image, "rb") as f:
-        fd = f.fileno()
-        with loop_create_device(ctl, fd, offset=offset, sizelimit=size) as lo:
-            yield os.path.join("/dev", lo.devname)
-
+def loop_open(devmgr:devices.DeviceManager, name:str, image, size, offset=0):
+    """
+    Uses a DeviceManager to open the `name` at `offset`
+    Retuns a Device object and the path onto wich the image was loopback mounted
+    """
+    info = index.get_module_info("Device", "org.osbuild.loopback")
+    fname = os.path.basename(image)
+    options = {
+        "filename": fname,
+        "start": offset // SECTOR_SIZE,
+        "size": size // SECTOR_SIZE
+    }
+    dev = devices.Device(name, info, None, options)
+    reply = devmgr.open(dev)
+    return {
+        "Device": dev,
+        "path": os.path.join("/dev", reply["path"])
+    }
 
 @contextlib.contextmanager
 def convert_image(image, fmt):
@@ -2488,18 +2477,12 @@ def ensure_device_file(path: str, major: int, minor: int):
         os.mknod(path, 0o600 | stat.S_IFBLK, os.makedev(major, minor))
 
 
-@contextlib.contextmanager
-def discover_lvm(dev) -> Generator[Dict[str, Any], None, None]:
+def discover_lvm(dev:str, parent:devices.Device, devmgr:devices.DeviceManager):
     # find the volume group name for the device file
     vg_name = volume_group_for_device(dev)
 
-    # activate it
-    r = subprocess.run(["vgchange", "-ay", vg_name],
-                       stdout=subprocess.DEVNULL,
-                       stderr=subprocess.PIPE,
-                       check=False)
-    if r.returncode != 0:
-        raise RuntimeError(r.stderr.strip())
+    # activating LVM is done OSBuild side.
+    # However we still have to get OSBuild the name of the VG to open
 
     try:
         # Find all logical volumes in the volume group
@@ -2523,10 +2506,30 @@ def discover_lvm(dev) -> Generator[Dict[str, Any], None, None]:
         parsed = list(map(lambda l: l.split(";"), data.split("\n")))
         volumes = OrderedDict()
 
+        # devices_map stores for each device path onto the system the corresponding
+        # OSBuild's Device object
+        devices_map = {}
+
         for vol in parsed:
             vol = list(map(lambda v: v.strip(), vol))
             assert len(vol) == 4
-            name, voldev, major, minor = vol
+            name, _, _, _ = vol
+
+            options = {
+                "volume": name,
+            }
+
+            # Create an OSBuild device object for the LVM partition
+            device = devices.Device(
+                        name,
+                        index.get_module_info("Device", "org.osbuild.lvm2.lv"),
+                        parent,
+                        options)
+            reply = devmgr.open(device)
+            voldev = reply["path"] # get the path where is mounted the device
+            minor = reply["node"]["minor"]
+            major = reply["node"]["major"]
+
             info = {
                 "device": voldev
             }
@@ -2536,37 +2539,51 @@ def discover_lvm(dev) -> Generator[Dict[str, Any], None, None]:
             volumes[name] = info
             if name.startswith("root"):
                 volumes.move_to_end(name, last=False)
-        yield {
+
+            # associate the device path with the Device object, we will need it to
+            # mount later on.
+            devices_map[voldev] = device
+        # get back both the device map and the result that'll go in the JSON report
+        return devices_map, {
             "lvm": True,
             "lvm.vg": vg_name,
             "lvm.volumes": volumes
         }
 
     finally:
-        r = subprocess.run(["vgchange", "-an", vg_name],
-                            stdout=subprocess.DEVNULL,
-                            stderr=subprocess.PIPE,
-                            check=False)
-        if r.returncode != 0:
-            raise RuntimeError(r.stderr.strip())
+        pass
 
 
 def partition_is_lvm(part: Dict) -> bool:
     return part["type"].upper() in ["E6D6D379-F507-44C2-A23C-238F2A3DF928", "8E"]
 
 
-def append_partitions(report, image, loctl):
+def append_partitions(report, image):
     partitions = report["partitions"]
+    with (tempfile.TemporaryDirectory() as mountpoint,
+          host.ServiceManager(monitor=monitor.NullMonitor(1)) as mgr):
 
-    with contextlib.ExitStack() as cm:
-        # open each partition as a loop device
+        devmgr = devices.DeviceManager(mgr, "/dev", os.path.dirname(image))
+
+        # Device map associate a path onto where the device is mounted with its
+        # corresponding Device object. Mount will require both the path and the
+        # Device object in order to do its job.
+        devices_map = {}
         filesystems = {}
         for part in partitions:
             start, size = part["start"], part["size"]
-            dev = cm.enter_context(loop_open(loctl, image, offset=start, size=size))
+            ret = loop_open(
+                    devmgr,
+                    part["partuuid"],
+                    image,
+                    size,
+                    offset=start)
+            dev = ret["path"]
+            devices_map[dev] = ret["Device"]
             read_partition(dev, part)
             if partition_is_lvm(part):
-                lvm = cm.enter_context(discover_lvm(dev))
+                dmap, lvm = discover_lvm(dev, ret["Device"], devmgr)
+                devices_map.update(dmap)
                 for vol in lvm["lvm.volumes"].values():
                     if vol["fstype"]:
                         mntopts = []
@@ -2600,6 +2617,7 @@ def append_partitions(report, image, loctl):
 
         # mount all partitions to ther respective mount points
         root_tree = ""
+        mmgr = mounts.MountManager(devmgr, mountpoint)
         for n, fstab_entry in enumerate(fstab):
             part_uuid = fstab_entry[0].split("=")[1].upper()
             part_device = filesystems[part_uuid]["device"]
@@ -2608,14 +2626,31 @@ def append_partitions(report, image, loctl):
             part_options = fstab_entry[3].split(",")
             part_options += filesystems[part_uuid].get("mntops", [])
 
+            if "ext4" in part_fstype:
+                info = index.get_module_info("Mount", "org.osbuild.ext4")
+            elif "vfat" in part_fstype:
+                info = index.get_module_info("Mount", "org.osbuild.fat")
+            elif "btrfs" in part_fstype:
+                info = index.get_module_info("Mount", "org.osbuild.btrfs")
+            elif "xfs" in part_fstype:
+                info = index.get_module_info("Mount", "org.osbuild.xfs")
+            else:
+                raise RuntimeError("Unknown file system")
+            options = { "readonly":True }
+
+
             # the first mount point should be root
             if n == 0:
                 if part_mountpoint != "/":
                     raise RuntimeError("The first mountpoint in sorted fstab entries is not '/'")
-                root_tree = cm.enter_context(mount(part_device, part_options))
-                continue
+                root_tree = mountpoint
 
-            cm.enter_context(mount_at(part_device, f"{root_tree}{part_mountpoint}", options=part_options, extra=["-t", part_fstype]))
+            mmgr.mount(mounts.Mount(
+                part_device,
+                info,
+                devices_map[part_device], # retrieves the associated Device Object
+                part_mountpoint,
+                options))
 
         if not root_tree:
             raise RuntimeError("The root filesystem tree is not mounted")
@@ -2624,14 +2659,18 @@ def append_partitions(report, image, loctl):
 
 
 def analyse_image(image) -> Dict[str, Any]:
-    loctl = loop.LoopControl()
-
     imgfmt = read_image_format(image)
     report: Dict[str, Any] = {"image-format": imgfmt}
 
     with convert_image(image, imgfmt) as target:
         size = os.stat(target).st_size
-        with loop_open(loctl, target, offset=0, size=size) as device:
+        with host.ServiceManager(monitor=monitor.NullMonitor(1)) as mgr:
+            device = loop_open(
+                    devices.DeviceManager(mgr, "/dev", os.path.dirname(target)),
+                    os.path.basename(target),
+                    target,
+                    size,
+                    offset=0)["path"]
             report["bootloader"] = read_bootloader_type(device)
             report.update(read_partition_table(device))
             if not report["partition-table"]:
@@ -2641,7 +2680,7 @@ def analyse_image(image) -> Dict[str, Any]:
                 return report
 
         # close loop device and descend into partitions on image file
-        append_partitions(report, target, loctl)
+        append_partitions(report, target)
         return report
 
 
@@ -2784,4 +2823,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
From https://github.com/osbuild/manifest-db/pull/72

We still have to discuss later on how to/where to move image-info. 
The thing is, Composer needs to have access to image-info when installed as an package, Manifest-DB can't provide this.
So the better place to do it is OSBuild as its packaged, is a dependency of Composer and overall is a good place to host a utility that uses its internals to run.

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
