### PR TITLE
test/cases: move CIV options into a variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,6 @@ stages:
   - rpmbuild
   - prepare-rhel-internal
   - test
-  - cleanup
   - finish
 
 .base:
@@ -764,19 +763,6 @@ Manifest-diff:
   artifacts:
     paths:
       - manifests.diff
-
-SCHEDULED_CLOUD_CLEANER:
-  stage: cleanup
-  tags:
-    - terraform
-  variables:
-    RUNNER: aws/centos-stream-8-x86_64
-    INTERNAL_NETWORK: "true"
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $CLEANUP == "true"'
-  script:
-    - schutzbot/deploy.sh
-    - schutzbot/scheduled_cloud_cleaner.sh
 
 SonarQube:
   stage: test

--- a/schutzbot/scheduled_cloud_cleaner.sh
+++ b/schutzbot/scheduled_cloud_cleaner.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-git clone https://github.com/osbuild/cloud-cleaner.git
-
-
-./cloud-cleaner/cloud_cleaner.sh

--- a/test/README.md
+++ b/test/README.md
@@ -260,13 +260,11 @@ the first line!
 
 ### Cloud cleaner
 
-Some tests deploy images to different clouds. After the tests run, these images
-get removed by cloud cleaner (`cmd/cloud-cleaner`). But if something fails during the tests, or the
-pipeline gets canceled, that image could get left behind in the cloud, wasting
-resources.
+[Cloud cleaner](https://github.com/osbuild/cloud-cleaner) is a tool designed to clean leftover cloud resources in order to reduce our costs.
 
-To deal with this problem, we have scheduled cloud cleaner (`schutzbot/scheduled_cloud_cleaner.sh`), that goes through all
-the clouds looking for testing resources that were not removed.
+Some tests deploy images to different clouds. After the tests run, these images get removed by the same tests. But if something fails during these, or a pipeline gets canceled, those images could get left behind in the cloud, wasting resources.
+
+Cloud cleaner is being executed every hour (on the CI of it's own repo), and it cleans resources that are not tagged with `persist=true`
 
 ## Integration testing
 

--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -199,9 +199,14 @@ greenprint "Pulling cloud-image-val container"
 if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
   # If running on CIV, get dev container
   TAG=${CI_COMMIT_REF_SLUG}
+  if [ -z "${CIV_OPTIONS:-}" ]; then
+    echo "ERROR: Please provide the variable CIV_OPTIONS"
+    exit 1
+  fi
 else
   # If not, get prod container
   TAG="prod"
+  CIV_OPTIONS=( -r=/tmp/resource-file.json -d -o=/tmp/report.xml -m="not pub" )
 fi
 
 CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val-test:$TAG"
@@ -236,7 +241,7 @@ sudo "${CONTAINER_RUNTIME}" run \
     -e AWS_REGION="${AWS_REGION}" \
     -v "${TEMPDIR}":/tmp:Z \
     "${CONTAINER_CLOUD_IMAGE_VAL}" \
-    python cloud-image-val.py -r /tmp/resource-file.json -d -o /tmp/report.xml -m 'not pub' && RESULTS=1 || RESULTS=0
+    python cloud-image-val.py "${CIV_OPTIONS[@]}" && RESULTS=1 || RESULTS=0
 
 mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
 

--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -199,9 +199,14 @@ greenprint "Pulling cloud-image-val container"
 if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
   # If running on CIV, get dev container
   TAG=${CI_COMMIT_REF_SLUG}
+  if [ -z "${CIV_OPTIONS:-}" ]; then
+    echo "ERROR: Please provide the variable CIV_OPTIONS"
+    exit 1
+  fi
 else
   # If not, get prod container
   TAG="prod"
+  CIV_OPTIONS=( -r=/tmp/resource-file.json -d -o=/tmp/report.xml -m="not pub" )
 fi
 
 CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val-test:$TAG"
@@ -233,7 +238,7 @@ sudo "${CONTAINER_RUNTIME}" run \
     -e ARM_TENANT_ID="${AZURE_TENANT_ID}" \
     -v "${TEMPDIR}":/tmp:Z \
     "${CONTAINER_CLOUD_IMAGE_VAL}" \
-    python cloud-image-val.py -r /tmp/resource-file.json -d -o /tmp/report.xml -m 'not pub' && RESULTS=1 || RESULTS=0
+    python cloud-image-val.py "${CIV_OPTIONS[@]}" && RESULTS=1 || RESULTS=0
 
 mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
 


### PR DESCRIPTION
In order to provide different options when running CIV from it's own CI, move them to the variable CIV_OPTIONS


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
