### PR TITLE
distro: remove duplicate version checks for fonts

### DIFF
--- a/internal/distro/fedora/package_sets.go
+++ b/internal/distro/fedora/package_sets.go
@@ -423,42 +423,20 @@ func anacondaPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	})
 
-	releasever := t.Arch().Distro().Releasever()
-	version, err := strconv.Atoi(releasever)
-	if err != nil {
-		panic("cannot convert releasever to int: " + err.Error())
-	}
-
-	if version <= 36 {
-		ps.Append(rpmmd.PackageSet{
+	if common.VersionLessThan(t.arch.distro.osVersion, "37") {
+		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"smc-meera-fonts",
 				"sil-scheherazade-fonts",
 			},
 		})
 	} else {
-		ps.Append(rpmmd.PackageSet{
+		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"rit-meera-new-fonts",
 				"sil-scheherazade-new-fonts",
 			},
 		})
-	}
-
-	if common.VersionLessThan(t.arch.distro.osVersion, "37") {
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"sil-scheherazade-fonts",
-			},
-		},
-		)
-	} else {
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"sil-scheherazade-new-fonts",
-			},
-		},
-		)
 	}
 
 	switch t.Arch().Name() {

--- a/test/data/manifests/fedora_36-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-image_installer-boot.json
@@ -9700,6 +9700,14 @@
                     }
                   },
                   {
+                    "id": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:712698d3c0080b76ea09d0564475bff3505aa6356c5b03f83ce35b5a38003f2e",
                     "options": {
                       "metadata": {
@@ -15031,6 +15039,9 @@
           },
           "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm"
           },
           "sha256:6b15ee0af777cef482ac7fdc0aac1776087edaee4c988dae384969e0dad0393d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/oscap-anaconda-addon-1.0-11.fc36.noarch.rpm"
@@ -26116,6 +26127,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/redhat-rpm-config-221-1.fc36.noarch.rpm",
         "checksum": "sha256:1483bed44de57b87448b2eb55db952425a5d12825405d912bdb5014ba7a7b0b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-image_installer_with_users-boot.json
@@ -9735,6 +9735,14 @@
                     }
                   },
                   {
+                    "id": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:712698d3c0080b76ea09d0564475bff3505aa6356c5b03f83ce35b5a38003f2e",
                     "options": {
                       "metadata": {
@@ -15192,6 +15200,9 @@
           },
           "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm"
           },
           "sha256:6b15ee0af777cef482ac7fdc0aac1776087edaee4c988dae384969e0dad0393d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/oscap-anaconda-addon-1.0-11.fc36.noarch.rpm"
@@ -26289,6 +26300,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/redhat-rpm-config-221-1.fc36.noarch.rpm",
         "checksum": "sha256:1483bed44de57b87448b2eb55db952425a5d12825405d912bdb5014ba7a7b0b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
@@ -9994,6 +9994,14 @@
                     }
                   },
                   {
+                    "id": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:712698d3c0080b76ea09d0564475bff3505aa6356c5b03f83ce35b5a38003f2e",
                     "options": {
                       "metadata": {
@@ -12170,6 +12178,9 @@
           },
           "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm"
           },
           "sha256:6b15ee0af777cef482ac7fdc0aac1776087edaee4c988dae384969e0dad0393d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/oscap-anaconda-addon-1.0-11.fc36.noarch.rpm"
@@ -23165,6 +23176,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/redhat-rpm-config-221-1.fc36.noarch.rpm",
         "checksum": "sha256:1483bed44de57b87448b2eb55db952425a5d12825405d912bdb5014ba7a7b0b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
@@ -10023,6 +10023,14 @@
                     }
                   },
                   {
+                    "id": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:712698d3c0080b76ea09d0564475bff3505aa6356c5b03f83ce35b5a38003f2e",
                     "options": {
                       "metadata": {
@@ -12221,6 +12229,9 @@
           },
           "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm"
           },
           "sha256:6b15ee0af777cef482ac7fdc0aac1776087edaee4c988dae384969e0dad0393d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/oscap-anaconda-addon-1.0-11.fc36.noarch.rpm"
@@ -23216,6 +23227,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/redhat-rpm-config-221-1.fc36.noarch.rpm",
         "checksum": "sha256:1483bed44de57b87448b2eb55db952425a5d12825405d912bdb5014ba7a7b0b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-image_installer-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-image_installer-boot.json
@@ -9892,6 +9892,14 @@
                     }
                   },
                   {
+                    "id": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:9bd46b3e217cee7580db6bccc9a4a2b362687b81a894f3f75de8ede1f530fcf1",
                     "options": {
                       "metadata": {
@@ -15299,6 +15307,9 @@
           },
           "sha256:6b14b466b7ba2d5b5462c6103620a61007722e91a7e8b53e0d2204df4a70040f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xorg-x11-drivers-2022-1.fc36.x86_64.rpm"
+          },
+          "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm"
           },
           "sha256:6b15ee0af777cef482ac7fdc0aac1776087edaee4c988dae384969e0dad0393d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/oscap-anaconda-addon-1.0-11.fc36.noarch.rpm"
@@ -26641,6 +26652,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/redhat-rpm-config-221-1.fc36.noarch.rpm",
         "checksum": "sha256:1483bed44de57b87448b2eb55db952425a5d12825405d912bdb5014ba7a7b0b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-image_installer_with_users-boot.json
@@ -9927,6 +9927,14 @@
                     }
                   },
                   {
+                    "id": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:9bd46b3e217cee7580db6bccc9a4a2b362687b81a894f3f75de8ede1f530fcf1",
                     "options": {
                       "metadata": {
@@ -15460,6 +15468,9 @@
           },
           "sha256:6b14b466b7ba2d5b5462c6103620a61007722e91a7e8b53e0d2204df4a70040f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xorg-x11-drivers-2022-1.fc36.x86_64.rpm"
+          },
+          "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm"
           },
           "sha256:6b15ee0af777cef482ac7fdc0aac1776087edaee4c988dae384969e0dad0393d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/oscap-anaconda-addon-1.0-11.fc36.noarch.rpm"
@@ -26814,6 +26825,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/redhat-rpm-config-221-1.fc36.noarch.rpm",
         "checksum": "sha256:1483bed44de57b87448b2eb55db952425a5d12825405d912bdb5014ba7a7b0b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_installer-boot.json
@@ -10178,6 +10178,14 @@
                     }
                   },
                   {
+                    "id": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:9bd46b3e217cee7580db6bccc9a4a2b362687b81a894f3f75de8ede1f530fcf1",
                     "options": {
                       "metadata": {
@@ -12337,6 +12345,9 @@
           },
           "sha256:6b14b466b7ba2d5b5462c6103620a61007722e91a7e8b53e0d2204df4a70040f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xorg-x11-drivers-2022-1.fc36.x86_64.rpm"
+          },
+          "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm"
           },
           "sha256:6b15ee0af777cef482ac7fdc0aac1776087edaee4c988dae384969e0dad0393d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/oscap-anaconda-addon-1.0-11.fc36.noarch.rpm"
@@ -23601,6 +23612,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/redhat-rpm-config-221-1.fc36.noarch.rpm",
         "checksum": "sha256:1483bed44de57b87448b2eb55db952425a5d12825405d912bdb5014ba7a7b0b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_installer_with_users-boot.json
@@ -10207,6 +10207,14 @@
                     }
                   },
                   {
+                    "id": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:9bd46b3e217cee7580db6bccc9a4a2b362687b81a894f3f75de8ede1f530fcf1",
                     "options": {
                       "metadata": {
@@ -12388,6 +12396,9 @@
           },
           "sha256:6b14b466b7ba2d5b5462c6103620a61007722e91a7e8b53e0d2204df4a70040f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xorg-x11-drivers-2022-1.fc36.x86_64.rpm"
+          },
+          "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm"
           },
           "sha256:6b15ee0af777cef482ac7fdc0aac1776087edaee4c988dae384969e0dad0393d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/oscap-anaconda-addon-1.0-11.fc36.noarch.rpm"
@@ -23652,6 +23663,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/redhat-rpm-config-221-1.fc36.noarch.rpm",
         "checksum": "sha256:1483bed44de57b87448b2eb55db952425a5d12825405d912bdb5014ba7a7b0b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/rit-meera-new-fonts-1.3-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b14f513aedb63267eb69943fe95cc50701e2f05bcf208450cef8185d3762c84",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_37-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-image_installer-boot.json
@@ -9076,6 +9076,14 @@
                     }
                   },
                   {
+                    "id": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a04c03e37ec845b27d119d2b61ffe4e5ef5a5aef363029e248a1bc7e589ffcf1",
                     "options": {
                       "metadata": {
@@ -16784,6 +16792,9 @@
           },
           "sha256:ee50ad1b7ba00ffed8c17a1df7b42800c3462a040281afd3500e1f7dd768c75b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libksba-1.6.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:ee7cf23d2959365faa32aabbe3632602592957aff6839ad1c924a6af7ec4c8ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/anaconda-widgets-37.12.6-1.fc37.aarch64.rpm"
@@ -25514,6 +25525,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/redhat-rpm-config-228-1.fc37.noarch.rpm",
         "checksum": "sha256:e0a77db21768e0fe22efa8a31131b3ace7494d36033cf670f5725956cf0121b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_37-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-image_installer_with_users-boot.json
@@ -9111,6 +9111,14 @@
                     }
                   },
                   {
+                    "id": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a04c03e37ec845b27d119d2b61ffe4e5ef5a5aef363029e248a1bc7e589ffcf1",
                     "options": {
                       "metadata": {
@@ -16973,6 +16981,9 @@
           },
           "sha256:ee50ad1b7ba00ffed8c17a1df7b42800c3462a040281afd3500e1f7dd768c75b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libksba-1.6.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:ee7cf23d2959365faa32aabbe3632602592957aff6839ad1c924a6af7ec4c8ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/anaconda-widgets-37.12.6-1.fc37.aarch64.rpm"
@@ -25703,6 +25714,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/redhat-rpm-config-228-1.fc37.noarch.rpm",
         "checksum": "sha256:e0a77db21768e0fe22efa8a31131b3ace7494d36033cf670f5725956cf0121b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
@@ -9370,6 +9370,14 @@
                     }
                   },
                   {
+                    "id": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a04c03e37ec845b27d119d2b61ffe4e5ef5a5aef363029e248a1bc7e589ffcf1",
                     "options": {
                       "metadata": {
@@ -13793,6 +13801,9 @@
           },
           "sha256:ee50ad1b7ba00ffed8c17a1df7b42800c3462a040281afd3500e1f7dd768c75b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libksba-1.6.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:ee7cf23d2959365faa32aabbe3632602592957aff6839ad1c924a6af7ec4c8ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/anaconda-widgets-37.12.6-1.fc37.aarch64.rpm"
@@ -22520,6 +22531,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/redhat-rpm-config-228-1.fc37.noarch.rpm",
         "checksum": "sha256:e0a77db21768e0fe22efa8a31131b3ace7494d36033cf670f5725956cf0121b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
@@ -9399,6 +9399,14 @@
                     }
                   },
                   {
+                    "id": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a04c03e37ec845b27d119d2b61ffe4e5ef5a5aef363029e248a1bc7e589ffcf1",
                     "options": {
                       "metadata": {
@@ -13844,6 +13852,9 @@
           },
           "sha256:ee50ad1b7ba00ffed8c17a1df7b42800c3462a040281afd3500e1f7dd768c75b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libksba-1.6.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:ee7cf23d2959365faa32aabbe3632602592957aff6839ad1c924a6af7ec4c8ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/anaconda-widgets-37.12.6-1.fc37.aarch64.rpm"
@@ -22571,6 +22582,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/redhat-rpm-config-228-1.fc37.noarch.rpm",
         "checksum": "sha256:e0a77db21768e0fe22efa8a31131b3ace7494d36033cf670f5725956cf0121b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_37-x86_64-image_installer-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-image_installer-boot.json
@@ -9220,6 +9220,14 @@
                     }
                   },
                   {
+                    "id": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:c36581484d517e4535f07db15b24e839d06ca987ac9313c8c255df33b2686bd2",
                     "options": {
                       "metadata": {
@@ -17150,6 +17158,9 @@
           },
           "sha256:ee4f3195ad615bd8a1170bfb744b892c20dc21ef177dbc70cd2fc77a3745ac58": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mesa-libxatracker-22.2.0-7.fc37.x86_64.rpm"
+          },
+          "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:eed91d8529a1eee7269fd28eccdb636a6fc6dcf30d607bdb7198329f3017a74a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/perl-Scalar-List-Utils-1.63-489.fc37.x86_64.rpm"
@@ -25990,6 +26001,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/redhat-rpm-config-228-1.fc37.noarch.rpm",
         "checksum": "sha256:e0a77db21768e0fe22efa8a31131b3ace7494d36033cf670f5725956cf0121b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_37-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-image_installer_with_users-boot.json
@@ -9255,6 +9255,14 @@
                     }
                   },
                   {
+                    "id": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:c36581484d517e4535f07db15b24e839d06ca987ac9313c8c255df33b2686bd2",
                     "options": {
                       "metadata": {
@@ -17336,6 +17344,9 @@
           },
           "sha256:ee4f3195ad615bd8a1170bfb744b892c20dc21ef177dbc70cd2fc77a3745ac58": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mesa-libxatracker-22.2.0-7.fc37.x86_64.rpm"
+          },
+          "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:eed91d8529a1eee7269fd28eccdb636a6fc6dcf30d607bdb7198329f3017a74a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/perl-Scalar-List-Utils-1.63-489.fc37.x86_64.rpm"
@@ -26179,6 +26190,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/redhat-rpm-config-228-1.fc37.noarch.rpm",
         "checksum": "sha256:e0a77db21768e0fe22efa8a31131b3ace7494d36033cf670f5725956cf0121b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_37-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_installer-boot.json
@@ -9506,6 +9506,14 @@
                     }
                   },
                   {
+                    "id": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:c36581484d517e4535f07db15b24e839d06ca987ac9313c8c255df33b2686bd2",
                     "options": {
                       "metadata": {
@@ -14079,6 +14087,9 @@
           },
           "sha256:ee4f3195ad615bd8a1170bfb744b892c20dc21ef177dbc70cd2fc77a3745ac58": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mesa-libxatracker-22.2.0-7.fc37.x86_64.rpm"
+          },
+          "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:eed91d8529a1eee7269fd28eccdb636a6fc6dcf30d607bdb7198329f3017a74a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/perl-Scalar-List-Utils-1.63-489.fc37.x86_64.rpm"
@@ -22907,6 +22918,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/redhat-rpm-config-228-1.fc37.noarch.rpm",
         "checksum": "sha256:e0a77db21768e0fe22efa8a31131b3ace7494d36033cf670f5725956cf0121b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_37-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_installer_with_users-boot.json
@@ -9535,6 +9535,14 @@
                     }
                   },
                   {
+                    "id": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:c36581484d517e4535f07db15b24e839d06ca987ac9313c8c255df33b2686bd2",
                     "options": {
                       "metadata": {
@@ -14130,6 +14138,9 @@
           },
           "sha256:ee4f3195ad615bd8a1170bfb744b892c20dc21ef177dbc70cd2fc77a3745ac58": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mesa-libxatracker-22.2.0-7.fc37.x86_64.rpm"
+          },
+          "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:eed91d8529a1eee7269fd28eccdb636a6fc6dcf30d607bdb7198329f3017a74a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/perl-Scalar-List-Utils-1.63-489.fc37.x86_64.rpm"
@@ -22958,6 +22969,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/redhat-rpm-config-228-1.fc37.noarch.rpm",
         "checksum": "sha256:e0a77db21768e0fe22efa8a31131b3ace7494d36033cf670f5725956cf0121b5",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:ee71685552cc0b0326efdb07720a1c6c4892d73746e21286211af3bb639363e0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_38-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-image_installer-boot.json
@@ -8948,6 +8948,14 @@
                     }
                   },
                   {
+                    "id": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:2d2032b93b6ea08001211263c26bf63038e4e6e13bbb4c96917e965c5f41c932",
                     "options": {
                       "metadata": {
@@ -13940,6 +13948,9 @@
           },
           "sha256:13b817376b576e9beff57a67010140d18f95f4887e02a1d088510720c98408a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/w/webrtc-audio-processing-0.3.1-9.fc37.aarch64.rpm"
+          },
+          "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:144c4282d31e637b4393163824fdd9b676dfed918878323f7894f99068eeb378": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xmlrpc-c-client-1.51.0-14.fc36.aarch64.rpm"
@@ -25198,6 +25209,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/redhat-rpm-config-232-1.fc38.noarch.rpm",
         "checksum": "sha256:2245fd2425b1f4c0860f7d3368d076330162e8eae8010168e8327755eef1c48c",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_38-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-image_installer_with_users-boot.json
@@ -8983,6 +8983,14 @@
                     }
                   },
                   {
+                    "id": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:2d2032b93b6ea08001211263c26bf63038e4e6e13bbb4c96917e965c5f41c932",
                     "options": {
                       "metadata": {
@@ -14109,6 +14117,9 @@
           },
           "sha256:13b817376b576e9beff57a67010140d18f95f4887e02a1d088510720c98408a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/w/webrtc-audio-processing-0.3.1-9.fc37.aarch64.rpm"
+          },
+          "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:144c4282d31e637b4393163824fdd9b676dfed918878323f7894f99068eeb378": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xmlrpc-c-client-1.51.0-14.fc36.aarch64.rpm"
@@ -25403,6 +25414,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/redhat-rpm-config-232-1.fc38.noarch.rpm",
         "checksum": "sha256:2245fd2425b1f4c0860f7d3368d076330162e8eae8010168e8327755eef1c48c",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
@@ -9025,6 +9025,14 @@
                     }
                   },
                   {
+                    "id": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:2d2032b93b6ea08001211263c26bf63038e4e6e13bbb4c96917e965c5f41c932",
                     "options": {
                       "metadata": {
@@ -10858,6 +10866,9 @@
           },
           "sha256:13b817376b576e9beff57a67010140d18f95f4887e02a1d088510720c98408a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/w/webrtc-audio-processing-0.3.1-9.fc37.aarch64.rpm"
+          },
+          "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:144c4282d31e637b4393163824fdd9b676dfed918878323f7894f99068eeb378": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xmlrpc-c-client-1.51.0-14.fc36.aarch64.rpm"
@@ -21880,6 +21891,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/redhat-rpm-config-232-1.fc38.noarch.rpm",
         "checksum": "sha256:2245fd2425b1f4c0860f7d3368d076330162e8eae8010168e8327755eef1c48c",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
@@ -9054,6 +9054,14 @@
                     }
                   },
                   {
+                    "id": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:2d2032b93b6ea08001211263c26bf63038e4e6e13bbb4c96917e965c5f41c932",
                     "options": {
                       "metadata": {
@@ -10909,6 +10917,9 @@
           },
           "sha256:13b817376b576e9beff57a67010140d18f95f4887e02a1d088510720c98408a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/w/webrtc-audio-processing-0.3.1-9.fc37.aarch64.rpm"
+          },
+          "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:144c4282d31e637b4393163824fdd9b676dfed918878323f7894f99068eeb378": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xmlrpc-c-client-1.51.0-14.fc36.aarch64.rpm"
@@ -21931,6 +21942,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/redhat-rpm-config-232-1.fc38.noarch.rpm",
         "checksum": "sha256:2245fd2425b1f4c0860f7d3368d076330162e8eae8010168e8327755eef1c48c",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_38-x86_64-image_installer-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-image_installer-boot.json
@@ -9084,6 +9084,14 @@
                     }
                   },
                   {
+                    "id": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:e53508a2d359295a73b368fbe2f3863805d7e457a2778d31ba02d7046dcaf3b6",
                     "options": {
                       "metadata": {
@@ -14200,6 +14208,9 @@
           },
           "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:147be185c9e6144b22c464d87a2c505e06f7ad059ed4944cf7b4fb9e6e032a0b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/t/tmux-3.3a-1.fc38.x86_64.rpm"
@@ -25649,6 +25660,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/redhat-rpm-config-232-1.fc38.noarch.rpm",
         "checksum": "sha256:2245fd2425b1f4c0860f7d3368d076330162e8eae8010168e8327755eef1c48c",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_38-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-image_installer_with_users-boot.json
@@ -9119,6 +9119,14 @@
                     }
                   },
                   {
+                    "id": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:e53508a2d359295a73b368fbe2f3863805d7e457a2778d31ba02d7046dcaf3b6",
                     "options": {
                       "metadata": {
@@ -14375,6 +14383,9 @@
           },
           "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:147be185c9e6144b22c464d87a2c505e06f7ad059ed4944cf7b4fb9e6e032a0b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/t/tmux-3.3a-1.fc38.x86_64.rpm"
@@ -25854,6 +25865,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/redhat-rpm-config-232-1.fc38.noarch.rpm",
         "checksum": "sha256:2245fd2425b1f4c0860f7d3368d076330162e8eae8010168e8327755eef1c48c",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_38-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_installer-boot.json
@@ -9153,6 +9153,14 @@
                     }
                   },
                   {
+                    "id": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:e53508a2d359295a73b368fbe2f3863805d7e457a2778d31ba02d7046dcaf3b6",
                     "options": {
                       "metadata": {
@@ -11026,6 +11034,9 @@
           },
           "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:147be185c9e6144b22c464d87a2c505e06f7ad059ed4944cf7b4fb9e6e032a0b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/t/tmux-3.3a-1.fc38.x86_64.rpm"
@@ -22248,6 +22259,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/redhat-rpm-config-232-1.fc38.noarch.rpm",
         "checksum": "sha256:2245fd2425b1f4c0860f7d3368d076330162e8eae8010168e8327755eef1c48c",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_38-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_installer_with_users-boot.json
@@ -9182,6 +9182,14 @@
                     }
                   },
                   {
+                    "id": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:e53508a2d359295a73b368fbe2f3863805d7e457a2778d31ba02d7046dcaf3b6",
                     "options": {
                       "metadata": {
@@ -11077,6 +11085,9 @@
           },
           "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm"
           },
           "sha256:147be185c9e6144b22c464d87a2c505e06f7ad059ed4944cf7b4fb9e6e032a0b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/t/tmux-3.3a-1.fc38.x86_64.rpm"
@@ -22299,6 +22310,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/redhat-rpm-config-232-1.fc38.noarch.rpm",
         "checksum": "sha256:2245fd2425b1f4c0860f7d3368d076330162e8eae8010168e8327755eef1c48c",
+        "check_gpg": true
+      },
+      {
+        "name": "rit-meera-new-fonts",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20221025/Packages/r/rit-meera-new-fonts-1.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:141aafdc62dbb26a65769d5712795869d035afe5951eb422e2873ca5d5d34f6c",
         "check_gpg": true
       },
       {


### PR DESCRIPTION
The new names of the packages are being added twice in two different checks, remove the redundant code.