### PR TITLE
`edge-simplified-installer` allows User & Group customizations

### DIFF
--- a/internal/distro/rhel8/imagetype.go
+++ b/internal/distro/rhel8/imagetype.go
@@ -2,6 +2,7 @@ package rhel8
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"strings"
 
@@ -399,6 +400,17 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 	// check the checksum instead of the URL, because the URL should have been used to resolve the checksum and we need both
 	if t.name == "edge-raw-image" && options.OSTree.FetchChecksum == "" {
 		return fmt.Errorf("edge raw images require specifying a URL from which to retrieve the OSTree commit")
+	}
+
+	// warn that user & group customizations on edge-commit, edge-container are deprecated
+	// TODO(edge): directly error if these options are provided when rhel-9.5's time arrives
+	if t.name == "edge-commit" || t.name == "edge-container" {
+		if customizations.GetUsers() != nil {
+			log.Printf("Please note that user customizations on %q image type are deprecated and will be removed in the near future\n", t.name)
+		}
+		if customizations.GetGroups() != nil {
+			log.Printf("Please note that group customizations on %q image type are deprecated and will be removed in the near future\n", t.name)
+		}
 	}
 
 	if kernelOpts := customizations.GetKernel(); kernelOpts.Append != "" && t.rpmOstree && (!t.bootable || t.bootISO) {

--- a/internal/distro/rhel8/imagetype.go
+++ b/internal/distro/rhel8/imagetype.go
@@ -363,7 +363,7 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 		}
 
 		if t.name == "edge-simplified-installer" {
-			allowed := []string{"InstallationDevice", "FDO"}
+			allowed := []string{"InstallationDevice", "FDO", "User", "Group"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
 			}

--- a/internal/distro/rhel9/imagetype.go
+++ b/internal/distro/rhel9/imagetype.go
@@ -2,6 +2,7 @@ package rhel9
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"strings"
 
@@ -379,6 +380,17 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 	// check the checksum instead of the URL, because the URL should have been used to resolve the checksum and we need both
 	if t.name == "edge-raw-image" && options.OSTree.FetchChecksum == "" {
 		return fmt.Errorf("edge raw images require specifying a URL from which to retrieve the OSTree commit")
+	}
+
+	// warn that user & group customizations on edge-commit, edge-container are deprecated
+	// TODO(edge): directly error if these options are provided when rhel-9.5's time arrives
+	if t.name == "edge-commit" || t.name == "edge-container" {
+		if customizations.GetUsers() != nil {
+			log.Printf("Please note that user customizations on %q image type are deprecated and will be removed in the near future\n", t.name)
+		}
+		if customizations.GetGroups() != nil {
+			log.Printf("Please note that group customizations on %q image type are deprecated and will be removed in the near future\n", t.name)
+		}
 	}
 
 	if kernelOpts := customizations.GetKernel(); kernelOpts.Append != "" && t.rpmOstree && t.name != "edge-raw-image" && t.name != "edge-simplified-installer" {

--- a/internal/distro/rhel9/imagetype.go
+++ b/internal/distro/rhel9/imagetype.go
@@ -332,7 +332,7 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 		}
 
 		if t.name == "edge-simplified-installer" {
-			allowed := []string{"InstallationDevice", "FDO", "Ignition", "Kernel"}
+			allowed := []string{"InstallationDevice", "FDO", "Ignition", "Kernel", "User", "Group"}
 			if err := customizations.CheckAllowed(allowed...); err != nil {
 				return fmt.Errorf("unsupported blueprint customizations found for boot ISO image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
 			}

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -415,6 +415,14 @@ groups = []
 [customizations]
 installation_device = "/dev/vda"
 
+[[customizations.user]]
+name = "simple"
+description = "Administrator account"
+password = "\$6\$GRmb7S0p8vsYmXzH\$o0E020S.9JQGaHkszoog4ha4AQVs3sk8q0DvLjSMxoxHBKnB2FBXGQ/OkwZQfW/76ktHd0NX5nls2LPxPuUdl."
+key = "${SSH_KEY_PUB}"
+home = "/home/simple/"
+groups = ["wheel"]
+
 [customizations.fdo]
 manufacturing_server_url="http://${FDO_SERVER_ADDRESS}:8080"
 diun_pub_key_insecure="true"
@@ -509,6 +517,7 @@ check_result
 greenprint "🕹 Get ostree install commit value"
 INSTALL_HASH=$(curl "${PROD_REPO_URL}/refs/heads/${OSTREE_REF}")
 
+# User simple in simplified-installer
 # Add instance IP address into /etc/ansible/hosts
 sudo tee "${TEMPDIR}"/inventory > /dev/null << EOF
 [ostree_guest]
@@ -516,7 +525,7 @@ ${HTTP_GUEST_ADDRESS}
 
 [ostree_guest:vars]
 ansible_python_interpreter=/usr/bin/python3
-ansible_user=admin
+ansible_user=simple
 ansible_private_key_file=${SSH_KEY}
 ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 ansible_become=yes 


### PR DESCRIPTION
This PR is about adding support for User customizations on `edge-simplified-installer` image types, and about giving a basic indication that user customizations on `edge-commit` and `edge-container` are deprecated and will no longer be supported in future RHEL edge versions.

Note the "basic indication" on giving the deprecation warning, currently it simply logs out the deprecation notice. I will add another PR in the near future handling the warning via weldr (working on that), this is simply so that QE can test user customizations on `edge-simplified-installer`.

--- 

Updated to also allow Group customizations and to give the same basic deprecation warning.

--- 
- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->