### PR TITLE
prometheus:: add arch label to dequeue metrics

### DIFF
--- a/internal/prometheus/job_metrics.go
+++ b/internal/prometheus/job_metrics.go
@@ -52,17 +52,17 @@ var (
 		Subsystem: WorkerSubsystem,
 		Help:      "Duration a job spends on the queue.",
 		Buckets:   []float64{.1, .2, .5, 1, 2, 4, 8, 16, 32, 40, 48, 64, 96, 128, 160, 192, 224, 256, 320, 382, 448, 512, 640, 768, 896, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192, 8704, 9216, 9728, 10240, 10752},
-	}, []string{"type", "tenant"})
+	}, []string{"type", "tenant", "arch"})
 )
 
 func EnqueueJobMetrics(jobType, tenant string) {
 	PendingJobs.WithLabelValues(jobType, tenant).Inc()
 }
 
-func DequeueJobMetrics(pending time.Time, started time.Time, jobType, tenant string) {
+func DequeueJobMetrics(pending time.Time, started time.Time, jobType, tenant, arch string) {
 	if !started.IsZero() && !pending.IsZero() {
 		diff := started.Sub(pending).Seconds()
-		JobWaitDuration.WithLabelValues(jobType, tenant).Observe(diff)
+		JobWaitDuration.WithLabelValues(jobType, tenant, arch).Observe(diff)
 		PendingJobs.WithLabelValues(jobType, tenant).Dec()
 		RunningJobs.WithLabelValues(jobType, tenant).Inc()
 	}


### PR DESCRIPTION
Only add the arch label for osbuild job types, as the finish metrics behave similarly. Having arch labels on dequeue metrics for any other job type (but not on the finish metrics) would produce weird results.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
