### PR TITLE
distro: assign pipeline-specific repos to package sets

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -199,8 +199,12 @@ func convertRepo(r repository) rpmmd.RepoConfig {
 		MirrorList:     r.MirrorList,
 		GPGKeys:        keys,
 		CheckGPG:       r.CheckGPG,
+		CheckRepoGPG:   false,
+		IgnoreSSL:      false,
 		MetadataExpire: r.MetadataExpire,
+		RHSM:           r.RHSM,
 		ImageTypeTags:  r.ImageTypeTags,
+		PackageSets:    r.PackageSets,
 	}
 }
 

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -212,12 +212,6 @@ func TestImageTypePipelineNames(t *testing.T) {
 						packageSets[plName] = minimalPackageSet
 					}
 
-					if distroName == "rhel-7" {
-						// add one more under "packages" for rhel-7
-						// TODO: this will be removed with the RHEL 7 rewrite
-						packageSets["packages"] = minimalPackageSet
-					}
-
 					m, err := imageType.Manifest(bp.Customizations, options, repos, packageSets, containers, seed)
 					require.NoError(err)
 					pm := new(manifest)

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -165,6 +165,7 @@ func getImageTypePkgSpecSets(imageType distro.ImageType, bp blueprint.Blueprint,
 	imgPackageSets := imageType.PackageSets(bp, options, repos)
 
 	solver := dnfjson.NewSolver(imageType.Arch().Distro().ModulePlatformID(), imageType.Arch().Distro().Releasever(), imageType.Arch().Name(), cacheDir)
+	solver.SetDNFJSONPath(dnfJsonPath)
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
 	for name, packages := range imgPackageSets {
 		res, err := solver.Depsolve(packages)

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -30,11 +30,12 @@ func TestDistro_Manifest(t *testing.T, pipelinePath string, prefix string, regis
 	require.Greaterf(t, len(fileNames), 0, "No pipelines found in %s for %s", pipelinePath, prefix)
 	for _, fileName := range fileNames {
 		type repository struct {
-			BaseURL    string `json:"baseurl,omitempty"`
-			Metalink   string `json:"metalink,omitempty"`
-			MirrorList string `json:"mirrorlist,omitempty"`
-			GPGKey     string `json:"gpgkey,omitempty"`
-			CheckGPG   bool   `json:"check_gpg,omitempty"`
+			BaseURL     string   `json:"baseurl,omitempty"`
+			Metalink    string   `json:"metalink,omitempty"`
+			MirrorList  string   `json:"mirrorlist,omitempty"`
+			GPGKey      string   `json:"gpgkey,omitempty"`
+			CheckGPG    bool     `json:"check_gpg,omitempty"`
+			PackageSets []string `json:"package-sets,omitempty"`
 		}
 		type composeRequest struct {
 			Distro       string                `json:"distro"`
@@ -67,12 +68,13 @@ func TestDistro_Manifest(t *testing.T, pipelinePath string, prefix string, regis
 			}
 
 			repos[i] = rpmmd.RepoConfig{
-				Name:       fmt.Sprintf("repo-%d", i),
-				BaseURL:    repo.BaseURL,
-				Metalink:   repo.Metalink,
-				MirrorList: repo.MirrorList,
-				GPGKeys:    keys,
-				CheckGPG:   repo.CheckGPG,
+				Name:        fmt.Sprintf("repo-%d", i),
+				BaseURL:     repo.BaseURL,
+				Metalink:    repo.Metalink,
+				MirrorList:  repo.MirrorList,
+				GPGKeys:     keys,
+				CheckGPG:    repo.CheckGPG,
+				PackageSets: repo.PackageSets,
 			}
 		}
 		t.Run(path.Base(fileName), func(t *testing.T) {

--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -559,7 +559,6 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 	}
 
 	// amend with repository information
-	globalRepos := make([]rpmmd.RepoConfig, 0)
 	for _, repo := range repos {
 		if len(repo.PackageSets) > 0 {
 			// only apply the repo to the listed package sets
@@ -568,10 +567,6 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 				ps.Repositories = append(ps.Repositories, repo)
 				packageSets[psName] = ps
 			}
-		} else {
-			// no package sets were listed, so apply the repo
-			// to all package sets
-			globalRepos = append(globalRepos, repo)
 		}
 	}
 
@@ -610,7 +605,7 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 	}
 
 	// create a manifest object and instantiate it with the computed packageSetChains
-	manifest, err := t.initializeManifest(&bp, options, globalRepos, packageSets, containers, 0)
+	manifest, err := t.initializeManifest(&bp, options, repos, packageSets, containers, 0)
 	if err != nil {
 		// TODO: handle manifest initialization errors more gracefully, we
 		// refuse to initialize manifests with invalid config.

--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -30,7 +30,7 @@ const (
 	// package set names
 
 	// main/common os image package set name
-	osPkgsKey = "packages"
+	osPkgsKey = "os"
 
 	// container package set name
 	containerPkgsKey = "container"

--- a/internal/distro/rhel7/distro.go
+++ b/internal/distro/rhel7/distro.go
@@ -28,7 +28,7 @@ const (
 	// package set names
 
 	// main/common os image package set name
-	osPkgsKey = "packages"
+	osPkgsKey = "os"
 
 	// blueprint package set name
 	blueprintPkgsKey = "blueprint"

--- a/internal/distro/rhel7/distro.go
+++ b/internal/distro/rhel7/distro.go
@@ -409,7 +409,6 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 	}
 
 	// amend with repository information
-	globalRepos := make([]rpmmd.RepoConfig, 0)
 	for _, repo := range repos {
 		if len(repo.PackageSets) > 0 {
 			// only apply the repo to the listed package sets
@@ -418,10 +417,6 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 				ps.Repositories = append(ps.Repositories, repo)
 				packageSets[psName] = ps
 			}
-		} else {
-			// no package sets were listed, so apply the repo
-			// to all package sets
-			globalRepos = append(globalRepos, repo)
 		}
 	}
 
@@ -442,13 +437,14 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 	}
 
 	// create a manifest object and instantiate it with the computed packageSetChains
-	manifest, err := t.initializeManifest(&bp, options, globalRepos, packageSets, containers, 0)
+	manifest, err := t.initializeManifest(&bp, options, repos, packageSets, containers, 0)
 	if err != nil {
 		// TODO: handle manifest initialization errors more gracefully, we
 		// refuse to initialize manifests with invalid config.
 		logrus.Errorf("Initializing the manifest failed for %s (%s/%s): %v", t.Name(), t.arch.distro.Name(), t.arch.Name(), err)
 		return nil
 	}
+
 	return overridePackageNamesInSets(manifest.GetPackageSetChains())
 }
 

--- a/internal/distro/rhel8/imagetype.go
+++ b/internal/distro/rhel8/imagetype.go
@@ -256,7 +256,6 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 	}
 
 	// amend with repository information
-	globalRepos := make([]rpmmd.RepoConfig, 0)
 	for _, repo := range repos {
 		if len(repo.PackageSets) > 0 {
 			// only apply the repo to the listed package sets
@@ -265,10 +264,6 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 				ps.Repositories = append(ps.Repositories, repo)
 				packageSets[psName] = ps
 			}
-		} else {
-			// no package sets were listed, so apply the repo
-			// to all package sets
-			globalRepos = append(globalRepos, repo)
 		}
 	}
 
@@ -307,13 +302,14 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 	}
 
 	// create a manifest object and instantiate it with the computed packageSetChains
-	manifest, err := t.initializeManifest(&bp, options, globalRepos, packageSets, containers, 0)
+	manifest, err := t.initializeManifest(&bp, options, repos, packageSets, containers, 0)
 	if err != nil {
 		// TODO: handle manifest initialization errors more gracefully, we
 		// refuse to initialize manifests with invalid config.
 		logrus.Errorf("Initializing the manifest failed for %s (%s/%s): %v", t.Name(), t.arch.distro.Name(), t.arch.Name(), err)
 		return nil
 	}
+
 	return overridePackageNamesInSets(manifest.GetPackageSetChains())
 }
 

--- a/internal/distro/rhel8/imagetype.go
+++ b/internal/distro/rhel8/imagetype.go
@@ -26,7 +26,7 @@ const (
 	// package set names
 
 	// main/common os image package set name
-	osPkgsKey = "packages"
+	osPkgsKey = "os"
 
 	// container package set name
 	containerPkgsKey = "container"

--- a/internal/distro/rhel9/edge.go
+++ b/internal/distro/rhel9/edge.go
@@ -38,7 +38,7 @@ var (
 			osPkgsKey: edgeCommitPackageSet,
 			containerPkgsKey: func(t *imageType) rpmmd.PackageSet {
 				return rpmmd.PackageSet{
-					Include: []string{"nginx"},
+					Include: []string{"nginx"}, // FIXME: this has no effect
 				}
 			},
 		},

--- a/internal/distro/rhel9/imagetype.go
+++ b/internal/distro/rhel9/imagetype.go
@@ -29,7 +29,7 @@ const (
 	buildPkgsKey = "build"
 
 	// main/common os image package set name
-	osPkgsKey = "packages"
+	osPkgsKey = "os"
 
 	// container package set name
 	containerPkgsKey = "container"

--- a/internal/distro/rhel9/imagetype.go
+++ b/internal/distro/rhel9/imagetype.go
@@ -256,7 +256,6 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 	}
 
 	// amend with repository information
-	globalRepos := make([]rpmmd.RepoConfig, 0)
 	for _, repo := range repos {
 		if len(repo.PackageSets) > 0 {
 			// only apply the repo to the listed package sets
@@ -265,10 +264,6 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 				ps.Repositories = append(ps.Repositories, repo)
 				packageSets[psName] = ps
 			}
-		} else {
-			// no package sets were listed, so apply the repo
-			// to all package sets
-			globalRepos = append(globalRepos, repo)
 		}
 	}
 
@@ -307,7 +302,7 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 	}
 
 	// create a manifest object and instantiate it with the computed packageSetChains
-	manifest, err := t.initializeManifest(&bp, options, globalRepos, packageSets, containers, 0)
+	manifest, err := t.initializeManifest(&bp, options, repos, packageSets, containers, 0)
 	if err != nil {
 		// TODO: handle manifest initialization errors more gracefully, we
 		// refuse to initialize manifests with invalid config.

--- a/internal/distro/test_distro/distro.go
+++ b/internal/distro/test_distro/distro.go
@@ -21,7 +21,7 @@ const (
 	buildPkgsKey = "build"
 
 	// main/common os image package set name
-	osPkgsKey = "packages"
+	osPkgsKey = "os"
 
 	// blueprint package set name
 	blueprintPkgsKey = "blueprint"

--- a/internal/image/ostree_container.go
+++ b/internal/image/ostree_container.go
@@ -22,7 +22,7 @@ type OSTreeContainer struct {
 	OSTreeRef              string
 	OSTreeParent           *ostree.CommitSpec
 	OSVersion              string
-	ExtraContainerPackages rpmmd.PackageSet
+	ExtraContainerPackages rpmmd.PackageSet // FIXME: this is never read
 	ContainerLanguage      string
 	Filename               string
 }

--- a/internal/manifest/anaconda.go
+++ b/internal/manifest/anaconda.go
@@ -66,10 +66,11 @@ func NewAnaconda(m *Manifest,
 	kernelName,
 	product,
 	version string) *Anaconda {
+	name := "anaconda-tree"
 	p := &Anaconda{
-		Base:       NewBase(m, "anaconda-tree", buildPipeline),
+		Base:       NewBase(m, name, buildPipeline),
 		platform:   platform,
-		repos:      repos,
+		repos:      filterRepos(repos, name),
 		kernelName: kernelName,
 		product:    product,
 		version:    version,

--- a/internal/manifest/build.go
+++ b/internal/manifest/build.go
@@ -25,11 +25,12 @@ type Build struct {
 // NewBuild creates a new build pipeline from the repositories in repos
 // and the specified packages.
 func NewBuild(m *Manifest, runner runner.Runner, repos []rpmmd.RepoConfig) *Build {
+	name := "build"
 	pipeline := &Build{
-		Base:       NewBase(m, "build", nil),
+		Base:       NewBase(m, name, nil),
 		runner:     runner,
 		dependents: make([]Pipeline, 0),
-		repos:      repos,
+		repos:      filterRepos(repos, name),
 	}
 	m.addPipeline(pipeline)
 	return pipeline

--- a/internal/manifest/commit_server_tree.go
+++ b/internal/manifest/commit_server_tree.go
@@ -60,6 +60,7 @@ func NewOSTreeCommitServer(m *Manifest,
 }
 
 func (p *OSTreeCommitServer) getPackageSetChain() []rpmmd.PackageSet {
+	// FIXME: container package is defined here
 	packages := []string{"nginx"}
 	return []rpmmd.PackageSet{
 		{

--- a/internal/manifest/commit_server_tree.go
+++ b/internal/manifest/commit_server_tree.go
@@ -41,10 +41,11 @@ func NewOSTreeCommitServer(m *Manifest,
 	commitPipeline *OSTreeCommit,
 	nginxConfigPath,
 	listenPort string) *OSTreeCommitServer {
+	name := "container-tree"
 	p := &OSTreeCommitServer{
-		Base:            NewBase(m, "container-tree", buildPipeline),
+		Base:            NewBase(m, name, buildPipeline),
 		platform:        platform,
-		repos:           repos,
+		repos:           filterRepos(repos, name),
 		commitPipeline:  commitPipeline,
 		nginxConfigPath: nginxConfigPath,
 		listenPort:      listenPort,

--- a/internal/manifest/coreos_installer.go
+++ b/internal/manifest/coreos_installer.go
@@ -50,10 +50,11 @@ func NewCoreOSInstaller(m *Manifest,
 	kernelName,
 	product,
 	version string) *CoreOSInstaller {
+	name := "coi-tree"
 	p := &CoreOSInstaller{
-		Base:       NewBase(m, "coi-tree", buildPipeline),
+		Base:       NewBase(m, name, buildPipeline),
 		platform:   platform,
-		repos:      repos,
+		repos:      filterRepos(repos, name),
 		kernelName: kernelName,
 		product:    product,
 		version:    version,

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -102,3 +102,23 @@ func (m Manifest) GetExports() []string {
 	}
 	return exports
 }
+
+// filterRepos returns a list of repositories that specify the given pipeline
+// name in their PackageSets list in addition to any global repositories
+// (global repositories are ones that do not specify any PackageSets).
+func filterRepos(repos []rpmmd.RepoConfig, plName string) []rpmmd.RepoConfig {
+	filtered := make([]rpmmd.RepoConfig, 0, len(repos))
+	for _, repo := range repos {
+		if len(repo.PackageSets) == 0 {
+			filtered = append(filtered, repo)
+			continue
+		}
+		for _, ps := range repo.PackageSets {
+			if ps == plName {
+				filtered = append(filtered, repo)
+				continue
+			}
+		}
+	}
+	return filtered
+}

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -154,9 +154,10 @@ func NewOS(m *Manifest,
 	buildPipeline *Build,
 	platform platform.Platform,
 	repos []rpmmd.RepoConfig) *OS {
+	name := "os"
 	p := &OS{
-		Base:     NewBase(m, "os", buildPipeline),
-		repos:    repos,
+		Base:     NewBase(m, name, buildPipeline),
+		repos:    filterRepos(repos, name),
 		platform: platform,
 	}
 	buildPipeline.addDependent(p)

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -3335,9 +3335,10 @@ func (api *API) payloadRepositories(distroName string) []rpmmd.RepoConfig {
 }
 
 // Returns all configured repositories as rpmmd.RepoConfig.
-// The first returned slice represents the Base repos (depending on the image
-// type), while the second value represents the payload repos (defined by user).
-// The difference from allRepositories() is that this method may return additional repositories,
+// Payload repositories (defined by the user) are assigned the payload package
+// set names from the image type.
+//
+// The difference from allRepositories() is that this method may return additional repositories
 // which are needed to build the specific image type. The allRepositories() can't do this, because
 // it is used in places where image types are not considered.
 func (api *API) allRepositoriesByImageType(imageType distro.ImageType) ([]rpmmd.RepoConfig, error) {
@@ -3349,7 +3350,7 @@ func (api *API) allRepositoriesByImageType(imageType distro.ImageType) ([]rpmmd.
 	payloadRepos := api.payloadRepositories(imageType.Arch().Distro().Name())
 	// tag payload repositories with the payload package set names and add them to list of repos
 	for _, pr := range payloadRepos {
-		pr.ImageTypeTags = imageType.PayloadPackageSets()
+		pr.PackageSets = imageType.PayloadPackageSets()
 		repos = append(repos, pr)
 	}
 

--- a/test/data/manifests/rhel_7-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-azure_rhui-boot.json
@@ -594,6 +594,9 @@
                     "id": "sha256:bfb092807d02f35824f86087b5baf279d92e3c2290d94bc00078b6ea0ec97c22"
                   },
                   {
+                    "id": "sha256:268251eccd384c5859b0e56457e9e6caeffaaa1c3621e4f6b096a2636a2dd6f4"
+                  },
+                  {
                     "id": "sha256:3b7e15c04916e85c82a35b0c30f3134692d032f3c5184f9bd558b87ee742117c"
                   },
                   {
@@ -1009,6 +1012,9 @@
                   },
                   {
                     "id": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+                  },
+                  {
+                    "id": "sha256:4c57540da6b6623811e693805e7fea4ea26fca0d332611b4c7d772cdc587ffa4"
                   },
                   {
                     "id": "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66"
@@ -1614,13 +1620,13 @@
                     "id": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
                   },
                   {
-                    "id": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
-                  },
-                  {
                     "id": "sha256:bcc8c0dd7c9650d12b89f7ed0c037709d41dcd13310cfaf48d44323f87735e2b"
                   },
                   {
                     "id": "sha256:08a7cd07930cc331c629d79dcfc919f44695cddbc60ae44b0af08d5618462484"
+                  },
+                  {
+                    "id": "sha256:bf67290204eecd89a5e8ddc171a9b320718b76c042be86de40b34ac7ef7d286b"
                   },
                   {
                     "id": "sha256:791a9cbd72458f4f28a5e7d267ad415c51f9647a60c5645cb288cc4cd85381ea"
@@ -1638,19 +1644,7 @@
                     "id": "sha256:2d777b3e8a9940a4d6111c7212bbbb44de83916e3a61457ea269107b29740e64"
                   },
                   {
-                    "id": "sha256:44067d820351d312a98fe1ac443abe0d665ee2abe126ffed30a02852e7829982"
-                  },
-                  {
-                    "id": "sha256:2585143d999b18c0613fd978acabe0f8d4454a761562454b5d1b7fbb14817a45"
-                  },
-                  {
-                    "id": "sha256:29453086d819698dc37f2ae638d20d7c4bf87d681d4031d6ae747a8025c79007"
-                  },
-                  {
-                    "id": "sha256:40a98b2b368731fc1cc323472b3b8aafb82e9bc8205009dabe9e822b30adb431"
-                  },
-                  {
-                    "id": "sha256:20ca404a59b969e7e5bc88bdced333ce241d5eb4682f703e72674a40603fda8c"
+                    "id": "sha256:66a79f8531a5a937f2db732219c36220ccfb925837b4d2e278bed040776703cb"
                   },
                   {
                     "id": "sha256:aec11b0267a711f6bee2824a9914e88ca55a01738bf409b7ef7e7a38e37a9037"
@@ -1668,6 +1662,9 @@
                     "id": "sha256:d1fb8b3c6fb9a98d63766c3c9a228bb97453ba62cc4a490b6c187b1dfe42fae2"
                   },
                   {
+                    "id": "sha256:3106a99a28a75685253fa53c53c3a96c3d111c7906d55b1328791388d876e823"
+                  },
+                  {
                     "id": "sha256:b8f77d5b3714ca6d1b19736ad13588997ab31dc39b036f842a07b061af0fd247"
                   },
                   {
@@ -1681,9 +1678,6 @@
                   },
                   {
                     "id": "sha256:b83c398d8040ad255360d3fb37f04982a31d7e51d81815c5fafaf0dbe8fda9e7"
-                  },
-                  {
-                    "id": "sha256:034def562f71d5c64101f5959acec91a91a6ed7f0e1ccdcb50f098938a437ef9"
                   },
                   {
                     "id": "sha256:3230783603695707b5b037f700c0293658afeff26541bde93c2743b335c70e1b"
@@ -1794,6 +1788,9 @@
                     "id": "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415"
                   },
                   {
+                    "id": "sha256:2d610eeb34df730f433610a9d3623451886ccd043f65953c2db84e9a7268141c"
+                  },
+                  {
                     "id": "sha256:047500594382798561653d0b20408180ee9de108330b00abb3812ae35d70930b"
                   },
                   {
@@ -1827,6 +1824,9 @@
                     "id": "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68"
                   },
                   {
+                    "id": "sha256:3219f3e002e9379a4c3fe6edd2153cad97332a4315831dcd6470d61f26d77b94"
+                  },
+                  {
                     "id": "sha256:f6b19736ea764179ea7be0d949d3d54a8fc763100194b26819886503e07d8c13"
                   },
                   {
@@ -1848,6 +1848,9 @@
                     "id": "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc"
                   },
                   {
+                    "id": "sha256:d463594c24b2c65dc4fdadd1bfd55ebf1e24615d61bd0c65447ed68da238d6e1"
+                  },
+                  {
                     "id": "sha256:8da1f1e2007d98f395befb666f18f9e26ab3009f638a566b985615b22e14fe13"
                   },
                   {
@@ -1864,6 +1867,12 @@
                   },
                   {
                     "id": "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06"
+                  },
+                  {
+                    "id": "sha256:ea31234316136f3f2180c5c2abe7e33985c35075070fe36fccb9b328a2a3f58d"
+                  },
+                  {
+                    "id": "sha256:c55543bce15d8d5d1c5aae6aa6b2b632c5682a99d180b62cf98aaedd9ee5c5cb"
                   },
                   {
                     "id": "sha256:b449b7f89b8ffbaf72bf66e1b3c9c0e215faaacaca33b69bca5d44aeedaa6d20"
@@ -1948,6 +1957,18 @@
                   },
                   {
                     "id": "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6"
+                  },
+                  {
+                    "id": "sha256:0a091be51a7a0a72a2e209d1b5cfd7f5643d4eb218cb9a0b4ac69771b7ebbd39"
+                  },
+                  {
+                    "id": "sha256:cb02939c0d4ae07ade4db2414bab24ef5bcdad76fff360709603156b0688f262"
+                  },
+                  {
+                    "id": "sha256:fb796af6e23592ece64707e400a08959a6b80d43c3326b84c11ad33b46e8f17d"
+                  },
+                  {
+                    "id": "sha256:6e63e98a154c72735e5ec0895e8d8d88821b7ec1379d7899da8eb1fa00054a5f"
                   },
                   {
                     "id": "sha256:60fe39f8078b432730cf7830ced13421d0850289f7e27b74109a2efaa2665b0c"
@@ -2200,63 +2221,6 @@
                   },
                   {
                     "id": "sha256:7a994d8e50f9e5ced5d2082a58ecfb8f79ab1656cec77c65ec67453fbd6839fb"
-                  },
-                  {
-                    "id": "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b"
-                  },
-                  {
-                    "id": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
-                  },
-                  {
-                    "id": "sha256:3996788fc70d7171ff6e76bda0961a246919fa7e1689000a3daa0c5e080513a7"
-                  },
-                  {
-                    "id": "sha256:5d32146c850a3fcd57b22ca6dce89533ffbd66d67fb3766526f3d6298f2b3736"
-                  },
-                  {
-                    "id": "sha256:5e0c7dc6d85c0971198bc7ef307ece04dca827ad6b585d13244b7f38e8ebbec0"
-                  },
-                  {
-                    "id": "sha256:070f190e8b046b63f11c256dd7db97c6d52bd003c07fc2d27c17b4ccc59fce95"
-                  },
-                  {
-                    "id": "sha256:3d6d67ac18cede7b2c6138c3ef3f0229bcce82b7408e5e979e8f1c36b565966e"
-                  },
-                  {
-                    "id": "sha256:8247226762011ab0f728756cdd6961fb0a8de6e40dd0946e15fbbf3ed504e52c"
-                  },
-                  {
-                    "id": "sha256:8343c381ab75a1ee65db0e3d9cdac7d8a83bb7ab2aaef5ed1059191efe008b8b"
-                  },
-                  {
-                    "id": "sha256:06693d2eb44ac57bc2bbefd18dc42751e96b6571803d1c17b5e68576c76fceef"
-                  },
-                  {
-                    "id": "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09"
-                  },
-                  {
-                    "id": "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904"
-                  },
-                  {
-                    "id": "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267"
-                  },
-                  {
-                    "id": "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3"
-                  },
-                  {
-                    "id": "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0"
-                  },
-                  {
-                    "id": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
-                  },
-                  {
-                    "id": "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f"
-                  },
-                  {
-                    "id": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
-                  },
-                  {
-                    "id": "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50"
                   },
                   {
                     "id": "sha256:000bd49aea30ee3534e6cde11188afa4b567711b13acbcf531e5542fc7b2aefe"
@@ -3127,9 +3091,6 @@
           "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-0.19.8.1-3.el7.x86_64.rpm"
           },
-          "sha256:034def562f71d5c64101f5959acec91a91a6ed7f0e1ccdcb50f098938a437ef9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-TimeDate-2.30-2.el7.noarch.rpm"
-          },
           "sha256:03691e07c6a6d7e149e429e2c19dfd9ed038d417f01cd69a496759daf22053fd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sos-3.9-2.el7.noarch.rpm"
           },
@@ -3151,17 +3112,11 @@
           "sha256:05b11d41594ae949abd8f0f65f265dd815fb1ae2e8618bb3be63a7b7062be100": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-cli-2.1.11-60.el7.x86_64.rpm"
           },
-          "sha256:06693d2eb44ac57bc2bbefd18dc42751e96b6571803d1c17b5e68576c76fceef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-URI/1.71/1.el7eng/noarch/perl-URI-1.71-1.el7eng.noarch.rpm"
-          },
           "sha256:06b51b9c622b2a097ae8ca07b443dcc956da5a9ea9f6785ea4c6893fdba7dd7b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-enhanced-7.4.629-7.el7.x86_64.rpm"
           },
           "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/which-2.20-7.el7.x86_64.rpm"
-          },
-          "sha256:070f190e8b046b63f11c256dd7db97c6d52bd003c07fc2d27c17b4ccc59fce95": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-IO-Socket-IP/0.31/1.el7eng/noarch/perl-IO-Socket-IP-0.31-1.el7eng.noarch.rpm"
           },
           "sha256:07aa5c8a348915ae684375cb75ab5e4d8c38bde2a90083126fe81c0ec7650db0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/alsa-firmware-1.0.28-2.el7.noarch.rpm"
@@ -3189,6 +3144,9 @@
           },
           "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm"
+          },
+          "sha256:0a091be51a7a0a72a2e209d1b5cfd7f5643d4eb218cb9a0b4ac69771b7ebbd39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-4.11.3-45.el7.x86_64.rpm"
           },
           "sha256:0a6d71d0c1c1d14f2a6885734232dbe2a06ca6a958a9b81f06cef008e58769c8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl4965-firmware-228.61.2.24-79.el7.noarch.rpm"
@@ -3343,9 +3301,6 @@
           "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-2.5-15.el7.x86_64.rpm"
           },
-          "sha256:20ca404a59b969e7e5bc88bdced333ce241d5eb4682f703e72674a40603fda8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Net-SSLeay-1.55-6.el7.x86_64.rpm"
-          },
           "sha256:21224107f63cbbb08284a5d99c01f85041b455474de2a7e0475702d6dc34b1af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/passwd-0.79-6.el7.x86_64.rpm"
           },
@@ -3388,9 +3343,6 @@
           "sha256:2540ffdba1bfc89714d18489247193d661ec5ac342159c3f5907e13981cf5a21": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mtr-0.85-7.el7.x86_64.rpm"
           },
-          "sha256:2585143d999b18c0613fd978acabe0f8d4454a761562454b5d1b7fbb14817a45": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-IO-Socket-SSL-1.94-7.el7.noarch.rpm"
-          },
           "sha256:259dccd3801c5f2b41438236eca586f8caaf0ae9e9789acd61b2affee56e924d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hwdata-0.252-9.7.el7.x86_64.rpm"
           },
@@ -3408,6 +3360,9 @@
           },
           "sha256:267734897a4458d183f8fc74ea6db8f82143767371e752d896d189bd5b3c5b1a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gperftools-libs-2.6.1-1.el7.x86_64.rpm"
+          },
+          "sha256:268251eccd384c5859b0e56457e9e6caeffaaa1c3621e4f6b096a2636a2dd6f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/PyYAML-3.10-11.el7.x86_64.rpm"
           },
           "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm"
@@ -3427,9 +3382,6 @@
           "sha256:290ccc1f3e22a77ce692e451a70d7483a358b38358f908b622e85ce93b9d12db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-7.4p1-21.el7.x86_64.rpm"
           },
-          "sha256:29453086d819698dc37f2ae638d20d7c4bf87d681d4031d6ae747a8025c79007": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Mozilla-CA-20130114-5.el7.noarch.rpm"
-          },
           "sha256:2a03d83873a95f5a41224ef37b6abc396c04472aa3efc96835baae9f4596e018": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tuned-2.11.0-9.el7.noarch.rpm"
           },
@@ -3448,17 +3400,14 @@
           "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm"
           },
-          "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-setuptools/38.4.0/3.el7ost/noarch/python2-setuptools-38.4.0-3.el7ost.noarch.rpm"
-          },
           "sha256:2bba49f3d27655dc966ac46c92773a61b06ba05e039c76b26622513d613acc69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dmidecode-3.12.2-4.el7.x86_64.rpm"
           },
+          "sha256:2d610eeb34df730f433610a9d3623451886ccd043f65953c2db84e9a7268141c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dateutil-1.5-7.el7.noarch.rpm"
+          },
           "sha256:2d777b3e8a9940a4d6111c7212bbbb44de83916e3a61457ea269107b29740e64": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Getopt-Long-2.40-3.el7.noarch.rpm"
-          },
-          "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-markupsafe/1.0/2.el7eng/x86_64/python2-markupsafe-1.0-2.el7eng.x86_64.rpm"
           },
           "sha256:2e3bb02e9028cfcae4f9945fccb663ed54ffd3b26e77bceabb2328ba3b433ae6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-anacron-1.4.11-23.el7.x86_64.rpm"
@@ -3487,6 +3436,9 @@
           "sha256:2fcf0cdbc2af078e48997356493e01094d5464be9bf6b93b9fada75b83a18130": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-libs-4.2.5-82.el7.x86_64.rpm"
           },
+          "sha256:3106a99a28a75685253fa53c53c3a96c3d111c7906d55b1328791388d876e823": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Scalar-List-Utils-1.27-248.el7.x86_64.rpm"
+          },
           "sha256:311477ee57b269f9693a70931066ef2852c030557fb3c61313308af71bf46b94": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-libs-lite-9.11.4-26.P2.el7.x86_64.rpm"
           },
@@ -3498,6 +3450,9 @@
           },
           "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:3219f3e002e9379a4c3fe6edd2153cad97332a4315831dcd6470d61f26d77b94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jinja2-2.7.2-4.el7.noarch.rpm"
           },
           "sha256:3230783603695707b5b037f700c0293658afeff26541bde93c2743b335c70e1b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-constant-1.27-2.el7.noarch.rpm"
@@ -3544,9 +3499,6 @@
           "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpwquality-1.2.3-5.el7.x86_64.rpm"
           },
-          "sha256:3996788fc70d7171ff6e76bda0961a246919fa7e1689000a3daa0c5e080513a7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Encode/2.78/2.1.el7/x86_64/perl-Encode-2.78-2.1.el7.x86_64.rpm"
-          },
           "sha256:39a9ade0e44eb4856e70940e8d3d581ada5e6b122744d5e957729042d1b7ff0b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-rhn-plugin-2.0.1-10.el7.noarch.rpm"
           },
@@ -3589,23 +3541,14 @@
           "sha256:3d30debfa65d5354cde7e515ddee39110d6f846647b806e46192fd7956100d9d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/scl-utils-20130529-19.el7.x86_64.rpm"
           },
-          "sha256:3d6d67ac18cede7b2c6138c3ef3f0229bcce82b7408e5e979e8f1c36b565966e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Mozilla-PublicSuffix/0.1.19/1.el7eng/noarch/perl-Mozilla-PublicSuffix-0.1.19-1.el7eng.noarch.rpm"
-          },
           "sha256:3da6456472355dc70e19cd3b5109a73b8f5c019bb7f24a6b17d7150314f07244": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl5000-firmware-8.83.5.1_1-79.el7.noarch.rpm"
           },
           "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm"
           },
-          "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python-six-1.9.0-4.el7eng.noarch.rpm"
-          },
           "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-libs-219-78.el7.x86_64.rpm"
-          },
-          "sha256:40a98b2b368731fc1cc323472b3b8aafb82e9bc8205009dabe9e822b30adb431": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Net-LibIDN-0.12-15.el7.x86_64.rpm"
           },
           "sha256:41365738eddbefb6b9aac6710780ad62b4ccfe00751e7ae4c7a66b990f5703cc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cloud-utils-growpart-0.29-5.el7.noarch.rpm"
@@ -3624,9 +3567,6 @@
           },
           "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-libs-0.19.8.1-3.el7.x86_64.rpm"
-          },
-          "sha256:44067d820351d312a98fe1ac443abe0d665ee2abe126ffed30a02852e7829982": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-HTTP-Date-6.02-8.el7.noarch.rpm"
           },
           "sha256:448840196e3439f64d64ac56e71d5e2e1d83b7100aeca7ac2719d70e7913f5e6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-libs-2.1.11-60.el7.x86_64.rpm"
@@ -3663,6 +3603,9 @@
           },
           "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm"
+          },
+          "sha256:4c57540da6b6623811e693805e7fea4ea26fca0d332611b4c7d772cdc587ffa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hardlink-1.0-19.el7.x86_64.rpm"
           },
           "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm"
@@ -3778,14 +3721,8 @@
           "sha256:5cbaafb7edb56eea2ae1b469597e1d24304b5f1f5294316bcb72d99b2edf1acd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/wget-1.14-18.el7_6.1.x86_64.rpm"
           },
-          "sha256:5d32146c850a3fcd57b22ca6dce89533ffbd66d67fb3766526f3d6298f2b3736": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-HTTP-CookieJar/0.006/1.el7eng/noarch/perl-HTTP-CookieJar-0.006-1.el7eng.noarch.rpm"
-          },
           "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libunistring-0.9.3-9.el7.x86_64.rpm"
-          },
-          "sha256:5e0c7dc6d85c0971198bc7ef307ece04dca827ad6b585d13244b7f38e8ebbec0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-HTTP-Tiny/0.047/1.el7eng/noarch/perl-HTTP-Tiny-0.047-1.el7eng.noarch.rpm"
           },
           "sha256:5ef4bbfe39568843c5bd64942183d10bc11db265c4eb7a067ec8063814c5d174": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pyudev-0.15-9.el7.noarch.rpm"
@@ -3832,6 +3769,9 @@
           "sha256:66149f8d65c73e297a392cf33a8c40e570ae8b16667c29d7ce967adade27eb7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl5150-firmware-8.24.2.2-79.el7.noarch.rpm"
           },
+          "sha256:66a79f8531a5a937f2db732219c36220ccfb925837b4d2e278bed040776703cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-HTTP-Tiny-0.033-3.el7.noarch.rpm"
+          },
           "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setup-2.8.71-11.el7.noarch.rpm"
           },
@@ -3862,9 +3802,6 @@
           "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm"
           },
-          "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-python-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
-          },
           "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-modules-2.02-0.87.el7.noarch.rpm"
           },
@@ -3888,6 +3825,9 @@
           },
           "sha256:6e54c37c51856a6be2dd8e22c0c8f9fbc82fd21f01c2f7c7295a29bbcdf1e824": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-lib-python-0.12.1-1.el7.noarch.rpm"
+          },
+          "sha256:6e63e98a154c72735e5ec0895e8d8d88821b7ec1379d7899da8eb1fa00054a5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-python-4.11.3-45.el7.x86_64.rpm"
           },
           "sha256:6e7dae153c72989bcbf0f9174f513dbca277578eba1fe08895b4dafb98308caf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-parent-0.225-244.el7.noarch.rpm"
@@ -3997,9 +3937,6 @@
           "sha256:8205a82a78e2c69335b4c0de5c0cf6ae401e5135b1e53044ebe5d2f51bec9af9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-python-2.5-34.el7.x86_64.rpm"
           },
-          "sha256:8247226762011ab0f728756cdd6961fb0a8de6e40dd0946e15fbbf3ed504e52c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Scalar-List-Utils/1.45/1.el7eng/x86_64/perl-Scalar-List-Utils-1.45-1.el7eng.x86_64.rpm"
-          },
           "sha256:827757b21e2a88b67e7991f003dd30afd778ee94d966d1d91619b05ba4f801fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdaemon-0.14-7.el7.x86_64.rpm"
           },
@@ -4014,9 +3951,6 @@
           },
           "sha256:83417516af90dbff01c37715535ecbf349cdb6cf2a39a7addd1544c8fb939803": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-config-generic-033-572.el7.x86_64.rpm"
-          },
-          "sha256:8343c381ab75a1ee65db0e3d9cdac7d8a83bb7ab2aaef5ed1059191efe008b8b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Test-Simple/1.302040/1.el7eng/noarch/perl-Test-Simple-1.302040-1.el7eng.noarch.rpm"
           },
           "sha256:838e27cadbb77a140e9c26664d37cd22d38f22500b8e9b587405e926bbb7c18f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/biosdevname-0.7.3-2.el7.x86_64.rpm"
@@ -4062,9 +3996,6 @@
           },
           "sha256:88ff978b561a31e1bec818870a09e7078e9f3d0f2530293dde79348ad2ee8697": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rdate-1.4-25.el7.x86_64.rpm"
-          },
-          "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-jinja2/2.8/2.el7eng/noarch/python-jinja2-2.8-2.el7eng.noarch.rpm"
           },
           "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm"
@@ -4209,9 +4140,6 @@
           },
           "sha256:9cbd12093d658f57664a1e385a5d38401b6c99e70f0b1cca029236ce950bf77d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hyperv-daemons-0-0.34.20180415git.el7.x86_64.rpm"
-          },
-          "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-dateutil/2.6.1/1.el7ost/noarch/python2-dateutil-2.6.1-1.el7ost.noarch.rpm"
           },
           "sha256:9d09e49c6f92e1673f0ce5486cb4e12588694793918a9265436000d2fcb88b7d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/psacct-6.6.1-13.el7.x86_64.rpm"
@@ -4453,6 +4381,9 @@
           "sha256:be68fe77c5c5abbaac3734d520a5056f0752e35eb5c911cd85c34088bd99888e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ethtool-0.8-8.el7.x86_64.rpm"
           },
+          "sha256:bf67290204eecd89a5e8ddc171a9b320718b76c042be86de40b34ac7ef7d286b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Encode-2.51-7.el7.x86_64.rpm"
+          },
           "sha256:bfb092807d02f35824f86087b5baf279d92e3c2290d94bc00078b6ea0ec97c22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-tui-1.18.8-1.el7.x86_64.rpm"
           },
@@ -4474,9 +4405,6 @@
           "sha256:c264f613eba75609c960c72ddaf52664c6b70fea1c5c7e87671d68d3bcf5fed6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-3.10.0-1160.el7.x86_64.rpm"
           },
-          "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-build-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
-          },
           "sha256:c3c3aa618f901b7335c4285dc04cf3cc6c5d1881f12bff2717a04f09af4289c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-setuptools-39.2.0-10.el7.noarch.rpm"
           },
@@ -4494,6 +4422,9 @@
           },
           "sha256:c5137a9d3b9aac4dba1262800fa480bbc979a62227ad31f0d837618cdf4377ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iprutils-2.4.17.1-3.el7.x86_64.rpm"
+          },
+          "sha256:c55543bce15d8d5d1c5aae6aa6b2b632c5682a99d180b62cf98aaedd9ee5c5cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-six-1.9.0-2.el7.noarch.rpm"
           },
           "sha256:c672527f93c914be54899edbd5f855c3c957e4493b218db7a69a4e6f54ce2e09": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python2-futures-3.1.1-5.el7.noarch.rpm"
@@ -4516,9 +4447,6 @@
           "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm"
           },
-          "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/PyYAML-3.12-12.el7eng.x86_64.rpm"
-          },
           "sha256:c95fb7d3137031016bce7742a5a56b2bdb83903d91004783a138cfb4def075ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sysstat-10.1.5-19.el7.x86_64.rpm"
           },
@@ -4530,6 +4458,9 @@
           },
           "sha256:cab023377a79bf3dc9317c1281abf4099aaccc0c95e69032fe2e563023a802f0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-libnm-1.18.8-1.el7.x86_64.rpm"
+          },
+          "sha256:cb02939c0d4ae07ade4db2414bab24ef5bcdad76fff360709603156b0688f262": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-build-libs-4.11.3-45.el7.x86_64.rpm"
           },
           "sha256:cc4b75e1ce83af2dbad9604e70bcf40e7f20ad8918a08f8b82f6d5e69efd9655": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-1.18.8-1.el7.x86_64.rpm"
@@ -4587,6 +4518,9 @@
           },
           "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:d463594c24b2c65dc4fdadd1bfd55ebf1e24615d61bd0c65447ed68da238d6e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-markupsafe-0.11-10.el7.x86_64.rpm"
           },
           "sha256:d4b2de8f877b5c86b4c6751fbfba32d805bff4ecbb6183831888c833fb1af967": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-server-7.4p1-21.el7.x86_64.rpm"
@@ -4714,6 +4648,9 @@
           "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm"
           },
+          "sha256:ea31234316136f3f2180c5c2abe7e33985c35075070fe36fccb9b328a2a3f58d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-setuptools-0.9.8-7.el7.noarch.rpm"
+          },
           "sha256:ea6c84fe12b97fb5511ffee78b31a8ffb0444fd41da21932503568df14a95e98": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lsscsi-0.27-6.el7.x86_64.rpm"
           },
@@ -4815,6 +4752,9 @@
           },
           "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdbm-1.10-8.el7.x86_64.rpm"
+          },
+          "sha256:fb796af6e23592ece64707e400a08959a6b80d43c3326b84c11ad33b46e8f17d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-libs-4.11.3-45.el7.x86_64.rpm"
           },
           "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm"
@@ -6397,6 +6337,15 @@
         "checksum": "sha256:bfb092807d02f35824f86087b5baf279d92e3c2290d94bc00078b6ea0ec97c22"
       },
       {
+        "name": "PyYAML",
+        "epoch": 0,
+        "version": "3.10",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/PyYAML-3.10-11.el7.x86_64.rpm",
+        "checksum": "sha256:268251eccd384c5859b0e56457e9e6caeffaaa1c3621e4f6b096a2636a2dd6f4"
+      },
+      {
         "name": "Red_Hat_Enterprise_Linux-Release_Notes-7-en-US",
         "epoch": 0,
         "version": "7",
@@ -7646,6 +7595,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm",
         "checksum": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.0",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hardlink-1.0-19.el7.x86_64.rpm",
+        "checksum": "sha256:4c57540da6b6623811e693805e7fea4ea26fca0d332611b4c7d772cdc587ffa4"
       },
       {
         "name": "hostname",
@@ -9457,15 +9415,6 @@
         "checksum": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
       },
       {
-        "name": "pcre2",
-        "epoch": 0,
-        "version": "10.23",
-        "release": "2.el7",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm",
-        "checksum": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
-      },
-      {
         "name": "perl",
         "epoch": 4,
         "version": "5.16.3",
@@ -9482,6 +9431,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Carp-1.26-244.el7.noarch.rpm",
         "checksum": "sha256:08a7cd07930cc331c629d79dcfc919f44695cddbc60ae44b0af08d5618462484"
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 0,
+        "version": "2.51",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Encode-2.51-7.el7.x86_64.rpm",
+        "checksum": "sha256:bf67290204eecd89a5e8ddc171a9b320718b76c042be86de40b34ac7ef7d286b"
       },
       {
         "name": "perl-Exporter",
@@ -9529,49 +9487,13 @@
         "checksum": "sha256:2d777b3e8a9940a4d6111c7212bbbb44de83916e3a61457ea269107b29740e64"
       },
       {
-        "name": "perl-HTTP-Date",
+        "name": "perl-HTTP-Tiny",
         "epoch": 0,
-        "version": "6.02",
-        "release": "8.el7",
+        "version": "0.033",
+        "release": "3.el7",
         "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-HTTP-Date-6.02-8.el7.noarch.rpm",
-        "checksum": "sha256:44067d820351d312a98fe1ac443abe0d665ee2abe126ffed30a02852e7829982"
-      },
-      {
-        "name": "perl-IO-Socket-SSL",
-        "epoch": 0,
-        "version": "1.94",
-        "release": "7.el7",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-IO-Socket-SSL-1.94-7.el7.noarch.rpm",
-        "checksum": "sha256:2585143d999b18c0613fd978acabe0f8d4454a761562454b5d1b7fbb14817a45"
-      },
-      {
-        "name": "perl-Mozilla-CA",
-        "epoch": 0,
-        "version": "20130114",
-        "release": "5.el7",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Mozilla-CA-20130114-5.el7.noarch.rpm",
-        "checksum": "sha256:29453086d819698dc37f2ae638d20d7c4bf87d681d4031d6ae747a8025c79007"
-      },
-      {
-        "name": "perl-Net-LibIDN",
-        "epoch": 0,
-        "version": "0.12",
-        "release": "15.el7",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Net-LibIDN-0.12-15.el7.x86_64.rpm",
-        "checksum": "sha256:40a98b2b368731fc1cc323472b3b8aafb82e9bc8205009dabe9e822b30adb431"
-      },
-      {
-        "name": "perl-Net-SSLeay",
-        "epoch": 0,
-        "version": "1.55",
-        "release": "6.el7",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Net-SSLeay-1.55-6.el7.x86_64.rpm",
-        "checksum": "sha256:20ca404a59b969e7e5bc88bdced333ce241d5eb4682f703e72674a40603fda8c"
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-HTTP-Tiny-0.033-3.el7.noarch.rpm",
+        "checksum": "sha256:66a79f8531a5a937f2db732219c36220ccfb925837b4d2e278bed040776703cb"
       },
       {
         "name": "perl-PathTools",
@@ -9619,6 +9541,15 @@
         "checksum": "sha256:d1fb8b3c6fb9a98d63766c3c9a228bb97453ba62cc4a490b6c187b1dfe42fae2"
       },
       {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 0,
+        "version": "1.27",
+        "release": "248.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Scalar-List-Utils-1.27-248.el7.x86_64.rpm",
+        "checksum": "sha256:3106a99a28a75685253fa53c53c3a96c3d111c7906d55b1328791388d876e823"
+      },
+      {
         "name": "perl-Socket",
         "epoch": 0,
         "version": "2.010",
@@ -9662,15 +9593,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Time-Local-1.2300-2.el7.noarch.rpm",
         "checksum": "sha256:b83c398d8040ad255360d3fb37f04982a31d7e51d81815c5fafaf0dbe8fda9e7"
-      },
-      {
-        "name": "perl-TimeDate",
-        "epoch": 1,
-        "version": "2.30",
-        "release": "2.el7",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-TimeDate-2.30-2.el7.noarch.rpm",
-        "checksum": "sha256:034def562f71d5c64101f5959acec91a91a6ed7f0e1ccdcb50f098938a437ef9"
       },
       {
         "name": "perl-constant",
@@ -9997,6 +9919,15 @@
         "checksum": "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415"
       },
       {
+        "name": "python-dateutil",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dateutil-1.5-7.el7.noarch.rpm",
+        "checksum": "sha256:2d610eeb34df730f433610a9d3623451886ccd043f65953c2db84e9a7268141c"
+      },
+      {
         "name": "python-decorator",
         "epoch": 0,
         "version": "3.4.0",
@@ -10096,6 +10027,15 @@
         "checksum": "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68"
       },
       {
+        "name": "python-jinja2",
+        "epoch": 0,
+        "version": "2.7.2",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jinja2-2.7.2-4.el7.noarch.rpm",
+        "checksum": "sha256:3219f3e002e9379a4c3fe6edd2153cad97332a4315831dcd6470d61f26d77b94"
+      },
+      {
         "name": "python-jsonpatch",
         "epoch": 0,
         "version": "1.2",
@@ -10159,6 +10099,15 @@
         "checksum": "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc"
       },
       {
+        "name": "python-markupsafe",
+        "epoch": 0,
+        "version": "0.11",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-markupsafe-0.11-10.el7.x86_64.rpm",
+        "checksum": "sha256:d463594c24b2c65dc4fdadd1bfd55ebf1e24615d61bd0c65447ed68da238d6e1"
+      },
+      {
         "name": "python-perf",
         "epoch": 0,
         "version": "3.10.0",
@@ -10211,6 +10160,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-schedutils-0.4-6.el7.x86_64.rpm",
         "checksum": "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06"
+      },
+      {
+        "name": "python-setuptools",
+        "epoch": 0,
+        "version": "0.9.8",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-setuptools-0.9.8-7.el7.noarch.rpm",
+        "checksum": "sha256:ea31234316136f3f2180c5c2abe7e33985c35075070fe36fccb9b328a2a3f58d"
+      },
+      {
+        "name": "python-six",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-six-1.9.0-2.el7.noarch.rpm",
+        "checksum": "sha256:c55543bce15d8d5d1c5aae6aa6b2b632c5682a99d180b62cf98aaedd9ee5c5cb"
       },
       {
         "name": "python-slip",
@@ -10463,6 +10430,42 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpcbind-0.2.0-49.el7.x86_64.rpm",
         "checksum": "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6"
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-4.11.3-45.el7.x86_64.rpm",
+        "checksum": "sha256:0a091be51a7a0a72a2e209d1b5cfd7f5643d4eb218cb9a0b4ac69771b7ebbd39"
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-build-libs-4.11.3-45.el7.x86_64.rpm",
+        "checksum": "sha256:cb02939c0d4ae07ade4db2414bab24ef5bcdad76fff360709603156b0688f262"
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-libs-4.11.3-45.el7.x86_64.rpm",
+        "checksum": "sha256:fb796af6e23592ece64707e400a08959a6b80d43c3326b84c11ad33b46e8f17d"
+      },
+      {
+        "name": "rpm-python",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-python-4.11.3-45.el7.x86_64.rpm",
+        "checksum": "sha256:6e63e98a154c72735e5ec0895e8d8d88821b7ec1379d7899da8eb1fa00054a5f"
       },
       {
         "name": "rsync",
@@ -11219,177 +11222,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530/Packages/rh-dotnetcore11-runtime-1.0-1.el7.x86_64.rpm",
         "checksum": "sha256:7a994d8e50f9e5ced5d2082a58ecfb8f79ab1656cec77c65ec67453fbd6839fb"
-      },
-      {
-        "name": "PyYAML",
-        "epoch": 0,
-        "version": "3.12",
-        "release": "12.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/PyYAML-3.12-12.el7eng.x86_64.rpm",
-        "checksum": "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b"
-      },
-      {
-        "name": "hardlink",
-        "epoch": 1,
-        "version": "1.3",
-        "release": "6.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm",
-        "checksum": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
-      },
-      {
-        "name": "perl-Encode",
-        "epoch": 3,
-        "version": "2.78",
-        "release": "2.1.el7",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Encode/2.78/2.1.el7/x86_64/perl-Encode-2.78-2.1.el7.x86_64.rpm",
-        "checksum": "sha256:3996788fc70d7171ff6e76bda0961a246919fa7e1689000a3daa0c5e080513a7"
-      },
-      {
-        "name": "perl-HTTP-CookieJar",
-        "epoch": 0,
-        "version": "0.006",
-        "release": "1.el7eng",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-HTTP-CookieJar/0.006/1.el7eng/noarch/perl-HTTP-CookieJar-0.006-1.el7eng.noarch.rpm",
-        "checksum": "sha256:5d32146c850a3fcd57b22ca6dce89533ffbd66d67fb3766526f3d6298f2b3736"
-      },
-      {
-        "name": "perl-HTTP-Tiny",
-        "epoch": 0,
-        "version": "0.047",
-        "release": "1.el7eng",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-HTTP-Tiny/0.047/1.el7eng/noarch/perl-HTTP-Tiny-0.047-1.el7eng.noarch.rpm",
-        "checksum": "sha256:5e0c7dc6d85c0971198bc7ef307ece04dca827ad6b585d13244b7f38e8ebbec0"
-      },
-      {
-        "name": "perl-IO-Socket-IP",
-        "epoch": 0,
-        "version": "0.31",
-        "release": "1.el7eng",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-IO-Socket-IP/0.31/1.el7eng/noarch/perl-IO-Socket-IP-0.31-1.el7eng.noarch.rpm",
-        "checksum": "sha256:070f190e8b046b63f11c256dd7db97c6d52bd003c07fc2d27c17b4ccc59fce95"
-      },
-      {
-        "name": "perl-Mozilla-PublicSuffix",
-        "epoch": 0,
-        "version": "0.1.19",
-        "release": "1.el7eng",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Mozilla-PublicSuffix/0.1.19/1.el7eng/noarch/perl-Mozilla-PublicSuffix-0.1.19-1.el7eng.noarch.rpm",
-        "checksum": "sha256:3d6d67ac18cede7b2c6138c3ef3f0229bcce82b7408e5e979e8f1c36b565966e"
-      },
-      {
-        "name": "perl-Scalar-List-Utils",
-        "epoch": 4,
-        "version": "1.45",
-        "release": "1.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Scalar-List-Utils/1.45/1.el7eng/x86_64/perl-Scalar-List-Utils-1.45-1.el7eng.x86_64.rpm",
-        "checksum": "sha256:8247226762011ab0f728756cdd6961fb0a8de6e40dd0946e15fbbf3ed504e52c"
-      },
-      {
-        "name": "perl-Test-Simple",
-        "epoch": 4,
-        "version": "1.302040",
-        "release": "1.el7eng",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Test-Simple/1.302040/1.el7eng/noarch/perl-Test-Simple-1.302040-1.el7eng.noarch.rpm",
-        "checksum": "sha256:8343c381ab75a1ee65db0e3d9cdac7d8a83bb7ab2aaef5ed1059191efe008b8b"
-      },
-      {
-        "name": "perl-URI",
-        "epoch": 4,
-        "version": "1.71",
-        "release": "1.el7eng",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-URI/1.71/1.el7eng/noarch/perl-URI-1.71-1.el7eng.noarch.rpm",
-        "checksum": "sha256:06693d2eb44ac57bc2bbefd18dc42751e96b6571803d1c17b5e68576c76fceef"
-      },
-      {
-        "name": "python-jinja2",
-        "epoch": 0,
-        "version": "2.8",
-        "release": "2.el7eng",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-jinja2/2.8/2.el7eng/noarch/python-jinja2-2.8-2.el7eng.noarch.rpm",
-        "checksum": "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09"
-      },
-      {
-        "name": "python-six",
-        "epoch": 0,
-        "version": "1.9.0",
-        "release": "4.el7eng",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python-six-1.9.0-4.el7eng.noarch.rpm",
-        "checksum": "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904"
-      },
-      {
-        "name": "python2-dateutil",
-        "epoch": 1,
-        "version": "2.6.1",
-        "release": "1.el7ost",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-dateutil/2.6.1/1.el7ost/noarch/python2-dateutil-2.6.1-1.el7ost.noarch.rpm",
-        "checksum": "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267"
-      },
-      {
-        "name": "python2-markupsafe",
-        "epoch": 0,
-        "version": "1.0",
-        "release": "2.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-markupsafe/1.0/2.el7eng/x86_64/python2-markupsafe-1.0-2.el7eng.x86_64.rpm",
-        "checksum": "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3"
-      },
-      {
-        "name": "python2-setuptools",
-        "epoch": 0,
-        "version": "38.4.0",
-        "release": "3.el7ost",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-setuptools/38.4.0/3.el7ost/noarch/python2-setuptools-38.4.0-3.el7ost.noarch.rpm",
-        "checksum": "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0"
-      },
-      {
-        "name": "rpm",
-        "epoch": 0,
-        "version": "4.11.3",
-        "release": "45.zfix_sighdr.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
-        "checksum": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
-      },
-      {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.11.3",
-        "release": "45.zfix_sighdr.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-build-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
-        "checksum": "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f"
-      },
-      {
-        "name": "rpm-libs",
-        "epoch": 0,
-        "version": "4.11.3",
-        "release": "45.zfix_sighdr.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
-        "checksum": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
-      },
-      {
-        "name": "rpm-python",
-        "epoch": 0,
-        "version": "4.11.3",
-        "release": "45.zfix_sighdr.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-python-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
-        "checksum": "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50"
       },
       {
         "name": "rhui-azure-rhel7",

--- a/test/data/manifests/rhel_7-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-qcow2-boot.json
@@ -572,6 +572,9 @@
                     "id": "sha256:9ae89ba6e5533df2ee1af8cab3ed8fd6be99a432eff3519783095a37cd710a66"
                   },
                   {
+                    "id": "sha256:268251eccd384c5859b0e56457e9e6caeffaaa1c3621e4f6b096a2636a2dd6f4"
+                  },
+                  {
                     "id": "sha256:3b7e15c04916e85c82a35b0c30f3134692d032f3c5184f9bd558b87ee742117c"
                   },
                   {
@@ -828,6 +831,9 @@
                   },
                   {
                     "id": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+                  },
+                  {
+                    "id": "sha256:4c57540da6b6623811e693805e7fea4ea26fca0d332611b4c7d772cdc587ffa4"
                   },
                   {
                     "id": "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66"
@@ -1217,9 +1223,6 @@
                     "id": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
                   },
                   {
-                    "id": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
-                  },
-                  {
                     "id": "sha256:f6b628ad8e07ea56d5dd75453611d680b959de24f3ea5552f6968d5282bce349"
                   },
                   {
@@ -1286,6 +1289,9 @@
                     "id": "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415"
                   },
                   {
+                    "id": "sha256:2d610eeb34df730f433610a9d3623451886ccd043f65953c2db84e9a7268141c"
+                  },
+                  {
                     "id": "sha256:047500594382798561653d0b20408180ee9de108330b00abb3812ae35d70930b"
                   },
                   {
@@ -1319,6 +1325,9 @@
                     "id": "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68"
                   },
                   {
+                    "id": "sha256:3219f3e002e9379a4c3fe6edd2153cad97332a4315831dcd6470d61f26d77b94"
+                  },
+                  {
                     "id": "sha256:f6b19736ea764179ea7be0d949d3d54a8fc763100194b26819886503e07d8c13"
                   },
                   {
@@ -1340,6 +1349,9 @@
                     "id": "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc"
                   },
                   {
+                    "id": "sha256:d463594c24b2c65dc4fdadd1bfd55ebf1e24615d61bd0c65447ed68da238d6e1"
+                  },
+                  {
                     "id": "sha256:8da1f1e2007d98f395befb666f18f9e26ab3009f638a566b985615b22e14fe13"
                   },
                   {
@@ -1356,6 +1368,12 @@
                   },
                   {
                     "id": "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06"
+                  },
+                  {
+                    "id": "sha256:ea31234316136f3f2180c5c2abe7e33985c35075070fe36fccb9b328a2a3f58d"
+                  },
+                  {
+                    "id": "sha256:c55543bce15d8d5d1c5aae6aa6b2b632c5682a99d180b62cf98aaedd9ee5c5cb"
                   },
                   {
                     "id": "sha256:b449b7f89b8ffbaf72bf66e1b3c9c0e215faaacaca33b69bca5d44aeedaa6d20"
@@ -1419,6 +1437,18 @@
                   },
                   {
                     "id": "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6"
+                  },
+                  {
+                    "id": "sha256:0a091be51a7a0a72a2e209d1b5cfd7f5643d4eb218cb9a0b4ac69771b7ebbd39"
+                  },
+                  {
+                    "id": "sha256:cb02939c0d4ae07ade4db2414bab24ef5bcdad76fff360709603156b0688f262"
+                  },
+                  {
+                    "id": "sha256:fb796af6e23592ece64707e400a08959a6b80d43c3326b84c11ad33b46e8f17d"
+                  },
+                  {
+                    "id": "sha256:6e63e98a154c72735e5ec0895e8d8d88821b7ec1379d7899da8eb1fa00054a5f"
                   },
                   {
                     "id": "sha256:60fe39f8078b432730cf7830ced13421d0850289f7e27b74109a2efaa2665b0c"
@@ -1551,39 +1581,6 @@
                   },
                   {
                     "id": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
-                  },
-                  {
-                    "id": "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b"
-                  },
-                  {
-                    "id": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
-                  },
-                  {
-                    "id": "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09"
-                  },
-                  {
-                    "id": "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904"
-                  },
-                  {
-                    "id": "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267"
-                  },
-                  {
-                    "id": "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3"
-                  },
-                  {
-                    "id": "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0"
-                  },
-                  {
-                    "id": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
-                  },
-                  {
-                    "id": "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f"
-                  },
-                  {
-                    "id": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
-                  },
-                  {
-                    "id": "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50"
                   }
                 ]
               }
@@ -2006,6 +2003,9 @@
           "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm"
           },
+          "sha256:0a091be51a7a0a72a2e209d1b5cfd7f5643d4eb218cb9a0b4ac69771b7ebbd39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-4.11.3-45.el7.x86_64.rpm"
+          },
           "sha256:0bb2ac8f0d7a970cd1c318d9b810ba9c0f9540bd0d62d391ec47b5da9415fd2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-libs-7.1-1.el7.x86_64.rpm"
           },
@@ -2138,6 +2138,9 @@
           "sha256:267734897a4458d183f8fc74ea6db8f82143767371e752d896d189bd5b3c5b1a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gperftools-libs-2.6.1-1.el7.x86_64.rpm"
           },
+          "sha256:268251eccd384c5859b0e56457e9e6caeffaaa1c3621e4f6b096a2636a2dd6f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/PyYAML-3.10-11.el7.x86_64.rpm"
+          },
           "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm"
           },
@@ -2168,14 +2171,11 @@
           "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm"
           },
-          "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-setuptools/38.4.0/3.el7ost/noarch/python2-setuptools-38.4.0-3.el7ost.noarch.rpm"
-          },
           "sha256:2bba49f3d27655dc966ac46c92773a61b06ba05e039c76b26622513d613acc69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dmidecode-3.12.2-4.el7.x86_64.rpm"
           },
-          "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-markupsafe/1.0/2.el7eng/x86_64/python2-markupsafe-1.0-2.el7eng.x86_64.rpm"
+          "sha256:2d610eeb34df730f433610a9d3623451886ccd043f65953c2db84e9a7268141c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dateutil-1.5-7.el7.noarch.rpm"
           },
           "sha256:2e3bb02e9028cfcae4f9945fccb663ed54ffd3b26e77bceabb2328ba3b433ae6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-anacron-1.4.11-23.el7.x86_64.rpm"
@@ -2191,6 +2191,9 @@
           },
           "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:3219f3e002e9379a4c3fe6edd2153cad97332a4315831dcd6470d61f26d77b94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jinja2-2.7.2-4.el7.noarch.rpm"
           },
           "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-5.2.2-1.el7.x86_64.rpm"
@@ -2255,9 +2258,6 @@
           "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm"
           },
-          "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python-six-1.9.0-4.el7eng.noarch.rpm"
-          },
           "sha256:3fd04125208bed410e43eb49b18d09cbdaa6e6b27f86c9bfb156103ad14711a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfsidmap-0.25-19.el7.x86_64.rpm"
           },
@@ -2305,6 +2305,9 @@
           },
           "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm"
+          },
+          "sha256:4c57540da6b6623811e693805e7fea4ea26fca0d332611b4c7d772cdc587ffa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hardlink-1.0-19.el7.x86_64.rpm"
           },
           "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm"
@@ -2432,9 +2435,6 @@
           "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm"
           },
-          "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-python-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
-          },
           "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-modules-2.02-0.87.el7.noarch.rpm"
           },
@@ -2458,6 +2458,9 @@
           },
           "sha256:6e54c37c51856a6be2dd8e22c0c8f9fbc82fd21f01c2f7c7295a29bbcdf1e824": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-lib-python-0.12.1-1.el7.noarch.rpm"
+          },
+          "sha256:6e63e98a154c72735e5ec0895e8d8d88821b7ec1379d7899da8eb1fa00054a5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-python-4.11.3-45.el7.x86_64.rpm"
           },
           "sha256:6ee12aa6e7b041aad0ac3d968b1ab18dacded8a489ad27b653242929af978e12": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grubby-8.28-26.el7.x86_64.rpm"
@@ -2549,9 +2552,6 @@
           "sha256:88e7108ff671d4e161a1fc1bd72c41c4cec8e80b74c5300b327183551824cc49": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpath_utils-0.2.1-32.el7.x86_64.rpm"
           },
-          "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-jinja2/2.8/2.el7eng/noarch/python-jinja2-2.8-2.el7eng.noarch.rpm"
-          },
           "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm"
           },
@@ -2635,9 +2635,6 @@
           },
           "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgudev1-219-78.el7.x86_64.rpm"
-          },
-          "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-dateutil/2.6.1/1.el7ost/noarch/python2-dateutil-2.6.1-1.el7ost.noarch.rpm"
           },
           "sha256:9d2cc8c7e7fe129b9e5c1e057870c82522e3104c05bbba9ee6ece56ec92900bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-minimal-7.4.629-7.el7.x86_64.rpm"
@@ -2798,9 +2795,6 @@
           "sha256:c264f613eba75609c960c72ddaf52664c6b70fea1c5c7e87671d68d3bcf5fed6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-3.10.0-1160.el7.x86_64.rpm"
           },
-          "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-build-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
-          },
           "sha256:c3c3aa618f901b7335c4285dc04cf3cc6c5d1881f12bff2717a04f09af4289c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-setuptools-39.2.0-10.el7.noarch.rpm"
           },
@@ -2812,6 +2806,9 @@
           },
           "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/findutils-4.5.11-6.el7.x86_64.rpm"
+          },
+          "sha256:c55543bce15d8d5d1c5aae6aa6b2b632c5682a99d180b62cf98aaedd9ee5c5cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-six-1.9.0-2.el7.noarch.rpm"
           },
           "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-common-2.02-0.87.el7.noarch.rpm"
@@ -2831,11 +2828,11 @@
           "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm"
           },
-          "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/PyYAML-3.12-12.el7eng.x86_64.rpm"
-          },
           "sha256:ca7bbd8e05c26a6152e8da8b176b92ea63fd1410967ea4643e4e271c084e1324": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:cb02939c0d4ae07ade4db2414bab24ef5bcdad76fff360709603156b0688f262": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-build-libs-4.11.3-45.el7.x86_64.rpm"
           },
           "sha256:cd1e435a74209901055546f73ae7c192f9ed646b74ffec0f798f2fa4e7c00492": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/emacs-filesystem-24.3-23.el7.noarch.rpm"
@@ -2875,6 +2872,9 @@
           },
           "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:d463594c24b2c65dc4fdadd1bfd55ebf1e24615d61bd0c65447ed68da238d6e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-markupsafe-0.11-10.el7.x86_64.rpm"
           },
           "sha256:d4b2de8f877b5c86b4c6751fbfba32d805bff4ecbb6183831888c833fb1af967": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-server-7.4p1-21.el7.x86_64.rpm"
@@ -2954,6 +2954,9 @@
           "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm"
           },
+          "sha256:ea31234316136f3f2180c5c2abe7e33985c35075070fe36fccb9b328a2a3f58d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-setuptools-0.9.8-7.el7.noarch.rpm"
+          },
           "sha256:eb71af5a9b4665611dbd3cd17ecaa3437c2ad0961f40ff743fcf2fa7292cff05": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnetfilter_conntrack-1.0.6-1.el7_3.x86_64.rpm"
           },
@@ -3019,6 +3022,9 @@
           },
           "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdbm-1.10-8.el7.x86_64.rpm"
+          },
+          "sha256:fb796af6e23592ece64707e400a08959a6b80d43c3326b84c11ad33b46e8f17d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-libs-4.11.3-45.el7.x86_64.rpm"
           },
           "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm"
@@ -4499,6 +4505,15 @@
         "checksum": "sha256:9ae89ba6e5533df2ee1af8cab3ed8fd6be99a432eff3519783095a37cd710a66"
       },
       {
+        "name": "PyYAML",
+        "epoch": 0,
+        "version": "3.10",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/PyYAML-3.10-11.el7.x86_64.rpm",
+        "checksum": "sha256:268251eccd384c5859b0e56457e9e6caeffaaa1c3621e4f6b096a2636a2dd6f4"
+      },
+      {
         "name": "Red_Hat_Enterprise_Linux-Release_Notes-7-en-US",
         "epoch": 0,
         "version": "7",
@@ -5271,6 +5286,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm",
         "checksum": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.0",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hardlink-1.0-19.el7.x86_64.rpm",
+        "checksum": "sha256:4c57540da6b6623811e693805e7fea4ea26fca0d332611b4c7d772cdc587ffa4"
       },
       {
         "name": "hostname",
@@ -6434,15 +6458,6 @@
         "checksum": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
       },
       {
-        "name": "pcre2",
-        "epoch": 0,
-        "version": "10.23",
-        "release": "2.el7",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm",
-        "checksum": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
-      },
-      {
         "name": "pinentry",
         "epoch": 0,
         "version": "0.8.1",
@@ -6641,6 +6656,15 @@
         "checksum": "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415"
       },
       {
+        "name": "python-dateutil",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dateutil-1.5-7.el7.noarch.rpm",
+        "checksum": "sha256:2d610eeb34df730f433610a9d3623451886ccd043f65953c2db84e9a7268141c"
+      },
+      {
         "name": "python-decorator",
         "epoch": 0,
         "version": "3.4.0",
@@ -6740,6 +6764,15 @@
         "checksum": "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68"
       },
       {
+        "name": "python-jinja2",
+        "epoch": 0,
+        "version": "2.7.2",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jinja2-2.7.2-4.el7.noarch.rpm",
+        "checksum": "sha256:3219f3e002e9379a4c3fe6edd2153cad97332a4315831dcd6470d61f26d77b94"
+      },
+      {
         "name": "python-jsonpatch",
         "epoch": 0,
         "version": "1.2",
@@ -6803,6 +6836,15 @@
         "checksum": "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc"
       },
       {
+        "name": "python-markupsafe",
+        "epoch": 0,
+        "version": "0.11",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-markupsafe-0.11-10.el7.x86_64.rpm",
+        "checksum": "sha256:d463594c24b2c65dc4fdadd1bfd55ebf1e24615d61bd0c65447ed68da238d6e1"
+      },
+      {
         "name": "python-perf",
         "epoch": 0,
         "version": "3.10.0",
@@ -6855,6 +6897,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-schedutils-0.4-6.el7.x86_64.rpm",
         "checksum": "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06"
+      },
+      {
+        "name": "python-setuptools",
+        "epoch": 0,
+        "version": "0.9.8",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-setuptools-0.9.8-7.el7.noarch.rpm",
+        "checksum": "sha256:ea31234316136f3f2180c5c2abe7e33985c35075070fe36fccb9b328a2a3f58d"
+      },
+      {
+        "name": "python-six",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-six-1.9.0-2.el7.noarch.rpm",
+        "checksum": "sha256:c55543bce15d8d5d1c5aae6aa6b2b632c5682a99d180b62cf98aaedd9ee5c5cb"
       },
       {
         "name": "python-slip",
@@ -7044,6 +7104,42 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpcbind-0.2.0-49.el7.x86_64.rpm",
         "checksum": "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6"
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-4.11.3-45.el7.x86_64.rpm",
+        "checksum": "sha256:0a091be51a7a0a72a2e209d1b5cfd7f5643d4eb218cb9a0b4ac69771b7ebbd39"
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-build-libs-4.11.3-45.el7.x86_64.rpm",
+        "checksum": "sha256:cb02939c0d4ae07ade4db2414bab24ef5bcdad76fff360709603156b0688f262"
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-libs-4.11.3-45.el7.x86_64.rpm",
+        "checksum": "sha256:fb796af6e23592ece64707e400a08959a6b80d43c3326b84c11ad33b46e8f17d"
+      },
+      {
+        "name": "rpm-python",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-python-4.11.3-45.el7.x86_64.rpm",
+        "checksum": "sha256:6e63e98a154c72735e5ec0895e8d8d88821b7ec1379d7899da8eb1fa00054a5f"
       },
       {
         "name": "rsync",
@@ -7440,105 +7536,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zlib-1.2.7-18.el7.x86_64.rpm",
         "checksum": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
-      },
-      {
-        "name": "PyYAML",
-        "epoch": 0,
-        "version": "3.12",
-        "release": "12.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/PyYAML-3.12-12.el7eng.x86_64.rpm",
-        "checksum": "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b"
-      },
-      {
-        "name": "hardlink",
-        "epoch": 1,
-        "version": "1.3",
-        "release": "6.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm",
-        "checksum": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
-      },
-      {
-        "name": "python-jinja2",
-        "epoch": 0,
-        "version": "2.8",
-        "release": "2.el7eng",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-jinja2/2.8/2.el7eng/noarch/python-jinja2-2.8-2.el7eng.noarch.rpm",
-        "checksum": "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09"
-      },
-      {
-        "name": "python-six",
-        "epoch": 0,
-        "version": "1.9.0",
-        "release": "4.el7eng",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python-six-1.9.0-4.el7eng.noarch.rpm",
-        "checksum": "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904"
-      },
-      {
-        "name": "python2-dateutil",
-        "epoch": 1,
-        "version": "2.6.1",
-        "release": "1.el7ost",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-dateutil/2.6.1/1.el7ost/noarch/python2-dateutil-2.6.1-1.el7ost.noarch.rpm",
-        "checksum": "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267"
-      },
-      {
-        "name": "python2-markupsafe",
-        "epoch": 0,
-        "version": "1.0",
-        "release": "2.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-markupsafe/1.0/2.el7eng/x86_64/python2-markupsafe-1.0-2.el7eng.x86_64.rpm",
-        "checksum": "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3"
-      },
-      {
-        "name": "python2-setuptools",
-        "epoch": 0,
-        "version": "38.4.0",
-        "release": "3.el7ost",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-setuptools/38.4.0/3.el7ost/noarch/python2-setuptools-38.4.0-3.el7ost.noarch.rpm",
-        "checksum": "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0"
-      },
-      {
-        "name": "rpm",
-        "epoch": 0,
-        "version": "4.11.3",
-        "release": "45.zfix_sighdr.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
-        "checksum": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
-      },
-      {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.11.3",
-        "release": "45.zfix_sighdr.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-build-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
-        "checksum": "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f"
-      },
-      {
-        "name": "rpm-libs",
-        "epoch": 0,
-        "version": "4.11.3",
-        "release": "45.zfix_sighdr.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
-        "checksum": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
-      },
-      {
-        "name": "rpm-python",
-        "epoch": 0,
-        "version": "4.11.3",
-        "release": "45.zfix_sighdr.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-python-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
-        "checksum": "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50"
       }
     ]
   },

--- a/test/data/manifests/rhel_7-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-qcow2_customize-boot.json
@@ -703,6 +703,9 @@
                     "id": "sha256:bfb092807d02f35824f86087b5baf279d92e3c2290d94bc00078b6ea0ec97c22"
                   },
                   {
+                    "id": "sha256:268251eccd384c5859b0e56457e9e6caeffaaa1c3621e4f6b096a2636a2dd6f4"
+                  },
+                  {
                     "id": "sha256:3b7e15c04916e85c82a35b0c30f3134692d032f3c5184f9bd558b87ee742117c"
                   },
                   {
@@ -995,6 +998,9 @@
                   },
                   {
                     "id": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+                  },
+                  {
+                    "id": "sha256:4c57540da6b6623811e693805e7fea4ea26fca0d332611b4c7d772cdc587ffa4"
                   },
                   {
                     "id": "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66"
@@ -1483,9 +1489,6 @@
                     "id": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
                   },
                   {
-                    "id": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
-                  },
-                  {
                     "id": "sha256:f6b628ad8e07ea56d5dd75453611d680b959de24f3ea5552f6968d5282bce349"
                   },
                   {
@@ -1561,6 +1564,9 @@
                     "id": "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415"
                   },
                   {
+                    "id": "sha256:2d610eeb34df730f433610a9d3623451886ccd043f65953c2db84e9a7268141c"
+                  },
+                  {
                     "id": "sha256:047500594382798561653d0b20408180ee9de108330b00abb3812ae35d70930b"
                   },
                   {
@@ -1594,6 +1600,9 @@
                     "id": "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68"
                   },
                   {
+                    "id": "sha256:3219f3e002e9379a4c3fe6edd2153cad97332a4315831dcd6470d61f26d77b94"
+                  },
+                  {
                     "id": "sha256:f6b19736ea764179ea7be0d949d3d54a8fc763100194b26819886503e07d8c13"
                   },
                   {
@@ -1615,6 +1624,9 @@
                     "id": "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc"
                   },
                   {
+                    "id": "sha256:d463594c24b2c65dc4fdadd1bfd55ebf1e24615d61bd0c65447ed68da238d6e1"
+                  },
+                  {
                     "id": "sha256:8da1f1e2007d98f395befb666f18f9e26ab3009f638a566b985615b22e14fe13"
                   },
                   {
@@ -1631,6 +1643,12 @@
                   },
                   {
                     "id": "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06"
+                  },
+                  {
+                    "id": "sha256:ea31234316136f3f2180c5c2abe7e33985c35075070fe36fccb9b328a2a3f58d"
+                  },
+                  {
+                    "id": "sha256:c55543bce15d8d5d1c5aae6aa6b2b632c5682a99d180b62cf98aaedd9ee5c5cb"
                   },
                   {
                     "id": "sha256:b449b7f89b8ffbaf72bf66e1b3c9c0e215faaacaca33b69bca5d44aeedaa6d20"
@@ -1697,6 +1715,18 @@
                   },
                   {
                     "id": "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6"
+                  },
+                  {
+                    "id": "sha256:0a091be51a7a0a72a2e209d1b5cfd7f5643d4eb218cb9a0b4ac69771b7ebbd39"
+                  },
+                  {
+                    "id": "sha256:cb02939c0d4ae07ade4db2414bab24ef5bcdad76fff360709603156b0688f262"
+                  },
+                  {
+                    "id": "sha256:fb796af6e23592ece64707e400a08959a6b80d43c3326b84c11ad33b46e8f17d"
+                  },
+                  {
+                    "id": "sha256:6e63e98a154c72735e5ec0895e8d8d88821b7ec1379d7899da8eb1fa00054a5f"
                   },
                   {
                     "id": "sha256:60fe39f8078b432730cf7830ced13421d0850289f7e27b74109a2efaa2665b0c"
@@ -1835,39 +1865,6 @@
                   },
                   {
                     "id": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
-                  },
-                  {
-                    "id": "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b"
-                  },
-                  {
-                    "id": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
-                  },
-                  {
-                    "id": "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09"
-                  },
-                  {
-                    "id": "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904"
-                  },
-                  {
-                    "id": "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267"
-                  },
-                  {
-                    "id": "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3"
-                  },
-                  {
-                    "id": "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0"
-                  },
-                  {
-                    "id": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
-                  },
-                  {
-                    "id": "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f"
-                  },
-                  {
-                    "id": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
-                  },
-                  {
-                    "id": "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50"
                   }
                 ]
               }
@@ -2587,6 +2584,9 @@
           "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm"
           },
+          "sha256:0a091be51a7a0a72a2e209d1b5cfd7f5643d4eb218cb9a0b4ac69771b7ebbd39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-4.11.3-45.el7.x86_64.rpm"
+          },
           "sha256:0a6d71d0c1c1d14f2a6885734232dbe2a06ca6a958a9b81f06cef008e58769c8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl4965-firmware-228.61.2.24-79.el7.noarch.rpm"
           },
@@ -2746,6 +2746,9 @@
           "sha256:267734897a4458d183f8fc74ea6db8f82143767371e752d896d189bd5b3c5b1a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gperftools-libs-2.6.1-1.el7.x86_64.rpm"
           },
+          "sha256:268251eccd384c5859b0e56457e9e6caeffaaa1c3621e4f6b096a2636a2dd6f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/PyYAML-3.10-11.el7.x86_64.rpm"
+          },
           "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm"
           },
@@ -2776,14 +2779,11 @@
           "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm"
           },
-          "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-setuptools/38.4.0/3.el7ost/noarch/python2-setuptools-38.4.0-3.el7ost.noarch.rpm"
-          },
           "sha256:2bba49f3d27655dc966ac46c92773a61b06ba05e039c76b26622513d613acc69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dmidecode-3.12.2-4.el7.x86_64.rpm"
           },
-          "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-markupsafe/1.0/2.el7eng/x86_64/python2-markupsafe-1.0-2.el7eng.x86_64.rpm"
+          "sha256:2d610eeb34df730f433610a9d3623451886ccd043f65953c2db84e9a7268141c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dateutil-1.5-7.el7.noarch.rpm"
           },
           "sha256:2e3bb02e9028cfcae4f9945fccb663ed54ffd3b26e77bceabb2328ba3b433ae6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-anacron-1.4.11-23.el7.x86_64.rpm"
@@ -2802,6 +2802,9 @@
           },
           "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:3219f3e002e9379a4c3fe6edd2153cad97332a4315831dcd6470d61f26d77b94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jinja2-2.7.2-4.el7.noarch.rpm"
           },
           "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-5.2.2-1.el7.x86_64.rpm"
@@ -2872,9 +2875,6 @@
           "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm"
           },
-          "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python-six-1.9.0-4.el7eng.noarch.rpm"
-          },
           "sha256:3fd04125208bed410e43eb49b18d09cbdaa6e6b27f86c9bfb156103ad14711a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfsidmap-0.25-19.el7.x86_64.rpm"
           },
@@ -2922,6 +2922,9 @@
           },
           "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm"
+          },
+          "sha256:4c57540da6b6623811e693805e7fea4ea26fca0d332611b4c7d772cdc587ffa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hardlink-1.0-19.el7.x86_64.rpm"
           },
           "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm"
@@ -3064,9 +3067,6 @@
           "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm"
           },
-          "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-python-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
-          },
           "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-modules-2.02-0.87.el7.noarch.rpm"
           },
@@ -3090,6 +3090,9 @@
           },
           "sha256:6e54c37c51856a6be2dd8e22c0c8f9fbc82fd21f01c2f7c7295a29bbcdf1e824": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-lib-python-0.12.1-1.el7.noarch.rpm"
+          },
+          "sha256:6e63e98a154c72735e5ec0895e8d8d88821b7ec1379d7899da8eb1fa00054a5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-python-4.11.3-45.el7.x86_64.rpm"
           },
           "sha256:6ee12aa6e7b041aad0ac3d968b1ab18dacded8a489ad27b653242929af978e12": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grubby-8.28-26.el7.x86_64.rpm"
@@ -3205,9 +3208,6 @@
           "sha256:88e7108ff671d4e161a1fc1bd72c41c4cec8e80b74c5300b327183551824cc49": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpath_utils-0.2.1-32.el7.x86_64.rpm"
           },
-          "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-jinja2/2.8/2.el7eng/noarch/python-jinja2-2.8-2.el7eng.noarch.rpm"
-          },
           "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm"
           },
@@ -3306,9 +3306,6 @@
           },
           "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgudev1-219-78.el7.x86_64.rpm"
-          },
-          "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-dateutil/2.6.1/1.el7ost/noarch/python2-dateutil-2.6.1-1.el7ost.noarch.rpm"
           },
           "sha256:9d2cc8c7e7fe129b9e5c1e057870c82522e3104c05bbba9ee6ece56ec92900bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-minimal-7.4.629-7.el7.x86_64.rpm"
@@ -3496,9 +3493,6 @@
           "sha256:c264f613eba75609c960c72ddaf52664c6b70fea1c5c7e87671d68d3bcf5fed6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-3.10.0-1160.el7.x86_64.rpm"
           },
-          "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-build-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
-          },
           "sha256:c3c3aa618f901b7335c4285dc04cf3cc6c5d1881f12bff2717a04f09af4289c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-setuptools-39.2.0-10.el7.noarch.rpm"
           },
@@ -3516,6 +3510,9 @@
           },
           "sha256:c5137a9d3b9aac4dba1262800fa480bbc979a62227ad31f0d837618cdf4377ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iprutils-2.4.17.1-3.el7.x86_64.rpm"
+          },
+          "sha256:c55543bce15d8d5d1c5aae6aa6b2b632c5682a99d180b62cf98aaedd9ee5c5cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-six-1.9.0-2.el7.noarch.rpm"
           },
           "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-common-2.02-0.87.el7.noarch.rpm"
@@ -3535,14 +3532,14 @@
           "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm"
           },
-          "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/PyYAML-3.12-12.el7eng.x86_64.rpm"
-          },
           "sha256:ca7bbd8e05c26a6152e8da8b176b92ea63fd1410967ea4643e4e271c084e1324": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-3.10.0-1160.el7.x86_64.rpm"
           },
           "sha256:cab023377a79bf3dc9317c1281abf4099aaccc0c95e69032fe2e563023a802f0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-libnm-1.18.8-1.el7.x86_64.rpm"
+          },
+          "sha256:cb02939c0d4ae07ade4db2414bab24ef5bcdad76fff360709603156b0688f262": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-build-libs-4.11.3-45.el7.x86_64.rpm"
           },
           "sha256:cc4b75e1ce83af2dbad9604e70bcf40e7f20ad8918a08f8b82f6d5e69efd9655": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-1.18.8-1.el7.x86_64.rpm"
@@ -3588,6 +3585,9 @@
           },
           "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:d463594c24b2c65dc4fdadd1bfd55ebf1e24615d61bd0c65447ed68da238d6e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-markupsafe-0.11-10.el7.x86_64.rpm"
           },
           "sha256:d4b2de8f877b5c86b4c6751fbfba32d805bff4ecbb6183831888c833fb1af967": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-server-7.4p1-21.el7.x86_64.rpm"
@@ -3679,6 +3679,9 @@
           "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm"
           },
+          "sha256:ea31234316136f3f2180c5c2abe7e33985c35075070fe36fccb9b328a2a3f58d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-setuptools-0.9.8-7.el7.noarch.rpm"
+          },
           "sha256:ea6c84fe12b97fb5511ffee78b31a8ffb0444fd41da21932503568df14a95e98": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lsscsi-0.27-6.el7.x86_64.rpm"
           },
@@ -3750,6 +3753,9 @@
           },
           "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdbm-1.10-8.el7.x86_64.rpm"
+          },
+          "sha256:fb796af6e23592ece64707e400a08959a6b80d43c3326b84c11ad33b46e8f17d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-libs-4.11.3-45.el7.x86_64.rpm"
           },
           "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm"
@@ -5334,6 +5340,15 @@
         "checksum": "sha256:bfb092807d02f35824f86087b5baf279d92e3c2290d94bc00078b6ea0ec97c22"
       },
       {
+        "name": "PyYAML",
+        "epoch": 0,
+        "version": "3.10",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/PyYAML-3.10-11.el7.x86_64.rpm",
+        "checksum": "sha256:268251eccd384c5859b0e56457e9e6caeffaaa1c3621e4f6b096a2636a2dd6f4"
+      },
+      {
         "name": "Red_Hat_Enterprise_Linux-Release_Notes-7-en-US",
         "epoch": 0,
         "version": "7",
@@ -6214,6 +6229,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm",
         "checksum": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.0",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hardlink-1.0-19.el7.x86_64.rpm",
+        "checksum": "sha256:4c57540da6b6623811e693805e7fea4ea26fca0d332611b4c7d772cdc587ffa4"
       },
       {
         "name": "hostname",
@@ -7674,15 +7698,6 @@
         "checksum": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
       },
       {
-        "name": "pcre2",
-        "epoch": 0,
-        "version": "10.23",
-        "release": "2.el7",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm",
-        "checksum": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
-      },
-      {
         "name": "pinentry",
         "epoch": 0,
         "version": "0.8.1",
@@ -7908,6 +7923,15 @@
         "checksum": "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415"
       },
       {
+        "name": "python-dateutil",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dateutil-1.5-7.el7.noarch.rpm",
+        "checksum": "sha256:2d610eeb34df730f433610a9d3623451886ccd043f65953c2db84e9a7268141c"
+      },
+      {
         "name": "python-decorator",
         "epoch": 0,
         "version": "3.4.0",
@@ -8007,6 +8031,15 @@
         "checksum": "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68"
       },
       {
+        "name": "python-jinja2",
+        "epoch": 0,
+        "version": "2.7.2",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jinja2-2.7.2-4.el7.noarch.rpm",
+        "checksum": "sha256:3219f3e002e9379a4c3fe6edd2153cad97332a4315831dcd6470d61f26d77b94"
+      },
+      {
         "name": "python-jsonpatch",
         "epoch": 0,
         "version": "1.2",
@@ -8070,6 +8103,15 @@
         "checksum": "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc"
       },
       {
+        "name": "python-markupsafe",
+        "epoch": 0,
+        "version": "0.11",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-markupsafe-0.11-10.el7.x86_64.rpm",
+        "checksum": "sha256:d463594c24b2c65dc4fdadd1bfd55ebf1e24615d61bd0c65447ed68da238d6e1"
+      },
+      {
         "name": "python-perf",
         "epoch": 0,
         "version": "3.10.0",
@@ -8122,6 +8164,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-schedutils-0.4-6.el7.x86_64.rpm",
         "checksum": "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06"
+      },
+      {
+        "name": "python-setuptools",
+        "epoch": 0,
+        "version": "0.9.8",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-setuptools-0.9.8-7.el7.noarch.rpm",
+        "checksum": "sha256:ea31234316136f3f2180c5c2abe7e33985c35075070fe36fccb9b328a2a3f58d"
+      },
+      {
+        "name": "python-six",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-six-1.9.0-2.el7.noarch.rpm",
+        "checksum": "sha256:c55543bce15d8d5d1c5aae6aa6b2b632c5682a99d180b62cf98aaedd9ee5c5cb"
       },
       {
         "name": "python-slip",
@@ -8320,6 +8380,42 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpcbind-0.2.0-49.el7.x86_64.rpm",
         "checksum": "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6"
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-4.11.3-45.el7.x86_64.rpm",
+        "checksum": "sha256:0a091be51a7a0a72a2e209d1b5cfd7f5643d4eb218cb9a0b4ac69771b7ebbd39"
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-build-libs-4.11.3-45.el7.x86_64.rpm",
+        "checksum": "sha256:cb02939c0d4ae07ade4db2414bab24ef5bcdad76fff360709603156b0688f262"
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-libs-4.11.3-45.el7.x86_64.rpm",
+        "checksum": "sha256:fb796af6e23592ece64707e400a08959a6b80d43c3326b84c11ad33b46e8f17d"
+      },
+      {
+        "name": "rpm-python",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpm-python-4.11.3-45.el7.x86_64.rpm",
+        "checksum": "sha256:6e63e98a154c72735e5ec0895e8d8d88821b7ec1379d7899da8eb1fa00054a5f"
       },
       {
         "name": "rsync",
@@ -8734,105 +8830,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zlib-1.2.7-18.el7.x86_64.rpm",
         "checksum": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
-      },
-      {
-        "name": "PyYAML",
-        "epoch": 0,
-        "version": "3.12",
-        "release": "12.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/PyYAML-3.12-12.el7eng.x86_64.rpm",
-        "checksum": "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b"
-      },
-      {
-        "name": "hardlink",
-        "epoch": 1,
-        "version": "1.3",
-        "release": "6.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm",
-        "checksum": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
-      },
-      {
-        "name": "python-jinja2",
-        "epoch": 0,
-        "version": "2.8",
-        "release": "2.el7eng",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-jinja2/2.8/2.el7eng/noarch/python-jinja2-2.8-2.el7eng.noarch.rpm",
-        "checksum": "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09"
-      },
-      {
-        "name": "python-six",
-        "epoch": 0,
-        "version": "1.9.0",
-        "release": "4.el7eng",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python-six-1.9.0-4.el7eng.noarch.rpm",
-        "checksum": "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904"
-      },
-      {
-        "name": "python2-dateutil",
-        "epoch": 1,
-        "version": "2.6.1",
-        "release": "1.el7ost",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-dateutil/2.6.1/1.el7ost/noarch/python2-dateutil-2.6.1-1.el7ost.noarch.rpm",
-        "checksum": "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267"
-      },
-      {
-        "name": "python2-markupsafe",
-        "epoch": 0,
-        "version": "1.0",
-        "release": "2.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-markupsafe/1.0/2.el7eng/x86_64/python2-markupsafe-1.0-2.el7eng.x86_64.rpm",
-        "checksum": "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3"
-      },
-      {
-        "name": "python2-setuptools",
-        "epoch": 0,
-        "version": "38.4.0",
-        "release": "3.el7ost",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-setuptools/38.4.0/3.el7ost/noarch/python2-setuptools-38.4.0-3.el7ost.noarch.rpm",
-        "checksum": "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0"
-      },
-      {
-        "name": "rpm",
-        "epoch": 0,
-        "version": "4.11.3",
-        "release": "45.zfix_sighdr.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
-        "checksum": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
-      },
-      {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.11.3",
-        "release": "45.zfix_sighdr.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-build-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
-        "checksum": "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f"
-      },
-      {
-        "name": "rpm-libs",
-        "epoch": 0,
-        "version": "4.11.3",
-        "release": "45.zfix_sighdr.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
-        "checksum": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
-      },
-      {
-        "name": "rpm-python",
-        "epoch": 0,
-        "version": "4.11.3",
-        "release": "45.zfix_sighdr.el7eng",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-python-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
-        "checksum": "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50"
       }
     ]
   },


### PR DESCRIPTION
Assign pipeline-specific repositories to package sets before returning the package set chains.  This is a workaround for a bug where repositories with pipeline restrictions are ignored.

In the new distro definitions, repositories are assigned to pipelines while building the manifest.  The manifest then returns package set chains with repository information from the GetPackageSetChains() method.  However, the manifest is only initialised with the global repos and the package set specific repos are ignored.

~~A more correct fix for this issue would be to pass all repositories to each pipeline initialisation function (e.g., `NewBuild()`) and have each pick the repositories that matches its own name (+ any that have no restrictions).  However this would require more changes and would take more time to implement.  I think the bug is critical enough to fix quickly and clean up later.~~

## Update

Wrote a cleaner fix and unit test to catch any regressions.

## Bugs
Fixes #3290
Fixes COMPOSER-1902
