### PR TITLE
Add support for ImageID in os-release and rhsm facts

### DIFF
--- a/cmd/osbuild-playground/my-image.go
+++ b/cmd/osbuild-playground/my-image.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 
 	"github.com/osbuild/osbuild-composer/internal/artifact"
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/disk"
 	"github.com/osbuild/osbuild-composer/internal/manifest"
 	"github.com/osbuild/osbuild-composer/internal/platform"
@@ -33,9 +34,14 @@ func (img *MyImage) InstantiateManifest(m *manifest.Manifest,
 	build := manifest.NewBuild(m, runner, repos)
 	build.Checkpoint()
 
-	// create an x86_64 platform with bios boot
-	platform := &platform.X86{
-		BIOS: true,
+	var build_platform platform.Platform
+	switch common.CurrentArch() {
+	case "aarch64":
+		build_platform = &platform.Aarch64{}
+	default:
+		build_platform = &platform.X86{
+			BIOS: true,
+		}
 	}
 
 	// TODO: add helper
@@ -45,9 +51,12 @@ func (img *MyImage) InstantiateManifest(m *manifest.Manifest,
 	}
 
 	// create a minimal bootable OS tree
-	os := manifest.NewOS(m, build, platform, repos)
+	os := manifest.NewOS(m, build, build_platform, repos)
 	os.PartitionTable = pt   // we need a partition table
 	os.KernelName = "kernel" // use the default fedora kernel
+	os.OSCustomizations.Language = "en_US.UTF-8"
+	os.OSCustomizations.Hostname = "my-host"
+	os.OSCustomizations.Timezone = "UTC"
 
 	// create a raw image containing the OS tree created above
 	raw := manifest.NewRawImage(m, build, os)

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -55,7 +55,7 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 
 	store := path.Join(state_dir, "osbuild-store")
 
-	_, err = osbuild.RunOSBuild(bytes, store, "./", manifest.GetExports(), manifest.GetCheckpoints(), nil, false, os.Stdout)
+	_, err = osbuild.RunOSBuild(bytes, "playground-build", store, "./", manifest.GetExports(), manifest.GetCheckpoints(), nil, false, os.Stdout)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not run osbuild: %s", err.Error())
 	}

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -370,7 +370,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 	}
 
 	// Run osbuild and handle two kinds of errors
-	osbuildJobResult.OSBuildOutput, err = osbuild.RunOSBuild(jobArgs.Manifest, impl.Store, outputDirectory, exports, nil, extraEnv, true, os.Stderr)
+	osbuildJobResult.OSBuildOutput, err = osbuild.RunOSBuild(jobArgs.Manifest, job.Id().String(), impl.Store, outputDirectory, exports, nil, extraEnv, true, os.Stderr)
 	// First handle the case when "running" osbuild failed
 	if err != nil {
 		osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, "osbuild build failed", nil)

--- a/internal/osbuild/osbuild-exec_test.go
+++ b/internal/osbuild/osbuild-exec_test.go
@@ -1,0 +1,131 @@
+package osbuild
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type MockManifest struct {
+	Pipelines []MockPipeline `json:"pipelines"`
+}
+
+type MockPipeline struct {
+	Name string `json:"name"`
+	Stages []MockStage `json:"stages"`
+}
+
+type MockStage struct {
+	Type string `json:"type"`
+	Options interface{} `json:"options"`
+}
+
+func makeInvalidManifest() []byte {
+	return []byte{0}
+}
+
+func makeManifestWithNoOsStage() []byte {
+	m, _ := json.Marshal(&MockManifest {
+		Pipelines: []MockPipeline {
+			{
+				Name: "not-os",
+				Stages: []MockStage{},
+			},
+		},
+	})
+
+	return m
+}
+
+func makeManifestWithOsStage() []byte {
+	m, _ := json.Marshal(&MockManifest {
+		Pipelines: []MockPipeline {
+			{
+				Name: "os",
+				Stages: []MockStage{},
+			},
+		},
+	})
+
+	return m
+}
+
+func makeManifestWithOsStageAndRhsmStage() []byte {
+	opts := make(map[string]map[string]interface{})
+	opts["facts"] = make(map[string]interface{})
+
+	m, _ := json.Marshal(&MockManifest {
+		Pipelines: []MockPipeline {
+			{
+				Name: "os",
+				Stages: []MockStage{
+					{
+						Type: "org.osbuild.rhsm.facts",
+						Options: opts,
+					},
+				},
+			},
+		},
+	})
+
+	return m
+}
+
+func TestInjection_InvalidManifest(t *testing.T) {
+	buf, err := injectJobDetailsStageIntoManifest(makeInvalidManifest(), "FOO")
+
+	assert.Nil(t, buf)
+	assert.NotNil(t, err)
+}
+
+
+func TestInjection_NotOSStageManifest(t *testing.T) {
+	buf, err := injectJobDetailsStageIntoManifest(makeManifestWithNoOsStage(), "FOO")
+
+	assert.Nil(t, buf)
+	assert.NotNil(t, err)
+}
+
+
+func TestInjection_ManifestWithOsStage(t *testing.T) {
+	buf, err := injectJobDetailsStageIntoManifest(makeManifestWithOsStage(), "FOO")
+
+	assert.Nil(t, err)
+	expected := `
+	{
+		"pipelines": [
+			{
+				"name": "os",
+				"stages": [
+					{"type": "org.osbuild.os-release.image_id", "options": {"image_id": "FOO"}}
+				]
+			}
+		]
+	}
+	`
+
+	assert.JSONEq(t, string(buf), expected)
+}
+
+
+func TestInjection_ManifestWithOsAndRhsm(t *testing.T) {
+	buf, err := injectJobDetailsStageIntoManifest(makeManifestWithOsStageAndRhsmStage(), "FOO")
+
+	assert.Nil(t, err)
+	expected := `
+	{
+		"pipelines": [
+			{
+				"name": "os",
+				"stages": [
+					{"type": "org.osbuild.rhsm.facts", "options": {"facts": {"image-builder.osbuild-composer.image_id": "FOO"}}},
+					{"type": "org.osbuild.os-release.image_id", "options": {"image_id": "FOO"}}
+				]
+			}
+		]
+	}
+	`
+
+	assert.JSONEq(t, string(buf), expected)
+}


### PR DESCRIPTION
This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

Depends on: osbuild/osbuild#1246

---

Verified using docker-compose setup that this is the correct JobID:

![imagebuilder](https://user-images.githubusercontent.com/572844/222271316-accc42da-6869-4035-9b8b-6cca158cb5c0.png)

```
[potato@localhost devel]$ virt-cat image.qcow2 /etc/os-release
NAME="CentOS Stream"
VERSION="8"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="8"
PLATFORM_ID="platform:el8"
PRETTY_NAME="CentOS Stream 8"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:8"
HOME_URL="https://centos.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux 8"
REDHAT_SUPPORT_PRODUCT_VERSION="CentOS Stream"
IMAGE_ID=450fee58-2226-43f9-93be-33082ee564a2
[potato@localhost devel]$ virt-cat image.qcow2 /etc/rhsm/facts/osbuild.facts
{"image-builder.osbuild-composer.api-type": "test-api", "image-builder.osbuild-composer.image_id": "450fee58-2226-43f9-93be-33082ee564a2"}
```


<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
