### PR TITLE
Fedora/iot-raw-image: support custom files and directories in `/etc` (+ services customization)

### DIFF
--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -795,6 +795,14 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 		}
 	}
 
+	if t.name == "iot-raw-image" {
+		allowed := []string{"User", "Group", "Directories", "Files", "Services"}
+		if err := customizations.CheckAllowed(allowed...); err != nil {
+			return nil, fmt.Errorf("unsupported blueprint customizations found for image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
+		}
+		// TODO: consider additional checks, such as those in "edge-simplified-installer" in RHEL distros
+	}
+
 	// BootISO's have limited support for customizations.
 	// TODO: Support kernel name selection for image-installer
 	if t.bootISO {

--- a/internal/distro/fedora/distro_test.go
+++ b/internal/distro/fedora/distro_test.go
@@ -418,12 +418,14 @@ func TestDistro_ManifestError(t *testing.T) {
 			}
 			testPackageSpecSets := distro_test_common.GetTestingImagePackageSpecSets("kernel", imgType)
 			_, _, err := imgType.Manifest(bp.Customizations, imgOpts, nil, testPackageSpecSets, nil, 0)
-			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" {
+			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "kernel boot parameter customizations are not supported for ostree types")
 			} else if imgTypeName == "iot-installer" {
 				assert.EqualError(t, err, fmt.Sprintf("boot ISO image type \"%s\" requires specifying a URL from which to retrieve the OSTree commit", imgTypeName))
 			} else if imgTypeName == "image-installer" {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for boot ISO image type \"%s\": (allowed: User, Group)", imgTypeName))
+			} else if imgTypeName == "iot-raw-image" {
+				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else {
 				assert.NoError(t, err)
 			}
@@ -565,8 +567,10 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, nil, 0)
-			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" {
+			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
+			} else if imgTypeName == "iot-raw-image" {
+				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "image-installer" {
 				continue
 			} else {
@@ -594,8 +598,10 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			testPackageSpecSets := distro_test_common.GetTestingImagePackageSpecSets("kernel", imgType)
 			_, _, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, testPackageSpecSets, nil, 0)
-			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" {
+			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
+			} else if imgTypeName == "iot-raw-image" {
+				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "image-installer" {
 				continue
 			} else {
@@ -730,8 +736,10 @@ func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, _, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, nil, 0)
-			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" {
+			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
+			} else if imgTypeName == "iot-raw-image" {
+				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "image-installer" {
 				continue
 			} else {
@@ -759,8 +767,10 @@ func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			testPackageSpecSets := distro_test_common.GetTestingImagePackageSpecSets("kernel", imgType)
 			_, _, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, testPackageSpecSets, nil, 0)
-			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" {
+			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
+			} else if imgTypeName == "iot-raw-image" {
+				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "image-installer" {
 				continue
 			} else {

--- a/internal/distro/fedora/images.go
+++ b/internal/distro/fedora/images.go
@@ -412,6 +412,16 @@ func iotRawImage(workload workload.Workload,
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
+	var err error
+	img.Directories, err = blueprint.DirectoryCustomizationsToFsNodeDirectories(customizations.GetDirectories())
+	if err != nil {
+		return nil, err
+	}
+	img.Files, err = blueprint.FileCustomizationsToFsNodeFiles(customizations.GetFiles())
+	if err != nil {
+		return nil, err
+	}
+
 	// "rw" kernel option is required when /sysroot is mounted read-only to
 	// keep stateful parts of the filesystem writeable (/var/ and /etc)
 	img.KernelOptionsAppend = []string{"modprobe.blacklist=vc4", "rw"}

--- a/internal/distro/rhel8/imagetype.go
+++ b/internal/distro/rhel8/imagetype.go
@@ -433,9 +433,17 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 		}
 	}
 
-	// check the checksum instead of the URL, because the URL should have been used to resolve the checksum and we need both
-	if t.name == "edge-raw-image" && options.OSTree.FetchChecksum == "" {
-		return warnings, fmt.Errorf("edge raw images require specifying a URL from which to retrieve the OSTree commit")
+	if t.name == "edge-raw-image" {
+		// check the checksum instead of the URL, because the URL should have been used to resolve the checksum and we need both
+		if options.OSTree.FetchChecksum == "" {
+			return warnings, fmt.Errorf("edge raw images require specifying a URL from which to retrieve the OSTree commit")
+		}
+
+		allowed := []string{"User", "Group"}
+		if err := customizations.CheckAllowed(allowed...); err != nil {
+			return warnings, fmt.Errorf("unsupported blueprint customizations found for image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
+		}
+		// TODO: consider additional checks, such as those in "edge-simplified-installer"
 	}
 
 	// warn that user & group customizations on edge-commit, edge-container are deprecated

--- a/internal/distro/rhel9/imagetype.go
+++ b/internal/distro/rhel9/imagetype.go
@@ -413,9 +413,17 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 		}
 	}
 
-	// check the checksum instead of the URL, because the URL should have been used to resolve the checksum and we need both
-	if t.name == "edge-raw-image" && options.OSTree.FetchChecksum == "" {
-		return warnings, fmt.Errorf("edge raw images require specifying a URL from which to retrieve the OSTree commit")
+	if t.name == "edge-raw-image" {
+		// check the checksum instead of the URL, because the URL should have been used to resolve the checksum and we need both
+		if options.OSTree.FetchChecksum == "" {
+			return warnings, fmt.Errorf("edge raw images require specifying a URL from which to retrieve the OSTree commit")
+		}
+
+		allowed := []string{"Ignition", "Kernel", "User", "Group"}
+		if err := customizations.CheckAllowed(allowed...); err != nil {
+			return warnings, fmt.Errorf("unsupported blueprint customizations found for image type %q: (allowed: %s)", t.name, strings.Join(allowed, ", "))
+		}
+		// TODO: consider additional checks, such as those in "edge-simplified-installer"
 	}
 
 	// warn that user & group customizations on edge-commit, edge-container are deprecated

--- a/internal/image/ostree_raw.go
+++ b/internal/image/ostree_raw.go
@@ -64,6 +64,10 @@ func ostreeCompressedImagePipelines(img *OSTreeRawImage, m *manifest.Manifest, b
 	osPipeline.Directories = img.Directories
 	osPipeline.Files = img.Files
 
+	// other image types (e.g. live) pass the workload to the pipeline.
+	osPipeline.EnabledServices = img.Workload.GetServices()
+	osPipeline.DisabledServices = img.Workload.GetDisabledServices()
+
 	imagePipeline := manifest.NewRawOStreeImage(m, buildPipeline, img.Platform, osPipeline)
 
 	xzPipeline := manifest.NewXZ(m, buildPipeline, imagePipeline)

--- a/internal/image/ostree_raw.go
+++ b/internal/image/ostree_raw.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/osbuild/osbuild-composer/internal/artifact"
 	"github.com/osbuild/osbuild-composer/internal/disk"
+	"github.com/osbuild/osbuild-composer/internal/fsnode"
 	"github.com/osbuild/osbuild-composer/internal/manifest"
 	"github.com/osbuild/osbuild-composer/internal/ostree"
 	"github.com/osbuild/osbuild-composer/internal/platform"
@@ -38,6 +39,9 @@ type OSTreeRawImage struct {
 	Filename string
 
 	Ignition bool
+
+	Directories []*fsnode.Directory
+	Files       []*fsnode.File
 }
 
 func NewOSTreeRawImage(commit ostree.CommitSpec) *OSTreeRawImage {
@@ -57,6 +61,8 @@ func ostreeCompressedImagePipelines(img *OSTreeRawImage, m *manifest.Manifest, b
 	osPipeline.Users = img.Users
 	osPipeline.Groups = img.Groups
 	osPipeline.SysrootReadOnly = img.SysrootReadOnly
+	osPipeline.Directories = img.Directories
+	osPipeline.Files = img.Files
 
 	imagePipeline := manifest.NewRawOStreeImage(m, buildPipeline, img.Platform, osPipeline)
 

--- a/internal/manifest/ostree_deployment.go
+++ b/internal/manifest/ostree_deployment.go
@@ -44,6 +44,9 @@ type OSTreeDeployment struct {
 
 	Directories []*fsnode.Directory
 	Files       []*fsnode.File
+
+	EnabledServices  []string
+	DisabledServices []string
 }
 
 // NewOSTreeDeployment creates a pipeline for an ostree deployment from a
@@ -273,6 +276,15 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 			stage.MountOSTree(p.osName, p.commit.Ref, 0)
 		}
 		pipeline.AddStages(fileStages...)
+	}
+
+	if len(p.EnabledServices) != 0 || len(p.DisabledServices) != 0 {
+		systemdStage := osbuild.NewSystemdStage(&osbuild.SystemdStageOptions{
+			EnabledServices:  p.EnabledServices,
+			DisabledServices: p.DisabledServices,
+		})
+		systemdStage.MountOSTree(p.osName, p.commit.Ref, 0)
+		pipeline.AddStage(systemdStage)
 	}
 
 	pipeline.AddStage(osbuild.NewOSTreeSelinuxStage(

--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -90,6 +90,7 @@ KERNEL_RT_PKG="kernel-rt"
 
 # Set up variables.
 SYSROOT_RO="false"
+CUSTOM_DIRS_FILES="false"
 
 case "${ID}-${VERSION_ID}" in
     "rhel-8.8")
@@ -119,6 +120,7 @@ case "${ID}-${VERSION_ID}" in
         OS_VARIANT="fedora-unknown"
         OSTREE_OSNAME="fedora-iot"
         SYSROOT_RO="true"
+        CUSTOM_DIRS_FILES="true"
         ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
@@ -507,6 +509,36 @@ groups = ["wheel"]
 EOF
 fi
 
+# Add directory and files customization, and services customization for testing
+if [[ "$CUSTOM_DIRS_FILES" == "true" ]]; then
+    tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
+[[customizations.directories]]
+path = "/etc/custom_dir/dir1"
+user = 1020
+group = 1020
+mode = "0770"
+ensure_parents = true
+
+[[customizations.files]]
+path = "/etc/systemd/system/custom.service"
+data = "[Unit]\nDescription=Custom service\n[Service]\nType=oneshot\nRemainAfterExit=yes\nExecStart=/usr/bin/false\n[Install]\nWantedBy=multi-user.target\n"
+
+[[customizations.files]]
+path = "/etc/custom_file.txt"
+data = "image builder is the best\n"
+
+[[customizations.directories]]
+path = "/etc/systemd/system/custom.service.d"
+
+[[customizations.files]]
+path = "/etc/systemd/system/custom.service.d/override.conf"
+data = "[Service]\nExecStart=\nExecStart=/usr/bin/cat /etc/custom_file.txt\n"
+
+[customizations.services]
+enabled = ["custom.service"]
+EOF
+fi
+
 greenprint "📄 raw image blueprint"
 cat "$BLUEPRINT_FILE"
 
@@ -624,6 +656,7 @@ EOF
         -e edge_type=edge-raw-image \
         -e ostree_commit="${INSTALL_HASH}" \
         -e sysroot_ro="$SYSROOT_RO" \
+        -e test_custom_dirs_files="$CUSTOM_DIRS_FILES" \
         /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
     check_result
 
@@ -652,6 +685,7 @@ EOF
             -e edge_type=edge-raw-image \
             -e ostree_commit="${INSTALL_HASH}" \
             -e sysroot_ro="$SYSROOT_RO" \
+            -e test_custom_dirs_files="$CUSTOM_DIRS_FILES" \
             /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
         check_result
     fi
@@ -753,6 +787,7 @@ sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
     -e edge_type=edge-raw-image \
     -e ostree_commit="${INSTALL_HASH}" \
     -e sysroot_ro="$SYSROOT_RO" \
+    -e test_custom_dirs_files="$CUSTOM_DIRS_FILES" \
     /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 
@@ -783,6 +818,7 @@ EOF
         -e edge_type=edge-raw-image \
         -e ostree_commit="${INSTALL_HASH}" \
         -e sysroot_ro="$SYSROOT_RO" \
+        -e test_custom_dirs_files="$CUSTOM_DIRS_FILES" \
         /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
     check_result
 fi
@@ -833,6 +869,36 @@ description = "Administrator account"
 password = "\$6\$GRmb7S0p8vsYmXzH\$o0E020S.9JQGaHkszoog4ha4AQVs3sk8q0DvLjSMxoxHBKnB2FBXGQ/OkwZQfW/76ktHd0NX5nls2LPxPuUdl."
 home = "/home/admin/"
 groups = ["wheel"]
+EOF
+fi
+
+# Add directory and files customization, and services customization for testing
+if [[ "$CUSTOM_DIRS_FILES" == "true" ]]; then
+    tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
+[[customizations.directories]]
+path = "/etc/custom_dir/dir1"
+user = 1020
+group = 1020
+mode = "0770"
+ensure_parents = true
+
+[[customizations.files]]
+path = "/etc/systemd/system/custom.service"
+data = "[Unit]\nDescription=Custom service\n[Service]\nType=oneshot\nRemainAfterExit=yes\nExecStart=/usr/bin/false\n[Install]\nWantedBy=multi-user.target\n"
+
+[[customizations.files]]
+path = "/etc/custom_file.txt"
+data = "image builder is the best\n"
+
+[[customizations.directories]]
+path = "/etc/systemd/system/custom.service.d"
+
+[[customizations.files]]
+path = "/etc/systemd/system/custom.service.d/override.conf"
+data = "[Service]\nExecStart=\nExecStart=/usr/bin/cat /etc/custom_file.txt\n"
+
+[customizations.services]
+enabled = ["custom.service"]
 EOF
 fi
 
@@ -945,6 +1011,7 @@ EOF
         -e edge_type=edge-raw-image \
         -e ostree_commit="${UPGRADE_HASH}" \
         -e sysroot_ro="$SYSROOT_RO" \
+        -e test_custom_dirs_files="$CUSTOM_DIRS_FILES" \
         /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
     check_result
 fi
@@ -974,6 +1041,7 @@ sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
     -e edge_type=edge-raw-image \
     -e ostree_commit="${UPGRADE_HASH}" \
     -e sysroot_ro="$SYSROOT_RO" \
+    -e test_custom_dirs_files="$CUSTOM_DIRS_FILES" \
     /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 

--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -617,12 +617,20 @@ EOF
     sudo /usr/libexec/osbuild-composer-test/ansible-blocking-io.py
 
     # Test IoT/Edge OS
-    sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type="${OSTREE_OSNAME}" -e skip_rollback_test="true" -e ignition="${HAS_IGNITION}" -e edge_type=edge-raw-image -e ostree_commit="${INSTALL_HASH}" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+    sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+        -e image_type="${OSTREE_OSNAME}" \
+        -e skip_rollback_test="true" \
+        -e ignition="${HAS_IGNITION}" \
+        -e edge_type=edge-raw-image \
+        -e ostree_commit="${INSTALL_HASH}" \
+        -e sysroot_ro="$SYSROOT_RO" \
+        /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
     check_result
 
+    # Test the same playbook with the user created by Ignition
     if [[ ${IGNITION} -eq 0 ]]; then
-    # Add instance IP address into /etc/ansible/hosts
-      sudo tee "${TEMPDIR}"/inventory > /dev/null << EOF
+        # Add instance IP address into /etc/ansible/hosts
+        sudo tee "${TEMPDIR}"/inventory > /dev/null << EOF
 [ostree_guest]
 ${BIOS_GUEST_ADDRESS}
 
@@ -636,9 +644,16 @@ ansible_become_method=sudo
 ansible_become_pass=${EDGE_USER_PASSWORD}
 EOF
 
-      # Test IoT/Edge OS
-      sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type="${OSTREE_OSNAME}" -e skip_rollback_test="true" -e ignition="${HAS_IGNITION}" -e edge_type=edge-raw-image -e ostree_commit="${INSTALL_HASH}" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
-      check_result
+        # Test IoT/Edge OS
+        sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+            -e image_type="${OSTREE_OSNAME}" \
+            -e skip_rollback_test="true" \
+            -e ignition="${HAS_IGNITION}" \
+            -e edge_type=edge-raw-image \
+            -e ostree_commit="${INSTALL_HASH}" \
+            -e sysroot_ro="$SYSROOT_RO" \
+            /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+        check_result
     fi
 
     # Clean up BIOS VM
@@ -731,14 +746,22 @@ greenprint "fix stdio file non-blocking issue"
 sudo /usr/libexec/osbuild-composer-test/ansible-blocking-io.py
 
 # Test IoT/Edge OS
-sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type="${OSTREE_OSNAME}" -e skip_rollback_test="true" -e ignition="${HAS_IGNITION}" -e edge_type=edge-raw-image -e ostree_commit="${INSTALL_HASH}" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+    -e image_type="${OSTREE_OSNAME}" \
+    -e skip_rollback_test="true" \
+    -e ignition="${HAS_IGNITION}" \
+    -e edge_type=edge-raw-image \
+    -e ostree_commit="${INSTALL_HASH}" \
+    -e sysroot_ro="$SYSROOT_RO" \
+    /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 
 # test with ignition user
 
+# Test the same playbook with the user created by Ignition
 if [[ ${IGNITION} -eq 0 ]]; then
-  # Add instance IP address into /etc/ansible/hosts
-  sudo tee "${TEMPDIR}"/inventory > /dev/null << EOF
+    # Add instance IP address into /etc/ansible/hosts
+    sudo tee "${TEMPDIR}"/inventory > /dev/null << EOF
 [ostree_guest]
 ${UEFI_GUEST_ADDRESS}
 
@@ -752,9 +775,16 @@ ansible_become_method=sudo
 ansible_become_pass=${EDGE_USER_PASSWORD}
 EOF
 
-  # Test IoT/Edge OS
-  sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type="${OSTREE_OSNAME}" -e skip_rollback_test="true" -e ignition="${HAS_IGNITION}" -e edge_type=edge-raw-image -e ostree_commit="${INSTALL_HASH}" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
-  check_result
+    # Test IoT/Edge OS
+    sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+        -e image_type="${OSTREE_OSNAME}" \
+        -e skip_rollback_test="true" \
+        -e ignition="${HAS_IGNITION}" \
+        -e edge_type=edge-raw-image \
+        -e ostree_commit="${INSTALL_HASH}" \
+        -e sysroot_ro="$SYSROOT_RO" \
+        /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+    check_result
 fi
 
 ##################################################################
@@ -893,24 +923,30 @@ done
 check_result
 
 if [[ ${IGNITION} -eq 0 ]]; then
-  # Add instance IP address into /etc/ansible/hosts
-  sudo tee "${TEMPDIR}"/inventory > /dev/null << EOF
-  [ostree_guest]
-  ${UEFI_GUEST_ADDRESS}
+    # Add instance IP address into /etc/ansible/hosts
+    sudo tee "${TEMPDIR}"/inventory > /dev/null << EOF
+[ostree_guest]
+${UEFI_GUEST_ADDRESS}
 
-  [ostree_guest:vars]
-  ansible_python_interpreter=/usr/bin/python3
-  ansible_user=core
-  ansible_private_key_file=${SSH_KEY}
-  ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-  ansible_become=yes
-  ansible_become_method=sudo
-  ansible_become_pass=${EDGE_USER_PASSWORD}
+[ostree_guest:vars]
+ansible_python_interpreter=/usr/bin/python3
+ansible_user=core
+ansible_private_key_file=${SSH_KEY}
+ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+ansible_become=yes
+ansible_become_method=sudo
+ansible_become_pass=${EDGE_USER_PASSWORD}
 EOF
 
-  # Test IoT/Edge OS
-  sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type="${OSTREE_OSNAME}" -e skip_rollback_test="true" -e edge_type=edge-raw-image -e ostree_commit="${UPGRADE_HASH}" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
-  check_result
+    # Test IoT/Edge OS
+    sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+        -e image_type="${OSTREE_OSNAME}" \
+        -e skip_rollback_test="true" \
+        -e edge_type=edge-raw-image \
+        -e ostree_commit="${UPGRADE_HASH}" \
+        -e sysroot_ro="$SYSROOT_RO" \
+        /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+    check_result
 fi
 
 # Add instance IP address into /etc/ansible/hosts
@@ -933,7 +969,12 @@ greenprint "fix stdio file non-blocking issue"
 sudo /usr/libexec/osbuild-composer-test/ansible-blocking-io.py
 
 # Test IoT/Edge OS
-sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type="${OSTREE_OSNAME}" -e edge_type=edge-raw-image -e ostree_commit="${UPGRADE_HASH}" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+    -e image_type="${OSTREE_OSNAME}" \
+    -e edge_type=edge-raw-image \
+    -e ostree_commit="${UPGRADE_HASH}" \
+    -e sysroot_ro="$SYSROOT_RO" \
+    /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 
 # Final success clean up

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -548,7 +548,13 @@ greenprint "fix stdio file non-blocking issue"
 sudo /usr/libexec/osbuild-composer-test/ansible-blocking-io.py
 
 # Test IoT/Edge OS
-sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type=redhat -e ostree_commit="${INSTALL_HASH}" -e edge_type=edge-simplified-installer -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+    -e image_type=redhat \
+    -e ostree_commit="${INSTALL_HASH}" \
+    -e edge_type=edge-simplified-installer \
+    -e fdo_credential="true" \
+    -e sysroot_ro="$SYSROOT_RO" \
+    /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 
 # Clean up BIOS VM
@@ -710,7 +716,14 @@ if [[ "$ANSIBLE_USER" == "fdouser" ]]; then
 fi
 
 # Test IoT/Edge OS
-sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type=redhat -e ostree_commit="${INSTALL_HASH}" -e skip_rollback_test="true" -e edge_type=edge-simplified-installer -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+    -e image_type=redhat \
+    -e ostree_commit="${INSTALL_HASH}" \
+    -e skip_rollback_test="true" \
+    -e edge_type=edge-simplified-installer \
+    -e fdo_credential="true" \
+    -e sysroot_ro="$SYSROOT_RO" \
+    /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 
 # Clean up BIOS VM
@@ -849,7 +862,14 @@ greenprint "fix stdio file non-blocking issue"
 sudo /usr/libexec/osbuild-composer-test/ansible-blocking-io.py
 
 # Test IoT/Edge OS
-sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type=redhat -e ostree_commit="${INSTALL_HASH}" -e skip_rollback_test="true" -e edge_type=edge-simplified-installer -e fdo_credential="true" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+    -e image_type=redhat \
+    -e ostree_commit="${INSTALL_HASH}" \
+    -e skip_rollback_test="true" \
+    -e edge_type=edge-simplified-installer \
+    -e fdo_credential="true" \
+    -e sysroot_ro="$SYSROOT_RO" \
+    /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 
 greenprint "🧹 Clean up VM"
@@ -1079,7 +1099,15 @@ EOF
     sudo /usr/libexec/osbuild-composer-test/ansible-blocking-io.py
 
     # Test IoT/Edge OS
-    sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type=redhat -e ostree_commit="${INSTALL_HASH}" -e skip_rollback_test="true" -e ignition="${HAS_IGNITION}" -e edge_type=edge-simplified-installer -e fdo_credential="false" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+    sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+        -e image_type=redhat \
+        -e ostree_commit="${INSTALL_HASH}" \
+        -e skip_rollback_test="true" \
+        -e ignition="${HAS_IGNITION}" \
+        -e edge_type=edge-simplified-installer \
+        -e fdo_credential="false" \
+        -e sysroot_ro="$SYSROOT_RO" \
+        /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
     check_result
   fi
 
@@ -1105,7 +1133,15 @@ EOF
   sudo /usr/libexec/osbuild-composer-test/ansible-blocking-io.py
 
   # Test IoT/Edge OS
-  sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type=redhat -e ostree_commit="${INSTALL_HASH}" -e skip_rollback_test="true" -e ignition="${HAS_IGNITION}" -e edge_type=edge-simplified-installer -e fdo_credential="false" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+  sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+    -e image_type=redhat \
+    -e ostree_commit="${INSTALL_HASH}" \
+    -e skip_rollback_test="true" \
+    -e ignition="${HAS_IGNITION}" \
+    -e edge_type=edge-simplified-installer \
+    -e fdo_credential="false" \
+    -e sysroot_ro="$SYSROOT_RO" \
+    /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
   check_result
 
   greenprint "🧹 Clean up VM"
@@ -1254,7 +1290,15 @@ EOF
   sudo /usr/libexec/osbuild-composer-test/ansible-blocking-io.py
 
   # Test IoT/Edge OS
-  sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type=redhat -e ostree_commit="${INSTALL_HASH}" -e skip_rollback_test="true" -e ignition="${HAS_IGNITION}" -e edge_type=edge-simplified-installer -e fdo_credential="false" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+  sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+    -e image_type=redhat \
+    -e ostree_commit="${INSTALL_HASH}" \
+    -e skip_rollback_test="true" \
+    -e ignition="${HAS_IGNITION}" \
+    -e edge_type=edge-simplified-installer \
+    -e fdo_credential="false" \
+    -e sysroot_ro="$SYSROOT_RO" \
+    /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
   check_result
 fi
 
@@ -1280,7 +1324,15 @@ greenprint "fix stdio file non-blocking issue"
 sudo /usr/libexec/osbuild-composer-test/ansible-blocking-io.py
 
 # Test IoT/Edge OS
-sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type=redhat -e ostree_commit="${INSTALL_HASH}" -e skip_rollback_test="true" -e ignition="${HAS_IGNITION}" -e edge_type=edge-simplified-installer -e fdo_credential="false" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+    -e image_type=redhat \
+    -e ostree_commit="${INSTALL_HASH}" \
+    -e skip_rollback_test="true" \
+    -e ignition="${HAS_IGNITION}" \
+    -e edge_type=edge-simplified-installer \
+    -e fdo_credential="false" \
+    -e sysroot_ro="$SYSROOT_RO" \
+    /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 
 ########################
@@ -1421,7 +1473,14 @@ EOF
   sudo /usr/libexec/osbuild-composer-test/ansible-blocking-io.py
 
   # Test IoT/Edge OS
-  sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type=redhat -e ostree_commit="${UPGRADE_HASH}" -e skip_rollback_test="true" -e edge_type=edge-simplified-installer -e fdo_credential="false" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+  sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+    -e image_type=redhat \
+    -e ostree_commit="${UPGRADE_HASH}" \
+    -e skip_rollback_test="true" \
+    -e edge_type=edge-simplified-installer \
+    -e fdo_credential="false" \
+    -e sysroot_ro="$SYSROOT_RO" \
+    /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
   check_result
 fi
 
@@ -1447,7 +1506,14 @@ greenprint "fix stdio file non-blocking issue"
 sudo /usr/libexec/osbuild-composer-test/ansible-blocking-io.py
 
 # Test IoT/Edge OS
-sudo ansible-playbook -v -i "${TEMPDIR}"/inventory -e image_type=redhat -e ostree_commit="${UPGRADE_HASH}" -e skip_rollback_test="true" -e edge_type=edge-simplified-installer -e fdo_credential="false" -e sysroot_ro="$SYSROOT_RO" /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
+sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
+    -e image_type=redhat \
+    -e ostree_commit="${UPGRADE_HASH}" \
+    -e skip_rollback_test="true" \
+    -e edge_type=edge-simplified-installer \
+    -e fdo_credential="false" \
+    -e sysroot_ro="$SYSROOT_RO" \
+    /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 
 # Final success clean up

--- a/test/data/manifests/fedora_36-aarch64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_raw_image_customizations-boot.json
@@ -1,0 +1,6201 @@
+{
+  "compose-request": {
+    "distro": "fedora-36",
+    "arch": "aarch64",
+    "image-type": "iot-raw-image",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-modular-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-modular-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      }
+    ],
+    "filename": "image.raw.xz",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {
+      "customizations": {
+        "user": [
+          {
+            "name": "user2",
+            "description": "description 2",
+            "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+            "home": "/home/home2",
+            "shell": "/bin/sh",
+            "groups": [
+              "group1"
+            ],
+            "uid": 1020,
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "uid": 1060,
+            "gid": 1060
+          }
+        ],
+        "group": [
+          {
+            "name": "group1",
+            "gid": 1030
+          },
+          {
+            "name": "group2",
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "gid": 1060
+          }
+        ],
+        "services": {
+          "enabled": [
+            "custom.service"
+          ]
+        },
+        "directories": [
+          {
+            "path": "/etc/systemd/system/custom.service.d"
+          },
+          {
+            "path": "/etc/custom_dir",
+            "user": 1020,
+            "group": 1050,
+            "mode": "0770"
+          }
+        ],
+        "files": [
+          {
+            "path": "/etc/systemd/system/custom.service",
+            "data": "[Unit]\nDescription=Custom service\n\n[Service]\nExecStart=/usr/bin/false\n\n[Install]\nWantedBy=multi-user.target\n"
+          },
+          {
+            "path": "/etc/systemd/system/custom.service.d/override.conf",
+            "data": "[Service]\nExecStart=\nExecStart=/usr/bin/cat /etc/custom_file.txt\n"
+          },
+          {
+            "path": "/etc/custom_file.txt",
+            "user": "root",
+            "group": "root",
+            "mode": "0644",
+            "data": "image builder is the best"
+          },
+          {
+            "path": "/etc/empty_file.txt",
+            "user": 0,
+            "group": 0
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora36",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b26994af6e0aafe1706f898ed1be912044c648b6c2633a5b6ece597a524f0cd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41c95fd87ce2a0b728954ed6848ebf80e4519837f745f6dbeac729f2abe3b651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d3f567968ae37eb62da4a462efb65e9ac701e1e5c653f031b56c41011b2cad0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d36faded5e082ec50b4cdde0597f1c05455a16418649fd5b519cd5ee70c385b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d340f2c15954e2fd736c443b80ea433353fc4dc143e8c8613e068ed98f618060",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2871a06d747d6ee8e48aeaa7dd2988a90cfdfa122ab3cb40d5e3842c868c3fcb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b26743879b27a885e74eaf8ed2af86ed783c883b8b03878c377a169343631ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:defb15188b8bbe620e531f18a42684ddddbe7a6c76e67941b520fc9d9d66a56b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a93ddba157c3ed782eb2837d8776015b502e8340438fa0fc542325dfc0ad8f0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ac5303ac6a3e0bece7270d9b36a5c3f7d522374607cbafc74bf04c72fc5f3d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32bdee52ac0cb28a8b55acaf3fc80e407d79758099da5487838cd41c871b5812",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63a7183b381bcdc27a0f40f49330acdf1d8df39f38ac5a41fcfd6e300d4ceb44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b62055e75833f9668150628dc7e8f9ac18c52d8876dcdf1a7882b871b26300b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75a95515417e48f51d88341d54d09e002c46f41a74ec35811435feefa2ecb370",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12654036e2d1dd40bff4e9c81a48a6ea85e52484b548382177f3f4ccf905e6a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2960bca7d94a6533182b3d72331d3369c774bc5ee9cb842b6a2acec83c53bb6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f34685b66f0b0847aaac6903e0b92d2ff778e0d8f5e95c7852ee38bb87100a78",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0855f5b2b07917099be76c6813474b45cfa73d7ee5c3afad4e20d3f9ccc970d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bb7051047e7a1e8bc3b4960cea2dde77ec452c18383d16f2258216f489100525",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f3f15f994cb5869e83f8446726501e7ce73c0281b5738bd1134d0480d86949e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8eeb1a2e783a61a814b20b12cddb3ffec8b27c02c6fbdcbf3cdef583fa59fa04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c0ed9385ccb82bec74755e2ba3977a1edecfc449998b88e03e1096f8f5084d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2498f161d9d4d847efdc08c44edf420a8eab5605572a98ddded1ddce78ffdb57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9caa3d6d1d101b8fccbea3f13004308300b326dc675989bac3b3a7d178201812",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d17ce6aa8886afdc6acbf54208c18b49155e9169e0804eeb4958105d484c930c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35cf2b8514afcfb6f041237c21b47cf9b5f09ac5fbff4cf659d478ed00232b40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2be980efad7c111d859023ff1562c2b3663179fda9713e76946a12df33e3992",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f94e4072a677d5315650798b6ad0251023e9dfe91e5eb933a5c0a44df1d54b6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d62545616da3a47fd25b32f03fcfa2f35473d111b972f10b33393419b96773e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cf4d3f64e9460dd6206027f5760b3ad5b1284f0a33cddba9c34c7e03a87f794",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b6a7cf86b9a8741590da8a1a72a20cea153babf004db8f543e51ebedce6df0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5edc290d9f5ab21421fd23f0454472ca1086fdad55bc0c1ce992684788a47b17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce799cfef53276047634cf1418c6463c2bd06ffce8d3b41272cd9f3e16d2d242",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07d6ac3bde8fd80b026d90087b17816aa544f60aedcf67c57cabb83bfba68112",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36844ba28f2810c5cf2c9bf29cf669923633ce092eb3da22e19a914c6b4c4423",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70672771b5d1207a7994f362e2ffa281f086f8f186f4a1cf7cd880860e2398ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7831d46fa728bbab5efd9e99e745bc09492a795e9d817489f2e7803bf1090f0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:395681166f6d4583b9c55c27097b14cbccbdf4997604c7216263b10b61f8be07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b86bcc1281e914ae95c73e7411cc452ece3a046cac231b93f10bdc808f1bd48",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80966bbe97ae88bfc2b5078430d969934e3b4783dbbfe53c9ee026a7ad1b9d29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:159cf2b554839fb1dafc536a1d34e6a9939277f13d697758883a0421efe70e74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b555fdd0f94fcf4be7cd6463383695c498ebea961d1be4889b53cce335be024",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e21aee15d4e4e3396e17cb3534cf1bcb62beb0407601a3ecf604f93f1c990212",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aeeaaee02ad1c8f2b6a9db1089f380c22384ba38305ad79c60cb234c560a76dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26daa044e4be5b368e8a6e07a858b7498490884525b415efa202a76f3470f6ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e48b23e4a1a8bda84676cfb25fb882997da07d4ddeb80acfbb0f44c5b22e0229",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a4d4c406f155118922251901587997317b1f3904f88bc358573f384645ad5c83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:065befa0aa9e24df7b5c5c29943ff559b0508600a668ede3f75aa86dfb306ae1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db82a25bca1d37ce148e2b7fd4edbf5ef673573a650a46ede399f92d6c5d1384",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d580be005d64283434e750f9ef760554ce814dfaa527699541a655f5d7de4d8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d3293398c397ada3d74243def9e2aaa72b2944383924213aef7fd8ccfcfcbf5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5fc05299dd26a52da3011a466b1454da89727ab7dd7815595bd162b83adc28b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d86220c34713ac28d674be349ccc9eb53aa790c2b39025596532ffb92eafcbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26d9bfa8bcccabc4565c64027146f39a11f4750e937179a9e023ec272aa3a480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6619af57c800fb5ec8cdd5ec8ea070897f012c968235f748e313d4de71abd342",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:364f7226e498df8c3100d07a2795413268fdc1bc0ef038e3b58265d1f45bb0d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a2faf2c81074e12b902585c1dc9df7a5c4dfe9abd651c9849a5cdf52462d2b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa387421816ee1b9b1313282810c8a05da4175e3817f13a71486e9608a3617e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bca37331b74e29d61d3646bdf174bc2636d0bc7b00ff202ba34e8e3c5f2c5fc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:168429c25bcc7d36dde47ef25e5aaf1ca50b7f6f9350a058c45f4e67d5cdce40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:072a3e0a47d47dd1d448a43d4c0bd603fd1f299bab06c0eae973ca561d58008a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3e59e5f31162de26de52097469ef2bdbae38e25137d6366b5200898044af8ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab0f174db1bf134f5288510c8c7c0fa64d3d28ac85ed45fb58d6e0d4ae8af564",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2646322ae496c10f0ad319945a943e726010e2e1e6e7dcf904b7ffcacff9662f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c20f377409f00597b57dd1cffdccf306adf5aaaaff94c1d56170001ff008a1c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:730660a380d55edad432386e9119a2e3f3b589bbbe8df4261d058a03064e11d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8efcccc5141a5360ab8af037ad9be02d2b617a43db19117133e672806245e34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d5810b77445814c25236a80b1cb9de5bf8b437b7f5d0a03c010e9b84ee2d5f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": false,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "user2": {
+                  "uid": 1020,
+                  "gid": 1050,
+                  "groups": [
+                    "group1"
+                  ],
+                  "description": "description 2",
+                  "home": "/home/home2",
+                  "shell": "/bin/sh",
+                  "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                },
+                "user3": {
+                  "uid": 1060,
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.groups",
+            "options": {
+              "groups": {
+                "group1": {
+                  "gid": 1030
+                },
+                "group2": {
+                  "gid": 1050
+                },
+                "user3": {
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/etc/systemd/system/custom.service.d",
+                  "exist_ok": true
+                },
+                {
+                  "path": "/etc/custom_dir"
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "mode": "0770"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "user": 1020,
+                  "group": 1050
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                  }
+                ]
+              },
+              "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                  }
+                ]
+              },
+              "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                  }
+                ]
+              },
+              "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  }
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                  "to": "tree:///etc/systemd/system/custom.service",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                  "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                  "to": "tree:///etc/custom_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                  "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "mode": "0644"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "user": "root",
+                  "group": "root"
+                },
+                "/etc/empty_file.txt": {
+                  "user": 0,
+                  "group": 0
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.systemd",
+            "options": {
+              "enabled_services": [
+                "custom.service"
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "dos",
+              "uuid": "0xc1748067",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "06"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "83"
+                },
+                {
+                  "size": 5263360,
+                  "start": 3125248,
+                  "type": "83"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263360,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263360
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "ostree-tree": {
+                "type": "org.osbuild.ostree.checkout",
+                "origin": "org.osbuild.source",
+                "references": [
+                  ""
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "to": "mount://root/boot/efi/config.txt"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "to": "mount://root/boot/efi/rpi-u-boot.bin"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "to": "mount://root/boot/efi/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263360
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "xz",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.xz",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "image.raw.xz"
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.aarch64.rpm"
+          },
+          "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.aarch64.rpm"
+          },
+          "sha256:065befa0aa9e24df7b5c5c29943ff559b0508600a668ede3f75aa86dfb306ae1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.aarch64.rpm"
+          },
+          "sha256:072a3e0a47d47dd1d448a43d4c0bd603fd1f299bab06c0eae973ca561d58008a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/ostree-2022.4-2.fc36.aarch64.rpm"
+          },
+          "sha256:07d6ac3bde8fd80b026d90087b17816aa544f60aedcf67c57cabb83bfba68112": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.aarch64.rpm"
+          },
+          "sha256:0855f5b2b07917099be76c6813474b45cfa73d7ee5c3afad4e20d3f9ccc970d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.aarch64.rpm"
+          },
+          "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efi-filesystem-5-5.fc36.noarch.rpm"
+          },
+          "sha256:0b26743879b27a885e74eaf8ed2af86ed783c883b8b03878c377a169343631ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse3-3.10.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm"
+          },
+          "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm"
+          },
+          "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:12654036e2d1dd40bff4e9c81a48a6ea85e52484b548382177f3f4ccf905e6a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.aarch64.rpm"
+          },
+          "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.aarch64.rpm"
+          },
+          "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.aarch64.rpm"
+          },
+          "sha256:159cf2b554839fb1dafc536a1d34e6a9939277f13d697758883a0421efe70e74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/aardvark-dns-1.0.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:168429c25bcc7d36dde47ef25e5aaf1ca50b7f6f9350a058c45f4e67d5cdce40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.aarch64.rpm"
+          },
+          "sha256:1b86bcc1281e914ae95c73e7411cc452ece3a046cac231b93f10bdc808f1bd48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/w/which-2.21-32.fc36.aarch64.rpm"
+          },
+          "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.aarch64.rpm"
+          },
+          "sha256:1f3f15f994cb5869e83f8446726501e7ce73c0281b5738bd1134d0480d86949e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnet-1.2-5.fc36.aarch64.rpm"
+          },
+          "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.aarch64.rpm"
+          },
+          "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.aarch64.rpm"
+          },
+          "sha256:2498f161d9d4d847efdc08c44edf420a8eab5605572a98ddded1ddce78ffdb57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:2646322ae496c10f0ad319945a943e726010e2e1e6e7dcf904b7ffcacff9662f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:26d9bfa8bcccabc4565c64027146f39a11f4750e937179a9e023ec272aa3a480": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:26daa044e4be5b368e8a6e07a858b7498490884525b415efa202a76f3470f6ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/criu-libs-3.17-4.fc36.aarch64.rpm"
+          },
+          "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:2871a06d747d6ee8e48aeaa7dd2988a90cfdfa122ab3cb40d5e3842c868c3fcb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-common-3.10.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:2960bca7d94a6533182b3d72331d3369c774bc5ee9cb842b6a2acec83c53bb6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm"
+          },
+          "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm"
+          },
+          "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.aarch64.rpm"
+          },
+          "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:32bdee52ac0cb28a8b55acaf3fc80e407d79758099da5487838cd41c871b5812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:35cf2b8514afcfb6f041237c21b47cf9b5f09ac5fbff4cf659d478ed00232b40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libslirp-4.6.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:364f7226e498df8c3100d07a2795413268fdc1bc0ef038e3b58265d1f45bb0d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.aarch64.rpm"
+          },
+          "sha256:36844ba28f2810c5cf2c9bf29cf669923633ce092eb3da22e19a914c6b4c4423": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm"
+          },
+          "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:395681166f6d4583b9c55c27097b14cbccbdf4997604c7216263b10b61f8be07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/t/tar-1.34-3.fc36.aarch64.rpm"
+          },
+          "sha256:3a2faf2c81074e12b902585c1dc9df7a5c4dfe9abd651c9849a5cdf52462d2b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mokutil-0.6.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.aarch64.rpm"
+          },
+          "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-5.41-4.fc36.aarch64.rpm"
+          },
+          "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.aarch64.rpm"
+          },
+          "sha256:3d3293398c397ada3d74243def9e2aaa72b2944383924213aef7fd8ccfcfcbf5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.aarch64.rpm"
+          },
+          "sha256:3d86220c34713ac28d674be349ccc9eb53aa790c2b39025596532ffb92eafcbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/popt-1.18-7.fc36.aarch64.rpm"
+          },
+          "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sed-4.8-10.fc36.aarch64.rpm"
+          },
+          "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.aarch64.rpm"
+          },
+          "sha256:41c95fd87ce2a0b728954ed6848ebf80e4519837f745f6dbeac729f2abe3b651": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.aarch64.rpm"
+          },
+          "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm"
+          },
+          "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.aarch64.rpm"
+          },
+          "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm"
+          },
+          "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:4d36faded5e082ec50b4cdde0597f1c05455a16418649fd5b519cd5ee70c385b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.aarch64.rpm"
+          },
+          "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.aarch64.rpm"
+          },
+          "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.aarch64.rpm"
+          },
+          "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.aarch64.rpm"
+          },
+          "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.aarch64.rpm"
+          },
+          "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.aarch64.rpm"
+          },
+          "sha256:5b555fdd0f94fcf4be7cd6463383695c498ebea961d1be4889b53cce335be024": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/container-selinux-2.188.0-1.fc36.noarch.rpm"
+          },
+          "sha256:5b6a7cf86b9a8741590da8a1a72a20cea153babf004db8f543e51ebedce6df0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.aarch64.rpm"
+          },
+          "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm"
+          },
+          "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:5cf4d3f64e9460dd6206027f5760b3ad5b1284f0a33cddba9c34c7e03a87f794": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/npth-1.6-8.fc36.aarch64.rpm"
+          },
+          "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:5edc290d9f5ab21421fd23f0454472ca1086fdad55bc0c1ce992684788a47b17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:5fc05299dd26a52da3011a466b1454da89727ab7dd7815595bd162b83adc28b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-efi-aa64-2.06-42.fc36.aarch64.rpm"
+          },
+          "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:63a7183b381bcdc27a0f40f49330acdf1d8df39f38ac5a41fcfd6e300d4ceb44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.aarch64.rpm"
+          },
+          "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.aarch64.rpm"
+          },
+          "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.aarch64.rpm"
+          },
+          "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.aarch64.rpm"
+          },
+          "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm"
+          },
+          "sha256:6619af57c800fb5ec8cdd5ec8ea070897f012c968235f748e313d4de71abd342": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-29-7.fc36.aarch64.rpm"
+          },
+          "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.aarch64.rpm"
+          },
+          "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm"
+          },
+          "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.aarch64.rpm"
+          },
+          "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm"
+          },
+          "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm"
+          },
+          "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm"
+          },
+          "sha256:70672771b5d1207a7994f362e2ffa281f086f8f186f4a1cf7cd880860e2398ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm"
+          },
+          "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.aarch64.rpm"
+          },
+          "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.aarch64.rpm"
+          },
+          "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm"
+          },
+          "sha256:730660a380d55edad432386e9119a2e3f3b589bbbe8df4261d058a03064e11d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/rpm-ostree-libs-2022.10-3.fc36.aarch64.rpm"
+          },
+          "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.aarch64.rpm"
+          },
+          "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.aarch64.rpm"
+          },
+          "sha256:75a95515417e48f51d88341d54d09e002c46f41a74ec35811435feefa2ecb370": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbsd-0.10.0-9.fc36.aarch64.rpm"
+          },
+          "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.aarch64.rpm"
+          },
+          "sha256:7831d46fa728bbab5efd9e99e745bc09492a795e9d817489f2e7803bf1090f0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/slirp4netns-1.2.0-0.2.beta.0.fc36.aarch64.rpm"
+          },
+          "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.aarch64.rpm"
+          },
+          "sha256:7ac5303ac6a3e0bece7270d9b36a5c3f7d522374607cbafc74bf04c72fc5f3d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.aarch64.rpm"
+          },
+          "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:80966bbe97ae88bfc2b5078430d969934e3b4783dbbfe53c9ee026a7ad1b9d29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/y/yajl-2.1.0-18.fc36.aarch64.rpm"
+          },
+          "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.aarch64.rpm"
+          },
+          "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm"
+          },
+          "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-056-1.fc36.aarch64.rpm"
+          },
+          "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.aarch64.rpm"
+          },
+          "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm"
+          },
+          "sha256:8c0ed9385ccb82bec74755e2ba3977a1edecfc449998b88e03e1096f8f5084d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.aarch64.rpm"
+          },
+          "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:8d3f567968ae37eb62da4a462efb65e9ac701e1e5c653f031b56c41011b2cad0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efibootmgr-16-12.fc36.aarch64.rpm"
+          },
+          "sha256:8eeb1a2e783a61a814b20b12cddb3ffec8b27c02c6fbdcbf3cdef583fa59fa04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.aarch64.rpm"
+          },
+          "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.aarch64.rpm"
+          },
+          "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm"
+          },
+          "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.aarch64.rpm"
+          },
+          "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm"
+          },
+          "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.aarch64.rpm"
+          },
+          "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.aarch64.rpm"
+          },
+          "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.aarch64.rpm"
+          },
+          "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:9caa3d6d1d101b8fccbea3f13004308300b326dc675989bac3b3a7d178201812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:9d5810b77445814c25236a80b1cb9de5bf8b437b7f5d0a03c010e9b84ee2d5f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/skopeo-1.8.0-8.fc36.aarch64.rpm"
+          },
+          "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grep-3.7-2.fc36.aarch64.rpm"
+          },
+          "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:a4d4c406f155118922251901587997317b1f3904f88bc358573f384645ad5c83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fuse-overlayfs-1.9-1.fc36.aarch64.rpm"
+          },
+          "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.aarch64.rpm"
+          },
+          "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm"
+          },
+          "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:a93ddba157c3ed782eb2837d8776015b502e8340438fa0fc542325dfc0ad8f0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:aa387421816ee1b9b1313282810c8a05da4175e3817f13a71486e9608a3617e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:ab0f174db1bf134f5288510c8c7c0fa64d3d28ac85ed45fb58d6e0d4ae8af564": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:aeeaaee02ad1c8f2b6a9db1089f380c22384ba38305ad79c60cb234c560a76dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/criu-3.17-4.fc36.aarch64.rpm"
+          },
+          "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm"
+          },
+          "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.aarch64.rpm"
+          },
+          "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:b26994af6e0aafe1706f898ed1be912044c648b6c2633a5b6ece597a524f0cd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:b62055e75833f9668150628dc7e8f9ac18c52d8876dcdf1a7882b871b26300b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm"
+          },
+          "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.aarch64.rpm"
+          },
+          "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.aarch64.rpm"
+          },
+          "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.aarch64.rpm"
+          },
+          "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.aarch64.rpm"
+          },
+          "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.aarch64.rpm"
+          },
+          "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/readline-8.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:bb7051047e7a1e8bc3b4960cea2dde77ec452c18383d16f2258216f489100525": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:bca37331b74e29d61d3646bdf174bc2636d0bc7b00ff202ba34e8e3c5f2c5fc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/netavark-1.0.3-3.fc36.aarch64.rpm"
+          },
+          "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.aarch64.rpm"
+          },
+          "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:c20f377409f00597b57dd1cffdccf306adf5aaaaff94c1d56170001ff008a1c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/rpm-ostree-2022.10-3.fc36.aarch64.rpm"
+          },
+          "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:c3e59e5f31162de26de52097469ef2bdbae38e25137d6366b5200898044af8ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/ostree-libs-2022.4-2.fc36.aarch64.rpm"
+          },
+          "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.aarch64.rpm"
+          },
+          "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.aarch64.rpm"
+          },
+          "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm"
+          },
+          "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm"
+          },
+          "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.aarch64.rpm"
+          },
+          "sha256:ce799cfef53276047634cf1418c6463c2bd06ffce8d3b41272cd9f3e16d2d242": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.aarch64.rpm"
+          },
+          "sha256:d17ce6aa8886afdc6acbf54208c18b49155e9169e0804eeb4958105d484c930c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.aarch64.rpm"
+          },
+          "sha256:d340f2c15954e2fd736c443b80ea433353fc4dc143e8c8613e068ed98f618060": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-2.9.9-14.fc36.aarch64.rpm"
+          },
+          "sha256:d580be005d64283434e750f9ef760554ce814dfaa527699541a655f5d7de4d8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.aarch64.rpm"
+          },
+          "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.aarch64.rpm"
+          },
+          "sha256:d62545616da3a47fd25b32f03fcfa2f35473d111b972f10b33393419b96773e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.aarch64.rpm"
+          },
+          "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.aarch64.rpm"
+          },
+          "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.aarch64.rpm"
+          },
+          "sha256:db82a25bca1d37ce148e2b7fd4edbf5ef673573a650a46ede399f92d6c5d1384": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.aarch64.rpm"
+          },
+          "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm"
+          },
+          "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:defb15188b8bbe620e531f18a42684ddddbe7a6c76e67941b520fc9d9d66a56b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse3-libs-3.10.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.aarch64.rpm"
+          },
+          "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:e21aee15d4e4e3396e17cb3534cf1bcb62beb0407601a3ecf604f93f1c990212": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/containers-common-1-56.fc36.noarch.rpm"
+          },
+          "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm"
+          },
+          "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm"
+          },
+          "sha256:e48b23e4a1a8bda84676cfb25fb882997da07d4ddeb80acfbb0f44c5b22e0229": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crun-1.4.5-1.fc36.aarch64.rpm"
+          },
+          "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.aarch64.rpm"
+          },
+          "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm"
+          },
+          "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.aarch64.rpm"
+          },
+          "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:f2be980efad7c111d859023ff1562c2b3663179fda9713e76946a12df33e3992": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.aarch64.rpm"
+          },
+          "sha256:f34685b66f0b0847aaac6903e0b92d2ff778e0d8f5e95c7852ee38bb87100a78": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.aarch64.rpm"
+          },
+          "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.aarch64.rpm"
+          },
+          "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.aarch64.rpm"
+          },
+          "sha256:f8efcccc5141a5360ab8af037ad9be02d2b617a43db19117133e672806245e34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/shim-aa64-15.6-1.aarch64.rpm"
+          },
+          "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:f94e4072a677d5315650798b6ad0251023e9dfe91e5eb933a5c0a44df1d54b6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm"
+          },
+          "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.aarch64.rpm"
+          },
+          "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.aarch64.rpm"
+          }
+        }
+      },
+      "org.osbuild.inline": {
+        "items": {
+          "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+            "encoding": "base64",
+            "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+          },
+          "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+            "encoding": "base64",
+            "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+          },
+          "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+            "encoding": "base64",
+            "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+          },
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+            "encoding": "base64",
+            "data": ""
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.aarch64.rpm",
+        "checksum": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b26994af6e0aafe1706f898ed1be912044c648b6c2633a5b6ece597a524f0cd2",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.aarch64.rpm",
+        "checksum": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.aarch64.rpm",
+        "checksum": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.aarch64.rpm",
+        "checksum": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm",
+        "checksum": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:41c95fd87ce2a0b728954ed6848ebf80e4519837f745f6dbeac729f2abe3b651",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "5.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efi-filesystem-5-5.fc36.noarch.rpm",
+        "checksum": "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efibootmgr-16-12.fc36.aarch64.rpm",
+        "checksum": "sha256:8d3f567968ae37eb62da4a462efb65e9ac701e1e5c653f031b56c41011b2cad0",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4d36faded5e082ec50b4cdde0597f1c05455a16418649fd5b519cd5ee70c385b",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-2.9.9-14.fc36.aarch64.rpm",
+        "checksum": "sha256:d340f2c15954e2fd736c443b80ea433353fc4dc143e8c8613e068ed98f618060",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-common-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2871a06d747d6ee8e48aeaa7dd2988a90cfdfa122ab3cb40d5e3842c868c3fcb",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.aarch64.rpm",
+        "checksum": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse3-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:0b26743879b27a885e74eaf8ed2af86ed783c883b8b03878c377a169343631ec",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse3-libs-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:defb15188b8bbe620e531f18a42684ddddbe7a6c76e67941b520fc9d9d66a56b",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:a93ddba157c3ed782eb2837d8776015b502e8340438fa0fc542325dfc0ad8f0d",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grep-3.7-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.aarch64.rpm",
+        "checksum": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.aarch64.rpm",
+        "checksum": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.aarch64.rpm",
+        "checksum": "sha256:7ac5303ac6a3e0bece7270d9b36a5c3f7d522374607cbafc74bf04c72fc5f3d3",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:32bdee52ac0cb28a8b55acaf3fc80e407d79758099da5487838cd41c871b5812",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.aarch64.rpm",
+        "checksum": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.aarch64.rpm",
+        "checksum": "sha256:63a7183b381bcdc27a0f40f49330acdf1d8df39f38ac5a41fcfd6e300d4ceb44",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.aarch64.rpm",
+        "checksum": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm",
+        "checksum": "sha256:b62055e75833f9668150628dc7e8f9ac18c52d8876dcdf1a7882b871b26300b5",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.aarch64.rpm",
+        "checksum": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+        "check_gpg": true
+      },
+      {
+        "name": "libbsd",
+        "epoch": 0,
+        "version": "0.10.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbsd-0.10.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:75a95515417e48f51d88341d54d09e002c46f41a74ec35811435feefa2ecb370",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.aarch64.rpm",
+        "checksum": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.aarch64.rpm",
+        "checksum": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "41.20210910cvs.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.aarch64.rpm",
+        "checksum": "sha256:12654036e2d1dd40bff4e9c81a48a6ea85e52484b548382177f3f4ccf905e6a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.aarch64.rpm",
+        "checksum": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "39.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2960bca7d94a6533182b3d72331d3369c774bc5ee9cb842b6a2acec83c53bb6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.aarch64.rpm",
+        "checksum": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:f34685b66f0b0847aaac6903e0b92d2ff778e0d8f5e95c7852ee38bb87100a78",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.aarch64.rpm",
+        "checksum": "sha256:0855f5b2b07917099be76c6813474b45cfa73d7ee5c3afad4e20d3f9ccc970d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:bb7051047e7a1e8bc3b4960cea2dde77ec452c18383d16f2258216f489100525",
+        "check_gpg": true
+      },
+      {
+        "name": "libnet",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnet-1.2-5.fc36.aarch64.rpm",
+        "checksum": "sha256:1f3f15f994cb5869e83f8446726501e7ce73c0281b5738bd1134d0480d86949e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.aarch64.rpm",
+        "checksum": "sha256:8eeb1a2e783a61a814b20b12cddb3ffec8b27c02c6fbdcbf3cdef583fa59fa04",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "21.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.aarch64.rpm",
+        "checksum": "sha256:8c0ed9385ccb82bec74755e2ba3977a1edecfc449998b88e03e1096f8f5084d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2498f161d9d4d847efdc08c44edf420a8eab5605572a98ddded1ddce78ffdb57",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:9caa3d6d1d101b8fccbea3f13004308300b326dc675989bac3b3a7d178201812",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.aarch64.rpm",
+        "checksum": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.aarch64.rpm",
+        "checksum": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d17ce6aa8886afdc6acbf54208c18b49155e9169e0804eeb4958105d484c930c",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+        "check_gpg": true
+      },
+      {
+        "name": "libslirp",
+        "epoch": 0,
+        "version": "4.6.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libslirp-4.6.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:35cf2b8514afcfb6f041237c21b47cf9b5f09ac5fbff4cf659d478ed00232b40",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.aarch64.rpm",
+        "checksum": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.aarch64.rpm",
+        "checksum": "sha256:f2be980efad7c111d859023ff1562c2b3663179fda9713e76946a12df33e3992",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.aarch64.rpm",
+        "checksum": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm",
+        "checksum": "sha256:f94e4072a677d5315650798b6ad0251023e9dfe91e5eb933a5c0a44df1d54b6d",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.aarch64.rpm",
+        "checksum": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.aarch64.rpm",
+        "checksum": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:d62545616da3a47fd25b32f03fcfa2f35473d111b972f10b33393419b96773e6",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/npth-1.6-8.fc36.aarch64.rpm",
+        "checksum": "sha256:5cf4d3f64e9460dd6206027f5760b3ad5b1284f0a33cddba9c34c7e03a87f794",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.aarch64.rpm",
+        "checksum": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.aarch64.rpm",
+        "checksum": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5b6a7cf86b9a8741590da8a1a72a20cea153babf004db8f543e51ebedce6df0c",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5edc290d9f5ab21421fd23f0454472ca1086fdad55bc0c1ce992684788a47b17",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.aarch64.rpm",
+        "checksum": "sha256:ce799cfef53276047634cf1418c6463c2bd06ffce8d3b41272cd9f3e16d2d242",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.aarch64.rpm",
+        "checksum": "sha256:07d6ac3bde8fd80b026d90087b17816aa544f60aedcf67c57cabb83bfba68112",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "21.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm",
+        "checksum": "sha256:36844ba28f2810c5cf2c9bf29cf669923633ce092eb3da22e19a914c6b4c4423",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/popt-1.18-7.fc36.aarch64.rpm",
+        "checksum": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.aarch64.rpm",
+        "checksum": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:70672771b5d1207a7994f362e2ffa281f086f8f186f4a1cf7cd880860e2398ff",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/readline-8.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sed-4.8-10.fc36.aarch64.rpm",
+        "checksum": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+        "check_gpg": true
+      },
+      {
+        "name": "slirp4netns",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "0.2.beta.0.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/slirp4netns-1.2.0-0.2.beta.0.fc36.aarch64.rpm",
+        "checksum": "sha256:7831d46fa728bbab5efd9e99e745bc09492a795e9d817489f2e7803bf1090f0c",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/t/tar-1.34-3.fc36.aarch64.rpm",
+        "checksum": "sha256:395681166f6d4583b9c55c27097b14cbccbdf4997604c7216263b10b61f8be07",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "32.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/w/which-2.21-32.fc36.aarch64.rpm",
+        "checksum": "sha256:1b86bcc1281e914ae95c73e7411cc452ece3a046cac231b93f10bdc808f1bd48",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+        "check_gpg": true
+      },
+      {
+        "name": "yajl",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "18.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/y/yajl-2.1.0-18.fc36.aarch64.rpm",
+        "checksum": "sha256:80966bbe97ae88bfc2b5078430d969934e3b4783dbbfe53c9ee026a7ad1b9d29",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.aarch64.rpm",
+        "checksum": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+        "check_gpg": true
+      },
+      {
+        "name": "aardvark-dns",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/aardvark-dns-1.0.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:159cf2b554839fb1dafc536a1d34e6a9939277f13d697758883a0421efe70e74",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.188.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/container-selinux-2.188.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:5b555fdd0f94fcf4be7cd6463383695c498ebea961d1be4889b53cce335be024",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "56.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/containers-common-1-56.fc36.noarch.rpm",
+        "checksum": "sha256:e21aee15d4e4e3396e17cb3534cf1bcb62beb0407601a3ecf604f93f1c990212",
+        "check_gpg": true
+      },
+      {
+        "name": "criu",
+        "epoch": 0,
+        "version": "3.17",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/criu-3.17-4.fc36.aarch64.rpm",
+        "checksum": "sha256:aeeaaee02ad1c8f2b6a9db1089f380c22384ba38305ad79c60cb234c560a76dd",
+        "check_gpg": true
+      },
+      {
+        "name": "criu-libs",
+        "epoch": 0,
+        "version": "3.17",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/criu-libs-3.17-4.fc36.aarch64.rpm",
+        "checksum": "sha256:26daa044e4be5b368e8a6e07a858b7498490884525b415efa202a76f3470f6ff",
+        "check_gpg": true
+      },
+      {
+        "name": "crun",
+        "epoch": 0,
+        "version": "1.4.5",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crun-1.4.5-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e48b23e4a1a8bda84676cfb25fb882997da07d4ddeb80acfbb0f44c5b22e0229",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fuse-overlayfs-1.9-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a4d4c406f155118922251901587997317b1f3904f88bc358573f384645ad5c83",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.72.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:065befa0aa9e24df7b5c5c29943ff559b0508600a668ede3f75aa86dfb306ae1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.aarch64.rpm",
+        "checksum": "sha256:db82a25bca1d37ce148e2b7fd4edbf5ef673573a650a46ede399f92d6c5d1384",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d580be005d64283434e750f9ef760554ce814dfaa527699541a655f5d7de4d8c",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.6",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3d3293398c397ada3d74243def9e2aaa72b2944383924213aef7fd8ccfcfcbf5",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-efi-aa64-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:5fc05299dd26a52da3011a466b1454da89727ab7dd7815595bd162b83adc28b7",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.aarch64.rpm",
+        "checksum": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.aarch64.rpm",
+        "checksum": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "69.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:3d86220c34713ac28d674be349ccc9eb53aa790c2b39025596532ffb92eafcbc",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.6.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:26d9bfa8bcccabc4565c64027146f39a11f4750e937179a9e023ec272aa3a480",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6619af57c800fb5ec8cdd5ec8ea070897f012c968235f748e313d4de71abd342",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.aarch64.rpm",
+        "checksum": "sha256:364f7226e498df8c3100d07a2795413268fdc1bc0ef038e3b58265d1f45bb0d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mokutil-0.6.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3a2faf2c81074e12b902585c1dc9df7a5c4dfe9abd651c9849a5cdf52462d2b5",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs91",
+        "epoch": 0,
+        "version": "91.11.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:aa387421816ee1b9b1313282810c8a05da4175e3817f13a71486e9608a3617e5",
+        "check_gpg": true
+      },
+      {
+        "name": "netavark",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/netavark-1.0.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:bca37331b74e29d61d3646bdf174bc2636d0bc7b00ff202ba34e8e3c5f2c5fc5",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:168429c25bcc7d36dde47ef25e5aaf1ca50b7f6f9350a058c45f4e67d5cdce40",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2022.4",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/ostree-2022.4-2.fc36.aarch64.rpm",
+        "checksum": "sha256:072a3e0a47d47dd1d448a43d4c0bd603fd1f299bab06c0eae973ca561d58008a",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2022.4",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/ostree-libs-2022.4-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c3e59e5f31162de26de52097469ef2bdbae38e25137d6366b5200898044af8ef",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.aarch64.rpm",
+        "checksum": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:ab0f174db1bf134f5288510c8c7c0fa64d3d28ac85ed45fb58d6e0d4ae8af564",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2646322ae496c10f0ad319945a943e726010e2e1e6e7dcf904b7ffcacff9662f",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2022.10",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/rpm-ostree-2022.10-3.fc36.aarch64.rpm",
+        "checksum": "sha256:c20f377409f00597b57dd1cffdccf306adf5aaaaff94c1d56170001ff008a1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2022.10",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/r/rpm-ostree-libs-2022.10-3.fc36.aarch64.rpm",
+        "checksum": "sha256:730660a380d55edad432386e9119a2e3f3b589bbbe8df4261d058a03064e11d0",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/shim-aa64-15.6-1.aarch64.rpm",
+        "checksum": "sha256:f8efcccc5141a5360ab8af037ad9be02d2b617a43db19117133e672806245e34",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.8.0",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/skopeo-1.8.0-8.fc36.aarch64.rpm",
+        "checksum": "sha256:9d5810b77445814c25236a80b1cb9de5bf8b437b7f5d0a03c010e9b84ee2d5f7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_36-x86_64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_raw_image_customizations-boot.json
@@ -1,0 +1,6042 @@
+{
+  "compose-request": {
+    "distro": "fedora-36",
+    "arch": "x86_64",
+    "image-type": "iot-raw-image",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-modular-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-modular-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      }
+    ],
+    "filename": "image.raw.xz",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {
+      "customizations": {
+        "user": [
+          {
+            "name": "user2",
+            "description": "description 2",
+            "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+            "home": "/home/home2",
+            "shell": "/bin/sh",
+            "groups": [
+              "group1"
+            ],
+            "uid": 1020,
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "uid": 1060,
+            "gid": 1060
+          }
+        ],
+        "group": [
+          {
+            "name": "group1",
+            "gid": 1030
+          },
+          {
+            "name": "group2",
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "gid": 1060
+          }
+        ],
+        "services": {
+          "enabled": [
+            "custom.service"
+          ]
+        },
+        "directories": [
+          {
+            "path": "/etc/systemd/system/custom.service.d"
+          },
+          {
+            "path": "/etc/custom_dir",
+            "user": 1020,
+            "group": 1050,
+            "mode": "0770"
+          }
+        ],
+        "files": [
+          {
+            "path": "/etc/systemd/system/custom.service",
+            "data": "[Unit]\nDescription=Custom service\n\n[Service]\nExecStart=/usr/bin/false\n\n[Install]\nWantedBy=multi-user.target\n"
+          },
+          {
+            "path": "/etc/systemd/system/custom.service.d/override.conf",
+            "data": "[Service]\nExecStart=\nExecStart=/usr/bin/cat /etc/custom_file.txt\n"
+          },
+          {
+            "path": "/etc/custom_file.txt",
+            "user": "root",
+            "group": "root",
+            "mode": "0644",
+            "data": "image builder is the best"
+          },
+          {
+            "path": "/etc/empty_file.txt",
+            "user": 0,
+            "group": 0
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora36",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28b98634695e2f0a9f5f616b84ecb21d2726f1b360ca16ba8f48aceda4a8e0fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55b9b9595efb83f4f6638c47125817cabb3b486ecbc786d4ce2b014e8a81cca9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6e85834503eae1bf62340e8d24b208faabbf632151425675dc4075a27e112f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaf42f29c0f991a0059fcaa41c79b1ebff0c243c5b8f398bfba2aab2b5c89cf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca8c7a8350a0c4a167c7bf6a61cfb905dd149afb4cdb63ac0f69523d918ccbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8a95c8441067e37fdfc67d0aacd42106d0a867856920c6b68b82b11a7b451a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e9aa89d498f2e5b6c5e065d0cca55e51b24599bb518993d26ebcb74ed854b33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d421f90fe86af10fae33ff65f1eecd8ac24ee2b5f6292cbfcc9de292ad9f64b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4cf97f8df32e57949d6cd29c95da335bc3f1b8bbe8d5f73dfb327e64fd500e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6218b686e396a0eec312f93e7d1418e00b7a32ae95926fb7d7835f44e72f8526",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aef4b7bd425f1118403818bf469878b1ba2881d21385074bec813d1ba3f3fb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4538200e6752e1cc8844a50115193d736ee06d4fb6096c51bd925d1a2bd9bd8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f4f8b80a39f4cde1a15072097cba266333cc1a840f494c7f33affbcc0f66f49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed95c9f74b17649179c36919f3f195a9ff2358cadf7c840dec789b39f27ba58e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dffa57881ede2980c3384f2d8890b60169581414031b25253f9bf032ae7ed48e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b4a9e98cb73582362e6e70390c1c643b26f50c289ea0acbc74b5bb75d85e23b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:991f6fd822110685e42f499f3059cc5abab2beeff405fc24c74f9e89c41088b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:995d03ccc92a1c35fc0e25a7f7ba3f4bde6bac5068220a0e2722f377dfaf26a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00cda4f023ab0f5d5b64f29cc36325e2b1395bf5c23547c515140051d50df1cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a954624b2af4942322be233d78bac6156e71dd20a5386710cc1359b4df6c673",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc3339d24b5e60cb8967a671cd9dd357955f46c3825ccf1e4a3b542dcc4ae19a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08786a771c7d95deefd7e8dea790e7e14fbf337c2fff980778005a9fb7a0050c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a397257a1b5fc428cc663bf266b3feccbe94198d5ebe93bc168022d64dbf4fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:899f4f96d68160c167c1b59f8b3e0dd4e4586864c312e4377fc1a5cc58a054ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a028d16393155c75d89016ddc1d5fa3b9c05ad3c6393aa6366a4ea330431532d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cfca5594ac4866140e0faf0406a12d664be1b394211b53f320d40a5c508fe3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d514b1df4f58c8c23e7a386dc8edcf616339a0b2ee84aad2203c034c2cb439d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23cc660bf40b82d9c1739412d9cdcaebb70da60ae2d05cf2a9fbea088f22cdd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70f255fc22530dc6213d015700dd237d0173784e616cbc2ffc284e5a2f7b10c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6fb42c4b7617f96e5ef0c7050315d7a7e0a4100cec0cfee39722a8301ebec8e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c77199fb123dc6f9a0ce3f7f10e0f0519f2cbf5d5439e76d13df1837cd349934",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c7c429d157a9e803c56ac9b28bf74ae8908fc0d33515c9729ed51509a696026",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d995b70b266834c71640b61a57f4a83c011035cebea52813d9faca21e9bda52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d748ab15ed2bf7f64489dd6c0819ce7f5419af488322703553b2318c542c78fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cce2c735fd092558a5d050708e93200768f523bc36a4071a6c2857c6bad23f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30bb23da61ac270b3a011384f2e87a41d7a31e1808b21e6ca7caa60491c9c630",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d3c82560ae7297807cfdfea6f9ecc02d797abe59fe46fdcf1397beed1428bb6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d13861af07abf6fdd3dd5a14ca8b6f161e655dc26081f1f9227500fdc8da1db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30b93c6d5187de68b694cf045120008d2883808620ef5ef41c7660ca96bd7e9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:332620da4762df8391c487dc3ddc16c89247655dd67beefe3f0db9cfa0e74b9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c37464437e66777e8643400078416cb1a3a490c4b65caa332f276693740335c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b555fdd0f94fcf4be7cd6463383695c498ebea961d1be4889b53cce335be024",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e21aee15d4e4e3396e17cb3534cf1bcb62beb0407601a3ecf604f93f1c990212",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f1b592212480b44e3b3417ec3bc789147086ca9d9986caf32b7f0e08ae4c98b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f23f832520473dbcdc9c0aa08e66c0f6b2916e38c8c302779865f56ccd9c8bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7c2c88ccdce73b2fc7f603f4aefabacbbc3492465c1ee8e7b8762fdfcea3e09",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48759a05ad2b8718c1ad803f5e78d99f285400827c575c63c3e92b7e8d3426b8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:035efd371a5a69a7ea1c833af1bdcf74e7f70b6ba36f961f37bddcc9732e0bee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d86ab10e70b5bcdfa8f437196fe10a8a5256cb16b941162e329c5d2eabffd70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:075b89e5b1b132eacb4e6057d00764c9ee342b95d926d819c0e711d2c3ee8ac3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e6402679ebbb705a4cb74a238d34fdfd62c395a8b3d28fc0faafc27e6f4a73f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c4a0eafc33b320af3e6c370d1e9d3506f92b02607ef2ec773c602ba504da00a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55085d771e68ac6ed4be095c5cce52bf39f49d0c65bdfdc92d6a0fe2493c99a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76842198d98983f83241be2ae73b24efd580ee0af7d0a5a301dd02a7c417c801",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb149c8897d2e78727e2dac441bcc05e064e045edb73705af0a0c57a5d17fe4e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae15191393ec4f56460271f47e1cc2ac7bc847ccb03eaf0035175d1c28c219a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66ec27d6c6b52dcd456accf412d14db29ca5cf976194b721407a9f5feedc1dc8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94021f69bdd5e8be4b186081e6b5748a27b37e8d7762ca6b8973bc0f1ab8b16c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cbe77f12e6654fc4dbc36420957d900b53646200f9512487a14079c0b5f0e7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2b02e6ee909472aeb994d0040e1255ffd6c45150c32d9b084609d928caada61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5533e1ed4ca3afeb2e5285a235a1e800af97eff5807afcdb8b9607c112cdd58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84484e17ea1ba68a3e5c7843376ab63cde44a35546a38d00f8377a435d83f102",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7090f335d0d210b20ec4b8ac8adb1b801c51eea363d52d3b48f821512e38500",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:901a4d6e3875a08f48665f5ddb9d169d75639f85d93e1a877a155c026eaceada",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:477375a543c97c8228c8d6cc495c187a84368530b1c890d8371251a7bca0bfea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab0f16df1b636974ea7f885df471ee7987843909e2b380ec5e51c1496935ee96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc9e1d57af84ad965d533c76162c1d31808b96705a085e679e061f1385acb70e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1f32a25e39bb63ecb720a9c410f24fa7c9d0898de5e3b08a5fbe0527852cfd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": false,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "user2": {
+                  "uid": 1020,
+                  "gid": 1050,
+                  "groups": [
+                    "group1"
+                  ],
+                  "description": "description 2",
+                  "home": "/home/home2",
+                  "shell": "/bin/sh",
+                  "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                },
+                "user3": {
+                  "uid": 1060,
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.groups",
+            "options": {
+              "groups": {
+                "group1": {
+                  "gid": 1030
+                },
+                "group2": {
+                  "gid": 1050
+                },
+                "user3": {
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/etc/systemd/system/custom.service.d",
+                  "exist_ok": true
+                },
+                {
+                  "path": "/etc/custom_dir"
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "mode": "0770"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "user": 1020,
+                  "group": 1050
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                  }
+                ]
+              },
+              "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                  }
+                ]
+              },
+              "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                  }
+                ]
+              },
+              "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  }
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                  "to": "tree:///etc/systemd/system/custom.service",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                  "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                  "to": "tree:///etc/custom_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                  "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "mode": "0644"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "user": "root",
+                  "group": "root"
+                },
+                "/etc/empty_file.txt": {
+                  "user": 0,
+                  "group": 0
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.systemd",
+            "options": {
+              "enabled_services": [
+                "custom.service"
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 5263327,
+                  "start": 3125248,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263327,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263327
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "xz",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.xz",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "image.raw.xz"
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:00cda4f023ab0f5d5b64f29cc36325e2b1395bf5c23547c515140051d50df1cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:035efd371a5a69a7ea1c833af1bdcf74e7f70b6ba36f961f37bddcc9732e0bee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.x86_64.rpm"
+          },
+          "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:075b89e5b1b132eacb4e6057d00764c9ee342b95d926d819c0e711d2c3ee8ac3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.x86_64.rpm"
+          },
+          "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:08786a771c7d95deefd7e8dea790e7e14fbf337c2fff980778005a9fb7a0050c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.x86_64.rpm"
+          },
+          "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.x86_64.rpm"
+          },
+          "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.x86_64.rpm"
+          },
+          "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efi-filesystem-5-5.fc36.noarch.rpm"
+          },
+          "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:0cbe77f12e6654fc4dbc36420957d900b53646200f9512487a14079c0b5f0e7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/netavark-1.0.3-3.fc36.x86_64.rpm"
+          },
+          "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm"
+          },
+          "sha256:0e6402679ebbb705a4cb74a238d34fdfd62c395a8b3d28fc0faafc27e6f4a73f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.x86_64.rpm"
+          },
+          "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:0f1b592212480b44e3b3417ec3bc789147086ca9d9986caf32b7f0e08ae4c98b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/criu-3.17-4.fc36.x86_64.rpm"
+          },
+          "sha256:0f23f832520473dbcdc9c0aa08e66c0f6b2916e38c8c302779865f56ccd9c8bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/criu-libs-3.17-4.fc36.x86_64.rpm"
+          },
+          "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm"
+          },
+          "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.x86_64.rpm"
+          },
+          "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.x86_64.rpm"
+          },
+          "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.x86_64.rpm"
+          },
+          "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:1cce2c735fd092558a5d050708e93200768f523bc36a4071a6c2857c6bad23f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm"
+          },
+          "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:1f4f8b80a39f4cde1a15072097cba266333cc1a840f494c7f33affbcc0f66f49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm"
+          },
+          "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.x86_64.rpm"
+          },
+          "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.x86_64.rpm"
+          },
+          "sha256:23cc660bf40b82d9c1739412d9cdcaebb70da60ae2d05cf2a9fbea088f22cdd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm"
+          },
+          "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.x86_64.rpm"
+          },
+          "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm"
+          },
+          "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:28b98634695e2f0a9f5f616b84ecb21d2726f1b360ca16ba8f48aceda4a8e0fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm"
+          },
+          "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.x86_64.rpm"
+          },
+          "sha256:2d13861af07abf6fdd3dd5a14ca8b6f161e655dc26081f1f9227500fdc8da1db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/t/tar-1.34-3.fc36.x86_64.rpm"
+          },
+          "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm"
+          },
+          "sha256:30b93c6d5187de68b694cf045120008d2883808620ef5ef41c7660ca96bd7e9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/w/which-2.21-32.fc36.x86_64.rpm"
+          },
+          "sha256:30bb23da61ac270b3a011384f2e87a41d7a31e1808b21e6ca7caa60491c9c630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.x86_64.rpm"
+          },
+          "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:332620da4762df8391c487dc3ddc16c89247655dd67beefe3f0db9cfa0e74b9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/y/yajl-2.1.0-18.fc36.x86_64.rpm"
+          },
+          "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.x86_64.rpm"
+          },
+          "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.x86_64.rpm"
+          },
+          "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.x86_64.rpm"
+          },
+          "sha256:3d86ab10e70b5bcdfa8f437196fe10a8a5256cb16b941162e329c5d2eabffd70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.x86_64.rpm"
+          },
+          "sha256:3e9aa89d498f2e5b6c5e065d0cca55e51b24599bb518993d26ebcb74ed854b33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse3-3.10.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.x86_64.rpm"
+          },
+          "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.x86_64.rpm"
+          },
+          "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm"
+          },
+          "sha256:4538200e6752e1cc8844a50115193d736ee06d4fb6096c51bd925d1a2bd9bd8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.x86_64.rpm"
+          },
+          "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.x86_64.rpm"
+          },
+          "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm"
+          },
+          "sha256:477375a543c97c8228c8d6cc495c187a84368530b1c890d8371251a7bca0bfea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/rpm-ostree-2022.10-3.fc36.x86_64.rpm"
+          },
+          "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:48759a05ad2b8718c1ad803f5e78d99f285400827c575c63c3e92b7e8d3426b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fuse-overlayfs-1.9-1.fc36.x86_64.rpm"
+          },
+          "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-5.41-4.fc36.x86_64.rpm"
+          },
+          "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.x86_64.rpm"
+          },
+          "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.x86_64.rpm"
+          },
+          "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.x86_64.rpm"
+          },
+          "sha256:4aef4b7bd425f1118403818bf469878b1ba2881d21385074bec813d1ba3f3fb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:4cfca5594ac4866140e0faf0406a12d664be1b394211b53f320d40a5c508fe3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libslirp-4.6.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:4d3c82560ae7297807cfdfea6f9ecc02d797abe59fe46fdcf1397beed1428bb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/slirp4netns-1.2.0-0.2.beta.0.fc36.x86_64.rpm"
+          },
+          "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.x86_64.rpm"
+          },
+          "sha256:55085d771e68ac6ed4be095c5cce52bf39f49d0c65bdfdc92d6a0fe2493c99a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:55b9b9595efb83f4f6638c47125817cabb3b486ecbc786d4ce2b014e8a81cca9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.x86_64.rpm"
+          },
+          "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.x86_64.rpm"
+          },
+          "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.x86_64.rpm"
+          },
+          "sha256:5b555fdd0f94fcf4be7cd6463383695c498ebea961d1be4889b53cce335be024": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/container-selinux-2.188.0-1.fc36.noarch.rpm"
+          },
+          "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.x86_64.rpm"
+          },
+          "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm"
+          },
+          "sha256:5c4a0eafc33b320af3e6c370d1e9d3506f92b02607ef2ec773c602ba504da00a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-efi-x64-2.06-42.fc36.x86_64.rpm"
+          },
+          "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.x86_64.rpm"
+          },
+          "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-056-1.fc36.x86_64.rpm"
+          },
+          "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.x86_64.rpm"
+          },
+          "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:6218b686e396a0eec312f93e7d1418e00b7a32ae95926fb7d7835f44e72f8526": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.x86_64.rpm"
+          },
+          "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm"
+          },
+          "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.x86_64.rpm"
+          },
+          "sha256:66ec27d6c6b52dcd456accf412d14db29ca5cf976194b721407a9f5feedc1dc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mokutil-0.6.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm"
+          },
+          "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.x86_64.rpm"
+          },
+          "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.x86_64.rpm"
+          },
+          "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.x86_64.rpm"
+          },
+          "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.x86_64.rpm"
+          },
+          "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.x86_64.rpm"
+          },
+          "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm"
+          },
+          "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm"
+          },
+          "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:6c7c429d157a9e803c56ac9b28bf74ae8908fc0d33515c9729ed51509a696026": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm"
+          },
+          "sha256:6fb42c4b7617f96e5ef0c7050315d7a7e0a4100cec0cfee39722a8301ebec8e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/npth-1.6-8.fc36.x86_64.rpm"
+          },
+          "sha256:70f255fc22530dc6213d015700dd237d0173784e616cbc2ffc284e5a2f7b10c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm"
+          },
+          "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/popt-1.18-7.fc36.x86_64.rpm"
+          },
+          "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:76842198d98983f83241be2ae73b24efd580ee0af7d0a5a301dd02a7c417c801": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.x86_64.rpm"
+          },
+          "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:7d995b70b266834c71640b61a57f4a83c011035cebea52813d9faca21e9bda52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.x86_64.rpm"
+          },
+          "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:84484e17ea1ba68a3e5c7843376ab63cde44a35546a38d00f8377a435d83f102": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/ostree-libs-2022.4-2.fc36.x86_64.rpm"
+          },
+          "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm"
+          },
+          "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:899f4f96d68160c167c1b59f8b3e0dd4e4586864c312e4377fc1a5cc58a054ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:8a397257a1b5fc428cc663bf266b3feccbe94198d5ebe93bc168022d64dbf4fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:8a954624b2af4942322be233d78bac6156e71dd20a5386710cc1359b4df6c673": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnet-1.2-5.fc36.x86_64.rpm"
+          },
+          "sha256:8b4a9e98cb73582362e6e70390c1c643b26f50c289ea0acbc74b5bb75d85e23b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.x86_64.rpm"
+          },
+          "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:901a4d6e3875a08f48665f5ddb9d169d75639f85d93e1a877a155c026eaceada": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.x86_64.rpm"
+          },
+          "sha256:94021f69bdd5e8be4b186081e6b5748a27b37e8d7762ca6b8973bc0f1ab8b16c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.x86_64.rpm"
+          },
+          "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.x86_64.rpm"
+          },
+          "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm"
+          },
+          "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm"
+          },
+          "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-29-7.fc36.x86_64.rpm"
+          },
+          "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:991f6fd822110685e42f499f3059cc5abab2beeff405fc24c74f9e89c41088b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:995d03ccc92a1c35fc0e25a7f7ba3f4bde6bac5068220a0e2722f377dfaf26a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.x86_64.rpm"
+          },
+          "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.x86_64.rpm"
+          },
+          "sha256:a028d16393155c75d89016ddc1d5fa3b9c05ad3c6393aa6366a4ea330431532d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.x86_64.rpm"
+          },
+          "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.x86_64.rpm"
+          },
+          "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:a2b02e6ee909472aeb994d0040e1255ffd6c45150c32d9b084609d928caada61": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.x86_64.rpm"
+          },
+          "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm"
+          },
+          "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm"
+          },
+          "sha256:ab0f16df1b636974ea7f885df471ee7987843909e2b380ec5e51c1496935ee96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/rpm-ostree-libs-2022.10-3.fc36.x86_64.rpm"
+          },
+          "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:aca8c7a8350a0c4a167c7bf6a61cfb905dd149afb4cdb63ac0f69523d918ccbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-2.9.9-14.fc36.x86_64.rpm"
+          },
+          "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm"
+          },
+          "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.x86_64.rpm"
+          },
+          "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:b1f32a25e39bb63ecb720a9c410f24fa7c9d0898de5e3b08a5fbe0527852cfd9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/skopeo-1.8.0-8.fc36.x86_64.rpm"
+          },
+          "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.x86_64.rpm"
+          },
+          "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:bc3339d24b5e60cb8967a671cd9dd357955f46c3825ccf1e4a3b542dcc4ae19a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.x86_64.rpm"
+          },
+          "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm"
+          },
+          "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.x86_64.rpm"
+          },
+          "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.x86_64.rpm"
+          },
+          "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.x86_64.rpm"
+          },
+          "sha256:c37464437e66777e8643400078416cb1a3a490c4b65caa332f276693740335c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/aardvark-dns-1.0.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grep-3.7-2.fc36.x86_64.rpm"
+          },
+          "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.x86_64.rpm"
+          },
+          "sha256:c77199fb123dc6f9a0ce3f7f10e0f0519f2cbf5d5439e76d13df1837cd349934": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm"
+          },
+          "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.x86_64.rpm"
+          },
+          "sha256:c8a95c8441067e37fdfc67d0aacd42106d0a867856920c6b68b82b11a7b451a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-common-3.10.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm"
+          },
+          "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.x86_64.rpm"
+          },
+          "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.x86_64.rpm"
+          },
+          "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.x86_64.rpm"
+          },
+          "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:d421f90fe86af10fae33ff65f1eecd8ac24ee2b5f6292cbfcc9de292ad9f64b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse3-libs-3.10.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm"
+          },
+          "sha256:d4cf97f8df32e57949d6cd29c95da335bc3f1b8bbe8d5f73dfb327e64fd500e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:d514b1df4f58c8c23e7a386dc8edcf616339a0b2ee84aad2203c034c2cb439d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.x86_64.rpm"
+          },
+          "sha256:d5533e1ed4ca3afeb2e5285a235a1e800af97eff5807afcdb8b9607c112cdd58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/ostree-2022.4-2.fc36.x86_64.rpm"
+          },
+          "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:d6e85834503eae1bf62340e8d24b208faabbf632151425675dc4075a27e112f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efibootmgr-16-12.fc36.x86_64.rpm"
+          },
+          "sha256:d748ab15ed2bf7f64489dd6c0819ce7f5419af488322703553b2318c542c78fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.x86_64.rpm"
+          },
+          "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sed-4.8-10.fc36.x86_64.rpm"
+          },
+          "sha256:dae15191393ec4f56460271f47e1cc2ac7bc847ccb03eaf0035175d1c28c219a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.x86_64.rpm"
+          },
+          "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-compat-4.4.28-1.fc36.x86_64.rpm"
+          },
+          "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.x86_64.rpm"
+          },
+          "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/readline-8.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm"
+          },
+          "sha256:dffa57881ede2980c3384f2d8890b60169581414031b25253f9bf032ae7ed48e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.x86_64.rpm"
+          },
+          "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:e21aee15d4e4e3396e17cb3534cf1bcb62beb0407601a3ecf604f93f1c990212": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/containers-common-1-56.fc36.noarch.rpm"
+          },
+          "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm"
+          },
+          "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm"
+          },
+          "sha256:e7090f335d0d210b20ec4b8ac8adb1b801c51eea363d52d3b48f821512e38500": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:e7c2c88ccdce73b2fc7f603f4aefabacbbc3492465c1ee8e7b8762fdfcea3e09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crun-1.4.5-1.fc36.x86_64.rpm"
+          },
+          "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.x86_64.rpm"
+          },
+          "sha256:eaf42f29c0f991a0059fcaa41c79b1ebff0c243c5b8f398bfba2aab2b5c89cf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.x86_64.rpm"
+          },
+          "sha256:eb149c8897d2e78727e2dac441bcc05e064e045edb73705af0a0c57a5d17fe4e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.x86_64.rpm"
+          },
+          "sha256:ed95c9f74b17649179c36919f3f195a9ff2358cadf7c840dec789b39f27ba58e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbsd-0.10.0-9.fc36.x86_64.rpm"
+          },
+          "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.x86_64.rpm"
+          },
+          "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.x86_64.rpm"
+          },
+          "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.x86_64.rpm"
+          },
+          "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm"
+          },
+          "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.x86_64.rpm"
+          },
+          "sha256:fc9e1d57af84ad965d533c76162c1d31808b96705a085e679e061f1385acb70e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/shim-x64-15.6-1.x86_64.rpm"
+          }
+        }
+      },
+      "org.osbuild.inline": {
+        "items": {
+          "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+            "encoding": "base64",
+            "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+          },
+          "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+            "encoding": "base64",
+            "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+          },
+          "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+            "encoding": "base64",
+            "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+          },
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+            "encoding": "base64",
+            "data": ""
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.x86_64.rpm",
+        "checksum": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:28b98634695e2f0a9f5f616b84ecb21d2726f1b360ca16ba8f48aceda4a8e0fa",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm",
+        "checksum": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.x86_64.rpm",
+        "checksum": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.x86_64.rpm",
+        "checksum": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
+        "checksum": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:55b9b9595efb83f4f6638c47125817cabb3b486ecbc786d4ce2b014e8a81cca9",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "5.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efi-filesystem-5-5.fc36.noarch.rpm",
+        "checksum": "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efibootmgr-16-12.fc36.x86_64.rpm",
+        "checksum": "sha256:d6e85834503eae1bf62340e8d24b208faabbf632151425675dc4075a27e112f1",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.x86_64.rpm",
+        "checksum": "sha256:eaf42f29c0f991a0059fcaa41c79b1ebff0c243c5b8f398bfba2aab2b5c89cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-2.9.9-14.fc36.x86_64.rpm",
+        "checksum": "sha256:aca8c7a8350a0c4a167c7bf6a61cfb905dd149afb4cdb63ac0f69523d918ccbf",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-common-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c8a95c8441067e37fdfc67d0aacd42106d0a867856920c6b68b82b11a7b451a3",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.x86_64.rpm",
+        "checksum": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse3-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:3e9aa89d498f2e5b6c5e065d0cca55e51b24599bb518993d26ebcb74ed854b33",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse3-libs-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:d421f90fe86af10fae33ff65f1eecd8ac24ee2b5f6292cbfcc9de292ad9f64b5",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.x86_64.rpm",
+        "checksum": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:d4cf97f8df32e57949d6cd29c95da335bc3f1b8bbe8d5f73dfb327e64fd500e7",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grep-3.7-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.x86_64.rpm",
+        "checksum": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.x86_64.rpm",
+        "checksum": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.x86_64.rpm",
+        "checksum": "sha256:6218b686e396a0eec312f93e7d1418e00b7a32ae95926fb7d7835f44e72f8526",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:4aef4b7bd425f1118403818bf469878b1ba2881d21385074bec813d1ba3f3fb9",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4538200e6752e1cc8844a50115193d736ee06d4fb6096c51bd925d1a2bd9bd8d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.x86_64.rpm",
+        "checksum": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm",
+        "checksum": "sha256:1f4f8b80a39f4cde1a15072097cba266333cc1a840f494c7f33affbcc0f66f49",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.x86_64.rpm",
+        "checksum": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+        "check_gpg": true
+      },
+      {
+        "name": "libbsd",
+        "epoch": 0,
+        "version": "0.10.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbsd-0.10.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:ed95c9f74b17649179c36919f3f195a9ff2358cadf7c840dec789b39f27ba58e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.x86_64.rpm",
+        "checksum": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.x86_64.rpm",
+        "checksum": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "41.20210910cvs.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.x86_64.rpm",
+        "checksum": "sha256:dffa57881ede2980c3384f2d8890b60169581414031b25253f9bf032ae7ed48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.x86_64.rpm",
+        "checksum": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.x86_64.rpm",
+        "checksum": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "39.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:8b4a9e98cb73582362e6e70390c1c643b26f50c289ea0acbc74b5bb75d85e23b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.x86_64.rpm",
+        "checksum": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:991f6fd822110685e42f499f3059cc5abab2beeff405fc24c74f9e89c41088b5",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.x86_64.rpm",
+        "checksum": "sha256:995d03ccc92a1c35fc0e25a7f7ba3f4bde6bac5068220a0e2722f377dfaf26a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:00cda4f023ab0f5d5b64f29cc36325e2b1395bf5c23547c515140051d50df1cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libnet",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnet-1.2-5.fc36.x86_64.rpm",
+        "checksum": "sha256:8a954624b2af4942322be233d78bac6156e71dd20a5386710cc1359b4df6c673",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bc3339d24b5e60cb8967a671cd9dd357955f46c3825ccf1e4a3b542dcc4ae19a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "21.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.x86_64.rpm",
+        "checksum": "sha256:08786a771c7d95deefd7e8dea790e7e14fbf337c2fff980778005a9fb7a0050c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8a397257a1b5fc428cc663bf266b3feccbe94198d5ebe93bc168022d64dbf4fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:899f4f96d68160c167c1b59f8b3e0dd4e4586864c312e4377fc1a5cc58a054ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.x86_64.rpm",
+        "checksum": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.x86_64.rpm",
+        "checksum": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a028d16393155c75d89016ddc1d5fa3b9c05ad3c6393aa6366a4ea330431532d",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.x86_64.rpm",
+        "checksum": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libslirp",
+        "epoch": 0,
+        "version": "4.6.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libslirp-4.6.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:4cfca5594ac4866140e0faf0406a12d664be1b394211b53f320d40a5c508fe3a",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm",
+        "checksum": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.x86_64.rpm",
+        "checksum": "sha256:d514b1df4f58c8c23e7a386dc8edcf616339a0b2ee84aad2203c034c2cb439d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-compat-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm",
+        "checksum": "sha256:23cc660bf40b82d9c1739412d9cdcaebb70da60ae2d05cf2a9fbea088f22cdd3",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.x86_64.rpm",
+        "checksum": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.x86_64.rpm",
+        "checksum": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:70f255fc22530dc6213d015700dd237d0173784e616cbc2ffc284e5a2f7b10c9",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/npth-1.6-8.fc36.x86_64.rpm",
+        "checksum": "sha256:6fb42c4b7617f96e5ef0c7050315d7a7e0a4100cec0cfee39722a8301ebec8e3",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.x86_64.rpm",
+        "checksum": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c77199fb123dc6f9a0ce3f7f10e0f0519f2cbf5d5439e76d13df1837cd349934",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6c7c429d157a9e803c56ac9b28bf74ae8908fc0d33515c9729ed51509a696026",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.x86_64.rpm",
+        "checksum": "sha256:7d995b70b266834c71640b61a57f4a83c011035cebea52813d9faca21e9bda52",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.x86_64.rpm",
+        "checksum": "sha256:d748ab15ed2bf7f64489dd6c0819ce7f5419af488322703553b2318c542c78fe",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "21.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm",
+        "checksum": "sha256:1cce2c735fd092558a5d050708e93200768f523bc36a4071a6c2857c6bad23f8",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/popt-1.18-7.fc36.x86_64.rpm",
+        "checksum": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:30bb23da61ac270b3a011384f2e87a41d7a31e1808b21e6ca7caa60491c9c630",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/readline-8.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sed-4.8-10.fc36.x86_64.rpm",
+        "checksum": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+        "check_gpg": true
+      },
+      {
+        "name": "slirp4netns",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "0.2.beta.0.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/slirp4netns-1.2.0-0.2.beta.0.fc36.x86_64.rpm",
+        "checksum": "sha256:4d3c82560ae7297807cfdfea6f9ecc02d797abe59fe46fdcf1397beed1428bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/t/tar-1.34-3.fc36.x86_64.rpm",
+        "checksum": "sha256:2d13861af07abf6fdd3dd5a14ca8b6f161e655dc26081f1f9227500fdc8da1db",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "32.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/w/which-2.21-32.fc36.x86_64.rpm",
+        "checksum": "sha256:30b93c6d5187de68b694cf045120008d2883808620ef5ef41c7660ca96bd7e9c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+        "check_gpg": true
+      },
+      {
+        "name": "yajl",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "18.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/y/yajl-2.1.0-18.fc36.x86_64.rpm",
+        "checksum": "sha256:332620da4762df8391c487dc3ddc16c89247655dd67beefe3f0db9cfa0e74b9d",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.x86_64.rpm",
+        "checksum": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+        "check_gpg": true
+      },
+      {
+        "name": "aardvark-dns",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/aardvark-dns-1.0.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c37464437e66777e8643400078416cb1a3a490c4b65caa332f276693740335c0",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.188.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/container-selinux-2.188.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:5b555fdd0f94fcf4be7cd6463383695c498ebea961d1be4889b53cce335be024",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "56.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/containers-common-1-56.fc36.noarch.rpm",
+        "checksum": "sha256:e21aee15d4e4e3396e17cb3534cf1bcb62beb0407601a3ecf604f93f1c990212",
+        "check_gpg": true
+      },
+      {
+        "name": "criu",
+        "epoch": 0,
+        "version": "3.17",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/criu-3.17-4.fc36.x86_64.rpm",
+        "checksum": "sha256:0f1b592212480b44e3b3417ec3bc789147086ca9d9986caf32b7f0e08ae4c98b",
+        "check_gpg": true
+      },
+      {
+        "name": "criu-libs",
+        "epoch": 0,
+        "version": "3.17",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/criu-libs-3.17-4.fc36.x86_64.rpm",
+        "checksum": "sha256:0f23f832520473dbcdc9c0aa08e66c0f6b2916e38c8c302779865f56ccd9c8bc",
+        "check_gpg": true
+      },
+      {
+        "name": "crun",
+        "epoch": 0,
+        "version": "1.4.5",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crun-1.4.5-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e7c2c88ccdce73b2fc7f603f4aefabacbbc3492465c1ee8e7b8762fdfcea3e09",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fuse-overlayfs-1.9-1.fc36.x86_64.rpm",
+        "checksum": "sha256:48759a05ad2b8718c1ad803f5e78d99f285400827c575c63c3e92b7e8d3426b8",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.72.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:035efd371a5a69a7ea1c833af1bdcf74e7f70b6ba36f961f37bddcc9732e0bee",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.x86_64.rpm",
+        "checksum": "sha256:3d86ab10e70b5bcdfa8f437196fe10a8a5256cb16b941162e329c5d2eabffd70",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.x86_64.rpm",
+        "checksum": "sha256:075b89e5b1b132eacb4e6057d00764c9ee342b95d926d819c0e711d2c3ee8ac3",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.6",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0e6402679ebbb705a4cb74a238d34fdfd62c395a8b3d28fc0faafc27e6f4a73f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-efi-x64-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:5c4a0eafc33b320af3e6c370d1e9d3506f92b02607ef2ec773c602ba504da00a",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.x86_64.rpm",
+        "checksum": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.x86_64.rpm",
+        "checksum": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "69.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:55085d771e68ac6ed4be095c5cce52bf39f49d0c65bdfdc92d6a0fe2493c99a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.6.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:76842198d98983f83241be2ae73b24efd580ee0af7d0a5a301dd02a7c417c801",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:eb149c8897d2e78727e2dac441bcc05e064e045edb73705af0a0c57a5d17fe4e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.x86_64.rpm",
+        "checksum": "sha256:dae15191393ec4f56460271f47e1cc2ac7bc847ccb03eaf0035175d1c28c219a",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.x86_64.rpm",
+        "checksum": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mokutil-0.6.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:66ec27d6c6b52dcd456accf412d14db29ca5cf976194b721407a9f5feedc1dc8",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs91",
+        "epoch": 0,
+        "version": "91.11.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:94021f69bdd5e8be4b186081e6b5748a27b37e8d7762ca6b8973bc0f1ab8b16c",
+        "check_gpg": true
+      },
+      {
+        "name": "netavark",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/netavark-1.0.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0cbe77f12e6654fc4dbc36420957d900b53646200f9512487a14079c0b5f0e7d",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a2b02e6ee909472aeb994d0040e1255ffd6c45150c32d9b084609d928caada61",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2022.4",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/ostree-2022.4-2.fc36.x86_64.rpm",
+        "checksum": "sha256:d5533e1ed4ca3afeb2e5285a235a1e800af97eff5807afcdb8b9607c112cdd58",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2022.4",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/ostree-libs-2022.4-2.fc36.x86_64.rpm",
+        "checksum": "sha256:84484e17ea1ba68a3e5c7843376ab63cde44a35546a38d00f8377a435d83f102",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e7090f335d0d210b20ec4b8ac8adb1b801c51eea363d52d3b48f821512e38500",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:901a4d6e3875a08f48665f5ddb9d169d75639f85d93e1a877a155c026eaceada",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2022.10",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/rpm-ostree-2022.10-3.fc36.x86_64.rpm",
+        "checksum": "sha256:477375a543c97c8228c8d6cc495c187a84368530b1c890d8371251a7bca0bfea",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2022.10",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/r/rpm-ostree-libs-2022.10-3.fc36.x86_64.rpm",
+        "checksum": "sha256:ab0f16df1b636974ea7f885df471ee7987843909e2b380ec5e51c1496935ee96",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/shim-x64-15.6-1.x86_64.rpm",
+        "checksum": "sha256:fc9e1d57af84ad965d533c76162c1d31808b96705a085e679e061f1385acb70e",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.8.0",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/skopeo-1.8.0-8.fc36.x86_64.rpm",
+        "checksum": "sha256:b1f32a25e39bb63ecb720a9c410f24fa7c9d0898de5e3b08a5fbe0527852cfd9",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_37-aarch64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_raw_image_customizations-boot.json
@@ -1,0 +1,6269 @@
+{
+  "compose-request": {
+    "distro": "fedora-37",
+    "arch": "aarch64",
+    "image-type": "iot-raw-image",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-modular-development-20221025/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "image.raw.xz",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {
+      "customizations": {
+        "user": [
+          {
+            "name": "user2",
+            "description": "description 2",
+            "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+            "home": "/home/home2",
+            "shell": "/bin/sh",
+            "groups": [
+              "group1"
+            ],
+            "uid": 1020,
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "uid": 1060,
+            "gid": 1060
+          }
+        ],
+        "group": [
+          {
+            "name": "group1",
+            "gid": 1030
+          },
+          {
+            "name": "group2",
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "gid": 1060
+          }
+        ],
+        "services": {
+          "enabled": [
+            "custom.service"
+          ]
+        },
+        "directories": [
+          {
+            "path": "/etc/systemd/system/custom.service.d"
+          },
+          {
+            "path": "/etc/custom_dir",
+            "user": 1020,
+            "group": 1050,
+            "mode": "0770"
+          }
+        ],
+        "files": [
+          {
+            "path": "/etc/systemd/system/custom.service",
+            "data": "[Unit]\nDescription=Custom service\n\n[Service]\nExecStart=/usr/bin/false\n\n[Install]\nWantedBy=multi-user.target\n"
+          },
+          {
+            "path": "/etc/systemd/system/custom.service.d/override.conf",
+            "data": "[Service]\nExecStart=\nExecStart=/usr/bin/cat /etc/custom_file.txt\n"
+          },
+          {
+            "path": "/etc/custom_file.txt",
+            "user": "root",
+            "group": "root",
+            "mode": "0644",
+            "data": "image builder is the best"
+          },
+          {
+            "path": "/etc/empty_file.txt",
+            "user": 0,
+            "group": 0
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora37",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:c9a351964d88b8f4162b8349c7ef8c5aae3e56b53f2f9f4acc081c1d998bbb39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:539903a5db9dac34cd633a95db47af0c932118567e759108ec8b05f91992857f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3f64a9b092e5c9b829b955a2a63532462facd0cc967131211f0a90a6ed5453f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178c233d007c00f14ec0c0a5083907f3cf2889b998c8e7eefe25c8b04ebe1aef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e2ac5ec02616313b2c7a6d6ba73d860c4cc2380c2a7aa6336b3ed89c67c1392",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5676237d61fba60ed5fb483b792111aa397faf464460222438130b0f3bbbe609",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d86fcd8817424d684eaae4eb343eec10e7f793b8aa7284d95d4ec71d517084fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f99f0d1d4983db97df46b35119f2996db34f696b8f7281b197faa5aeb974aae7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9e1d9092c3654b4640e115afa1194edd2f4025ece6346c17eff15f127b57f01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1050a9675979c8ea71d673034094281225dfb6252814a6a4b959cc89a3fa467a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d57265c3bb44d183f7f619d7bf92f375bcbbc30e242d6df66e2533e5e9f84f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f83d5f59d9e289df361e2d46bf18143245b1324f3e2fb71b91ff7740a897a215",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f36d86571603115d5f8734021e8ccc61fd390f5ffef47fad572260b249c8757",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ddf983f0ceac0b053c17591225968b9dd9d31f1360564c7052d44b5e4551756",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:387b624bc5d55299367ac374ad3356e148eeb8c9163f8a64181571a54325dd2f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ad7f1bfee28c80f9d4282aa9f0e5d8fada533111fc03fd9c33e988766c6c380",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5547ad7034b539388be34c3c44c054fb7d99a98a372733283305a023387670a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea7104bffcc6792553e51c8bb8898c4c8649eb76055dd56e58d558e33d6a78ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04d878eeb31722ad495b34edd6bacafeffd5d13d39dfea5edff49daee5f28c58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4716da965a3141394efc6cfca127880bbab451c7cb285bfc48d1911d8402164",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:171856671d92ec11433940b504eb84f496f3132921b020dbb66172a5c7e1b138",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3bdc032c960668daf5ba86e7d695924879a21e939aee174858b5cbe2f4f0d3f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:130fca628d199df219a2c49dac899bd881abe73839e839e78d0e6754fe3336bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c83fc74498fb51302e56cf23f60712493d3003a25c44cb19b60aca5b1a683705",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59d84b98e1a0066e0cfc7ddb4f2559ded9803f7fef0c8b52d1ad0693b8f4dbae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51f204b5187519266c3496cc970150cb41fd23f07ff58c3ee6d8b44a319fb455",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76df070766b1d7460c3edf04cb404046a9b999e68dde6598c090140995a49dde",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f40c72435d400e98d507c95a1e4993d70ed5a80556a7436bc8c51c82fa92f2b8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c50aa26df3d6c070897a3349eb72f47d144a79bc387a38ecbdc63063e85af03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:590e97157cab0fe9f4e3661594cd2ab06d8b2af744fb11077fdaf3a1a8eb2ad9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e983c066245eb18c7209a3165fe9335efe0ef74dba849a47e1c1332dcf4c320",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47af1946fbfaa768f34e4d7818286123d1ea8679140479fa1b3c1d6f62560983",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:185ffaca4bf6de8e14842027e4c2258409619b16b7d05d2a5df1100d187024dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f12b98bc656a67fc7b378870598993e010e4df843fb998f7a439a0a14bc391ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:266dbc27e73ef589066244029bbf09de65d11ec1711fc76094694a74512e33c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59d4bbec71e99f25ac89228d5528aa56c2eeff0a2e8e83d405d3e378955cbae9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f27c1dea30a1eaeeaf6e69f30d30e0097aabf4f3a99413c3c4a47f90fcfa2a18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e410d25f43c86de6f76542b336aa40dd0a1c6d84a8fdbeff9ef2a2379ee4e45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60c9b8479deee53528d17e3ddf0d1dce61ca74036bf5d35038fea901b61f60c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26948aaefdcef47d8f73cae1f4ddede5853ccf6a5d4e2ef5d4a6d921547cef46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be9a015662acc23d54474a01f81a8f321359006b22850edcb41fdddc6f01b1cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c18091220a104278225bea1573077d807d205e2392f693bcb63a70c4387f141",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1c0880f9180fd54c99e2340fc9a0001bc489f5ff3ed8ab405cce9e35707c01b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99bc383fa8558a73027e63ff75f0978e4e2ff6b26be55f384c3f52e5aee97527",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:112978b8c5807ecf490d3559b1d701b48d75ff38dee451e4394584e2adff408c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3133da3cef48ae829fc6853acfa42c12c6dce9f8ebfd0b0318e81d728d90f228",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a19c9814acd3a96a1c6af95220a2e9e72242a2c653a38ef2964b711e509fc84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ccf0d18c15586c0a7ad9e7e69551fa9b997c25970701b5e635a981878c8a9dfe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3db34fee176285b0e73890ac0864c748bb091c256df197f885b31455dbb041f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f53bd8e9f409439671de3762d5cf348fbffd7d97885c5de3953964fd7a148ea1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dd5dd23c799bcec2ddccba07a99aff77a244c3a85717a307592ca6d3bc5f202",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0e859a97a8167af62e273093e454a01bfd64b9ff60897bc97711f3591970106",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88b28b9729a393374ffbce10301fc1829133dba58487caa525aaebc8fa070f56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9d09656e98dd744599be50d553e059d5b3c5236b617c5d05de9f0b2f505ff86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e40045d6d88a1a5bedeaf60f1391cad60bce787dda76fc5ad297fe3c98bf168",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4718a79261fa3420e90a53b57cc5d25ef92e11e6ff30d089cce717114fce679c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0608af59c99a96c3a1fd93ee4796779536299e6abb0a944a7448dc0ba939b875",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ef2400ff36fe50c2c2c33d503de10333c5b2be498791694b96d52a05949589d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:add56e5fb7330c434a8f6e2fcccf6bf817ae396b9c3c419e2b3c5eb2046b6812",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c71a3884722bdeeccbbcef5d9fcffa4c265d6486acb0f164d70c682bd91e1fdc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ccf5a8e68247b63ac2f4cc27db3d0d3eba7a93570e2a00125d327ac2606d8c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f55ce59e067b48e1148a5e40b09c7223804540bf1593fb3bcb687c252a074c40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e18c452746d0c9be98e298d7282f0f2c3f86fac4b1e78e6d4c9901a0b2f5656",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9176c93af66866fce7b6c0ddc2426bbb88d83d6d091da663ad8c4cb8f8b2615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a78e507d71c85c273d3aa7e0d7f151b342a508fbfe85717cf760ee172ef9d37",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2bd8534e896f251cd58b8cbb0b069fcaa464aa2a84fbd9d8187690f3c979fdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1c8670422ebe5aab49614e5264a61bc90ecc67e8ace5258ac94a04c8d8ecb7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee50ad1b7ba00ffed8c17a1df7b42800c3462a040281afd3500e1f7dd768c75b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45c5b537992ff64548b4ebf9b1e9c0f06fc77e895261e94c5a97e44d0773cc98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e40e9aaada115819d974b933bb33e6600d39fe13a91a9b4d5aa27c4decb06155",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a438727fa3c39124219607fbdb1ac4aa8240b59ba5f3da46adec7eb8b3702b66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:932f1548d9ca07579d56cf1ce527b34786cfebe8e07fc86106ac9d7a803ccfbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b3936a76dfa4094d9133ee6fbb8f0a58d41d54dc81f874bdb9086f06711112d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a96cd1a8ad454befdee1c14e9224dcc35949cce18f197f2f0841e03ac4d6e65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e3fbeb8bd1e999cd741083ef4235c4087988e1c6d75e24b784b2ddf7c5193de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f5d9782065476a664f6e4d450404858e175f75b055f844f8a939623854ef615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a16500df314e37275aaab3de6fff5f4211d65b44fa9c6ee9ba74e718101a10e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0131393ab117eb26be5e55451753229122f6ca97aa5b7872e65c9d691c0059d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af36734e49f06f79fee74fbeafb555b24fd7473d915a580d7fc3f1359d63eb88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dcf4b614ac88e26b9b344e0d6f3da257555f4402742e27abca969b0f439d6211",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4be185da5192918b485b25030b36f3e478bdc4bde19ebed1f80476931233ad30",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2b276a42f94d7982e5e2ef72d59b73b9313ea83792ea9bb35e2e5cb4fa5988d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72906b5aa7cc9f416f704bb0071972ddce6a08d251b1dcdf7253478153e8a20e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6aaae0fb24af1e41f043b5f782f0bd02bc88eb6d8de53c849d628bb03671b6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30f5623220f5e93c167a0765a73a78398c3ea9856924183a8b9ed4ae227c2c15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b9082cd1e6c405c75d7cfe43595b066a80226942da5ddc714b1e6309bcf44e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b1232e992e46c3897eaea57866d1ac655ebeff36448813fc5ddd84cd00da49a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18aac772a8f18c064c422f3c3d3be7a9f4756029f288a5b281e1da816b47f938",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cc7e6a19b5627e3e3bf941d5bef3ded55458eb226ed6e523e9a0d6a836b249f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a08019ab8471eb8e8bb8382acc0b8ea145852369d63293466a4af8ff2221263",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37ccd2182f8ca4f3843cd79dffd129efe19691b963f80d06cc990d74284e7674",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8cc5b5b5df546ba2a71ff6fd25adbeb01a27c7c503d53946463cc6108d4ff9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff00ca33d2a696f3b438a85da657f900df56d743f06a0163df3b051e74d9d9dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5466c4dc934d5abc1eb1a8ed1028e1f78fd4eea87ecc5954fa491a0879c0fe5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f81833addc3924f97efebcf3390fd375339a7e752e7b6ba9003162a248ec7b0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97b664f921653bc6d22abec3d906ff58a7a1d568a4e2f24a638b15f46ed8e058",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61eb54379561ee89f973c58c10b8507f64fc0d1b3bf11cb5624b236365eecc9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a34c6b913b7810ddef0831adefe154fb68150ead286b750a3dc3e15b56c75e9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76ed672b87d410a259b09885e8ad7a88b28f181a268c3b401356a43e41d38141",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:621a5f7a8b6f53c8b35225ee0112ec80f17cd317247faa2e4c083653f32f4d4b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c712e9a4fdd669f1bd5be16b453b5fe22ca6c7265845833086334ab73144fc89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a4df63a83c55de808a0cb14f70d0f7ef6ffb4887f0c6dd68d147ce610496b272",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c4160ab5e8672d41f10f4fe52f0b59cc28b21cd3a681ecd2ccd8dbcab56ed73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28392dd7269733e1b069c3111b9eee10ec590f7d58408c0b7e46e78923bc5fc1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64a7dd77389ef15d39b87388aa8c1b51186accd702fb91989ddbe729060adb55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d060e4e89bafa0e342cfdca9136c72c8d3f6af2adaecf2ef47e530c5edc8985",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2b8068fbb2231a515c60c491eb5b08808af1eb6d497eb33039125aac3eb7d63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce155c86d0bd2ff0bf29a3ffd454fcf085389e2568a6d158cad79c55f895d683",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5c484c04bbcb4c26ab7c5aed20cf1b472cda8c662865ca1f8060a21f6fc6593",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f0828f99bb2ad6a4107089e6d6f2c67a744bf78aaa6b1c641e04c03ed82b725",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba7fe160856cb5c4385d6cd5ed9b2973de52521e3a944dacf221eacc77dc44de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85746399da551cfc335f2a4b156460b4903a277861077cf919b3f5ecd7689e97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bef843589abaf3dfb3ff5c72b6630f5b6e6ec8d706f2d569d6b503385844444",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cc444fb3971b6889d20cb009bbe91cc464c2fc027e6aacd6927a13d3bbb10be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9f91971d2e252f6fd49c40b9feb62beda46c268f0ce1903e6396f7a0d35cc39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9cfbaf8447ef22431bcefb1542a31badae1a33de764e4cbb88e90faf42827519",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7f51a01499b5ad345c10a790688ff8837d894b8608daf0fd27250d8a20afa77",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3011b8c219f9f86fadd7bf1ae600db59364b5e425ae47117d090635812dccbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48410dce2b1c514e23d2e9e067714be0eb2923ff44e3ac7dde373a92474ff642",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9013badfcf2a78e4dd4a1f6ada593f3d1f9dd5935814abde7dd7de1fa9bb8c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae6fe8d3375b9cab9cbc289118654227b84d353d8102273d15600e403ccfbe3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5caf8f150fec9e984d40ae7efac186450be8ce215eda8a6f864606c10bce798c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbef4adf7285d497ec92e10715866a15648100373e579947afa1c28862cbca44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8eaa5255d8f5cd3a8f854c4de6082158fd6294bf779b654d5bc270906a425ebe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c2c0413d99049dd00a1f5ba19dc53f3ac0efecd31f315da2f2f9a987300ca05",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1764513e83380dcdc272841ee7ed52e118c1672d593f6632166bfe5ef955f6b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d621f333a2448e8bacb38e1d36cf53e4707a8adeb117b794ce75d4b6c243ddb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ea8162f7352cfe1963e3564f197d9a329eec75deb35ecb0b925ca24277a1ddf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1090174c3e6dfd17771c8368e16e191fbdeb69d075e22347becec5262f39bb3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:377612c800325778fedc210ccf925125dff0f8515c5bad99ac48df1c35d79a46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e6fb2a961d9e9823380d329642b68e752d56018b6f5ad0a7856a8fda723a9e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2883fa5857316ca804ab5293cdc0c3bb7d620da84d844852ee8ed983b98e3bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21ff10f140e20b99100befc3a38220925bfcceb8d2a7004dc8944420b62633dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2dac60f8875f9ae0aff2da3840d9e878a48650aa4c6d04ae6cc0b668aa7ba2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf7a37c0aeb74a472c54d948e2cd3978b813891402b76c5013929255b43de54c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d650642e10443dbb860a185980f3119518e8fffe3952535accec681fbd8ad8ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6738cecbdf2248efba296597ce75313a70219901923a2f3aef52af4825029409",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c616cd07150cb3de1e62b6b710f1405106c7310927076aa6cf89a2c94ffd13f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47c981aa9da90d9280f04145f13b7f771d3ccd74d9a776f438dcd10072bb4ae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ebf16596928342c62b0abc250f56f778e7b6428e0273ae5da88493d9effe2e3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8650dafee9357adb6e6f878e5c3eb32aeb72ccce5bf68056920e77c7abc8da9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db2227729ac01ec1712cb3630ae3ac81fbe6094b5d40f9a91690b1b8dd413eaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fdc54d7c86891b9c13859ee7befb690d2a4d12db3d8e01accf46a3d3bff732f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:660c430d505999d24d2c0cc023d6b6af1c691db8bfaf62d10d38963627b4a664",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbf24d19205ce8b9c2da7655d859f4c4e7753b5794bc90db3aabdf3e7784bc84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c4f83ad638d69349cd378420eeca16cb734c639da2a9c44cf04f44dc8fa5716",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1734d5da50fb27abe9208444bdc99f65c382790150492152b891d2d501d7bf9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "user2": {
+                  "uid": 1020,
+                  "gid": 1050,
+                  "groups": [
+                    "group1"
+                  ],
+                  "description": "description 2",
+                  "home": "/home/home2",
+                  "shell": "/bin/sh",
+                  "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                },
+                "user3": {
+                  "uid": 1060,
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.groups",
+            "options": {
+              "groups": {
+                "group1": {
+                  "gid": 1030
+                },
+                "group2": {
+                  "gid": 1050
+                },
+                "user3": {
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/etc/systemd/system/custom.service.d",
+                  "exist_ok": true
+                },
+                {
+                  "path": "/etc/custom_dir"
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "mode": "0770"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "user": 1020,
+                  "group": 1050
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                  }
+                ]
+              },
+              "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                  }
+                ]
+              },
+              "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                  }
+                ]
+              },
+              "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  }
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                  "to": "tree:///etc/systemd/system/custom.service",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                  "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                  "to": "tree:///etc/custom_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                  "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "mode": "0644"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "user": "root",
+                  "group": "root"
+                },
+                "/etc/empty_file.txt": {
+                  "user": 0,
+                  "group": 0
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.systemd",
+            "options": {
+              "enabled_services": [
+                "custom.service"
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "dos",
+              "uuid": "0xc1748067",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "06"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "83"
+                },
+                {
+                  "size": 5263360,
+                  "start": 3125248,
+                  "type": "83"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263360,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263360
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "ostree-tree": {
+                "type": "org.osbuild.ostree.checkout",
+                "origin": "org.osbuild.source",
+                "references": [
+                  ""
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "to": "mount://root/boot/efi/config.txt"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "to": "mount://root/boot/efi/rpi-u-boot.bin"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "to": "mount://root/boot/efi/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263360
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "xz",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.xz",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "image.raw.xz"
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm"
+          },
+          "sha256:0131393ab117eb26be5e55451753229122f6ca97aa5b7872e65c9d691c0059d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm"
+          },
+          "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:04d878eeb31722ad495b34edd6bacafeffd5d13d39dfea5edff49daee5f28c58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm"
+          },
+          "sha256:0608af59c99a96c3a1fd93ee4796779536299e6abb0a944a7448dc0ba939b875": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbsd-0.10.0-10.fc37.aarch64.rpm"
+          },
+          "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm"
+          },
+          "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/selinux-policy-targeted-37.12-2.fc37.noarch.rpm"
+          },
+          "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc37.noarch.rpm"
+          },
+          "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cpio-2.13-13.fc37.aarch64.rpm"
+          },
+          "sha256:0c18091220a104278225bea1573077d807d205e2392f693bcb63a70c4387f141": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gnupg2-smime-2.3.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:0c2c0413d99049dd00a1f5ba19dc53f3ac0efecd31f315da2f2f9a987300ca05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-4.18.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:0c4160ab5e8672d41f10f4fe52f0b59cc28b21cd3a681ecd2ccd8dbcab56ed73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nettle-3.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:0d060e4e89bafa0e342cfdca9136c72c8d3f6af2adaecf2ef47e530c5edc8985": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openldap-2.6.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:0ddf983f0ceac0b053c17591225968b9dd9d31f1360564c7052d44b5e4551756": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/criu-libs-3.17.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:1050a9675979c8ea71d673034094281225dfb6252814a6a4b959cc89a3fa467a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/coreutils-9.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:1090174c3e6dfd17771c8368e16e191fbdeb69d075e22347becec5262f39bb3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-plugin-selinux-4.18.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:112978b8c5807ecf490d3559b1d701b48d75ff38dee451e4394584e2adff408c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-efi-aa64-2.06-58.fc37.aarch64.rpm"
+          },
+          "sha256:130fca628d199df219a2c49dac899bd881abe73839e839e78d0e6754fe3336bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/efivar-libs-38-5.fc37.aarch64.rpm"
+          },
+          "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/setup-2.14.1-2.fc37.noarch.rpm"
+          },
+          "sha256:171856671d92ec11433940b504eb84f496f3132921b020dbb66172a5c7e1b138": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dracut-config-generic-057-3.fc37.aarch64.rpm"
+          },
+          "sha256:1764513e83380dcdc272841ee7ed52e118c1672d593f6632166bfe5ef955f6b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-libs-4.18.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:178c233d007c00f14ec0c0a5083907f3cf2889b998c8e7eefe25c8b04ebe1aef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:185ffaca4bf6de8e14842027e4c2258409619b16b7d05d2a5df1100d187024dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-envsubst-0.21-19.0.20220203.fc37.aarch64.rpm"
+          },
+          "sha256:18aac772a8f18c064c422f3c3d3be7a9f4756029f288a5b281e1da816b47f938": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libstdc++-12.2.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm"
+          },
+          "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:1c4f83ad638d69349cd378420eeca16cb734c639da2a9c44cf04f44dc8fa5716": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/y/yajl-2.1.0-19.fc37.aarch64.rpm"
+          },
+          "sha256:1ccf5a8e68247b63ac2f4cc27db3d0d3eba7a93570e2a00125d327ac2606d8c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgcc-12.2.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:1fdc54d7c86891b9c13859ee7befb690d2a4d12db3d8e01accf46a3d3bff732f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/w/which-2.21-35.fc37.aarch64.rpm"
+          },
+          "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:21ff10f140e20b99100befc3a38220925bfcceb8d2a7004dc8944420b62633dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/slirp4netns-1.2.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libfido2-1.11.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:266dbc27e73ef589066244029bbf09de65d11ec1711fc76094694a74512e33c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-runtime-0.21-19.0.20220203.fc37.aarch64.rpm"
+          },
+          "sha256:26948aaefdcef47d8f73cae1f4ddede5853ccf6a5d4e2ef5d4a6d921547cef46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-minimal-langpack-2.36-7.fc37.aarch64.rpm"
+          },
+          "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-common-2.06-58.fc37.noarch.rpm"
+          },
+          "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:28392dd7269733e1b069c3111b9eee10ec590f7d58408c0b7e46e78923bc5fc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nftables-1.0.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:2a96cd1a8ad454befdee1c14e9224dcc35949cce18f197f2f0841e03ac4d6e65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnftnl-1.2.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:2dd5dd23c799bcec2ddccba07a99aff77a244c3a85717a307592ca6d3bc5f202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm"
+          },
+          "sha256:2e40045d6d88a1a5bedeaf60f1391cad60bce787dda76fc5ad297fe3c98bf168": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:2ea8162f7352cfe1963e3564f197d9a329eec75deb35ecb0b925ca24277a1ddf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-ostree-libs-2022.13-1.fc37.aarch64.rpm"
+          },
+          "sha256:30f5623220f5e93c167a0765a73a78398c3ea9856924183a8b9ed4ae227c2c15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libslirp-4.7.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:3133da3cef48ae829fc6853acfa42c12c6dce9f8ebfd0b0318e81d728d90f228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-tools-2.06-58.fc37.aarch64.rpm"
+          },
+          "sha256:377612c800325778fedc210ccf925125dff0f8515c5bad99ac48df1c35d79a46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/shadow-utils-4.12.3-2.fc37.aarch64.rpm"
+          },
+          "sha256:37ccd2182f8ca4f3843cd79dffd129efe19691b963f80d06cc990d74284e7674": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libusb1-1.0.25-9.fc37.aarch64.rpm"
+          },
+          "sha256:387b624bc5d55299367ac374ad3356e148eeb8c9163f8a64181571a54325dd2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/crun-1.6-2.fc37.aarch64.rpm"
+          },
+          "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm"
+          },
+          "sha256:3bdc032c960668daf5ba86e7d695924879a21e939aee174858b5cbe2f4f0d3f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm"
+          },
+          "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/file-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:3f5d9782065476a664f6e4d450404858e175f75b055f844f8a939623854ef615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnl3-3.7.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:45c5b537992ff64548b4ebf9b1e9c0f06fc77e895261e94c5a97e44d0773cc98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmnl-1.0.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm"
+          },
+          "sha256:4718a79261fa3420e90a53b57cc5d25ef92e11e6ff30d089cce717114fce679c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:47af1946fbfaa768f34e4d7818286123d1ea8679140479fa1b3c1d6f62560983": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse3-libs-3.10.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:47c981aa9da90d9280f04145f13b7f771d3ccd74d9a776f438dcd10072bb4ae4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-resolved-251.6-609.fc37.aarch64.rpm"
+          },
+          "sha256:48410dce2b1c514e23d2e9e067714be0eb2923ff44e3ac7dde373a92474ff642": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/popt-1.19-1.fc37.aarch64.rpm"
+          },
+          "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc37.noarch.rpm"
+          },
+          "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm"
+          },
+          "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libuuid-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:4b3936a76dfa4094d9133ee6fbb8f0a58d41d54dc81f874bdb9086f06711112d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnfnetlink-1.0.1-22.fc37.aarch64.rpm"
+          },
+          "sha256:4be185da5192918b485b25030b36f3e478bdc4bde19ebed1f80476931233ad30": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:4cc7e6a19b5627e3e3bf941d5bef3ded55458eb226ed6e523e9a0d6a836b249f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:4e18c452746d0c9be98e298d7282f0f2c3f86fac4b1e78e6d4c9901a0b2f5656": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgomp-12.2.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:4f0828f99bb2ad6a4107089e6d6f2c67a744bf78aaa6b1c641e04c03ed82b725": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/ostree-libs-2022.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:51f204b5187519266c3496cc970150cb41fd23f07ff58c3ee6d8b44a319fb455": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-libs-0.187-8.fc37.aarch64.rpm"
+          },
+          "sha256:539903a5db9dac34cd633a95db47af0c932118567e759108ec8b05f91992857f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/alternatives-1.19-3.fc37.aarch64.rpm"
+          },
+          "sha256:5547ad7034b539388be34c3c44c054fb7d99a98a372733283305a023387670a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/curl-7.85.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:5676237d61fba60ed5fb483b792111aa397faf464460222438130b0f3bbbe609": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bash-5.1.16-4.fc37.aarch64.rpm"
+          },
+          "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm"
+          },
+          "sha256:58b9082cd1e6c405c75d7cfe43595b066a80226942da5ddc714b1e6309bcf44e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm"
+          },
+          "sha256:590e97157cab0fe9f4e3661594cd2ab06d8b2af744fb11077fdaf3a1a8eb2ad9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse-overlayfs-1.9-3.fc37.aarch64.rpm"
+          },
+          "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pigz-2.7-2.fc37.aarch64.rpm"
+          },
+          "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmount-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:59d4bbec71e99f25ac89228d5528aa56c2eeff0a2e8e83d405d3e378955cbae9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glib2-2.74.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:59d84b98e1a0066e0cfc7ddb4f2559ded9803f7fef0c8b52d1ad0693b8f4dbae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-libelf-0.187-8.fc37.aarch64.rpm"
+          },
+          "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm"
+          },
+          "sha256:5ad7f1bfee28c80f9d4282aa9f0e5d8fada533111fc03fd9c33e988766c6c380": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:5caf8f150fec9e984d40ae7efac186450be8ce215eda8a6f864606c10bce798c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-3.11.0~rc2-1.fc37.aarch64.rpm"
+          },
+          "sha256:5cc444fb3971b6889d20cb009bbe91cc464c2fc027e6aacd6927a13d3bbb10be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pinentry-1.2.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:5e2ac5ec02616313b2c7a6d6ba73d860c4cc2380c2a7aa6336b3ed89c67c1392": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:5e6fb2a961d9e9823380d329642b68e752d56018b6f5ad0a7856a8fda723a9e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/shim-aa64-15.6-2.aarch64.rpm"
+          },
+          "sha256:5e983c066245eb18c7209a3165fe9335efe0ef74dba849a47e1c1332dcf4c320": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse3-3.10.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-common-1.14.2-1.fc37.noarch.rpm"
+          },
+          "sha256:60c9b8479deee53528d17e3ddf0d1dce61ca74036bf5d35038fea901b61f60c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-gconv-extra-2.36-7.fc37.aarch64.rpm"
+          },
+          "sha256:61eb54379561ee89f973c58c10b8507f64fc0d1b3bf11cb5624b236365eecc9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm"
+          },
+          "sha256:621a5f7a8b6f53c8b35225ee0112ec80f17cd317247faa2e4c083653f32f4d4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mozjs102-102.3.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:64a7dd77389ef15d39b87388aa8c1b51186accd702fb91989ddbe729060adb55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/npth-1.6-9.fc37.aarch64.rpm"
+          },
+          "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm"
+          },
+          "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sed-4.8-11.fc37.aarch64.rpm"
+          },
+          "sha256:660c430d505999d24d2c0cc023d6b6af1c691db8bfaf62d10d38963627b4a664": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xz-5.2.5-10.fc37.aarch64.rpm"
+          },
+          "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm"
+          },
+          "sha256:6738cecbdf2248efba296597ce75313a70219901923a2f3aef52af4825029409": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-networkd-251.6-609.fc37.aarch64.rpm"
+          },
+          "sha256:6a16500df314e37275aaab3de6fff5f4211d65b44fa9c6ee9ba74e718101a10e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpcap-1.10.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:6b1232e992e46c3897eaea57866d1ac655ebeff36448813fc5ddd84cd00da49a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libssh-0.10.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:6c50aa26df3d6c070897a3349eb72f47d144a79bc387a38ecbdc63063e85af03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse-common-3.10.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:6d57265c3bb44d183f7f619d7bf92f375bcbbc30e242d6df66e2533e5e9f84f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/coreutils-common-9.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm"
+          },
+          "sha256:72906b5aa7cc9f416f704bb0071972ddce6a08d251b1dcdf7253478153e8a20e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libssh-config-0.10.4-1.fc37.noarch.rpm"
+          },
+          "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:76df070766b1d7460c3edf04cb404046a9b999e68dde6598c090140995a49dde": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:76ed672b87d410a259b09885e8ad7a88b28f181a268c3b401356a43e41d38141": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/util-linux-core-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:7a78e507d71c85c273d3aa7e0d7f151b342a508fbfe85717cf760ee172ef9d37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libibverbs-41.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:7e3fbeb8bd1e999cd741083ef4235c4087988e1c6d75e24b784b2ddf7c5193de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnghttp2-1.49.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.aarch64.rpm"
+          },
+          "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-common-37-14.noarch.rpm"
+          },
+          "sha256:85746399da551cfc335f2a4b156460b4903a277861077cf919b3f5ecd7689e97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:88b28b9729a393374ffbce10301fc1829133dba58487caa525aaebc8fa070f56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kpartx-0.9.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:8a08019ab8471eb8e8bb8382acc0b8ea145852369d63293466a4af8ff2221263": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm"
+          },
+          "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm"
+          },
+          "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grep-3.7-4.fc37.aarch64.rpm"
+          },
+          "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc37.noarch.rpm"
+          },
+          "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm"
+          },
+          "sha256:8e410d25f43c86de6f76542b336aa40dd0a1c6d84a8fdbeff9ef2a2379ee4e45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-common-2.36-7.fc37.aarch64.rpm"
+          },
+          "sha256:8eaa5255d8f5cd3a8f854c4de6082158fd6294bf779b654d5bc270906a425ebe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/readline-8.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:8ef2400ff36fe50c2c2c33d503de10333c5b2be498791694b96d52a05949589d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcurl-7.85.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:932f1548d9ca07579d56cf1ce527b34786cfebe8e07fc86106ac9d7a803ccfbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.aarch64.rpm"
+          },
+          "sha256:97b664f921653bc6d22abec3d906ff58a7a1d568a4e2f24a638b15f46ed8e058": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/lua-libs-5.4.4-4.fc37.aarch64.rpm"
+          },
+          "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm"
+          },
+          "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-repos-37-1.noarch.rpm"
+          },
+          "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblkid-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:99bc383fa8558a73027e63ff75f0978e4e2ff6b26be55f384c3f52e5aee97527": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:9a19c9814acd3a96a1c6af95220a2e9e72242a2c653a38ef2964b711e509fc84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-tools-minimal-2.06-58.fc37.aarch64.rpm"
+          },
+          "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-37-14.noarch.rpm"
+          },
+          "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm"
+          },
+          "sha256:9bef843589abaf3dfb3ff5c72b6630f5b6e6ec8d706f2d569d6b503385844444": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc37.aarch64.rpm"
+          },
+          "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:9cfbaf8447ef22431bcefb1542a31badae1a33de764e4cbb88e90faf42827519": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/polkit-121-4.fc37.aarch64.rpm"
+          },
+          "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/device-mapper-libs-1.02.175-9.fc37.aarch64.rpm"
+          },
+          "sha256:9f36d86571603115d5f8734021e8ccc61fd390f5ffef47fad572260b249c8757": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/criu-3.17.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm"
+          },
+          "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/selinux-policy-37.12-2.fc37.noarch.rpm"
+          },
+          "sha256:a2b276a42f94d7982e5e2ef72d59b73b9313ea83792ea9bb35e2e5cb4fa5988d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:a34c6b913b7810ddef0831adefe154fb68150ead286b750a3dc3e15b56c75e9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mkpasswd-5.5.13-2.fc37.aarch64.rpm"
+          },
+          "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm"
+          },
+          "sha256:a3db34fee176285b0e73890ac0864c748bb091c256df197f885b31455dbb041f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/jansson-2.13.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:a438727fa3c39124219607fbdb1ac4aa8240b59ba5f3da46adec7eb8b3702b66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnet-1.2-6.fc37.aarch64.rpm"
+          },
+          "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/device-mapper-1.02.175-9.fc37.aarch64.rpm"
+          },
+          "sha256:a4df63a83c55de808a0cb14f70d0f7ef6ffb4887f0c6dd68d147ce610496b272": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/netavark-1.1.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsmartcols-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:a6aaae0fb24af1e41f043b5f782f0bd02bc88eb6d8de53c849d628bb03671b6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm"
+          },
+          "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kmod-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tar-1.34-3.fc36.aarch64.rpm"
+          },
+          "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:add56e5fb7330c434a8f6e2fcccf6bf817ae396b9c3c419e2b3c5eb2046b6812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libedit-3.1-42.20210910cvs.fc37.aarch64.rpm"
+          },
+          "sha256:ae6fe8d3375b9cab9cbc289118654227b84d353d8102273d15600e403ccfbe3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/protobuf-c-1.4.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:af36734e49f06f79fee74fbeafb555b24fd7473d915a580d7fc3f1359d63eb88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/librepo-1.14.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:b1c0880f9180fd54c99e2340fc9a0001bc489f5ff3ed8ab405cce9e35707c01b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gnutls-3.7.7-1.fc37.aarch64.rpm"
+          },
+          "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.aarch64.rpm"
+          },
+          "sha256:b3f64a9b092e5c9b829b955a2a63532462facd0cc967131211f0a90a6ed5453f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/audit-libs-3.0.9-1.fc37.aarch64.rpm"
+          },
+          "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm"
+          },
+          "sha256:b7f51a01499b5ad345c10a790688ff8837d894b8608daf0fd27250d8a20afa77": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/polkit-libs-121-4.fc37.aarch64.rpm"
+          },
+          "sha256:b9d09656e98dd744599be50d553e059d5b3c5236b617c5d05de9f0b2f505ff86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm"
+          },
+          "sha256:b9e1d9092c3654b4640e115afa1194edd2f4025ece6346c17eff15f127b57f01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/containers-common-1-66.fc37.noarch.rpm"
+          },
+          "sha256:ba7fe160856cb5c4385d6cd5ed9b2973de52521e3a944dacf221eacc77dc44de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcsc-lite-1.9.9-1.fc37.aarch64.rpm"
+          },
+          "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm"
+          },
+          "sha256:bbef4adf7285d497ec92e10715866a15648100373e579947afa1c28862cbca44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc37.aarch64.rpm"
+          },
+          "sha256:be9a015662acc23d54474a01f81a8f321359006b22850edcb41fdddc6f01b1cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gnupg2-2.3.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-gpg-keys-37-1.noarch.rpm"
+          },
+          "sha256:bf7a37c0aeb74a472c54d948e2cd3978b813891402b76c5013929255b43de54c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-251.6-609.fc37.aarch64.rpm"
+          },
+          "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcap-2.48-5.fc37.aarch64.rpm"
+          },
+          "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gzip-1.12-2.fc37.aarch64.rpm"
+          },
+          "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre-8.45-1.fc37.2.aarch64.rpm"
+          },
+          "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:c5c484c04bbcb4c26ab7c5aed20cf1b472cda8c662865ca1f8060a21f6fc6593": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/ostree-2022.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:c616cd07150cb3de1e62b6b710f1405106c7310927076aa6cf89a2c94ffd13f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-pam-251.6-609.fc37.aarch64.rpm"
+          },
+          "sha256:c712e9a4fdd669f1bd5be16b453b5fe22ca6c7265845833086334ab73144fc89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm"
+          },
+          "sha256:c71a3884722bdeeccbbcef5d9fcffa4c265d6486acb0f164d70c682bd91e1fdc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm"
+          },
+          "sha256:c83fc74498fb51302e56cf23f60712493d3003a25c44cb19b60aca5b1a683705": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc37.aarch64.rpm"
+          },
+          "sha256:c8650dafee9357adb6e6f878e5c3eb32aeb72ccce5bf68056920e77c7abc8da9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tpm2-tools-5.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:c9a351964d88b8f4162b8349c7ef8c5aae3e56b53f2f9f4acc081c1d998bbb39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/aardvark-dns-1.1.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:ccf0d18c15586c0a7ad9e7e69551fa9b997c25970701b5e635a981878c8a9dfe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/iptables-libs-1.8.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:ce155c86d0bd2ff0bf29a3ffd454fcf085389e2568a6d158cad79c55f895d683": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm"
+          },
+          "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:d0e859a97a8167af62e273093e454a01bfd64b9ff60897bc97711f3591970106": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-2.5.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:d3011b8c219f9f86fadd7bf1ae600db59364b5e425ae47117d090635812dccbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm"
+          },
+          "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm"
+          },
+          "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm"
+          },
+          "sha256:d621f333a2448e8bacb38e1d36cf53e4707a8adeb117b794ce75d4b6c243ddb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-ostree-2022.13-1.fc37.aarch64.rpm"
+          },
+          "sha256:d650642e10443dbb860a185980f3119518e8fffe3952535accec681fbd8ad8ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-libs-251.6-609.fc37.aarch64.rpm"
+          },
+          "sha256:d86fcd8817424d684eaae4eb343eec10e7f793b8aa7284d95d4ec71d517084fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bubblewrap-0.5.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:db2227729ac01ec1712cb3630ae3ac81fbe6094b5d40f9a91690b1b8dd413eaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:dcf4b614ac88e26b9b344e0d6f3da257555f4402742e27abca969b0f439d6211": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:e1c8670422ebe5aab49614e5264a61bc90ecc67e8ace5258ac94a04c8d8ecb7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libidn2-2.3.3-2.fc37.aarch64.rpm"
+          },
+          "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm"
+          },
+          "sha256:e2dac60f8875f9ae0aff2da3840d9e878a48650aa4c6d04ae6cc0b668aa7ba2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sqlite-libs-3.39.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:e40e9aaada115819d974b933bb33e6600d39fe13a91a9b4d5aa27c4decb06155": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:e4716da965a3141394efc6cfca127880bbab451c7cb285bfc48d1911d8402164": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dracut-057-3.fc37.aarch64.rpm"
+          },
+          "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:e8cc5b5b5df546ba2a71ff6fd25adbeb01a27c7c503d53946463cc6108d4ff9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxcrypt-4.4.28-3.fc37.aarch64.rpm"
+          },
+          "sha256:ea7104bffcc6792553e51c8bb8898c4c8649eb76055dd56e58d558e33d6a78ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-1.14.2-1.fc37.aarch64.rpm"
+          },
+          "sha256:ebf16596928342c62b0abc250f56f778e7b6428e0273ae5da88493d9effe2e3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-udev-251.6-609.fc37.aarch64.rpm"
+          },
+          "sha256:ee50ad1b7ba00ffed8c17a1df7b42800c3462a040281afd3500e1f7dd768c75b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libksba-1.6.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-identity-basic-37-14.noarch.rpm"
+          },
+          "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tzdata-2022d-1.fc37.noarch.rpm"
+          },
+          "sha256:f12b98bc656a67fc7b378870598993e010e4df843fb998f7a439a0a14bc391ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-libs-0.21-19.0.20220203.fc37.aarch64.rpm"
+          },
+          "sha256:f1734d5da50fb27abe9208444bdc99f65c382790150492152b891d2d501d7bf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zchunk-libs-1.2.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libkcapi-1.4.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:f27c1dea30a1eaeeaf6e69f30d30e0097aabf4f3a99413c3c4a47f90fcfa2a18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-2.36-7.fc37.aarch64.rpm"
+          },
+          "sha256:f2883fa5857316ca804ab5293cdc0c3bb7d620da84d844852ee8ed983b98e3bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/skopeo-1.9.2-1.fc37.aarch64.rpm"
+          },
+          "sha256:f2b8068fbb2231a515c60c491eb5b08808af1eb6d497eb33039125aac3eb7d63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssl-libs-3.0.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:f2bd8534e896f251cd58b8cbb0b069fcaa464aa2a84fbd9d8187690f3c979fdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libicu-71.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm"
+          },
+          "sha256:f40c72435d400e98d507c95a1e4993d70ed5a80556a7436bc8c51c82fa92f2b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse-2.9.9-15.fc37.aarch64.rpm"
+          },
+          "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grubby-8.40-66.fc37.aarch64.rpm"
+          },
+          "sha256:f53bd8e9f409439671de3762d5cf348fbffd7d97885c5de3953964fd7a148ea1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/json-c-0.16-2.fc37.aarch64.rpm"
+          },
+          "sha256:f5466c4dc934d5abc1eb1a8ed1028e1f78fd4eea87ecc5954fa491a0879c0fe5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm"
+          },
+          "sha256:f55ce59e067b48e1148a5e40b09c7223804540bf1593fb3bcb687c252a074c40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm"
+          },
+          "sha256:f81833addc3924f97efebcf3390fd375339a7e752e7b6ba9003162a248ec7b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:f83d5f59d9e289df361e2d46bf18143245b1324f3e2fb71b91ff7740a897a215": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cracklib-2.9.7-30.fc37.aarch64.rpm"
+          },
+          "sha256:f9013badfcf2a78e4dd4a1f6ada593f3d1f9dd5935814abde7dd7de1fa9bb8c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/procps-ng-3.3.17-6.fc37.aarch64.rpm"
+          },
+          "sha256:f9176c93af66866fce7b6c0ddc2426bbb88d83d6d091da663ad8c4cb8f8b2615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgpg-error-1.45-2.fc37.aarch64.rpm"
+          },
+          "sha256:f99f0d1d4983db97df46b35119f2996db34f696b8f7281b197faa5aeb974aae7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/container-selinux-2.190.0-1.fc37.noarch.rpm"
+          },
+          "sha256:f9f91971d2e252f6fd49c40b9feb62beda46c268f0ce1903e6396f7a0d35cc39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm"
+          },
+          "sha256:fbf24d19205ce8b9c2da7655d859f4c4e7753b5794bc90db3aabdf3e7784bc84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xz-libs-5.2.5-10.fc37.aarch64.rpm"
+          },
+          "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libfdisk-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/util-linux-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:ff00ca33d2a696f3b438a85da657f900df56d743f06a0163df3b051e74d9d9dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxml2-2.9.14-3.fc37.aarch64.rpm"
+          },
+          "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm"
+          },
+          "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm"
+          }
+        }
+      },
+      "org.osbuild.inline": {
+        "items": {
+          "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+            "encoding": "base64",
+            "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+          },
+          "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+            "encoding": "base64",
+            "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+          },
+          "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+            "encoding": "base64",
+            "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+          },
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+            "encoding": "base64",
+            "data": ""
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "aardvark-dns",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/aardvark-dns-1.1.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:c9a351964d88b8f4162b8349c7ef8c5aae3e56b53f2f9f4acc081c1d998bbb39",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/alternatives-1.19-3.fc37.aarch64.rpm",
+        "checksum": "sha256:539903a5db9dac34cd633a95db47af0c932118567e759108ec8b05f91992857f",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/audit-libs-3.0.9-1.fc37.aarch64.rpm",
+        "checksum": "sha256:b3f64a9b092e5c9b829b955a2a63532462facd0cc967131211f0a90a6ed5453f",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:178c233d007c00f14ec0c0a5083907f3cf2889b998c8e7eefe25c8b04ebe1aef",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:5e2ac5ec02616313b2c7a6d6ba73d860c4cc2380c2a7aa6336b3ed89c67c1392",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bash-5.1.16-4.fc37.aarch64.rpm",
+        "checksum": "sha256:5676237d61fba60ed5fb483b792111aa397faf464460222438130b0f3bbbe609",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bubblewrap-0.5.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d86fcd8817424d684eaae4eb343eec10e7f793b8aa7284d95d4ec71d517084fd",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm",
+        "checksum": "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.190.0",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/container-selinux-2.190.0-1.fc37.noarch.rpm",
+        "checksum": "sha256:f99f0d1d4983db97df46b35119f2996db34f696b8f7281b197faa5aeb974aae7",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "66.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/containers-common-1-66.fc37.noarch.rpm",
+        "checksum": "sha256:b9e1d9092c3654b4640e115afa1194edd2f4025ece6346c17eff15f127b57f01",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/coreutils-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:1050a9675979c8ea71d673034094281225dfb6252814a6a4b959cc89a3fa467a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/coreutils-common-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:6d57265c3bb44d183f7f619d7bf92f375bcbbc30e242d6df66e2533e5e9f84f0",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cpio-2.13-13.fc37.aarch64.rpm",
+        "checksum": "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cracklib-2.9.7-30.fc37.aarch64.rpm",
+        "checksum": "sha256:f83d5f59d9e289df361e2d46bf18143245b1324f3e2fb71b91ff7740a897a215",
+        "check_gpg": true
+      },
+      {
+        "name": "criu",
+        "epoch": 0,
+        "version": "3.17.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/criu-3.17.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:9f36d86571603115d5f8734021e8ccc61fd390f5ffef47fad572260b249c8757",
+        "check_gpg": true
+      },
+      {
+        "name": "criu-libs",
+        "epoch": 0,
+        "version": "3.17.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/criu-libs-3.17.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:0ddf983f0ceac0b053c17591225968b9dd9d31f1360564c7052d44b5e4551756",
+        "check_gpg": true
+      },
+      {
+        "name": "crun",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/crun-1.6-2.fc37.aarch64.rpm",
+        "checksum": "sha256:387b624bc5d55299367ac374ad3356e148eeb8c9163f8a64181571a54325dd2f",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5ad7f1bfee28c80f9d4282aa9f0e5d8fada533111fc03fd9c33e988766c6c380",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/curl-7.85.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5547ad7034b539388be34c3c44c054fb7d99a98a372733283305a023387670a9",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.aarch64.rpm",
+        "checksum": "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-1.14.2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ea7104bffcc6792553e51c8bb8898c4c8649eb76055dd56e58d558e33d6a78ac",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm",
+        "checksum": "sha256:04d878eeb31722ad495b34edd6bacafeffd5d13d39dfea5edff49daee5f28c58",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dbus-common-1.14.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/device-mapper-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/device-mapper-libs-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dracut-057-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e4716da965a3141394efc6cfca127880bbab451c7cb285bfc48d1911d8402164",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "057",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dracut-config-generic-057-3.fc37.aarch64.rpm",
+        "checksum": "sha256:171856671d92ec11433940b504eb84f496f3132921b020dbb66172a5c7e1b138",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm",
+        "checksum": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:3bdc032c960668daf5ba86e7d695924879a21e939aee174858b5cbe2f4f0d3f9",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/efivar-libs-38-5.fc37.aarch64.rpm",
+        "checksum": "sha256:130fca628d199df219a2c49dac899bd881abe73839e839e78d0e6754fe3336bf",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc37.aarch64.rpm",
+        "checksum": "sha256:c83fc74498fb51302e56cf23f60712493d3003a25c44cb19b60aca5b1a683705",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc37.noarch.rpm",
+        "checksum": "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-libelf-0.187-8.fc37.aarch64.rpm",
+        "checksum": "sha256:59d84b98e1a0066e0cfc7ddb4f2559ded9803f7fef0c8b52d1ad0693b8f4dbae",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/elfutils-libs-0.187-8.fc37.aarch64.rpm",
+        "checksum": "sha256:51f204b5187519266c3496cc970150cb41fd23f07ff58c3ee6d8b44a319fb455",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:76df070766b1d7460c3edf04cb404046a9b999e68dde6598c090140995a49dde",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-gpg-keys-37-1.noarch.rpm",
+        "checksum": "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-37-14.noarch.rpm",
+        "checksum": "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-common-37-14.noarch.rpm",
+        "checksum": "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-release-identity-basic-37-14.noarch.rpm",
+        "checksum": "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fedora-repos-37-1.noarch.rpm",
+        "checksum": "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/file-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:f40c72435d400e98d507c95a1e4993d70ed5a80556a7436bc8c51c82fa92f2b8",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse-common-3.10.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:6c50aa26df3d6c070897a3349eb72f47d144a79bc387a38ecbdc63063e85af03",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse-overlayfs-1.9-3.fc37.aarch64.rpm",
+        "checksum": "sha256:590e97157cab0fe9f4e3661594cd2ab06d8b2af744fb11077fdaf3a1a8eb2ad9",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse3-3.10.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:5e983c066245eb18c7209a3165fe9335efe0ef74dba849a47e1c1332dcf4c320",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/f/fuse3-libs-3.10.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:47af1946fbfaa768f34e4d7818286123d1ea8679140479fa1b3c1d6f62560983",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm",
+        "checksum": "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-envsubst-0.21-19.0.20220203.fc37.aarch64.rpm",
+        "checksum": "sha256:185ffaca4bf6de8e14842027e4c2258409619b16b7d05d2a5df1100d187024dd",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-libs-0.21-19.0.20220203.fc37.aarch64.rpm",
+        "checksum": "sha256:f12b98bc656a67fc7b378870598993e010e4df843fb998f7a439a0a14bc391ff",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gettext-runtime-0.21-19.0.20220203.fc37.aarch64.rpm",
+        "checksum": "sha256:266dbc27e73ef589066244029bbf09de65d11ec1711fc76094694a74512e33c2",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.74.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glib2-2.74.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:59d4bbec71e99f25ac89228d5528aa56c2eeff0a2e8e83d405d3e378955cbae9",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-2.36-7.fc37.aarch64.rpm",
+        "checksum": "sha256:f27c1dea30a1eaeeaf6e69f30d30e0097aabf4f3a99413c3c4a47f90fcfa2a18",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-common-2.36-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8e410d25f43c86de6f76542b336aa40dd0a1c6d84a8fdbeff9ef2a2379ee4e45",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-gconv-extra-2.36-7.fc37.aarch64.rpm",
+        "checksum": "sha256:60c9b8479deee53528d17e3ddf0d1dce61ca74036bf5d35038fea901b61f60c2",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/glibc-minimal-langpack-2.36-7.fc37.aarch64.rpm",
+        "checksum": "sha256:26948aaefdcef47d8f73cae1f4ddede5853ccf6a5d4e2ef5d4a6d921547cef46",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gnupg2-2.3.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:be9a015662acc23d54474a01f81a8f321359006b22850edcb41fdddc6f01b1cf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gnupg2-smime-2.3.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:0c18091220a104278225bea1573077d807d205e2392f693bcb63a70c4387f141",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.7",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gnutls-3.7.7-1.fc37.aarch64.rpm",
+        "checksum": "sha256:b1c0880f9180fd54c99e2340fc9a0001bc489f5ff3ed8ab405cce9e35707c01b",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:99bc383fa8558a73027e63ff75f0978e4e2ff6b26be55f384c3f52e5aee97527",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grep-3.7-4.fc37.aarch64.rpm",
+        "checksum": "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-common-2.06-58.fc37.noarch.rpm",
+        "checksum": "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-efi-aa64-2.06-58.fc37.aarch64.rpm",
+        "checksum": "sha256:112978b8c5807ecf490d3559b1d701b48d75ff38dee451e4394584e2adff408c",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-tools-2.06-58.fc37.aarch64.rpm",
+        "checksum": "sha256:3133da3cef48ae829fc6853acfa42c12c6dce9f8ebfd0b0318e81d728d90f228",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grub2-tools-minimal-2.06-58.fc37.aarch64.rpm",
+        "checksum": "sha256:9a19c9814acd3a96a1c6af95220a2e9e72242a2c653a38ef2964b711e509fc84",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "66.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/grubby-8.40-66.fc37.aarch64.rpm",
+        "checksum": "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/g/gzip-1.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/i/iptables-libs-1.8.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ccf0d18c15586c0a7ad9e7e69551fa9b997c25970701b5e635a981878c8a9dfe",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/jansson-2.13.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a3db34fee176285b0e73890ac0864c748bb091c256df197f885b31455dbb041f",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/json-c-0.16-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f53bd8e9f409439671de3762d5cf348fbffd7d97885c5de3953964fd7a148ea1",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2dd5dd23c799bcec2ddccba07a99aff77a244c3a85717a307592ca6d3bc5f202",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-2.5.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d0e859a97a8167af62e273093e454a01bfd64b9ff60897bc97711f3591970106",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kmod-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/kpartx-0.9.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:88b28b9729a393374ffbce10301fc1829133dba58487caa525aaebc8fa070f56",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm",
+        "checksum": "sha256:b9d09656e98dd744599be50d553e059d5b3c5236b617c5d05de9f0b2f505ff86",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2e40045d6d88a1a5bedeaf60f1391cad60bce787dda76fc5ad297fe3c98bf168",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:4718a79261fa3420e90a53b57cc5d25ef92e11e6ff30d089cce717114fce679c",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libblkid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm",
+        "checksum": "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b",
+        "check_gpg": true
+      },
+      {
+        "name": "libbsd",
+        "epoch": 0,
+        "version": "0.10.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libbsd-0.10.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:0608af59c99a96c3a1fd93ee4796779536299e6abb0a944a7448dc0ba939b875",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcap-2.48-5.fc37.aarch64.rpm",
+        "checksum": "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm",
+        "checksum": "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libcurl-7.85.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:8ef2400ff36fe50c2c2c33d503de10333c5b2be498791694b96d52a05949589d",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm",
+        "checksum": "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "42.20210910cvs.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libedit-3.1-42.20210910cvs.fc37.aarch64.rpm",
+        "checksum": "sha256:add56e5fb7330c434a8f6e2fcccf6bf817ae396b9c3c419e2b3c5eb2046b6812",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libfdisk-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:c71a3884722bdeeccbbcef5d9fcffa4c265d6486acb0f164d70c682bd91e1fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libfido2-1.11.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgcc-12.2.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:1ccf5a8e68247b63ac2f4cc27db3d0d3eba7a93570e2a00125d327ac2606d8c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:f55ce59e067b48e1148a5e40b09c7223804540bf1593fb3bcb687c252a074c40",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgomp-12.2.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4e18c452746d0c9be98e298d7282f0f2c3f86fac4b1e78e6d4c9901a0b2f5656",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libgpg-error-1.45-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f9176c93af66866fce7b6c0ddc2426bbb88d83d6d091da663ad8c4cb8f8b2615",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "41.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libibverbs-41.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7a78e507d71c85c273d3aa7e0d7f151b342a508fbfe85717cf760ee172ef9d37",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "71.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libicu-71.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f2bd8534e896f251cd58b8cbb0b069fcaa464aa2a84fbd9d8187690f3c979fdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libidn2-2.3.3-2.fc37.aarch64.rpm",
+        "checksum": "sha256:e1c8670422ebe5aab49614e5264a61bc90ecc67e8ace5258ac94a04c8d8ecb7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libkcapi-1.4.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libksba-1.6.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ee50ad1b7ba00ffed8c17a1df7b42800c3462a040281afd3500e1f7dd768c75b",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmnl-1.0.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:45c5b537992ff64548b4ebf9b1e9c0f06fc77e895261e94c5a97e44d0773cc98",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:e40e9aaada115819d974b933bb33e6600d39fe13a91a9b4d5aa27c4decb06155",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libmount-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libnet",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnet-1.2-6.fc37.aarch64.rpm",
+        "checksum": "sha256:a438727fa3c39124219607fbdb1ac4aa8240b59ba5f3da46adec7eb8b3702b66",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.aarch64.rpm",
+        "checksum": "sha256:932f1548d9ca07579d56cf1ce527b34786cfebe8e07fc86106ac9d7a803ccfbb",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "22.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnfnetlink-1.0.1-22.fc37.aarch64.rpm",
+        "checksum": "sha256:4b3936a76dfa4094d9133ee6fbb8f0a58d41d54dc81f874bdb9086f06711112d",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnftnl-1.2.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2a96cd1a8ad454befdee1c14e9224dcc35949cce18f197f2f0841e03ac4d6e65",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.49.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnghttp2-1.49.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7e3fbeb8bd1e999cd741083ef4235c4087988e1c6d75e24b784b2ddf7c5193de",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnl3-3.7.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:3f5d9782065476a664f6e4d450404858e175f75b055f844f8a939623854ef615",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpcap-1.10.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:6a16500df314e37275aaab3de6fff5f4211d65b44fa9c6ee9ba74e718101a10e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm",
+        "checksum": "sha256:0131393ab117eb26be5e55451753229122f6ca97aa5b7872e65c9d691c0059d9",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/librepo-1.14.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:af36734e49f06f79fee74fbeafb555b24fd7473d915a580d7fc3f1359d63eb88",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:dcf4b614ac88e26b9b344e0d6f3da257555f4402742e27abca969b0f439d6211",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:4be185da5192918b485b25030b36f3e478bdc4bde19ebed1f80476931233ad30",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a2b276a42f94d7982e5e2ef72d59b73b9313ea83792ea9bb35e2e5cb4fa5988d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:72906b5aa7cc9f416f704bb0071972ddce6a08d251b1dcdf7253478153e8a20e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:a6aaae0fb24af1e41f043b5f782f0bd02bc88eb6d8de53c849d628bb03671b6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444",
+        "check_gpg": true
+      },
+      {
+        "name": "libslirp",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libslirp-4.7.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:30f5623220f5e93c167a0765a73a78398c3ea9856924183a8b9ed4ae227c2c15",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsmartcols-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm",
+        "checksum": "sha256:58b9082cd1e6c405c75d7cfe43595b066a80226942da5ddc714b1e6309bcf44e",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libssh-0.10.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:6b1232e992e46c3897eaea57866d1ac655ebeff36448813fc5ddd84cd00da49a",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libssh-config-0.10.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libstdc++-12.2.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:18aac772a8f18c064c422f3c3d3be7a9f4756029f288a5b281e1da816b47f938",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4cc7e6a19b5627e3e3bf941d5bef3ded55458eb226ed6e523e9a0d6a836b249f",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm",
+        "checksum": "sha256:8a08019ab8471eb8e8bb8382acc0b8ea145852369d63293466a4af8ff2221263",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libusb1-1.0.25-9.fc37.aarch64.rpm",
+        "checksum": "sha256:37ccd2182f8ca4f3843cd79dffd129efe19691b963f80d06cc990d74284e7674",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libuuid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxcrypt-4.4.28-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e8cc5b5b5df546ba2a71ff6fd25adbeb01a27c7c503d53946463cc6108d4ff9a",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libxml2-2.9.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ff00ca33d2a696f3b438a85da657f900df56d743f06a0163df3b051e74d9d9dc",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm",
+        "checksum": "sha256:f5466c4dc934d5abc1eb1a8ed1028e1f78fd4eea87ecc5954fa491a0879c0fe5",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f81833addc3924f97efebcf3390fd375339a7e752e7b6ba9003162a248ec7b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/lua-libs-5.4.4-4.fc37.aarch64.rpm",
+        "checksum": "sha256:97b664f921653bc6d22abec3d906ff58a7a1d568a4e2f24a638b15f46ed8e058",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm",
+        "checksum": "sha256:61eb54379561ee89f973c58c10b8507f64fc0d1b3bf11cb5624b236365eecc9f",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mkpasswd-5.5.13-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a34c6b913b7810ddef0831adefe154fb68150ead286b750a3dc3e15b56c75e9d",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:76ed672b87d410a259b09885e8ad7a88b28f181a268c3b401356a43e41d38141",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs102",
+        "epoch": 0,
+        "version": "102.3.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mozjs102-102.3.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:621a5f7a8b6f53c8b35225ee0112ec80f17cd317247faa2e4c083653f32f4d4b",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:c712e9a4fdd669f1bd5be16b453b5fe22ca6c7265845833086334ab73144fc89",
+        "check_gpg": true
+      },
+      {
+        "name": "netavark",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/netavark-1.1.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a4df63a83c55de808a0cb14f70d0f7ef6ffb4887f0c6dd68d147ce610496b272",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nettle-3.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0c4160ab5e8672d41f10f4fe52f0b59cc28b21cd3a681ecd2ccd8dbcab56ed73",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/nftables-1.0.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:28392dd7269733e1b069c3111b9eee10ec590f7d58408c0b7e46e78923bc5fc1",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/n/npth-1.6-9.fc37.aarch64.rpm",
+        "checksum": "sha256:64a7dd77389ef15d39b87388aa8c1b51186accd702fb91989ddbe729060adb55",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openldap-2.6.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0d060e4e89bafa0e342cfdca9136c72c8d3f6af2adaecf2ef47e530c5edc8985",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssl-libs-3.0.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f2b8068fbb2231a515c60c491eb5b08808af1eb6d497eb33039125aac3eb7d63",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ce155c86d0bd2ff0bf29a3ffd454fcf085389e2568a6d158cad79c55f895d683",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm",
+        "checksum": "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2022.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/ostree-2022.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c5c484c04bbcb4c26ab7c5aed20cf1b472cda8c662865ca1f8060a21f6fc6593",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2022.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/o/ostree-libs-2022.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4f0828f99bb2ad6a4107089e6d6f2c67a744bf78aaa6b1c641e04c03ed82b725",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre-8.45-1.fc37.2.aarch64.rpm",
+        "checksum": "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm",
+        "checksum": "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcsc-lite-1.9.9-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ba7fe160856cb5c4385d6cd5ed9b2973de52521e3a944dacf221eacc77dc44de",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:85746399da551cfc335f2a4b156460b4903a277861077cf919b3f5ecd7689e97",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc37.aarch64.rpm",
+        "checksum": "sha256:9bef843589abaf3dfb3ff5c72b6630f5b6e6ec8d706f2d569d6b503385844444",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pigz-2.7-2.fc37.aarch64.rpm",
+        "checksum": "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/pinentry-1.2.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5cc444fb3971b6889d20cb009bbe91cc464c2fc027e6aacd6927a13d3bbb10be",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:f9f91971d2e252f6fd49c40b9feb62beda46c268f0ce1903e6396f7a0d35cc39",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/polkit-121-4.fc37.aarch64.rpm",
+        "checksum": "sha256:9cfbaf8447ef22431bcefb1542a31badae1a33de764e4cbb88e90faf42827519",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/polkit-libs-121-4.fc37.aarch64.rpm",
+        "checksum": "sha256:b7f51a01499b5ad345c10a790688ff8837d894b8608daf0fd27250d8a20afa77",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "22.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm",
+        "checksum": "sha256:d3011b8c219f9f86fadd7bf1ae600db59364b5e425ae47117d090635812dccbf",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/popt-1.19-1.fc37.aarch64.rpm",
+        "checksum": "sha256:48410dce2b1c514e23d2e9e067714be0eb2923ff44e3ac7dde373a92474ff642",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/procps-ng-3.3.17-6.fc37.aarch64.rpm",
+        "checksum": "sha256:f9013badfcf2a78e4dd4a1f6ada593f3d1f9dd5935814abde7dd7de1fa9bb8c3",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/protobuf-c-1.4.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ae6fe8d3375b9cab9cbc289118654227b84d353d8102273d15600e403ccfbe3b",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc37.noarch.rpm",
+        "checksum": "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-3.11.0~rc2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5caf8f150fec9e984d40ae7efac186450be8ce215eda8a6f864606c10bce798c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:bbef4adf7285d497ec92e10715866a15648100373e579947afa1c28862cbca44",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/readline-8.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8eaa5255d8f5cd3a8f854c4de6082158fd6294bf779b654d5bc270906a425ebe",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-4.18.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0c2c0413d99049dd00a1f5ba19dc53f3ac0efecd31f315da2f2f9a987300ca05",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-libs-4.18.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:1764513e83380dcdc272841ee7ed52e118c1672d593f6632166bfe5ef955f6b1",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2022.13",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-ostree-2022.13-1.fc37.aarch64.rpm",
+        "checksum": "sha256:d621f333a2448e8bacb38e1d36cf53e4707a8adeb117b794ce75d4b6c243ddb5",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2022.13",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-ostree-libs-2022.13-1.fc37.aarch64.rpm",
+        "checksum": "sha256:2ea8162f7352cfe1963e3564f197d9a329eec75deb35ecb0b925ca24277a1ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/r/rpm-plugin-selinux-4.18.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:1090174c3e6dfd17771c8368e16e191fbdeb69d075e22347becec5262f39bb3a",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sed-4.8-11.fc37.aarch64.rpm",
+        "checksum": "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.12",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/selinux-policy-37.12-2.fc37.noarch.rpm",
+        "checksum": "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.12",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/selinux-policy-targeted-37.12-2.fc37.noarch.rpm",
+        "checksum": "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.12.3",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/shadow-utils-4.12.3-2.fc37.aarch64.rpm",
+        "checksum": "sha256:377612c800325778fedc210ccf925125dff0f8515c5bad99ac48df1c35d79a46",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/shim-aa64-15.6-2.aarch64.rpm",
+        "checksum": "sha256:5e6fb2a961d9e9823380d329642b68e752d56018b6f5ad0a7856a8fda723a9e3",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.9.2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/skopeo-1.9.2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f2883fa5857316ca804ab5293cdc0c3bb7d620da84d844852ee8ed983b98e3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "slirp4netns",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/slirp4netns-1.2.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:21ff10f140e20b99100befc3a38220925bfcceb8d2a7004dc8944420b62633dc",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/sqlite-libs-3.39.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:e2dac60f8875f9ae0aff2da3840d9e878a48650aa4c6d04ae6cc0b668aa7ba2b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:bf7a37c0aeb74a472c54d948e2cd3978b813891402b76c5013929255b43de54c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-libs-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:d650642e10443dbb860a185980f3119518e8fffe3952535accec681fbd8ad8ea",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-networkd-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:6738cecbdf2248efba296597ce75313a70219901923a2f3aef52af4825029409",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-pam-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:c616cd07150cb3de1e62b6b710f1405106c7310927076aa6cf89a2c94ffd13f6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-resolved-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:47c981aa9da90d9280f04145f13b7f771d3ccd74d9a776f438dcd10072bb4ae4",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/s/systemd-udev-251.6-609.fc37.aarch64.rpm",
+        "checksum": "sha256:ebf16596928342c62b0abc250f56f778e7b6428e0273ae5da88493d9effe2e3f",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tar-1.34-3.fc36.aarch64.rpm",
+        "checksum": "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tpm2-tools-5.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:c8650dafee9357adb6e6f878e5c3eb32aeb72ccce5bf68056920e77c7abc8da9",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:db2227729ac01ec1712cb3630ae3ac81fbe6094b5d40f9a91690b1b8dd413eaa",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022d",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tzdata-2022d-1.fc37.noarch.rpm",
+        "checksum": "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/util-linux-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/u/util-linux-core-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "35.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/w/which-2.21-35.fc37.aarch64.rpm",
+        "checksum": "sha256:1fdc54d7c86891b9c13859ee7befb690d2a4d12db3d8e01accf46a3d3bff732f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xz-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:660c430d505999d24d2c0cc023d6b6af1c691db8bfaf62d10d38963627b4a664",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/x/xz-libs-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:fbf24d19205ce8b9c2da7655d859f4c4e7753b5794bc90db3aabdf3e7784bc84",
+        "check_gpg": true
+      },
+      {
+        "name": "yajl",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "19.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/y/yajl-2.1.0-19.fc37.aarch64.rpm",
+        "checksum": "sha256:1c4f83ad638d69349cd378420eeca16cb734c639da2a9c44cf04f44dc8fa5716",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zchunk-libs-1.2.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f1734d5da50fb27abe9208444bdc99f65c382790150492152b891d2d501d7bf9",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_37-x86_64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_raw_image_customizations-boot.json
@@ -1,0 +1,6110 @@
+{
+  "compose-request": {
+    "distro": "fedora-37",
+    "arch": "x86_64",
+    "image-type": "iot-raw-image",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-modular-development-20221025/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "image.raw.xz",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {
+      "customizations": {
+        "user": [
+          {
+            "name": "user2",
+            "description": "description 2",
+            "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+            "home": "/home/home2",
+            "shell": "/bin/sh",
+            "groups": [
+              "group1"
+            ],
+            "uid": 1020,
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "uid": 1060,
+            "gid": 1060
+          }
+        ],
+        "group": [
+          {
+            "name": "group1",
+            "gid": 1030
+          },
+          {
+            "name": "group2",
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "gid": 1060
+          }
+        ],
+        "services": {
+          "enabled": [
+            "custom.service"
+          ]
+        },
+        "directories": [
+          {
+            "path": "/etc/systemd/system/custom.service.d"
+          },
+          {
+            "path": "/etc/custom_dir",
+            "user": 1020,
+            "group": 1050,
+            "mode": "0770"
+          }
+        ],
+        "files": [
+          {
+            "path": "/etc/systemd/system/custom.service",
+            "data": "[Unit]\nDescription=Custom service\n\n[Service]\nExecStart=/usr/bin/false\n\n[Install]\nWantedBy=multi-user.target\n"
+          },
+          {
+            "path": "/etc/systemd/system/custom.service.d/override.conf",
+            "data": "[Service]\nExecStart=\nExecStart=/usr/bin/cat /etc/custom_file.txt\n"
+          },
+          {
+            "path": "/etc/custom_file.txt",
+            "user": "root",
+            "group": "root",
+            "mode": "0644",
+            "data": "image builder is the best"
+          },
+          {
+            "path": "/etc/empty_file.txt",
+            "user": 0,
+            "group": 0
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora37",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:c999e49255db5e95b6b5a9ef3dcbc07e828e0718cf8dbe147bac62ac8dc82409",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9ca97b6dc978f2a3895963780b0a99c794e5db5ce3f18e16951449fb11c74c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23cda2a639c358757ee35ce6270ba3d0c6cd779309ff528e7c08c0239737dffb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74ee0b4664d9300b0538372064e74e1609f5bf89a4cef76c7849d774af7295cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:68e0f60ad19cf5f0f211f0e14b96b42db87806d9536eb05386cf9bf168891c2f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21ab08a6ce4ff5213d541878e456f7c1ea9da5b76c342fe1c55641a77e187b23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:192808b88d6473b4bdb33ffe8aa37f2b01ca3e2b76d9b221db8a9eee1ab5d201",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f99f0d1d4983db97df46b35119f2996db34f696b8f7281b197faa5aeb974aae7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9e1d9092c3654b4640e115afa1194edd2f4025ece6346c17eff15f127b57f01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd4d0c1b5490e1cee5e461b89eb1b1e7bb40c40de981cfd73ac060103a5c42a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31af27f44c4a8d06068389731d3a5adc0fd45b1c8ce4d28163f938e68fa58cbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3847abdc8ff973aeb0fb7e681bdf7c37b19cd49e5df17e8bf6bc35f34615c88f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3eea98413bd05506258a3fe592c7f781d58c7143e8f3767d528b875267b95613",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45a1bc7c64e5aadb8e9b7936ff36150c885771b5be34a7223fec24a0ec0620e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0ff6a9301f19f512576bae26583104540973e33dbf619e9948bc838f3a6d714",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a9c9f908326ce672180964c0dee6a387fefce9f4e49dacbca87f4aa8bf1e31f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec82b6cad1b898aaa474a6f68aa67840cbb1d70b515c2255ade5ada88cb3d587",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b1e2c27345206db40bd782541b00575f3d36e238a6905c75d67c2407ca4adbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5bbfce30b88c0b4f06c4ad0c80645cfec9c23248d7c734d76607d8bc500c43f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8914ca12a258fb7729a231325e4c269a97d38d6d6961dfebaa4a74d92babad8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e3ddc2f83def37e6c6799890e4a3c12220491045a656e308b2d306e165e64bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:157a95e5d0a70dcb97682ae484d6238e99db218071855483283c61486029ce8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1333de1f729a9f570251d37764c5c20faf596e9cff41643832d33f74bae24a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce9deb715d28bc1ef130ebf8c7d8f28fd774123da3e6d60eecaaca887d0a5f4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad9b6aeba4041769fbb2d9f3aeb72e3534c7f572f2021ec309e337efb4fe5b64",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3ef7332845114c912be8ba53e198af4e92edb5475809e9d3e6a2ad3202380d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b9b252702c66da50fde953741fe5470d53cb955dddf6a50d890002927517f0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de73e6a453152a5e3635d4796d4b92587f7ad9428647cf85a9bc9506839ed1e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f2c3773b6d2a19f5b2a3ea190b210a9f06e186eff763e70662c63fe5c85d394",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f82c5883afa3a2d8b0d2870393ac9c1195d78932eafe4a24f39deb7f1cfb9e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47e1ed14816cd8b66a07911789defd41d6b840baf8ccd0439f99dd1ded4ff15d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:559626f87751e9b10db9237e0bf05589081f69a5436ee88344352cbb5c4ef7cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f197117a201e561bc919198df573394e7c97dce2fda2382e3a2495c7ab9e8cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b9c5fe598d258b0dbbf454b01ba844aa678bf5c7333bd16e98ba4c62a242f9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bad0c7e6a8c83996b3aa2056481ea9e1868a3b5f01608c2e1b4364e7b365415e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0cdff45179a19a455bef375aed366f9323397a05bc7850a52fd2a106f34cc7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6dec8d3c7b09c9e9114d18081660c5d01b82a34986db43f437aef2a28163fcf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c309c850576d198d785c6f4b36fb5a30705983851cc846075c26bb51d2007de1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd59eec6fc00b4f8adff9031597fbceca1f7ef0aef5e5a7a68f275056713e2fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b62248de9e972c39877fa9e4aeb91ef46b7436d5e92624efc9154f6fa6b9e88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c688de5844e5bbe41b94e7f84612d96c59e4d1348f7c8f596baaa5227e871ed7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5081d23a1ae79d9ce3abb22648a358c1d07d55e03c1aa2ffa9f920a9871344aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31c439058714931736b9a7e4bc5b2c70d47ed188721c40cb8b8839bb3c5ee732",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03209772270d0f1fcac1b006d2d4b4bff967a001e7c9fdc6ed97950fede5e3cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94bce8259108638ea7232af46208addfea8da92027b2bcfba5477e72403c75ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f560288796308a8a5c85ecc3be5214d76cca7d9a69db29981de11910c989ab4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3a149d5a46833b3e166c4610649954e9dcf78a1960f107ea74145a41e06e2d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:57a1d67b5a9c1151e3f3c9401ff7f4704f91307f0d95d5ea7b276e9095748e20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c63e2ad394b69e31da35ddb4578c8b0c45b7d1bbf6015c92434627ad4b243263",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae406fca4514b396783fc79f20f20501eaf357389ccbb0b0c6207bdaadbf236",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:598ddb966e5ac4f664f2cbe9d0087b62c1a4067a1f1af24f290d7f681956e29c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c660eada8cb6e2d2b0c035a9d1696db945761c07e7900b8003b1b405243adef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ccf3b0e27bcba1698f7e14b1f52743ef4d59833b41cf24dd5b1aa490c389b22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:159f17086ec145c629cedca9a038bc0c8fa38b4a8f7f0f0e9bedba0f3e76af28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e41b0d094a6635221cc015437ce4131c9ce502a4d4d2a5c1b51ac36ad0ccd21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:337900b23fc2550547c243e11b7a65284c53c844a3882e0b67e2fbb93f8bf1db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da835508dec9697fe91325943cf0aa123fbd229771496b142f752f0c560588c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff2ca237124563e6c9490abd6802f8d83f66d147e7fd60f8b5196bf78a8ba72e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d81e04636fdf51ce19c3647652e37fa7775dad171ac563ac97fae4636ce6c6e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc5f7ca1ce86cd9380525b383624bdc1afa52d98db624cfdece7b08086f829d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9978e30981c695105d1ecc67ef0b3216ab3413a9d93907390e8577de3b11c478",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca802ad5d10b2728ba10bf98bb16796585d69ec775f5452b3a43718e07c4667a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63a20a87a52e9ab38a252c30f4ef64ad836340d4209dbfcf91c0b869798a3fb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7cb7fd8b0694ff882c9ce27b14e93d91f25469547d5f76e55d113aae6c3b5fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58fc922b01b99cf99809121ca2d3134853a5cc06ec5b8b5f6a0de7eec5c12202",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1a35de9152869803d6667926c330f7e0bffdb52c0d513ee0f3ecdc25f289aff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e022d35d3834e81cdb7c9582086acce4dff74a026ea600f6a5cb86388d231423",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b47b9de40f3d89a23347d11bdec27879263d0cc4a76eef57ba93fda2cebf617e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6aa832d8cc2c70fe044fec76c5769f282a0c2c92749591e96b7d2e6053393eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7bd0358110b6b80f3e4facb097746b19c8d82b3fa079a6dddb80582aae42cad9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:222b5fda22454bd84e33157a67100a88b5c69801aa6692cc5d8277a75fa77cfe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e5767c70bc9f6429b6e9a66ce2cb75e90eea0d9a48392e1e9eb54480fcabd8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:44e396c693edeea0a6db316428af4bd7b2c0df41ce562e2f951b871b70a10bc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ea5031e6eb8d915f4c2910527c3cac1c7cb969fded5057f21be5873a22bad3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52447c45094ab085c5883024b1788e66a7d60d425f48d4dcf6683cd5be0ec087",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4543c991e6f536468d9d47527a201b58b9bc049364a6bdfe15a2f910a02e68f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:213ea8f5cd8ed07a61d13e3e32b66f9f9d3e992b121414ae6fd9d3af3cf49e5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddc6d5cb5a094abc04b93e4018dd178aa1c527c80f2059c21963d3621a428989",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d36aae2debf54b1eae06fe21f3cd7e2f904810f618c987372b14e94097bbef3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0de55e331087a0c931dbff4ff4973dfd54b190b2ba112e6c22ea8f13dd0329d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a5b4e2e1dd388c3c13d79af971fb8efd522f5c2ba8d257875f02c16b4858214",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7c409363b5a1a459b8ceb987866fc54e1feee5d4d2919d31295c8526b7d96f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66305d7a3ca92165f1c17e14cc29ea70280fa1c1fd3bf223b5b1d4f7d1ce0dd8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e918bc5b11c8abfec9343e1b0bd88087b792e85c604427d5cdc32733f70b3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:775c3da0e9e2961262c552292f98dc80f4b05bde52573539148ff4cb51459a51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e45a35d7f68a2657719b18ad53c9efd5a2ca86deab37a886ddc1d1515593ce33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1adc02db53d619c3afe65182be399a9d08a7bcdf8cb9be04edc4b5c99da5cf42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aa568fef0ff3141c9deb6a0e8cfe1e3649d8efbbe04cd7390c0681c447748fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9546058ef3561af0a5e24d50469fc2317afb6aa760363c9348bd2374a31cb5e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76dcdfd95452e176f64d6008d114e9415cd8384c5c0d3300fe644c137b6917fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:012a7fbcbffc0c6d9a7101fb29eef81cd7ba18d3bb427b3aa0c9ae3a27ba2b2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ce5fc1b93217cd4b9db8b47bcd548ac401047ac73f48d1bfd66f0ffb91fd21a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7d0f5ded000fe57622ed2e551dbfad3b86b6bfdcd7d33a5e3c0862b9fcf6dfd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:539f9b54e9f497f0d40374f3d863a62c6fcc4e54a7336ac54445344612fc151c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54ebc02523f7b85a9b790aec6be0b6ef01e377216bd76fc0ada4354fa0f0d8e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c105f54738fba9793dad9b6ab2e88b4ae05cc47b9ea062cd7215b69d11ce0e1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffbcf2d3558dec17023a930d8e278756ffec150d943b66239085043e06fbce59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93476a87e1531898ab2a95a701d918ce589c4da252aac2c615ba650138664feb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08c7782ae9fe49cbec8db74d566061656689bf48cc2977bd0dd8daf3d645133c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9af923799a1ee9a07dbfe10ba28c3a28bc081d77648b1b5f6271f426af7212b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad6916df8df2312e346eca458eb7d21394618e559db385a1059609b93839ccb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47a3ce5b9228ccb688da7458828fef2138f6e4215e73941922dda962aecd14f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6852acb272e0e3f5bcc195a0c858fcf4334abbdba1fa40df67d06d7e08a0cd22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fe2d98578b0c4454536faacbaafd66d1754b8439bb6332d7576a741f4c72208",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:763343a0a0c30885b064b920ceaee7b4846298d07c8975ca5e2a0ce72e0982a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6bf0c6a9c2a00e9e06988299543a9bb1aec4445014b11216db6d6c2e2253bda9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c42642046bf068a2d0cc32f38cdc56d0c92af48eb131fc8dce55a997142f2e88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7bff42a7164385e2ca87fe11bfc8ff6e50d56f8da32b5ebd1e5f0a4508b66b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:557322822a4aa090b2c4d24154f25a7417b1015327c92f463d98161e46f65c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:376d8e1728bea2915e73898571cf46b15303b8af32fb0395099fb11896653b8a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e569deaa2224255e0ac3286fc591ca18abc2bc6c5e71460abae00a3c54c3efec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2662ac74bdff1706965ab83236c1c65c34287e8008eac2785b9b52ffe01816dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b01cb100fa03ec4ac41532662cda8aa9f47ff4abe5f33b2cbf682c311fba841",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de4dcfa7271758f759bfa291ac552eccb586047ee0b91471991bb46b2161b2a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c562efa8f886aa0ca1d6bb55b532f88f8030bf6400e14e65f5a6601df1c0f8a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20b825188654b5b5d17340ce6a78cbd3504e74729f8cfb83150b6798db4a586f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3df7fd45694c994a41077966f80f48d28a5466c21e161c92d05629cc64efe0e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e16b0c15a0820ca0795ac8e5cd196c4c8bef3dfebd70eef28a5152a2c69a9386",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd67360c39e9d4bd6eb9c6179ec2fa68382715129a8a43972e9fe63ee870f420",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3c9a6a1611d967fbff4321b5b1ae54377fed22454298859108138c1f64b0c63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64112ed94189c99bddc05003aa3bdea8a5486e8cf056678512586864b41985ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46a9be44b3444815a0197dd85953bf87710d3ea3d8f9fbfff23068ca85885070",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:128b958d194fd77cb888807aa6bf46c3ebcec2e345ce2cefc202def4b8d678a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62ee4e0aa9f6ba95aacb3a62f2221acfff510f6cd4cfa870cf68cbb9f9d42201",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed6c8cd71a52822a69c6dd28d2a112a0f772983a20e037884c7821d9eddef6ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7eb9468d77618514bf861da405e2c85b2411efe81577ebc586fd9c25e5ae4194",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:359602208228e24f4d2b4f0ab057ad7ca604ed3f23b0873e7efe395a0c3df25e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9da2a72d8eeb2057b30f35dce959c9e3c8045cabe07fad248b22c05e79a1d187",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d240fcb09ece28c26912e4be521605c4dbe4fe340837474b52eed0f98a462400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ab8c75a2f9ee929bbfdb722abc00fb96252e4e76c66f1d292cfe01330f3d56a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b59985bde8c374933ce87766de67f010fd10e0d43803b2d792c34f64f923bac1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4da0677be2e68ab8e7d9132c6350186cf7c1116f545515fc16a43f6daaa92ddf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45616a57f9055382a0612ad493e956358382a8a62796aa2f54d060e275ff1783",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1851797c98801d91ca39184249774dbb71f319072da6fc25ee170fee2f07503",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8958e57d4f99bea5bd52c17f26ff5973dabe941aaa279cfca576c3b7c055c4b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc8e6626c3c8ea2dc183400a6f3a98de9eecd237e099bf589e42b24881256770",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b2bd8783d542d769eb6c440974af90451fd44353f291b9f89873b56b20490ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b392a609fd5f688d073dcade1548fb15f7d7a2b3b37e235aaae9ae07ccecbfb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18188e5455ce48c41c2aa87d9c28a6b0d632e7372d6284455f1a982676f8dccc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1838a0aa547578b45ead6c5f1ccb66493ba06d881e5d4163309f8333b4b74988",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9da9b36d4a3a55ee49e582743900a561093e3625b1e0a90f80e36797de7baa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80b1424e54ba0e84149d8ab536b7fc3e31469a571ae3f0e11077bee8b663af9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4d4230f282f18fcd120bdbff40382d8c04d322675612d9fd85e1461c62b66c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1302b8a938e3c8235510f02d1500b36b03ca8990b5380280ba0a383416c75f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d5c9d11876f3a1688d31fa669986eaaa4c0717435ca99e78fb86bf5ddc193cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f9541ae85dcbefd66fd88c014ccf176b8a6b32788443981490d3a76381c2cc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0ca9c6ed5935cde0094694127c13b99a441207eb084f44fb3aa093669c9957c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b6ec4b5e92ae158d215c9f419173bf825870677717fe4a1375fc16e38cd479b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "user2": {
+                  "uid": 1020,
+                  "gid": 1050,
+                  "groups": [
+                    "group1"
+                  ],
+                  "description": "description 2",
+                  "home": "/home/home2",
+                  "shell": "/bin/sh",
+                  "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                },
+                "user3": {
+                  "uid": 1060,
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.groups",
+            "options": {
+              "groups": {
+                "group1": {
+                  "gid": 1030
+                },
+                "group2": {
+                  "gid": 1050
+                },
+                "user3": {
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/etc/systemd/system/custom.service.d",
+                  "exist_ok": true
+                },
+                {
+                  "path": "/etc/custom_dir"
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "mode": "0770"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "user": 1020,
+                  "group": 1050
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                  }
+                ]
+              },
+              "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                  }
+                ]
+              },
+              "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                  }
+                ]
+              },
+              "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  }
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                  "to": "tree:///etc/systemd/system/custom.service",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                  "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                  "to": "tree:///etc/custom_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                  "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "mode": "0644"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "user": "root",
+                  "group": "root"
+                },
+                "/etc/empty_file.txt": {
+                  "user": 0,
+                  "group": 0
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.systemd",
+            "options": {
+              "enabled_services": [
+                "custom.service"
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 5263327,
+                  "start": 3125248,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263327,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263327
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "xz",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.xz",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "image.raw.xz"
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:012a7fbcbffc0c6d9a7101fb29eef81cd7ba18d3bb427b3aa0c9ae3a27ba2b2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libusb1-1.0.25-9.fc37.x86_64.rpm"
+          },
+          "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:03209772270d0f1fcac1b006d2d4b4bff967a001e7c9fdc6ed97950fede5e3cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gpgme-1.17.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/selinux-policy-targeted-37.12-2.fc37.noarch.rpm"
+          },
+          "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc37.noarch.rpm"
+          },
+          "sha256:08c7782ae9fe49cbec8db74d566061656689bf48cc2977bd0dd8daf3d645133c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mkpasswd-5.5.13-2.fc37.x86_64.rpm"
+          },
+          "sha256:0b01cb100fa03ec4ac41532662cda8aa9f47ff4abe5f33b2cbf682c311fba841": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:0b2bd8783d542d769eb6c440974af90451fd44353f291b9f89873b56b20490ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-libs-251.6-609.fc37.x86_64.rpm"
+          },
+          "sha256:0de55e331087a0c931dbff4ff4973dfd54b190b2ba112e6c22ea8f13dd0329d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsecret-0.20.5-2.fc37.x86_64.rpm"
+          },
+          "sha256:0e3ddc2f83def37e6c6799890e4a3c12220491045a656e308b2d306e165e64bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dracut-config-generic-057-3.fc37.x86_64.rpm"
+          },
+          "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm"
+          },
+          "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:128b958d194fd77cb888807aa6bf46c3ebcec2e345ce2cefc202def4b8d678a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-3.11.0~rc2-1.fc37.x86_64.rpm"
+          },
+          "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:157a95e5d0a70dcb97682ae484d6238e99db218071855483283c61486029ce8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/efibootmgr-18-2.fc37.x86_64.rpm"
+          },
+          "sha256:159f17086ec145c629cedca9a038bc0c8fa38b4a8f7f0f0e9bedba0f3e76af28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm"
+          },
+          "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/setup-2.14.1-2.fc37.noarch.rpm"
+          },
+          "sha256:18188e5455ce48c41c2aa87d9c28a6b0d632e7372d6284455f1a982676f8dccc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-pam-251.6-609.fc37.x86_64.rpm"
+          },
+          "sha256:1838a0aa547578b45ead6c5f1ccb66493ba06d881e5d4163309f8333b4b74988": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-resolved-251.6-609.fc37.x86_64.rpm"
+          },
+          "sha256:192808b88d6473b4bdb33ffe8aa37f2b01ca3e2b76d9b221db8a9eee1ab5d201": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bubblewrap-0.5.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:1ab8c75a2f9ee929bbfdb722abc00fb96252e4e76c66f1d292cfe01330f3d56a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-plugin-selinux-4.18.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:1adc02db53d619c3afe65182be399a9d08a7bcdf8cb9be04edc4b5c99da5cf42": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libssh-0.10.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:1b1e2c27345206db40bd782541b00575f3d36e238a6905c75d67c2407ca4adbd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-1.14.2-1.fc37.x86_64.rpm"
+          },
+          "sha256:1b9c5fe598d258b0dbbf454b01ba844aa678bf5c7333bd16e98ba4c62a242f9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-libs-0.21-19.0.20220203.fc37.x86_64.rpm"
+          },
+          "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm"
+          },
+          "sha256:1ce5fc1b93217cd4b9db8b47bcd548ac401047ac73f48d1bfd66f0ffb91fd21a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxcrypt-4.4.28-3.fc37.x86_64.rpm"
+          },
+          "sha256:1e7bff42a7164385e2ca87fe11bfc8ff6e50d56f8da32b5ebd1e5f0a4508b66b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssl-libs-3.0.5-2.fc37.x86_64.rpm"
+          },
+          "sha256:1f2c3773b6d2a19f5b2a3ea190b210a9f06e186eff763e70662c63fe5c85d394": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse-common-3.10.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:20b825188654b5b5d17340ce6a78cbd3504e74729f8cfb83150b6798db4a586f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm"
+          },
+          "sha256:213ea8f5cd8ed07a61d13e3e32b66f9f9d3e992b121414ae6fd9d3af3cf49e5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpcap-1.10.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:21ab08a6ce4ff5213d541878e456f7c1ea9da5b76c342fe1c55641a77e187b23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bash-5.1.16-4.fc37.x86_64.rpm"
+          },
+          "sha256:222b5fda22454bd84e33157a67100a88b5c69801aa6692cc5d8277a75fa77cfe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnet-1.2-6.fc37.x86_64.rpm"
+          },
+          "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sed-4.8-11.fc37.x86_64.rpm"
+          },
+          "sha256:23cda2a639c358757ee35ce6270ba3d0c6cd779309ff528e7c08c0239737dffb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/audit-libs-3.0.9-1.fc37.x86_64.rpm"
+          },
+          "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/util-linux-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:2662ac74bdff1706965ab83236c1c65c34287e8008eac2785b9b52ffe01816dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcsc-lite-1.9.9-1.fc37.x86_64.rpm"
+          },
+          "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-common-2.06-58.fc37.noarch.rpm"
+          },
+          "sha256:2a5b4e2e1dd388c3c13d79af971fb8efd522f5c2ba8d257875f02c16b4858214": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm"
+          },
+          "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libkcapi-1.4.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:31af27f44c4a8d06068389731d3a5adc0fd45b1c8ce4d28163f938e68fa58cbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/coreutils-common-9.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:31c439058714931736b9a7e4bc5b2c70d47ed188721c40cb8b8839bb3c5ee732": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gnutls-3.7.7-1.fc37.x86_64.rpm"
+          },
+          "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm"
+          },
+          "sha256:337900b23fc2550547c243e11b7a65284c53c844a3882e0b67e2fbb93f8bf1db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libassuan-2.5.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:359602208228e24f4d2b4f0ab057ad7ca604ed3f23b0873e7efe395a0c3df25e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-libs-4.18.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:376d8e1728bea2915e73898571cf46b15303b8af32fb0395099fb11896653b8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/ostree-2022.5-2.fc37.x86_64.rpm"
+          },
+          "sha256:3847abdc8ff973aeb0fb7e681bdf7c37b19cd49e5df17e8bf6bc35f34615c88f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cracklib-2.9.7-30.fc37.x86_64.rpm"
+          },
+          "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm"
+          },
+          "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm"
+          },
+          "sha256:3d36aae2debf54b1eae06fe21f3cd7e2f904810f618c987372b14e94097bbef3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/librepo-1.14.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:3df7fd45694c994a41077966f80f48d28a5466c21e161c92d05629cc64efe0e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/polkit-121-4.fc37.x86_64.rpm"
+          },
+          "sha256:3eea98413bd05506258a3fe592c7f781d58c7143e8f3767d528b875267b95613": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/criu-3.17.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gzip-1.12-2.fc37.x86_64.rpm"
+          },
+          "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm"
+          },
+          "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:44e396c693edeea0a6db316428af4bd7b2c0df41ce562e2f951b871b70a10bc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnfnetlink-1.0.1-22.fc37.x86_64.rpm"
+          },
+          "sha256:4543c991e6f536468d9d47527a201b58b9bc049364a6bdfe15a2f910a02e68f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnl3-3.7.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:45616a57f9055382a0612ad493e956358382a8a62796aa2f54d060e275ff1783": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/skopeo-1.9.2-1.fc37.x86_64.rpm"
+          },
+          "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:45a1bc7c64e5aadb8e9b7936ff36150c885771b5be34a7223fec24a0ec0620e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/criu-libs-3.17.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:46a9be44b3444815a0197dd85953bf87710d3ea3d8f9fbfff23068ca85885070": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/protobuf-c-1.4.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:47a3ce5b9228ccb688da7458828fef2138f6e4215e73941922dda962aecd14f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm"
+          },
+          "sha256:47e1ed14816cd8b66a07911789defd41d6b840baf8ccd0439f99dd1ded4ff15d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse3-3.10.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grubby-8.40-66.fc37.x86_64.rpm"
+          },
+          "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc37.noarch.rpm"
+          },
+          "sha256:4aa568fef0ff3141c9deb6a0e8cfe1e3649d8efbbe04cd7390c0681c447748fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libstdc++-12.2.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm"
+          },
+          "sha256:4d5c9d11876f3a1688d31fa669986eaaa4c0717435ca99e78fb86bf5ddc193cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xz-5.2.5-10.fc37.x86_64.rpm"
+          },
+          "sha256:4da0677be2e68ab8e7d9132c6350186cf7c1116f545515fc16a43f6daaa92ddf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/shim-x64-15.6-2.x86_64.rpm"
+          },
+          "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.x86_64.rpm"
+          },
+          "sha256:4f197117a201e561bc919198df573394e7c97dce2fda2382e3a2495c7ab9e8cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-envsubst-0.21-19.0.20220203.fc37.x86_64.rpm"
+          },
+          "sha256:5081d23a1ae79d9ce3abb22648a358c1d07d55e03c1aa2ffa9f920a9871344aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gnupg2-smime-2.3.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmount-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:52447c45094ab085c5883024b1788e66a7d60d425f48d4dcf6683cd5be0ec087": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnghttp2-1.49.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:539f9b54e9f497f0d40374f3d863a62c6fcc4e54a7336ac54445344612fc151c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxml2-2.9.14-3.fc37.x86_64.rpm"
+          },
+          "sha256:54ebc02523f7b85a9b790aec6be0b6ef01e377216bd76fc0ada4354fa0f0d8e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libyaml-0.2.5-8.fc37.x86_64.rpm"
+          },
+          "sha256:557322822a4aa090b2c4d24154f25a7417b1015327c92f463d98161e46f65c1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.x86_64.rpm"
+          },
+          "sha256:559626f87751e9b10db9237e0bf05589081f69a5436ee88344352cbb5c4ef7cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse3-libs-3.10.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cpio-2.13-13.fc37.x86_64.rpm"
+          },
+          "sha256:57a1d67b5a9c1151e3f3c9401ff7f4704f91307f0d95d5ea7b276e9095748e20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/iptables-libs-1.8.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm"
+          },
+          "sha256:58fc922b01b99cf99809121ca2d3134853a5cc06ec5b8b5f6a0de7eec5c12202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libibverbs-41.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:598ddb966e5ac4f664f2cbe9d0087b62c1a4067a1f1af24f290d7f681956e29c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/json-glib-1.6.6-3.fc37.x86_64.rpm"
+          },
+          "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm"
+          },
+          "sha256:5ea5031e6eb8d915f4c2910527c3cac1c7cb969fded5057f21be5873a22bad3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnftnl-1.2.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libfido2-1.11.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-common-1.14.2-1.fc37.noarch.rpm"
+          },
+          "sha256:62ee4e0aa9f6ba95aacb3a62f2221acfff510f6cd4cfa870cf68cbb9f9d42201": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc37.x86_64.rpm"
+          },
+          "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:63a20a87a52e9ab38a252c30f4ef64ad836340d4209dbfcf91c0b869798a3fb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgomp-12.2.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:64112ed94189c99bddc05003aa3bdea8a5486e8cf056678512586864b41985ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/procps-ng-3.3.17-6.fc37.x86_64.rpm"
+          },
+          "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm"
+          },
+          "sha256:66305d7a3ca92165f1c17e14cc29ea70280fa1c1fd3bf223b5b1d4f7d1ce0dd8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm"
+          },
+          "sha256:6852acb272e0e3f5bcc195a0c858fcf4334abbdba1fa40df67d06d7e08a0cd22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/netavark-1.1.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:68e0f60ad19cf5f0f211f0e14b96b42db87806d9536eb05386cf9bf168891c2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:6b392a609fd5f688d073dcade1548fb15f7d7a2b3b37e235aaae9ae07ccecbfb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-networkd-251.6-609.fc37.x86_64.rpm"
+          },
+          "sha256:6b9b252702c66da50fde953741fe5470d53cb955dddf6a50d890002927517f0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:6bf0c6a9c2a00e9e06988299543a9bb1aec4445014b11216db6d6c2e2253bda9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/npth-1.6-9.fc37.x86_64.rpm"
+          },
+          "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:6dec8d3c7b09c9e9114d18081660c5d01b82a34986db43f437aef2a28163fcf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-2.36-7.fc37.x86_64.rpm"
+          },
+          "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm"
+          },
+          "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm"
+          },
+          "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libssh-config-0.10.4-1.fc37.noarch.rpm"
+          },
+          "sha256:74ee0b4664d9300b0538372064e74e1609f5bf89a4cef76c7849d774af7295cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:763343a0a0c30885b064b920ceaee7b4846298d07c8975ca5e2a0ce72e0982a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nftables-1.0.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:76dcdfd95452e176f64d6008d114e9415cd8384c5c0d3300fe644c137b6917fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm"
+          },
+          "sha256:775c3da0e9e2961262c552292f98dc80f4b05bde52573539148ff4cb51459a51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libslirp-4.7.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libfdisk-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.x86_64.rpm"
+          },
+          "sha256:7b62248de9e972c39877fa9e4aeb91ef46b7436d5e92624efc9154f6fa6b9e88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-minimal-langpack-2.36-7.fc37.x86_64.rpm"
+          },
+          "sha256:7b6ec4b5e92ae158d215c9f419173bf825870677717fe4a1375fc16e38cd479b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zchunk-libs-1.2.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:7bd0358110b6b80f3e4facb097746b19c8d82b3fa079a6dddb80582aae42cad9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/device-mapper-libs-1.02.175-9.fc37.x86_64.rpm"
+          },
+          "sha256:7c660eada8cb6e2d2b0c035a9d1696db945761c07e7900b8003b1b405243adef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-2.5.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:7c7c409363b5a1a459b8ceb987866fc54e1feee5d4d2919d31295c8526b7d96f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:7e5767c70bc9f6429b6e9a66ce2cb75e90eea0d9a48392e1e9eb54480fcabd8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.x86_64.rpm"
+          },
+          "sha256:7eb9468d77618514bf861da405e2c85b2411efe81577ebc586fd9c25e5ae4194": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-4.18.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:80b1424e54ba0e84149d8ab536b7fc3e31469a571ae3f0e11077bee8b663af9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tpm2-tools-5.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-common-37-14.noarch.rpm"
+          },
+          "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pigz-2.7-2.fc37.x86_64.rpm"
+          },
+          "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre-8.45-1.fc37.2.x86_64.rpm"
+          },
+          "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc37.noarch.rpm"
+          },
+          "sha256:8e41b0d094a6635221cc015437ce4131c9ce502a4d4d2a5c1b51ac36ad0ccd21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:8f82c5883afa3a2d8b0d2870393ac9c1195d78932eafe4a24f39deb7f1cfb9e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse-overlayfs-1.9-3.fc37.x86_64.rpm"
+          },
+          "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:8fe2d98578b0c4454536faacbaafd66d1754b8439bb6332d7576a741f4c72208": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nettle-3.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsmartcols-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:93476a87e1531898ab2a95a701d918ce589c4da252aac2c615ba650138664feb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm"
+          },
+          "sha256:94bce8259108638ea7232af46208addfea8da92027b2bcfba5477e72403c75ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-efi-x64-2.06-58.fc37.x86_64.rpm"
+          },
+          "sha256:9546058ef3561af0a5e24d50469fc2317afb6aa760363c9348bd2374a31cb5e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tar-1.34-3.fc36.x86_64.rpm"
+          },
+          "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm"
+          },
+          "sha256:97e918bc5b11c8abfec9343e1b0bd88087b792e85c604427d5cdc32733f70b3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-repos-37-1.noarch.rpm"
+          },
+          "sha256:9978e30981c695105d1ecc67ef0b3216ab3413a9d93907390e8577de3b11c478": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgcc-12.2.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:9a9c9f908326ce672180964c0dee6a387fefce9f4e49dacbca87f4aa8bf1e31f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:9af923799a1ee9a07dbfe10ba28c3a28bc081d77648b1b5f6271f426af7212b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mokutil-0.6.0-5.fc37.x86_64.rpm"
+          },
+          "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-37-14.noarch.rpm"
+          },
+          "sha256:9ccf3b0e27bcba1698f7e14b1f52743ef4d59833b41cf24dd5b1aa490c389b22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kpartx-0.9.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:9da2a72d8eeb2057b30f35dce959c9e3c8045cabe07fad248b22c05e79a1d187": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-ostree-2022.13-1.fc37.x86_64.rpm"
+          },
+          "sha256:9f560288796308a8a5c85ecc3be5214d76cca7d9a69db29981de11910c989ab4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-tools-2.06-58.fc37.x86_64.rpm"
+          },
+          "sha256:9f9541ae85dcbefd66fd88c014ccf176b8a6b32788443981490d3a76381c2cc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xz-libs-5.2.5-10.fc37.x86_64.rpm"
+          },
+          "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm"
+          },
+          "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/selinux-policy-37.12-2.fc37.noarch.rpm"
+          },
+          "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:a3a149d5a46833b3e166c4610649954e9dcf78a1960f107ea74145a41e06e2d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-tools-minimal-2.06-58.fc37.x86_64.rpm"
+          },
+          "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm"
+          },
+          "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm"
+          },
+          "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm"
+          },
+          "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:a9ca97b6dc978f2a3895963780b0a99c794e5db5ce3f18e16951449fb11c74c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/alternatives-1.19-3.fc37.x86_64.rpm"
+          },
+          "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcap-2.48-5.fc37.x86_64.rpm"
+          },
+          "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:ad6916df8df2312e346eca458eb7d21394618e559db385a1059609b93839ccb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mozjs102-102.3.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:ad9b6aeba4041769fbb2d9f3aeb72e3534c7f572f2021ec309e337efb4fe5b64": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-libelf-0.187-8.fc37.x86_64.rpm"
+          },
+          "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblkid-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libuuid-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:b0ca9c6ed5935cde0094694127c13b99a441207eb084f44fb3aa093669c9957c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/y/yajl-2.1.0-19.fc37.x86_64.rpm"
+          },
+          "sha256:b0cdff45179a19a455bef375aed366f9323397a05bc7850a52fd2a106f34cc7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glib2-2.74.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:b1851797c98801d91ca39184249774dbb71f319072da6fc25ee170fee2f07503": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/slirp4netns-1.2.0-5.fc37.x86_64.rpm"
+          },
+          "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:b47b9de40f3d89a23347d11bdec27879263d0cc4a76eef57ba93fda2cebf617e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libksba-1.6.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kmod-30-2.fc37.x86_64.rpm"
+          },
+          "sha256:b59985bde8c374933ce87766de67f010fd10e0d43803b2d792c34f64f923bac1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/shadow-utils-4.12.3-2.fc37.x86_64.rpm"
+          },
+          "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm"
+          },
+          "sha256:b8914ca12a258fb7729a231325e4c269a97d38d6d6961dfebaa4a74d92babad8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dracut-057-3.fc37.x86_64.rpm"
+          },
+          "sha256:b8958e57d4f99bea5bd52c17f26ff5973dabe941aaa279cfca576c3b7c055c4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sqlite-libs-3.39.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:b9e1d9092c3654b4640e115afa1194edd2f4025ece6346c17eff15f127b57f01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/containers-common-1-66.fc37.noarch.rpm"
+          },
+          "sha256:bad0c7e6a8c83996b3aa2056481ea9e1868a3b5f01608c2e1b4364e7b365415e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-runtime-0.21-19.0.20220203.fc37.x86_64.rpm"
+          },
+          "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm"
+          },
+          "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-gpg-keys-37-1.noarch.rpm"
+          },
+          "sha256:c105f54738fba9793dad9b6ab2e88b4ae05cc47b9ea062cd7215b69d11ce0e1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:c309c850576d198d785c6f4b36fb5a30705983851cc846075c26bb51d2007de1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-common-2.36-7.fc37.x86_64.rpm"
+          },
+          "sha256:c42642046bf068a2d0cc32f38cdc56d0c92af48eb131fc8dce55a997142f2e88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openldap-2.6.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:c562efa8f886aa0ca1d6bb55b532f88f8030bf6400e14e65f5a6601df1c0f8a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pinentry-1.2.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/device-mapper-1.02.175-9.fc37.x86_64.rpm"
+          },
+          "sha256:c63e2ad394b69e31da35ddb4578c8b0c45b7d1bbf6015c92434627ad4b243263": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/jansson-2.13.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:c688de5844e5bbe41b94e7f84612d96c59e4d1348f7c8f596baaa5227e871ed7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gnupg2-2.3.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/file-5.42-4.fc37.x86_64.rpm"
+          },
+          "sha256:c999e49255db5e95b6b5a9ef3dcbc07e828e0718cf8dbe147bac62ac8dc82409": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/aardvark-dns-1.1.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:c9da9b36d4a3a55ee49e582743900a561093e3625b1e0a90f80e36797de7baa1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-udev-251.6-609.fc37.x86_64.rpm"
+          },
+          "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm"
+          },
+          "sha256:ca802ad5d10b2728ba10bf98bb16796585d69ec775f5452b3a43718e07c4667a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:cd4d0c1b5490e1cee5e461b89eb1b1e7bb40c40de981cfd73ac060103a5c42a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/coreutils-9.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:cd59eec6fc00b4f8adff9031597fbceca1f7ef0aef5e5a7a68f275056713e2fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-gconv-extra-2.36-7.fc37.x86_64.rpm"
+          },
+          "sha256:ce9deb715d28bc1ef130ebf8c7d8f28fd774123da3e6d60eecaaca887d0a5f4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc37.x86_64.rpm"
+          },
+          "sha256:d0ff6a9301f19f512576bae26583104540973e33dbf619e9948bc838f3a6d714": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/crun-1.6-2.fc37.x86_64.rpm"
+          },
+          "sha256:d1a35de9152869803d6667926c330f7e0bffdb52c0d513ee0f3ecdc25f289aff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libicu-71.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:d240fcb09ece28c26912e4be521605c4dbe4fe340837474b52eed0f98a462400": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-ostree-libs-2022.13-1.fc37.x86_64.rpm"
+          },
+          "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm"
+          },
+          "sha256:d4d4230f282f18fcd120bdbff40382d8c04d322675612d9fd85e1461c62b66c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm"
+          },
+          "sha256:d6aa832d8cc2c70fe044fec76c5769f282a0c2c92749591e96b7d2e6053393eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmnl-1.0.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:d7cb7fd8b0694ff882c9ce27b14e93d91f25469547d5f76e55d113aae6c3b5fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgpg-error-1.45-2.fc37.x86_64.rpm"
+          },
+          "sha256:d7d0f5ded000fe57622ed2e551dbfad3b86b6bfdcd7d33a5e3c0862b9fcf6dfd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxcrypt-compat-4.4.28-3.fc37.x86_64.rpm"
+          },
+          "sha256:d81e04636fdf51ce19c3647652e37fa7775dad171ac563ac97fae4636ce6c6e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libedit-3.1-42.20210910cvs.fc37.x86_64.rpm"
+          },
+          "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grep-3.7-4.fc37.x86_64.rpm"
+          },
+          "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:da835508dec9697fe91325943cf0aa123fbd229771496b142f752f0c560588c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbsd-0.10.0-10.fc37.x86_64.rpm"
+          },
+          "sha256:dae406fca4514b396783fc79f20f20501eaf357389ccbb0b0c6207bdaadbf236": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/json-c-0.16-2.fc37.x86_64.rpm"
+          },
+          "sha256:dc5f7ca1ce86cd9380525b383624bdc1afa52d98db624cfdece7b08086f829d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm"
+          },
+          "sha256:dc8e6626c3c8ea2dc183400a6f3a98de9eecd237e099bf589e42b24881256770": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-251.6-609.fc37.x86_64.rpm"
+          },
+          "sha256:ddc6d5cb5a094abc04b93e4018dd178aa1c527c80f2059c21963d3621a428989": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm"
+          },
+          "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm"
+          },
+          "sha256:de4dcfa7271758f759bfa291ac552eccb586047ee0b91471991bb46b2161b2a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc37.x86_64.rpm"
+          },
+          "sha256:de73e6a453152a5e3635d4796d4b92587f7ad9428647cf85a9bc9506839ed1e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse-2.9.9-15.fc37.x86_64.rpm"
+          },
+          "sha256:e022d35d3834e81cdb7c9582086acce4dff74a026ea600f6a5cb86388d231423": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libidn2-2.3.3-2.fc37.x86_64.rpm"
+          },
+          "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm"
+          },
+          "sha256:e16b0c15a0820ca0795ac8e5cd196c4c8bef3dfebd70eef28a5152a2c69a9386": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/polkit-libs-121-4.fc37.x86_64.rpm"
+          },
+          "sha256:e3c9a6a1611d967fbff4321b5b1ae54377fed22454298859108138c1f64b0c63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/popt-1.19-1.fc37.x86_64.rpm"
+          },
+          "sha256:e3ef7332845114c912be8ba53e198af4e92edb5475809e9d3e6a2ad3202380d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-libs-0.187-8.fc37.x86_64.rpm"
+          },
+          "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:e45a35d7f68a2657719b18ad53c9efd5a2ca86deab37a886ddc1d1515593ce33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsolv-0.7.22-3.fc37.x86_64.rpm"
+          },
+          "sha256:e569deaa2224255e0ac3286fc591ca18abc2bc6c5e71460abae00a3c54c3efec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/ostree-libs-2022.5-2.fc37.x86_64.rpm"
+          },
+          "sha256:e5bbfce30b88c0b4f06c4ad0c80645cfec9c23248d7c734d76607d8bc500c43f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm"
+          },
+          "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm"
+          },
+          "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm"
+          },
+          "sha256:ec82b6cad1b898aaa474a6f68aa67840cbb1d70b515c2255ade5ada88cb3d587": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/curl-7.85.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:ed6c8cd71a52822a69c6dd28d2a112a0f772983a20e037884c7821d9eddef6ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/readline-8.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm"
+          },
+          "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-identity-basic-37-14.noarch.rpm"
+          },
+          "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tzdata-2022d-1.fc37.noarch.rpm"
+          },
+          "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:f1302b8a938e3c8235510f02d1500b36b03ca8990b5380280ba0a383416c75f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/w/which-2.21-35.fc37.x86_64.rpm"
+          },
+          "sha256:f1333de1f729a9f570251d37764c5c20faf596e9cff41643832d33f74bae24a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/efivar-libs-38-5.fc37.x86_64.rpm"
+          },
+          "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm"
+          },
+          "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/util-linux-core-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:f99f0d1d4983db97df46b35119f2996db34f696b8f7281b197faa5aeb974aae7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/container-selinux-2.190.0-1.fc37.noarch.rpm"
+          },
+          "sha256:fd67360c39e9d4bd6eb9c6179ec2fa68382715129a8a43972e9fe63ee870f420": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.x86_64.rpm"
+          },
+          "sha256:ff2ca237124563e6c9490abd6802f8d83f66d147e7fd60f8b5196bf78a8ba72e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcurl-7.85.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:ffbcf2d3558dec17023a930d8e278756ffec150d943b66239085043e06fbce59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/lua-libs-5.4.4-4.fc37.x86_64.rpm"
+          }
+        }
+      },
+      "org.osbuild.inline": {
+        "items": {
+          "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+            "encoding": "base64",
+            "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+          },
+          "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+            "encoding": "base64",
+            "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+          },
+          "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+            "encoding": "base64",
+            "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+          },
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+            "encoding": "base64",
+            "data": ""
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "aardvark-dns",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/aardvark-dns-1.1.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c999e49255db5e95b6b5a9ef3dcbc07e828e0718cf8dbe147bac62ac8dc82409",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/alternatives-1.19-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a9ca97b6dc978f2a3895963780b0a99c794e5db5ce3f18e16951449fb11c74c4",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/audit-libs-3.0.9-1.fc37.x86_64.rpm",
+        "checksum": "sha256:23cda2a639c358757ee35ce6270ba3d0c6cd779309ff528e7c08c0239737dffb",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:74ee0b4664d9300b0538372064e74e1609f5bf89a4cef76c7849d774af7295cf",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:68e0f60ad19cf5f0f211f0e14b96b42db87806d9536eb05386cf9bf168891c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bash-5.1.16-4.fc37.x86_64.rpm",
+        "checksum": "sha256:21ab08a6ce4ff5213d541878e456f7c1ea9da5b76c342fe1c55641a77e187b23",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bubblewrap-0.5.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:192808b88d6473b4bdb33ffe8aa37f2b01ca3e2b76d9b221db8a9eee1ab5d201",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm",
+        "checksum": "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.190.0",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/container-selinux-2.190.0-1.fc37.noarch.rpm",
+        "checksum": "sha256:f99f0d1d4983db97df46b35119f2996db34f696b8f7281b197faa5aeb974aae7",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "66.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/containers-common-1-66.fc37.noarch.rpm",
+        "checksum": "sha256:b9e1d9092c3654b4640e115afa1194edd2f4025ece6346c17eff15f127b57f01",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/coreutils-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:cd4d0c1b5490e1cee5e461b89eb1b1e7bb40c40de981cfd73ac060103a5c42a0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/coreutils-common-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:31af27f44c4a8d06068389731d3a5adc0fd45b1c8ce4d28163f938e68fa58cbf",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cpio-2.13-13.fc37.x86_64.rpm",
+        "checksum": "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cracklib-2.9.7-30.fc37.x86_64.rpm",
+        "checksum": "sha256:3847abdc8ff973aeb0fb7e681bdf7c37b19cd49e5df17e8bf6bc35f34615c88f",
+        "check_gpg": true
+      },
+      {
+        "name": "criu",
+        "epoch": 0,
+        "version": "3.17.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/criu-3.17.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:3eea98413bd05506258a3fe592c7f781d58c7143e8f3767d528b875267b95613",
+        "check_gpg": true
+      },
+      {
+        "name": "criu-libs",
+        "epoch": 0,
+        "version": "3.17.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/criu-libs-3.17.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:45a1bc7c64e5aadb8e9b7936ff36150c885771b5be34a7223fec24a0ec0620e0",
+        "check_gpg": true
+      },
+      {
+        "name": "crun",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/crun-1.6-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d0ff6a9301f19f512576bae26583104540973e33dbf619e9948bc838f3a6d714",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:9a9c9f908326ce672180964c0dee6a387fefce9f4e49dacbca87f4aa8bf1e31f",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/curl-7.85.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:ec82b6cad1b898aaa474a6f68aa67840cbb1d70b515c2255ade5ada88cb3d587",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.x86_64.rpm",
+        "checksum": "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-1.14.2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:1b1e2c27345206db40bd782541b00575f3d36e238a6905c75d67c2407ca4adbd",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e5bbfce30b88c0b4f06c4ad0c80645cfec9c23248d7c734d76607d8bc500c43f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dbus-common-1.14.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:5f6afb47d6d4b78ecdd52221e263db36fa8a3e48e366e9687a199543a61f3aed",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/device-mapper-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/device-mapper-libs-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dracut-057-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b8914ca12a258fb7729a231325e4c269a97d38d6d6961dfebaa4a74d92babad8",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "057",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/d/dracut-config-generic-057-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0e3ddc2f83def37e6c6799890e4a3c12220491045a656e308b2d306e165e64bb",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm",
+        "checksum": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/efibootmgr-18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:157a95e5d0a70dcb97682ae484d6238e99db218071855483283c61486029ce8e",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/efivar-libs-38-5.fc37.x86_64.rpm",
+        "checksum": "sha256:f1333de1f729a9f570251d37764c5c20faf596e9cff41643832d33f74bae24a3",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc37.x86_64.rpm",
+        "checksum": "sha256:ce9deb715d28bc1ef130ebf8c7d8f28fd774123da3e6d60eecaaca887d0a5f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc37.noarch.rpm",
+        "checksum": "sha256:8c3fe28f4d2d976e82aa7dd285f3c836c9aaf0d7f022e51bf31ab13ef8bd667b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-libelf-0.187-8.fc37.x86_64.rpm",
+        "checksum": "sha256:ad9b6aeba4041769fbb2d9f3aeb72e3534c7f572f2021ec309e337efb4fe5b64",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/elfutils-libs-0.187-8.fc37.x86_64.rpm",
+        "checksum": "sha256:e3ef7332845114c912be8ba53e198af4e92edb5475809e9d3e6a2ad3202380d8",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:6b9b252702c66da50fde953741fe5470d53cb955dddf6a50d890002927517f0b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-gpg-keys-37-1.noarch.rpm",
+        "checksum": "sha256:bf315e20968e291f76bd566087c26ae3e19a36f3e3f80511058e8253ac8d3352",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-37-14.noarch.rpm",
+        "checksum": "sha256:9b9eff440dafa6765c639d12646b7914d7e061fd38847ad2e476eef0f3533a08",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-common-37-14.noarch.rpm",
+        "checksum": "sha256:80fa0ea18e3dc2c4de8d732c53982fb6883279865848a7ebc94eae2fd0161090",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "37",
+        "release": "14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-release-identity-basic-37-14.noarch.rpm",
+        "checksum": "sha256:f070bdd586ff3662e6f1e37cff99b7506f0fd5cf6309fd23ca408913faaa76c5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "37",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fedora-repos-37-1.noarch.rpm",
+        "checksum": "sha256:97ecefcabcbe0da05f0fc80847f6c4d3334d3698b62098bc7280ef833a213400",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/file-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse-2.9.9-15.fc37.x86_64.rpm",
+        "checksum": "sha256:de73e6a453152a5e3635d4796d4b92587f7ad9428647cf85a9bc9506839ed1e8",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse-common-3.10.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:1f2c3773b6d2a19f5b2a3ea190b210a9f06e186eff763e70662c63fe5c85d394",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm",
+        "checksum": "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse-overlayfs-1.9-3.fc37.x86_64.rpm",
+        "checksum": "sha256:8f82c5883afa3a2d8b0d2870393ac9c1195d78932eafe4a24f39deb7f1cfb9e6",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse3-3.10.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:47e1ed14816cd8b66a07911789defd41d6b840baf8ccd0439f99dd1ded4ff15d",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/f/fuse3-libs-3.10.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:559626f87751e9b10db9237e0bf05589081f69a5436ee88344352cbb5c4ef7cf",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm",
+        "checksum": "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-envsubst-0.21-19.0.20220203.fc37.x86_64.rpm",
+        "checksum": "sha256:4f197117a201e561bc919198df573394e7c97dce2fda2382e3a2495c7ab9e8cd",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-libs-0.21-19.0.20220203.fc37.x86_64.rpm",
+        "checksum": "sha256:1b9c5fe598d258b0dbbf454b01ba844aa678bf5c7333bd16e98ba4c62a242f9f",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "19.0.20220203.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gettext-runtime-0.21-19.0.20220203.fc37.x86_64.rpm",
+        "checksum": "sha256:bad0c7e6a8c83996b3aa2056481ea9e1868a3b5f01608c2e1b4364e7b365415e",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.74.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glib2-2.74.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b0cdff45179a19a455bef375aed366f9323397a05bc7850a52fd2a106f34cc7d",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-2.36-7.fc37.x86_64.rpm",
+        "checksum": "sha256:6dec8d3c7b09c9e9114d18081660c5d01b82a34986db43f437aef2a28163fcf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-common-2.36-7.fc37.x86_64.rpm",
+        "checksum": "sha256:c309c850576d198d785c6f4b36fb5a30705983851cc846075c26bb51d2007de1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-gconv-extra-2.36-7.fc37.x86_64.rpm",
+        "checksum": "sha256:cd59eec6fc00b4f8adff9031597fbceca1f7ef0aef5e5a7a68f275056713e2fc",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/glibc-minimal-langpack-2.36-7.fc37.x86_64.rpm",
+        "checksum": "sha256:7b62248de9e972c39877fa9e4aeb91ef46b7436d5e92624efc9154f6fa6b9e88",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gnupg2-2.3.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c688de5844e5bbe41b94e7f84612d96c59e4d1348f7c8f596baaa5227e871ed7",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gnupg2-smime-2.3.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:5081d23a1ae79d9ce3abb22648a358c1d07d55e03c1aa2ffa9f920a9871344aa",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.7",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gnutls-3.7.7-1.fc37.x86_64.rpm",
+        "checksum": "sha256:31c439058714931736b9a7e4bc5b2c70d47ed188721c40cb8b8839bb3c5ee732",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gpgme-1.17.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:03209772270d0f1fcac1b006d2d4b4bff967a001e7c9fdc6ed97950fede5e3cf",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grep-3.7-4.fc37.x86_64.rpm",
+        "checksum": "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-common-2.06-58.fc37.noarch.rpm",
+        "checksum": "sha256:26b3260ce406134b233ec03fcd03f94011b95ff702a68345a7a819bf80f0c124",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-efi-x64-2.06-58.fc37.x86_64.rpm",
+        "checksum": "sha256:94bce8259108638ea7232af46208addfea8da92027b2bcfba5477e72403c75ea",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-tools-2.06-58.fc37.x86_64.rpm",
+        "checksum": "sha256:9f560288796308a8a5c85ecc3be5214d76cca7d9a69db29981de11910c989ab4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "58.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grub2-tools-minimal-2.06-58.fc37.x86_64.rpm",
+        "checksum": "sha256:a3a149d5a46833b3e166c4610649954e9dcf78a1960f107ea74145a41e06e2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "66.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/grubby-8.40-66.fc37.x86_64.rpm",
+        "checksum": "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/g/gzip-1.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/iptables-libs-1.8.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:57a1d67b5a9c1151e3f3c9401ff7f4704f91307f0d95d5ea7b276e9095748e20",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/jansson-2.13.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:c63e2ad394b69e31da35ddb4578c8b0c45b7d1bbf6015c92434627ad4b243263",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/json-c-0.16-2.fc37.x86_64.rpm",
+        "checksum": "sha256:dae406fca4514b396783fc79f20f20501eaf357389ccbb0b0c6207bdaadbf236",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/j/json-glib-1.6.6-3.fc37.x86_64.rpm",
+        "checksum": "sha256:598ddb966e5ac4f664f2cbe9d0087b62c1a4067a1f1af24f290d7f681956e29c",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-2.5.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:7c660eada8cb6e2d2b0c035a9d1696db945761c07e7900b8003b1b405243adef",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kmod-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/kpartx-0.9.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9ccf3b0e27bcba1698f7e14b1f52743ef4d59833b41cf24dd5b1aa490c389b22",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm",
+        "checksum": "sha256:159f17086ec145c629cedca9a038bc0c8fa38b4a8f7f0f0e9bedba0f3e76af28",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8e41b0d094a6635221cc015437ce4131c9ce502a4d4d2a5c1b51ac36ad0ccd21",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm",
+        "checksum": "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libassuan-2.5.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:337900b23fc2550547c243e11b7a65284c53c844a3882e0b67e2fbb93f8bf1db",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libblkid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm",
+        "checksum": "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050",
+        "check_gpg": true
+      },
+      {
+        "name": "libbsd",
+        "epoch": 0,
+        "version": "0.10.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libbsd-0.10.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:da835508dec9697fe91325943cf0aa123fbd229771496b142f752f0c560588c2",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcap-2.48-5.fc37.x86_64.rpm",
+        "checksum": "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm",
+        "checksum": "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libcurl-7.85.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:ff2ca237124563e6c9490abd6802f8d83f66d147e7fd60f8b5196bf78a8ba72e",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm",
+        "checksum": "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "42.20210910cvs.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libedit-3.1-42.20210910cvs.fc37.x86_64.rpm",
+        "checksum": "sha256:d81e04636fdf51ce19c3647652e37fa7775dad171ac563ac97fae4636ce6c6e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm",
+        "checksum": "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libfdisk-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm",
+        "checksum": "sha256:dc5f7ca1ce86cd9380525b383624bdc1afa52d98db624cfdece7b08086f829d6",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libfido2-1.11.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgcc-12.2.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:9978e30981c695105d1ecc67ef0b3216ab3413a9d93907390e8577de3b11c478",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ca802ad5d10b2728ba10bf98bb16796585d69ec775f5452b3a43718e07c4667a",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgomp-12.2.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:63a20a87a52e9ab38a252c30f4ef64ad836340d4209dbfcf91c0b869798a3fb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libgpg-error-1.45-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d7cb7fd8b0694ff882c9ce27b14e93d91f25469547d5f76e55d113aae6c3b5fd",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "41.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libibverbs-41.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:58fc922b01b99cf99809121ca2d3134853a5cc06ec5b8b5f6a0de7eec5c12202",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "71.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libicu-71.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d1a35de9152869803d6667926c330f7e0bffdb52c0d513ee0f3ecdc25f289aff",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libidn2-2.3.3-2.fc37.x86_64.rpm",
+        "checksum": "sha256:e022d35d3834e81cdb7c9582086acce4dff74a026ea600f6a5cb86388d231423",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libkcapi-1.4.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libksba-1.6.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b47b9de40f3d89a23347d11bdec27879263d0cc4a76eef57ba93fda2cebf617e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmnl-1.0.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:d6aa832d8cc2c70fe044fec76c5769f282a0c2c92749591e96b7d2e6053393eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:7bd0358110b6b80f3e4facb097746b19c8d82b3fa079a6dddb80582aae42cad9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libmount-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnet",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnet-1.2-6.fc37.x86_64.rpm",
+        "checksum": "sha256:222b5fda22454bd84e33157a67100a88b5c69801aa6692cc5d8277a75fa77cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7e5767c70bc9f6429b6e9a66ce2cb75e90eea0d9a48392e1e9eb54480fcabd8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "22.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnfnetlink-1.0.1-22.fc37.x86_64.rpm",
+        "checksum": "sha256:44e396c693edeea0a6db316428af4bd7b2c0df41ce562e2f951b871b70a10bc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnftnl-1.2.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:5ea5031e6eb8d915f4c2910527c3cac1c7cb969fded5057f21be5873a22bad3c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.49.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnghttp2-1.49.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:52447c45094ab085c5883024b1788e66a7d60d425f48d4dcf6683cd5be0ec087",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnl3-3.7.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:4543c991e6f536468d9d47527a201b58b9bc049364a6bdfe15a2f910a02e68f6",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpcap-1.10.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:213ea8f5cd8ed07a61d13e3e32b66f9f9d3e992b121414ae6fd9d3af3cf49e5d",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm",
+        "checksum": "sha256:ddc6d5cb5a094abc04b93e4018dd178aa1c527c80f2059c21963d3621a428989",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/librepo-1.14.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:3d36aae2debf54b1eae06fe21f3cd7e2f904810f618c987372b14e94097bbef3",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsecret-0.20.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:0de55e331087a0c931dbff4ff4973dfd54b190b2ba112e6c22ea8f13dd0329d2",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:2a5b4e2e1dd388c3c13d79af971fb8efd522f5c2ba8d257875f02c16b4858214",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7c7c409363b5a1a459b8ceb987866fc54e1feee5d4d2919d31295c8526b7d96f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:66305d7a3ca92165f1c17e14cc29ea70280fa1c1fd3bf223b5b1d4f7d1ce0dd8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:97e918bc5b11c8abfec9343e1b0bd88087b792e85c604427d5cdc32733f70b3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494",
+        "check_gpg": true
+      },
+      {
+        "name": "libslirp",
+        "epoch": 0,
+        "version": "4.7.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libslirp-4.7.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:775c3da0e9e2961262c552292f98dc80f4b05bde52573539148ff4cb51459a51",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsmartcols-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libsolv-0.7.22-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e45a35d7f68a2657719b18ad53c9efd5a2ca86deab37a886ddc1d1515593ce33",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libssh-0.10.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:1adc02db53d619c3afe65182be399a9d08a7bcdf8cb9be04edc4b5c99da5cf42",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libssh-config-0.10.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:73e42ccda8bf6b2edcdcc80397096b75ee2d2bcc947efa9e8435417037240f26",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libstdc++-12.2.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:4aa568fef0ff3141c9deb6a0e8cfe1e3649d8efbbe04cd7390c0681c447748fe",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9546058ef3561af0a5e24d50469fc2317afb6aa760363c9348bd2374a31cb5e1",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm",
+        "checksum": "sha256:76dcdfd95452e176f64d6008d114e9415cd8384c5c0d3300fe644c137b6917fa",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libusb1-1.0.25-9.fc37.x86_64.rpm",
+        "checksum": "sha256:012a7fbcbffc0c6d9a7101fb29eef81cd7ba18d3bb427b3aa0c9ae3a27ba2b2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libuuid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxcrypt-4.4.28-3.fc37.x86_64.rpm",
+        "checksum": "sha256:1ce5fc1b93217cd4b9db8b47bcd548ac401047ac73f48d1bfd66f0ffb91fd21a",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxcrypt-compat-4.4.28-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d7d0f5ded000fe57622ed2e551dbfad3b86b6bfdcd7d33a5e3c0862b9fcf6dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libxml2-2.9.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:539f9b54e9f497f0d40374f3d863a62c6fcc4e54a7336ac54445344612fc151c",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libyaml-0.2.5-8.fc37.x86_64.rpm",
+        "checksum": "sha256:54ebc02523f7b85a9b790aec6be0b6ef01e377216bd76fc0ada4354fa0f0d8e3",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c105f54738fba9793dad9b6ab2e88b4ae05cc47b9ea062cd7215b69d11ce0e1c",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/lua-libs-5.4.4-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ffbcf2d3558dec17023a930d8e278756ffec150d943b66239085043e06fbce59",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm",
+        "checksum": "sha256:93476a87e1531898ab2a95a701d918ce589c4da252aac2c615ba650138664feb",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mkpasswd-5.5.13-2.fc37.x86_64.rpm",
+        "checksum": "sha256:08c7782ae9fe49cbec8db74d566061656689bf48cc2977bd0dd8daf3d645133c",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mokutil-0.6.0-5.fc37.x86_64.rpm",
+        "checksum": "sha256:9af923799a1ee9a07dbfe10ba28c3a28bc081d77648b1b5f6271f426af7212b2",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs102",
+        "epoch": 0,
+        "version": "102.3.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mozjs102-102.3.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:ad6916df8df2312e346eca458eb7d21394618e559db385a1059609b93839ccb9",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:47a3ce5b9228ccb688da7458828fef2138f6e4215e73941922dda962aecd14f8",
+        "check_gpg": true
+      },
+      {
+        "name": "netavark",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/netavark-1.1.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:6852acb272e0e3f5bcc195a0c858fcf4334abbdba1fa40df67d06d7e08a0cd22",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nettle-3.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8fe2d98578b0c4454536faacbaafd66d1754b8439bb6332d7576a741f4c72208",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nftables-1.0.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:763343a0a0c30885b064b920ceaee7b4846298d07c8975ca5e2a0ce72e0982a2",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/npth-1.6-9.fc37.x86_64.rpm",
+        "checksum": "sha256:6bf0c6a9c2a00e9e06988299543a9bb1aec4445014b11216db6d6c2e2253bda9",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openldap-2.6.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c42642046bf068a2d0cc32f38cdc56d0c92af48eb131fc8dce55a997142f2e88",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssl-libs-3.0.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1e7bff42a7164385e2ca87fe11bfc8ff6e50d56f8da32b5ebd1e5f0a4508b66b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:557322822a4aa090b2c4d24154f25a7417b1015327c92f463d98161e46f65c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm",
+        "checksum": "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2022.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/ostree-2022.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:376d8e1728bea2915e73898571cf46b15303b8af32fb0395099fb11896653b8a",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2022.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/o/ostree-libs-2022.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:e569deaa2224255e0ac3286fc591ca18abc2bc6c5e71460abae00a3c54c3efec",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre-8.45-1.fc37.2.x86_64.rpm",
+        "checksum": "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm",
+        "checksum": "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcsc-lite-1.9.9-1.fc37.x86_64.rpm",
+        "checksum": "sha256:2662ac74bdff1706965ab83236c1c65c34287e8008eac2785b9b52ffe01816dd",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:0b01cb100fa03ec4ac41532662cda8aa9f47ff4abe5f33b2cbf682c311fba841",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc37.x86_64.rpm",
+        "checksum": "sha256:de4dcfa7271758f759bfa291ac552eccb586047ee0b91471991bb46b2161b2a3",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pigz-2.7-2.fc37.x86_64.rpm",
+        "checksum": "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/pinentry-1.2.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c562efa8f886aa0ca1d6bb55b532f88f8030bf6400e14e65f5a6601df1c0f8a3",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm",
+        "checksum": "sha256:20b825188654b5b5d17340ce6a78cbd3504e74729f8cfb83150b6798db4a586f",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/polkit-121-4.fc37.x86_64.rpm",
+        "checksum": "sha256:3df7fd45694c994a41077966f80f48d28a5466c21e161c92d05629cc64efe0e6",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/polkit-libs-121-4.fc37.x86_64.rpm",
+        "checksum": "sha256:e16b0c15a0820ca0795ac8e5cd196c4c8bef3dfebd70eef28a5152a2c69a9386",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "22.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.x86_64.rpm",
+        "checksum": "sha256:fd67360c39e9d4bd6eb9c6179ec2fa68382715129a8a43972e9fe63ee870f420",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/popt-1.19-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e3c9a6a1611d967fbff4321b5b1ae54377fed22454298859108138c1f64b0c63",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/procps-ng-3.3.17-6.fc37.x86_64.rpm",
+        "checksum": "sha256:64112ed94189c99bddc05003aa3bdea8a5486e8cf056678512586864b41985ad",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/protobuf-c-1.4.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:46a9be44b3444815a0197dd85953bf87710d3ea3d8f9fbfff23068ca85885070",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:083295488e3623d13aa7b1d668ffe400da73d22b4d6e6608f045fb9887271b49",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc37.noarch.rpm",
+        "checksum": "sha256:48ebc4113a96d046067deebf8a10dba4026e5c95527bd5f8f3daf1064ea512ce",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-3.11.0~rc2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:128b958d194fd77cb888807aa6bf46c3ebcec2e345ce2cefc202def4b8d678a2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:62ee4e0aa9f6ba95aacb3a62f2221acfff510f6cd4cfa870cf68cbb9f9d42201",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/readline-8.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:ed6c8cd71a52822a69c6dd28d2a112a0f772983a20e037884c7821d9eddef6ba",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-4.18.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7eb9468d77618514bf861da405e2c85b2411efe81577ebc586fd9c25e5ae4194",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-libs-4.18.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:359602208228e24f4d2b4f0ab057ad7ca604ed3f23b0873e7efe395a0c3df25e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2022.13",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-ostree-2022.13-1.fc37.x86_64.rpm",
+        "checksum": "sha256:9da2a72d8eeb2057b30f35dce959c9e3c8045cabe07fad248b22c05e79a1d187",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2022.13",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-ostree-libs-2022.13-1.fc37.x86_64.rpm",
+        "checksum": "sha256:d240fcb09ece28c26912e4be521605c4dbe4fe340837474b52eed0f98a462400",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/r/rpm-plugin-selinux-4.18.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:1ab8c75a2f9ee929bbfdb722abc00fb96252e4e76c66f1d292cfe01330f3d56a",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sed-4.8-11.fc37.x86_64.rpm",
+        "checksum": "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.12",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/selinux-policy-37.12-2.fc37.noarch.rpm",
+        "checksum": "sha256:a1b5dea8c5483e91660edb4b04b80cca4b997e2438eb247d57fe3faffef68cf2",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.12",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/selinux-policy-targeted-37.12-2.fc37.noarch.rpm",
+        "checksum": "sha256:0760f1761b52c44ba4fe278116896f238ebab8887c695f6095fb8314bf6bc8c7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.12.3",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/shadow-utils-4.12.3-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b59985bde8c374933ce87766de67f010fd10e0d43803b2d792c34f64f923bac1",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/shim-x64-15.6-2.x86_64.rpm",
+        "checksum": "sha256:4da0677be2e68ab8e7d9132c6350186cf7c1116f545515fc16a43f6daaa92ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.9.2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/skopeo-1.9.2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:45616a57f9055382a0612ad493e956358382a8a62796aa2f54d060e275ff1783",
+        "check_gpg": true
+      },
+      {
+        "name": "slirp4netns",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/slirp4netns-1.2.0-5.fc37.x86_64.rpm",
+        "checksum": "sha256:b1851797c98801d91ca39184249774dbb71f319072da6fc25ee170fee2f07503",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/sqlite-libs-3.39.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b8958e57d4f99bea5bd52c17f26ff5973dabe941aaa279cfca576c3b7c055c4b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:dc8e6626c3c8ea2dc183400a6f3a98de9eecd237e099bf589e42b24881256770",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-libs-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:0b2bd8783d542d769eb6c440974af90451fd44353f291b9f89873b56b20490ea",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-networkd-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:6b392a609fd5f688d073dcade1548fb15f7d7a2b3b37e235aaae9ae07ccecbfb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-pam-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:18188e5455ce48c41c2aa87d9c28a6b0d632e7372d6284455f1a982676f8dccc",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-resolved-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:1838a0aa547578b45ead6c5f1ccb66493ba06d881e5d4163309f8333b4b74988",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.6",
+        "release": "609.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/s/systemd-udev-251.6-609.fc37.x86_64.rpm",
+        "checksum": "sha256:c9da9b36d4a3a55ee49e582743900a561093e3625b1e0a90f80e36797de7baa1",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tar-1.34-3.fc36.x86_64.rpm",
+        "checksum": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tpm2-tools-5.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:80b1424e54ba0e84149d8ab536b7fc3e31469a571ae3f0e11077bee8b663af9b",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d4d4230f282f18fcd120bdbff40382d8c04d322675612d9fd85e1461c62b66c7",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022d",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/t/tzdata-2022d-1.fc37.noarch.rpm",
+        "checksum": "sha256:f095b1a4d8e97c532a9c9de18b1b0445c038e3126620bda6cc6e8f53ed9fea07",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/util-linux-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/u/util-linux-core-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "35.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/w/which-2.21-35.fc37.x86_64.rpm",
+        "checksum": "sha256:f1302b8a938e3c8235510f02d1500b36b03ca8990b5380280ba0a383416c75f0",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xz-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:4d5c9d11876f3a1688d31fa669986eaaa4c0717435ca99e78fb86bf5ddc193cf",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/x/xz-libs-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:9f9541ae85dcbefd66fd88c014ccf176b8a6b32788443981490d3a76381c2cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "yajl",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "19.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/y/yajl-2.1.0-19.fc37.x86_64.rpm",
+        "checksum": "sha256:b0ca9c6ed5935cde0094694127c13b99a441207eb084f44fb3aa093669c9957c",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zchunk-libs-1.2.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7b6ec4b5e92ae158d215c9f419173bf825870677717fe4a1375fc16e38cd479b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_38-aarch64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_raw_image_customizations-boot.json
@@ -1,0 +1,5785 @@
+{
+  "compose-request": {
+    "distro": "fedora-38",
+    "arch": "aarch64",
+    "image-type": "iot-raw-image",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-branched-modular-20230310",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "image.raw.xz",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {
+      "customizations": {
+        "user": [
+          {
+            "name": "user2",
+            "description": "description 2",
+            "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+            "home": "/home/home2",
+            "shell": "/bin/sh",
+            "groups": [
+              "group1"
+            ],
+            "uid": 1020,
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "uid": 1060,
+            "gid": 1060
+          }
+        ],
+        "group": [
+          {
+            "name": "group1",
+            "gid": 1030
+          },
+          {
+            "name": "group2",
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "gid": 1060
+          }
+        ],
+        "services": {
+          "enabled": [
+            "custom.service"
+          ]
+        },
+        "directories": [
+          {
+            "path": "/etc/systemd/system/custom.service.d"
+          },
+          {
+            "path": "/etc/custom_dir",
+            "user": 1020,
+            "group": 1050,
+            "mode": "0770"
+          }
+        ],
+        "files": [
+          {
+            "path": "/etc/systemd/system/custom.service",
+            "data": "[Unit]\nDescription=Custom service\n\n[Service]\nExecStart=/usr/bin/false\n\n[Install]\nWantedBy=multi-user.target\n"
+          },
+          {
+            "path": "/etc/systemd/system/custom.service.d/override.conf",
+            "data": "[Service]\nExecStart=\nExecStart=/usr/bin/cat /etc/custom_file.txt\n"
+          },
+          {
+            "path": "/etc/custom_file.txt",
+            "user": "root",
+            "group": "root",
+            "mode": "0644",
+            "data": "image builder is the best"
+          },
+          {
+            "path": "/etc/empty_file.txt",
+            "user": 0,
+            "group": 0
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora38",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:ba72fbb32b033ac001d8a410f864e6e2e456dbcb2fba09a4849efc1205e6d0ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2038e0d7d9f572dc7cf4316a026580021b45374e189cf155849f292558e799b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd15bba53fc3e0c82c546a080c6f5441bed7d87587195843516949e230faf66a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7347986518175c4c649d2cdab6378d55a565fdedc1cd6519fc5e8140e06f8ca4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48897ef50d1d7fceced43f3fb3a8159e4aa4eacf87d4ed2a13880a9f6dcec6bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86e5cb2ff99e096a1d7a31bdd0a0038ba0aa6831ccd8804f5a04b262e2772dda",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbfa023e35aa0c917ca8b0f451b24af4582c769c65571e4c0d90c7dbbef92615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0ae3b4f311fd33c715a6805dcfa2779f6f44b596506cf0f6ff36af409d506ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40ec41204bdb8ce3dfa256a2f0c12b26ec0cb87a863fddda1cb5c5ac17b248b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24ef51235db87f815528627f58d9b7a1720e3984ecc382ec5d5833d2852d5c60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f5b6b7d0c17fb19292cd8fbb5fd4def006eb8ad7b24d8117c1e975322d05891",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13a5171648e217e0d3b3f7021dff491e736a39b5f7162a1c2bd3779bd3bcbd17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7a61dd5759669ca441ff0023eabd9af78d1455d4931ab0a31db0107a54b3fc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c09b8285b4fa856c472ff33e8220186fb35220161fcdd2b6054dc27574cf5066",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df36f338c43b86547adf17d9bfdadcad07f1ac7d6456bc416c29d3373e6287c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca5a06cd3eaa5701c9be12d3fabda97454e9a9e6aca9ffc586b9e14eb3952520",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a4d8cc770e436919ebad73a32168e2cd4da3cad8781d3cce6c9d654a5d3fe59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9828e6e75cd847a6cf4aa0d27d0f4884df5779546ff6b194a759a84e1894e85",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de090ad42c7e36fa7bb2e4408a6bab45e216c0420ae055b9ba1f96c20f804463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3124d8a892116345eab8f50b79835214599ea061cf66665397e9a1cf0f05ba5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:313910bb3c90cc31b7c82212fa71121c54b311f1d9af4eb78e50c7d39446ac86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9cf98847c92321215a42aa1061e143f35d10ac3e738943ce0ce00dafe1df9471",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04296a5d261f241802a92a70c9b000d98e11c0389d689af0bd19bb55abf75bbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786cec3721ba9907a4c69620cee6bc3952de8f27dec33f57d9939619b8514f87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38e6676864f276c4364b6324b787b6e19ad4d160107e9867a57fbbf84530a7ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b25ce7686cc5c1cf3d59e8a9ac89156e9f4bb846de8a6fb44ad33c1a19179067",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15a878661b48b5b4613601eacfc195b812e069a839324dd7d963c7a43d03f1eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:015477e0760f1cc1f080ca43716bcf05c9e40ff7394c26f25e5a4e5512f4074a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34eaff2e19c7ecf3be38670103a4ca8655c5670f42a3c32d4d1fd13de76be842",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdecabcb7a7e24b2c2d52220d2e958b42466e868416553a079a7f01c0d5ff0fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:433b6f621d595b607c4a9f73201e4be9b2a54535191b214b5905278e064c32cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19a1bf0b6a02842ec4d86d9a26a0fafb3864b8a18a05eec266d52bb58f3d1feb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b11aea62a9e6e4295e33c6856c1a32b8f50af5ae98750836d1f97163a8a17bdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df7f7e1774a64e458e4836972fc09673080e56490ec11b08327cb6137f1b9bd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4cfae4f2e8ebb6772c7c5d6ca6212f776c36e5da5c47bb0ef51f444e4a68d3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3baa568b572643be26056e5f5bebdbb061d726c635c78fc2a8970335c724064",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6dc8ec1d8f370cfb509220b23a418938f44280f4d7d4a92458a78a5980281062",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:503b9b7f3b947c4d1a50dfe8dac8064b726a09beade31f116c0e3fd5df5ad78a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89ef8e879fd7ae5dd9e54405accaf1b558bb98edb423eaf27cd44a45c7c443bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f295d316d8aaa426972fd9fff029497b28f9a7572da5faf7e1b121fc0868bd23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2be19d631bc2c3399af9c4a02a73c882cfc79a0296e3101304f5f41bdd5587a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d7d9e4cc7520cba86f679322b635238761b4a8ffb443cb3b2e8228d88a5bdaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a4df46e9482e6dd68f6ff70603e36aaf846d4767ecb69b034900813566f705d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ccaefa2ac125fc90c752808872eef3f72d0e159e4497a58a2b65ce0ca863ca0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bad9043c625b8d266cf0c817453af694b04d41e204270ce91b02013320e6a66d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9115d9bebae439ee8412571ca2c9815b6af517ac2b638fdd5365e291b3d428a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:beadcf8d546a7a1b8feafe3e82fbd22efb5bf329c6277a12b01bc4b13d77a583",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7b74094a5e268849ad2d86fbeb78b67b52c8aed96a88c855ac8fc7a274a569",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e5d1f7f81bae3c55bba8678097db8cf76d25b6495b05c7ee471fe515f0ede60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcaa481098470611f671e0b36520106c1f362cdb4ec709d8405b1f77d6c8c45f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3a5c06db2c5c85f759df7baae7f87b6390b9e126586a59fcdeaa68e23010e9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b162d37fea25914e42e63e6483127b4ac8889e5587f461989e6be6769e5f694",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1520d5466cbb6f853828e3d8454a0a2a255247a2eb08315b35f5e8e147e6504d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7577f8eaa1171a15629ec06c438266b6ce586b59fdf65f8bce8f449a16faea7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae88ef5dda0d2d000080a445ad51747a55df4fa94594fc11b1636639768e87be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6605dc2f943b0b947a19c97fae4bca7608b59f1483c97882686c7ca05c4af7ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd568ab6d1fcc43bf18bc353cbea23fe884c52f54079ee6ad5dfbc921cb72106",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb820f40785631e37e1a023f8494c75feb743e4a172a503ff3feccad1d24f391",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0107618d15c26f2cd52d1c52825e02bb2fdead1fd6449bd670427f5cf880757a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98204d9f002323eb100429184488ca9130659290c4446c974a9346a6e93df889",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2a8f241adc3298633c436f1ca4433a7cd7e9bbcf019865dab9d7e1c1c1094da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07c102c24aaa0e06cccf2968b5da223961571b1a22931834db21295711f94de1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a8c9a2d2b341f6aea2cac2dae0d1cdd01266fbd7cbbf4bc9a044039944f380",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:92b25b91d7e69e1c9ee6dff32948d244776a1ff75cd2eee87c3665cb427a33b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22672c886e6d1f1b49f962ff7258c12ac43b4b65cf60aa44651982ba36b0c973",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c4743682019a693624ede5af59d0eb4b112c3c493f91f0c59ffa7d3e171b301",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12b45030df4dad11f26ed6e6d0c1c749941fcf96dffd72bbd4c122293f85994b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d24979d1cf80f3906eab72efcac23bbbea35ef6eb10475631b5ffc32370621e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e2717a19a4f68657b5b82fccfc85e9bbb6dc3a29d87496b9f96edd3023c029f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1e2e146ad4254ab7bad7ea61acbc7318a9a3bcd254f8c5d06f15a2fa97c5c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:114871e86a9e186ae8ff94ea02235f4d1eb98f7ef22a6945435beb0044f35d7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08fe4ae654a7c12bf80888ad0f52dc8d28ad7cd79c74c2466fcc98ef9b229908",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b817b5ef5565a9190d29d77513dfbae65222fb156f80c4f64a03a12f0b8df52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b850dec7cc93073fd5c1dd6a86fcd4c300d046acb29c81d0cf1c0324a84a13ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:686fab2c75a3ecdc1573396c9dd97e7cdfc86da250bb0c01345ae0f0bb3831e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f45f46be9bfa2ed73829988839fd2ceca36600e3597605205841255b4556371c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73d3c84d2bd0f897c46f04fd4d3e816b0a77c5e1a5cb3e8b5a5ff22b86065351",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1fb07220d23a99fd4122fe207749d09122b7781719da301a6f43d5bb9f14ca7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:821d92639d372d0a91b18587c5b9c698ab93aa47260f100531ee57cf2d0eb13c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe44f2c8c66aa23acee69b313fae5e001b28d139319677ea4aa6a4d3dc2f134d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48ff03b4055e7d41b519fb552410334f9702a955981b06ef9bedfb7ddcf8181b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdc0d4aeb8f58c2ff8afdd4e4716145c0f6dcf1d71ccc44e3e0c4986e0054913",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07041e5bfeb6f98229333d7a77210942f67a5e6bc82bec5af0f7a51d401a68be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad059e8b67b65d9a0c87f6dab6c27e710c1e232b880475538d7f300cf763855e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2cef5121f03115ec8c49b55f61ed2a990861b9cde76f89645df461e34478c1f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83d32dc63c203187bce8ff7534440260235d51e0e9f1b0101d3f01c8adf59a20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5c2231369227e12b0c9e380a8ea0b6459a34eb73469b8e424a7467d11bc125c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33445abbe9ea176b4a1f40a3ad3bdc7aa3efb8398a627cbdc25dacaf5f95a74f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df039113134ebe1450875b29e86003ba6d70fd29ad154d861c7df212e821007c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85a45ca1842eef2537163421043df629daf951705453a8a6ce4c6b4d80c45a31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5319b25ee50ebf4c3e1f0e20a627110459179858455dfe4e5ea9ef98ac3a0f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35d5d6f894585c851435e1eba94c6fc5e9c7cea6eb689f40b560b98d2542ae20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:640116bfdde14e93341912ea1624c7a54944ed5335f79669c8da3c865ef4f900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd1cffeb7fd0ce84ee0223c0fb1325505d96803a781c399181ee8f86a0bac8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fa19567790fa568c37734961a36d3055308b0b640e67f58a5a25c0dd4c8e791",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84d0d30b0bc33e35a1ba0d0b8d7421b7b66242d8a7dee7c0728633201eb8a441",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:659e775e54fc94630a050d8ad717ab4bf60ec1ce5771936233b01764456d8573",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d678daeae88dedc53e06a79694ac5917341c30f2500e5e09928d0ed74c08a59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0dc74a66395954759fab10903160f3643a43d6b26497c68c36588726e2a83e5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53c7deb95ab9e9672f896a86ac4264d45a5ae6618f8aaa121d29acbca4aec9cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a38680aa5eb19d5f694ba4a6c15ba55a2439c29d2003ff7586f2268cb01f14a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f186cac7f4199f6927059b8adb3122c6c15e4f5ab92929aa25456164912c9ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23a74944220bbfc19d5d26ed1ecc24f6f0f3871a33c71569a15aa8d17101885b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1eeea74b3fe8500ee50fb3ad828ee4b980d41f568ad31c441df42b2daeff71c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9618eabe91acefaa7406a01e8ea2033cf3cf5111ab9e1738b80212b6375d78c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3dc4c94526a92526b1af09a991f588ec4b4143aeadc79866fbd7e1dd021107f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65f0e543799ac1d7b993d4eb44e76e0562f180d0cd108d0bab6574240fca6ea9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3f83992a7dd875f0ab4cdc421e2f96f36ebcdd06077dcf3c685b349fa25a553",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2396e128877a15edb4d75caa013a3bedd1bdc4f923aee8a967c687a702d72892",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:228736bb7c085e000a1c3b104bf5fb38ae2f60be99fe6a62ee67b44e9e571629",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bb473c20d69060ea166d4e111ac457230d35e8e5a440ed1fae3db4b6da5dc4b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:329683a63e8ac4bbc810e06338f0257db0b231f90eb86b19e864d4036b3a7ae3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ce087df2a91fd49e8e796e215d04125eaae9a334d3c55fead4f4eac7142a91e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f04577c4ac4fa114df989e3ff36c69d10cb2e4fdbf75691ac1498c770bc28a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a09e3668ccadb40503e28e2efd8ed3d0dec2946fc551856b25c845d8c6d08794",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbe6fe8f74c609ee672cfb35b75497ace1cdf17501a41f205bef49a806097e67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19ba66f8a1b897f620e4bfd5d66bd7e190460f5bc68288d4fda15f9a23063363",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a685678a81eadc35331a74023672a94d7e8a71ebb15aa19ee3e0c2b79d4c625e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01b4d4c566896c87ea8736a1a0406eb3480e5e9dec581a49c973ea30774cff52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2abcc292c06a17a25e60f0e8151c66943da7559c357e025f6acf0ece1cc1fea9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59035fd7df5f840f60fb189f96c5d12c2f0be34db6d91ba768358f797263d210",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9b3c5a71bd562a3c71f6510b8562ae093a683db22448f03fdf91814123dedf8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6871fd28de18a80a42d8b5a1088210c32e9dbff12c5395d25c76cf8b4e65612",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:044b32d2bb74e2ad1bde221b87c476c83c8274fbf6f30e928c7ef721f59c518a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc2566ef3de1b9983323341861fc4658422161e167eb29419deb2f438dd907e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec60544d1423d5ea064e6edbd7beb3cf98e78fe5de2980cc9200428aa3452516",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76382f66152a11217bfc5fa63aa8cc51ee0444bddab95f4810694eb83af21518",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f7e876d7352b9857ca1421b5503d329f4198d287c2cb21d45e77e639f77ccd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f658f37cc911a0ed122c445ee07555c27d8f98ddf30424bdaa528cdf0cfe166",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a73dbf0bb7b043b8469fab0128420673cab87911f9af0befbb12c32123f0374f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d63275a7fba7a2bf7a30df0e4a32f9955eb932bd32d80ccdf70b0ca45f138b90",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89fdf49c17b8e2ddc9b8860ccd6ffddda6656589faa7adf9b0bd701ee89b0e04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b21c89fe2abd9e577631d2541cd7cfb1af5e11e9493c90b354dc772bef35aa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf2e33036db5d364e097118c03b577f7296786cee248f1ff76a4228db48227c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b81eff17b72f9d25482a25eee089dea76ee1c2f853deae9b65e0fcad01bb8b66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90c932fe01f11a1ac5bfeb956aa4bf45570101e0b899e00c9a452e2c5666bea4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f35d38bf1a573e6dec25fab79a39f29dce274b3e617f5628999a3a6ff0bea009",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56ec328ba2bc798113071cb36196e69fff2e5bc3abb48be4cf263bfa101c827c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffa79d41f91cf48696bb9845b87eb8888efad8e52d914087d94de139363012a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a2b564a7855fd993a70efa5e5b2e8fdc1c5ae8635ab8314eb3a2df544764d60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5f8a73efcea92b3d5df1e23cbbbf19dc32382bc367632850c3bdb717566beb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:368d069f5630080a91013f51d3a4ecff6dbd4ffe29f667f6b73cfef681780190",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8b26543b81a634855287185000dcefe6c0e09f35bd77347e8215969aeda5959",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09f8de1e0c90ea397c7677df9e550a1296668a3e018bd58eb1f704b77d7e815c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a5c9e303d5586812b4bd3ca7bc1b1af1e1fe80a1764dabd84409468c1acacd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6164c42552319cacc4226dbb680be091ac0e0853a91b63c496822daff175b68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7bfc2e27dc453726495f11d21f2f4e79716be924d744a92d0a4e4fcb96acca8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8753e26208dc659797cafc163c8fa06c3924d2dc9fdf6ccee94647ff4edde735",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3b7939b663a7c169c436d40adcbf78b20386928ffb620e951703ef5e20b3ed8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a17d3ec2925c94030cf456e706bc96b7f4cccfc4119d5b1f5a89aa302da12ea5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6c268d36a199f6173e6ecc5cdbbc38b0e203d034ecb91ab09cb87d2107f0534",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80947c794b006db9f11bc4b5eade078fb29fcd0f4c44819683b232936fa830bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dff1f45a48b30cbe5b38a98dc4eb38da373f1248dc35f2256d245eb1fa9cfaa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cae55e7380b67c572cd4f793412c604707f77b2ae5e1bbb77133b17f35ab5e92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f811cc8fc811d631471eb6adabcc1014ea329258cf37c2a5f7b936830e3b2e57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3d8c2aff54c19cd260a210a1d077077e304f1396f13ad8ebba91c0c5a367d9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c67ee583c77d9afba9a8ed7e63f6afeab8c3b272c8c43eb3df6f31dfc83d9124",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c568a007b9dae0d471d6badf723161e565f921c2b1eb04e19aee5fbf7dc6e61b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f54c232b4713ac362a343800003ff7deff1c5e7c75710235b9cab5df55ef94a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c508a709e816951b3650e600925e691f180f25f92b68f2b0433ef3d787137f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff3cb745172d9bd639d22e13dc66e94b2df4dae847cbc55d63ae6a6c1b69bf49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6835ca1b00813eff887ef180d9a41f561f9f096a39a6446e5b25dc9da283f8e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11c6ef78372b52968cdea9fd2062bec3fd0cdd77209d5bff8c58da2dbb3f61ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25930a2fdaa748fc28850dc1afd3e02a497b0e4aac518d36be8c80a9fee91a24",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6ccad2fb8b08b10aff2cd6c5bee0d3bbaf839d28872090a616972f1161f1adbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40ee09498cf64c1474ab90c473c9f363bf51611b18d2a929bb57cb8b6be505f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:315097bc4f6f543ef241fe82935e9e89ea9e3e35fdea84a9eeee6dcea75aad70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:315ad79fbc53c6098168be87264263dd332e9b8df9fbc29a64b6fc44da182344",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:283b9a24381d643403c7957c5df4cb389890564082f1f16f9696ca8b35322930",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d101e3624bb04eee8fedae8425964f6276d2b50badb75b6885ac255ad2101ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1a639fc3080b7266b470b39ddb038e711b1c758e522b5cda2618fa3cc22c433",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7177fc17d2c1a947b971d5cc8528e477a19cca68000c30552f14f0a8e96b4ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81982f4c377e24e62cc250654706f2236d8c714d3381c48704ba5ea5ebf2a139",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca40dd03fc1eb93703ea43d9a96a70ad87792e1d675f7a9a762be71d8908c33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e915e3507eb1e877251ac175df26c3be8022b31daedc39fcfa2e05c1ef190911",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:310078572de43cf8be4ae7dd9041028fcdf4b4cba315ed3c97a53cf2049d6793",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0749ca93d398834c7e4f2c252100b1fc104a2f4461640ebe18928f2315ee0013",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ae21d35720ece7b6a01da963444603844d323a7d498b7bbcab2aa26aed1117a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a9ff34d2b8abc163eff8534a8798e95e077d77936838930240b6da876cf4c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29f0368744406e96a46faa1601aab4aa62107e232cb19ca72bca5116249acc1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2670a90b97a51893703b9617dc0368b4ec2aee9136f6351b3d06841dff284947",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1e11cf874a9ce02555a090a5bb783562854fbd037216e4c23cfbd1fa7f11ce0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69d7af8e50b97490006866fbedb5398419d1edf93376c2d70d4b159071ef8996",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5534bf882d968556f232d9419fcdeaf717123fedf55dddaf115b34eabf382678",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f759215cd4075a109ac771993890b0e42dbdeacd14ffdbd8c81dce12e39dafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2c4f6d1944d3eee2fe5bbd79c89865cc89bde742fdb9538093048cc95ca6d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc7f1b56cadb7d7c1f4b1dba4bca9a87b22071d592f1e06e25d0be7106dd418f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36e6835f02c897ea7d1929163cf0dba9317a9fe38637bfa349ecd291ba4b36ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96f465090b634df32e8d5c1e95e915b82da5537f38c46f9eec88484b719786c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ccbd03bfb04069ba7c0400dd1b6ccd54a8dd83b5cd8881d0c75ed7d8468da1f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:700764e38ea8bc1c019d0aec39542b1af5f0c00f169a2210ff8d80504d0ce2ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b476a1e74a3d193827e8a1d021b46847157a9faeae75d02e1a841a21895d4b38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cc37b098b36f89cdf93fc6eaf16bd650ab0b5e7040e789b567c42a934c5f03f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ffc6ebe5127bbc38080006a4fdeace052e8ca2765f41a8dd1190eee720b904d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40ea98773d45bd6bd6a1e756afd183711ba5b4d4c1e56777551e9af16c4979b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5fa3bc538b9b2cd12fc597400a656a60772c2874637d4932ae8db60082291d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:decf31a52963be8f8735646a1b51a5e574a2123486ec6813f5ba6e728f5b00c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe3273344f14113724d991eadf8ccfbc945ce7be74c80bfe667d33c0741f5eb3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:430204db219fd88d828a7b1e4ab0f716034128d10226266aa2ec3517ff48c0da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a7e6b04e4e03810cb47b3a028c089de84917b63c03bd8f1bc82322afa59c78f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb62b4c7c08929750ed58268b2552105c360e8c0e8adfc4e1a53bb398e69333c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa71f4f1c3cc79edc9343ea0fcf558bdfed408a094ddda0bbc7582a0c647fc7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30d5904ee6c1e49e2b78fd85c35202658945614fbd4f14b8e12dba342abaaf46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6902ed20a768a81df117a0ceeb0b0494c17966ebec2a2a4fbcb426aa4de60357",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:057af6e3125eb236993510cd5173b01865b82068a199737264b41690ca0fa631",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0527ff7d382107084ff5a8d5a5c9c95e4f2b526fbff98dfb251c947f4003efa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1257255c6b7842e0a8901cfc767dae55e22d642b920ef8250e6ded36a2b53615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:109073906a2f705f857104e3505315c122e4faa14142ad90d0bbdabcba257bc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b990ceb0f22e2147777ceace7f486a6021e9373a5ece97feee463bbc9793cb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa38c933e194c67185d9982e700bd67f65b9c8fbe23f0146a3a96987516eb668",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "user2": {
+                  "uid": 1020,
+                  "gid": 1050,
+                  "groups": [
+                    "group1"
+                  ],
+                  "description": "description 2",
+                  "home": "/home/home2",
+                  "shell": "/bin/sh",
+                  "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                },
+                "user3": {
+                  "uid": 1060,
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.groups",
+            "options": {
+              "groups": {
+                "group1": {
+                  "gid": 1030
+                },
+                "group2": {
+                  "gid": 1050
+                },
+                "user3": {
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/etc/systemd/system/custom.service.d",
+                  "exist_ok": true
+                },
+                {
+                  "path": "/etc/custom_dir"
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "mode": "0770"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "user": 1020,
+                  "group": 1050
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                  }
+                ]
+              },
+              "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                  }
+                ]
+              },
+              "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                  }
+                ]
+              },
+              "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  }
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                  "to": "tree:///etc/systemd/system/custom.service",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                  "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                  "to": "tree:///etc/custom_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                  "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "mode": "0644"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "user": "root",
+                  "group": "root"
+                },
+                "/etc/empty_file.txt": {
+                  "user": 0,
+                  "group": 0
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.systemd",
+            "options": {
+              "enabled_services": [
+                "custom.service"
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "dos",
+              "uuid": "0xc1748067",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "06"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "83"
+                },
+                {
+                  "size": 5263360,
+                  "start": 3125248,
+                  "type": "83"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263360,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263360
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "ostree-tree": {
+                "type": "org.osbuild.ostree.checkout",
+                "origin": "org.osbuild.source",
+                "references": [
+                  ""
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "to": "mount://root/boot/efi/config.txt"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "to": "mount://root/boot/efi/rpi-u-boot.bin"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "to": "mount://root/boot/efi/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263360
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "xz",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.xz",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "image.raw.xz"
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:0107618d15c26f2cd52d1c52825e02bb2fdead1fd6449bd670427f5cf880757a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-2.36.9000-10.fc38.aarch64.rpm"
+          },
+          "sha256:015477e0760f1cc1f080ca43716bcf05c9e40ff7394c26f25e5a4e5512f4074a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/duktape-2.6.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:01b4d4c566896c87ea8736a1a0406eb3480e5e9dec581a49c973ea30774cff52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:04296a5d261f241802a92a70c9b000d98e11c0389d689af0bd19bb55abf75bbd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/device-mapper-libs-1.02.185-1.fc38.aarch64.rpm"
+          },
+          "sha256:044b32d2bb74e2ad1bde221b87c476c83c8274fbf6f30e928c7ef721f59c518a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm"
+          },
+          "sha256:057af6e3125eb236993510cd5173b01865b82068a199737264b41690ca0fa631": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/w/which-2.21-35.fc37.aarch64.rpm"
+          },
+          "sha256:07041e5bfeb6f98229333d7a77210942f67a5e6bc82bec5af0f7a51d401a68be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:0749ca93d398834c7e4f2c252100b1fc104a2f4461640ebe18928f2315ee0013": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-3.11.0~rc2-1.fc38.aarch64.rpm"
+          },
+          "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm"
+          },
+          "sha256:07c102c24aaa0e06cccf2968b5da223961571b1a22931834db21295711f94de1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-minimal-langpack-2.36.9000-10.fc38.aarch64.rpm"
+          },
+          "sha256:08fe4ae654a7c12bf80888ad0f52dc8d28ad7cd79c74c2466fcc98ef9b229908": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grubby-8.40-67.fc38.aarch64.rpm"
+          },
+          "sha256:09f8de1e0c90ea397c7677df9e550a1296668a3e018bd58eb1f704b77d7e815c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:0a38680aa5eb19d5f694ba4a6c15ba55a2439c29d2003ff7586f2268cb01f14a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm"
+          },
+          "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-common-2.06-60.fc38.noarch.rpm"
+          },
+          "sha256:0ccaefa2ac125fc90c752808872eef3f72d0e159e4497a58a2b65ce0ca863ca0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm"
+          },
+          "sha256:0dc74a66395954759fab10903160f3643a43d6b26497c68c36588726e2a83e5a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm"
+          },
+          "sha256:0e5d1f7f81bae3c55bba8678097db8cf76d25b6495b05c7ee471fe515f0ede60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse-overlayfs-1.9-8.fc38.aarch64.rpm"
+          },
+          "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-common-38-0.4.noarch.rpm"
+          },
+          "sha256:0f658f37cc911a0ed122c445ee07555c27d8f98ddf30424bdaa528cdf0cfe166": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libssh-config-0.10.4-2.fc38.noarch.rpm"
+          },
+          "sha256:0ffc6ebe5127bbc38080006a4fdeace052e8ca2765f41a8dd1190eee720b904d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-252~rc2-612.fc38.aarch64.rpm"
+          },
+          "sha256:109073906a2f705f857104e3505315c122e4faa14142ad90d0bbdabcba257bc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xz-libs-5.2.7-1.fc38.aarch64.rpm"
+          },
+          "sha256:114871e86a9e186ae8ff94ea02235f4d1eb98f7ef22a6945435beb0044f35d7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-tools-minimal-2.06-60.fc38.aarch64.rpm"
+          },
+          "sha256:11c6ef78372b52968cdea9fd2062bec3fd0cdd77209d5bff8c58da2dbb3f61ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcsc-lite-1.9.9-1.fc38.aarch64.rpm"
+          },
+          "sha256:1257255c6b7842e0a8901cfc767dae55e22d642b920ef8250e6ded36a2b53615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xz-5.2.7-1.fc38.aarch64.rpm"
+          },
+          "sha256:12b45030df4dad11f26ed6e6d0c1c749941fcf96dffd72bbd4c122293f85994b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:13a5171648e217e0d3b3f7021dff491e736a39b5f7162a1c2bd3779bd3bcbd17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cpio-2.13-13.fc38.aarch64.rpm"
+          },
+          "sha256:1520d5466cbb6f853828e3d8454a0a2a255247a2eb08315b35f5e8e147e6504d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:15a878661b48b5b4613601eacfc195b812e069a839324dd7d963c7a43d03f1eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dracut-config-generic-057-4.fc38.aarch64.rpm"
+          },
+          "sha256:19a1bf0b6a02842ec4d86d9a26a0fafb3864b8a18a05eec266d52bb58f3d1feb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm"
+          },
+          "sha256:19ba66f8a1b897f620e4bfd5d66bd7e190460f5bc68288d4fda15f9a23063363": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/librepo-1.14.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:1a4d8cc770e436919ebad73a32168e2cd4da3cad8781d3cce6c9d654a5d3fe59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/curl-7.85.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:1b162d37fea25914e42e63e6483127b4ac8889e5587f461989e6be6769e5f694": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:1f186cac7f4199f6927059b8adb3122c6c15e4f5ab92929aa25456164912c9ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libfido2-1.12.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:1fa19567790fa568c37734961a36d3055308b0b640e67f58a5a25c0dd4c8e791": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:22672c886e6d1f1b49f962ff7258c12ac43b4b65cf60aa44651982ba36b0c973": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gnupg2-smime-2.3.8-1.fc38.aarch64.rpm"
+          },
+          "sha256:228736bb7c085e000a1c3b104bf5fb38ae2f60be99fe6a62ee67b44e9e571629": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libksba-1.6.2-1.fc38.aarch64.rpm"
+          },
+          "sha256:2396e128877a15edb4d75caa013a3bedd1bdc4f923aee8a967c687a702d72892": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:23a74944220bbfc19d5d26ed1ecc24f6f0f3871a33c71569a15aa8d17101885b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgcc-12.2.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:24ef51235db87f815528627f58d9b7a1720e3984ecc382ec5d5833d2852d5c60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/coreutils-9.1-8.fc38.aarch64.rpm"
+          },
+          "sha256:25930a2fdaa748fc28850dc1afd3e02a497b0e4aac518d36be8c80a9fee91a24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:25a5c9e303d5586812b4bd3ca7bc1b1af1e1fe80a1764dabd84409468c1acacd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mkpasswd-5.5.14-1.fc38.aarch64.rpm"
+          },
+          "sha256:25a8c9a2d2b341f6aea2cac2dae0d1cdd01266fbd7cbbf4bc9a044039944f380": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:2670a90b97a51893703b9617dc0368b4ec2aee9136f6351b3d06841dff284947": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-4.18.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:283b9a24381d643403c7957c5df4cb389890564082f1f16f9696ca8b35322930": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/polkit-121-4.fc38.aarch64.rpm"
+          },
+          "sha256:29f0368744406e96a46faa1601aab4aa62107e232cb19ca72bca5116249acc1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/readline-8.2-2.fc38.aarch64.rpm"
+          },
+          "sha256:2abcc292c06a17a25e60f0e8151c66943da7559c357e025f6acf0ece1cc1fea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:2b817b5ef5565a9190d29d77513dfbae65222fb156f80c4f64a03a12f0b8df52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gzip-1.12-2.fc37.aarch64.rpm"
+          },
+          "sha256:2b990ceb0f22e2147777ceace7f486a6021e9373a5ece97feee463bbc9793cb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zchunk-libs-1.2.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:2be19d631bc2c3399af9c4a02a73c882cfc79a0296e3101304f5f41bdd5587a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-rawhide-38-0.3.noarch.rpm"
+          },
+          "sha256:2cef5121f03115ec8c49b55f61ed2a990861b9cde76f89645df461e34478c1f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:2d24979d1cf80f3906eab72efcac23bbbea35ef6eb10475631b5ffc32370621e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grep-3.8-1.fc38.aarch64.rpm"
+          },
+          "sha256:2f04577c4ac4fa114df989e3ff36c69d10cb2e4fdbf75691ac1498c770bc28a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:30d5904ee6c1e49e2b78fd85c35202658945614fbd4f14b8e12dba342abaaf46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/util-linux-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:310078572de43cf8be4ae7dd9041028fcdf4b4cba315ed3c97a53cf2049d6793": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc38.noarch.rpm"
+          },
+          "sha256:313910bb3c90cc31b7c82212fa71121c54b311f1d9af4eb78e50c7d39446ac86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-common-1.14.4-1.fc38.noarch.rpm"
+          },
+          "sha256:315097bc4f6f543ef241fe82935e9e89ea9e3e35fdea84a9eeee6dcea75aad70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pinentry-1.2.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:315ad79fbc53c6098168be87264263dd332e9b8df9fbc29a64b6fc44da182344": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm"
+          },
+          "sha256:329683a63e8ac4bbc810e06338f0257db0b231f90eb86b19e864d4036b3a7ae3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmount-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:33445abbe9ea176b4a1f40a3ad3bdc7aa3efb8398a627cbdc25dacaf5f95a74f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:34eaff2e19c7ecf3be38670103a4ca8655c5670f42a3c32d4d1fd13de76be842": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:35d5d6f894585c851435e1eba94c6fc5e9c7cea6eb689f40b560b98d2542ae20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcap-2.48-5.fc37.aarch64.rpm"
+          },
+          "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-38-0.4.noarch.rpm"
+          },
+          "sha256:368d069f5630080a91013f51d3a4ecff6dbd4ffe29f667f6b73cfef681780190": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/lua-libs-5.4.4-6.fc38.aarch64.rpm"
+          },
+          "sha256:36e6835f02c897ea7d1929163cf0dba9317a9fe38637bfa349ecd291ba4b36ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/selinux-policy-targeted-37.13-1.fc38.noarch.rpm"
+          },
+          "sha256:38e6676864f276c4364b6324b787b6e19ad4d160107e9867a57fbbf84530a7ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:3a4df46e9482e6dd68f6ff70603e36aaf846d4767ecb69b034900813566f705d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:3a7e6b04e4e03810cb47b3a028c089de84917b63c03bd8f1bc82322afa59c78f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tpm2-tools-5.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:3ae21d35720ece7b6a01da963444603844d323a7d498b7bbcab2aa26aed1117a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc38.aarch64.rpm"
+          },
+          "sha256:3cc37b098b36f89cdf93fc6eaf16bd650ab0b5e7040e789b567c42a934c5f03f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sqlite-libs-3.39.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:3d7d9e4cc7520cba86f679322b635238761b4a8ffb443cb3b2e8228d88a5bdaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/file-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:3dc4c94526a92526b1af09a991f588ec4b4143aeadc79866fbd7e1dd021107f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgpg-error-1.46-1.fc38.aarch64.rpm"
+          },
+          "sha256:40ea98773d45bd6bd6a1e756afd183711ba5b4d4c1e56777551e9af16c4979b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-libs-252~rc2-612.fc38.aarch64.rpm"
+          },
+          "sha256:40ec41204bdb8ce3dfa256a2f0c12b26ec0cb87a863fddda1cb5c5ac17b248b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/containers-common-1-78.fc38.noarch.rpm"
+          },
+          "sha256:40ee09498cf64c1474ab90c473c9f363bf51611b18d2a929bb57cb8b6be505f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pigz-2.7-2.fc37.aarch64.rpm"
+          },
+          "sha256:430204db219fd88d828a7b1e4ab0f716034128d10226266aa2ec3517ff48c0da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-udev-252~rc2-612.fc38.aarch64.rpm"
+          },
+          "sha256:433b6f621d595b607c4a9f73201e4be9b2a54535191b214b5905278e064c32cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm"
+          },
+          "sha256:48897ef50d1d7fceced43f3fb3a8159e4aa4eacf87d4ed2a13880a9f6dcec6bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bash-5.2.2-2.fc38.aarch64.rpm"
+          },
+          "sha256:48ff03b4055e7d41b519fb552410334f9702a955981b06ef9bedfb7ddcf8181b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm"
+          },
+          "sha256:4a9ff34d2b8abc163eff8534a8798e95e077d77936838930240b6da876cf4c1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:4f759215cd4075a109ac771993890b0e42dbdeacd14ffdbd8c81dce12e39dafa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-plugin-selinux-4.18.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:503b9b7f3b947c4d1a50dfe8dac8064b726a09beade31f116c0e3fd5df5ad78a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:53c7deb95ab9e9672f896a86ac4264d45a5ae6618f8aaa121d29acbca4aec9cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libfdisk-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:5534bf882d968556f232d9419fcdeaf717123fedf55dddaf115b34eabf382678": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-ostree-libs-2022.14-1.fc38.aarch64.rpm"
+          },
+          "sha256:56ec328ba2bc798113071cb36196e69fff2e5bc3abb48be4cf263bfa101c827c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:59035fd7df5f840f60fb189f96c5d12c2f0be34db6d91ba768358f797263d210": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:5d678daeae88dedc53e06a79694ac5917341c30f2500e5e09928d0ed74c08a59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:640116bfdde14e93341912ea1624c7a54944ed5335f79669c8da3c865ef4f900": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:659e775e54fc94630a050d8ad717ab4bf60ec1ce5771936233b01764456d8573": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm"
+          },
+          "sha256:65f0e543799ac1d7b993d4eb44e76e0562f180d0cd108d0bab6574240fca6ea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libidn2-2.3.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:6605dc2f943b0b947a19c97fae4bca7608b59f1483c97882686c7ca05c4af7ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-libs-0.21.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:6835ca1b00813eff887ef180d9a41f561f9f096a39a6446e5b25dc9da283f8e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm"
+          },
+          "sha256:686fab2c75a3ecdc1573396c9dd97e7cdfc86da250bb0c01345ae0f0bb3831e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm"
+          },
+          "sha256:6902ed20a768a81df117a0ceeb0b0494c17966ebec2a2a4fbcb426aa4de60357": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/util-linux-core-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:69d7af8e50b97490006866fbedb5398419d1edf93376c2d70d4b159071ef8996": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-ostree-2022.14-1.fc38.aarch64.rpm"
+          },
+          "sha256:6ccad2fb8b08b10aff2cd6c5bee0d3bbaf839d28872090a616972f1161f1adbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc38.aarch64.rpm"
+          },
+          "sha256:6dc8ec1d8f370cfb509220b23a418938f44280f4d7d4a92458a78a5980281062": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-libs-0.187-8.fc38.aarch64.rpm"
+          },
+          "sha256:6f5b6b7d0c17fb19292cd8fbb5fd4def006eb8ad7b24d8117c1e975322d05891": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/coreutils-common-9.1-8.fc38.aarch64.rpm"
+          },
+          "sha256:700764e38ea8bc1c019d0aec39542b1af5f0c00f169a2210ff8d80504d0ce2ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/shim-aa64-15.6-2.aarch64.rpm"
+          },
+          "sha256:7347986518175c4c649d2cdab6378d55a565fdedc1cd6519fc5e8140e06f8ca4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:73d3c84d2bd0f897c46f04fd4d3e816b0a77c5e1a5cb3e8b5a5ff22b86065351": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:7577f8eaa1171a15629ec06c438266b6ce586b59fdf65f8bce8f449a16faea7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm"
+          },
+          "sha256:76382f66152a11217bfc5fa63aa8cc51ee0444bddab95f4810694eb83af21518": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:786cec3721ba9907a4c69620cee6bc3952de8f27dec33f57d9939619b8514f87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:7c4743682019a693624ede5af59d0eb4b112c3c493f91f0c59ffa7d3e171b301": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gnutls-3.7.8-8.fc38.aarch64.rpm"
+          },
+          "sha256:7c508a709e816951b3650e600925e691f180f25f92b68f2b0433ef3d787137f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm"
+          },
+          "sha256:7c7b74094a5e268849ad2d86fbeb78b67b52c8aed96a88c855ac8fc7a274a569": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm"
+          },
+          "sha256:7d101e3624bb04eee8fedae8425964f6276d2b50badb75b6885ac255ad2101ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/polkit-libs-121-4.fc38.aarch64.rpm"
+          },
+          "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-misc-2.5.1-3.fc38.noarch.rpm"
+          },
+          "sha256:80947c794b006db9f11bc4b5eade078fb29fcd0f4c44819683b232936fa830bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openldap-2.6.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:81982f4c377e24e62cc250654706f2236d8c714d3381c48704ba5ea5ebf2a139": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/procps-ng-3.3.17-8.fc38.aarch64.rpm"
+          },
+          "sha256:821d92639d372d0a91b18587c5b9c698ab93aa47260f100531ee57cf2d0eb13c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:83d32dc63c203187bce8ff7534440260235d51e0e9f1b0101d3f01c8adf59a20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libatomic-12.2.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:84d0d30b0bc33e35a1ba0d0b8d7421b7b66242d8a7dee7c0728633201eb8a441": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcurl-7.85.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:85a45ca1842eef2537163421043df629daf951705453a8a6ce4c6b4d80c45a31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:86e5cb2ff99e096a1d7a31bdd0a0038ba0aa6831ccd8804f5a04b262e2772dda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bubblewrap-0.5.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:8753e26208dc659797cafc163c8fa06c3924d2dc9fdf6ccee94647ff4edde735": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm"
+          },
+          "sha256:89ef8e879fd7ae5dd9e54405accaf1b558bb98edb423eaf27cd44a45c7c443bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-gpg-keys-38-0.3.noarch.rpm"
+          },
+          "sha256:89fdf49c17b8e2ddc9b8860ccd6ffddda6656589faa7adf9b0bd701ee89b0e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm"
+          },
+          "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm"
+          },
+          "sha256:8b21c89fe2abd9e577631d2541cd7cfb1af5e11e9493c90b354dc772bef35aa1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:8ce087df2a91fd49e8e796e215d04125eaae9a334d3c55fead4f4eac7142a91e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnghttp2-1.50.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:90c932fe01f11a1ac5bfeb956aa4bf45570101e0b899e00c9a452e2c5666bea4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libuuid-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:9115d9bebae439ee8412571ca2c9815b6af517ac2b638fdd5365e291b3d428a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse-2.9.9-15.fc37.aarch64.rpm"
+          },
+          "sha256:92b25b91d7e69e1c9ee6dff32948d244776a1ff75cd2eee87c3665cb427a33b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gnupg2-2.3.8-1.fc38.aarch64.rpm"
+          },
+          "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-legacy-2.5.1-3.fc38.noarch.rpm"
+          },
+          "sha256:96f465090b634df32e8d5c1e95e915b82da5537f38c46f9eec88484b719786c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/setup-2.14.2-1.fc38.noarch.rpm"
+          },
+          "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-identity-basic-38-0.4.noarch.rpm"
+          },
+          "sha256:98204d9f002323eb100429184488ca9130659290c4446c974a9346a6e93df889": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-common-2.36.9000-10.fc38.aarch64.rpm"
+          },
+          "sha256:9a2b564a7855fd993a70efa5e5b2e8fdc1c5ae8635ab8314eb3a2df544764d60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm"
+          },
+          "sha256:9cf98847c92321215a42aa1061e143f35d10ac3e738943ce0ce00dafe1df9471": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/device-mapper-1.02.185-1.fc38.aarch64.rpm"
+          },
+          "sha256:9e2717a19a4f68657b5b82fccfc85e9bbb6dc3a29d87496b9f96edd3023c029f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-efi-aa64-2.06-60.fc38.aarch64.rpm"
+          },
+          "sha256:9f7e876d7352b9857ca1421b5503d329f4198d287c2cb21d45e77e639f77ccd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libssh-0.10.4-2.fc38.aarch64.rpm"
+          },
+          "sha256:a0527ff7d382107084ff5a8d5a5c9c95e4f2b526fbff98dfb251c947f4003efa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/w/whois-nls-5.5.14-1.fc38.noarch.rpm"
+          },
+          "sha256:a09e3668ccadb40503e28e2efd8ed3d0dec2946fc551856b25c845d8c6d08794": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:a17d3ec2925c94030cf456e706bc96b7f4cccfc4119d5b1f5a89aa302da12ea5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nettle-3.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:a1eeea74b3fe8500ee50fb3ad828ee4b980d41f568ad31c441df42b2daeff71c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:a1fb07220d23a99fd4122fe207749d09122b7781719da301a6f43d5bb9f14ca7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kmod-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:a3124d8a892116345eab8f50b79835214599ea061cf66665397e9a1cf0f05ba5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm"
+          },
+          "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm"
+          },
+          "sha256:a685678a81eadc35331a74023672a94d7e8a71ebb15aa19ee3e0c2b79d4c625e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:a7177fc17d2c1a947b971d5cc8528e477a19cca68000c30552f14f0a8e96b4ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/popt-1.19-1.fc38.aarch64.rpm"
+          },
+          "sha256:a73dbf0bb7b043b8469fab0128420673cab87911f9af0befbb12c32123f0374f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libstdc++-12.2.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:a7bfc2e27dc453726495f11d21f2f4e79716be924d744a92d0a4e4fcb96acca8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:a9b3c5a71bd562a3c71f6510b8562ae093a683db22448f03fdf91814123dedf8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:aa71f4f1c3cc79edc9343ea0fcf558bdfed408a094ddda0bbc7582a0c647fc7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tzdata-2022e-1.fc38.noarch.rpm"
+          },
+          "sha256:aca40dd03fc1eb93703ea43d9a96a70ad87792e1d675f7a9a762be71d8908c33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc38.noarch.rpm"
+          },
+          "sha256:ad059e8b67b65d9a0c87f6dab6c27e710c1e232b880475538d7f300cf763855e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm"
+          },
+          "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm"
+          },
+          "sha256:ae88ef5dda0d2d000080a445ad51747a55df4fa94594fc11b1636639768e87be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-envsubst-0.21.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:b11aea62a9e6e4295e33c6856c1a32b8f50af5ae98750836d1f97163a8a17bdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/efivar-libs-38-5.fc37.aarch64.rpm"
+          },
+          "sha256:b25ce7686cc5c1cf3d59e8a9ac89156e9f4bb846de8a6fb44ad33c1a19179067": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dracut-057-4.fc38.aarch64.rpm"
+          },
+          "sha256:b2a8f241adc3298633c436f1ca4433a7cd7e9bbcf019865dab9d7e1c1c1094da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-gconv-extra-2.36.9000-10.fc38.aarch64.rpm"
+          },
+          "sha256:b2c4f6d1944d3eee2fe5bbd79c89865cc89bde742fdb9538093048cc95ca6d71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sed-4.8-11.fc37.aarch64.rpm"
+          },
+          "sha256:b3a5c06db2c5c85f759df7baae7f87b6390b9e126586a59fcdeaa68e23010e9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse3-libs-3.12.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:b3f83992a7dd875f0ab4cdc421e2f96f36ebcdd06077dcf3c685b349fa25a553": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libkcapi-1.4.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:b476a1e74a3d193827e8a1d021b46847157a9faeae75d02e1a841a21895d4b38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/skopeo-1.10.0-6.fc38.aarch64.rpm"
+          },
+          "sha256:b5319b25ee50ebf4c3e1f0e20a627110459179858455dfe4e5ea9ef98ac3a0f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm"
+          },
+          "sha256:b5c2231369227e12b0c9e380a8ea0b6459a34eb73469b8e424a7467d11bc125c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:b81eff17b72f9d25482a25eee089dea76ee1c2f853deae9b65e0fcad01bb8b66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:b850dec7cc93073fd5c1dd6a86fcd4c300d046acb29c81d0cf1c0324a84a13ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/j/json-c-0.16-2.fc37.aarch64.rpm"
+          },
+          "sha256:b8b26543b81a634855287185000dcefe6c0e09f35bd77347e8215969aeda5959": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm"
+          },
+          "sha256:b9618eabe91acefaa7406a01e8ea2033cf3cf5111ab9e1738b80212b6375d78c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgomp-12.2.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:ba72fbb32b033ac001d8a410f864e6e2e456dbcb2fba09a4849efc1205e6d0ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/alternatives-1.21-1.fc38.aarch64.rpm"
+          },
+          "sha256:bad9043c625b8d266cf0c817453af694b04d41e204270ce91b02013320e6a66d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:bb473c20d69060ea166d4e111ac457230d35e8e5a440ed1fae3db4b6da5dc4b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:bbfa023e35aa0c917ca8b0f451b24af4582c769c65571e4c0d90c7dbbef92615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm"
+          },
+          "sha256:bd568ab6d1fcc43bf18bc353cbea23fe884c52f54079ee6ad5dfbc921cb72106": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-runtime-0.21.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:bdd1cffeb7fd0ce84ee0223c0fb1325505d96803a781c399181ee8f86a0bac8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm"
+          },
+          "sha256:bdecabcb7a7e24b2c2d52220d2e958b42466e868416553a079a7f01c0d5ff0fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:beadcf8d546a7a1b8feafe3e82fbd22efb5bf329c6277a12b01bc4b13d77a583": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse-common-3.12.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:bf2e33036db5d364e097118c03b577f7296786cee248f1ff76a4228db48227c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libusb1-1.0.26-1.fc38.aarch64.rpm"
+          },
+          "sha256:c09b8285b4fa856c472ff33e8220186fb35220161fcdd2b6054dc27574cf5066": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/crypto-policies-20221003-1.gitcb1ad32.fc38.noarch.rpm"
+          },
+          "sha256:c568a007b9dae0d471d6badf723161e565f921c2b1eb04e19aee5fbf7dc6e61b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:c67ee583c77d9afba9a8ed7e63f6afeab8c3b272c8c43eb3df6f31dfc83d9124": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/ostree-libs-2022.6-1.fc38.aarch64.rpm"
+          },
+          "sha256:c6871fd28de18a80a42d8b5a1088210c32e9dbff12c5395d25c76cf8b4e65612": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:c6c268d36a199f6173e6ecc5cdbbc38b0e203d034ecb91ab09cb87d2107f0534": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/npth-1.6-10.fc38.aarch64.rpm"
+          },
+          "sha256:ca5a06cd3eaa5701c9be12d3fabda97454e9a9e6aca9ffc586b9e14eb3952520": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:cae55e7380b67c572cd4f793412c604707f77b2ae5e1bbb77133b17f35ab5e92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm"
+          },
+          "sha256:cbe6fe8f74c609ee672cfb35b75497ace1cdf17501a41f205bef49a806097e67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm"
+          },
+          "sha256:cc2566ef3de1b9983323341861fc4658422161e167eb29419deb2f438dd907e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsmartcols-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:ccbd03bfb04069ba7c0400dd1b6ccd54a8dd83b5cd8881d0c75ed7d8468da1f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/shadow-utils-4.12.3-3.fc38.aarch64.rpm"
+          },
+          "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm"
+          },
+          "sha256:d1e2e146ad4254ab7bad7ea61acbc7318a9a3bcd254f8c5d06f15a2fa97c5c1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-tools-2.06-60.fc38.aarch64.rpm"
+          },
+          "sha256:d3b7939b663a7c169c436d40adcbf78b20386928ffb620e951703ef5e20b3ed8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm"
+          },
+          "sha256:d63275a7fba7a2bf7a30df0e4a32f9955eb932bd32d80ccdf70b0ca45f138b90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:d9828e6e75cd847a6cf4aa0d27d0f4884df5779546ff6b194a759a84e1894e85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc38.aarch64.rpm"
+          },
+          "sha256:dc7f1b56cadb7d7c1f4b1dba4bca9a87b22071d592f1e06e25d0be7106dd418f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/selinux-policy-37.13-1.fc38.noarch.rpm"
+          },
+          "sha256:de090ad42c7e36fa7bb2e4408a6bab45e216c0420ae055b9ba1f96c20f804463": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-1.14.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:decf31a52963be8f8735646a1b51a5e574a2123486ec6813f5ba6e728f5b00c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-pam-252~rc2-612.fc38.aarch64.rpm"
+          },
+          "sha256:df039113134ebe1450875b29e86003ba6d70fd29ad154d861c7df212e821007c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblkid-2.38.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:df36f338c43b86547adf17d9bfdadcad07f1ac7d6456bc416c29d3373e6287c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/crypto-policies-scripts-20221003-1.gitcb1ad32.fc38.noarch.rpm"
+          },
+          "sha256:df7f7e1774a64e458e4836972fc09673080e56490ec11b08327cb6137f1b9bd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc38.aarch64.rpm"
+          },
+          "sha256:dff1f45a48b30cbe5b38a98dc4eb38da373f1248dc35f2256d245eb1fa9cfaa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssl-libs-3.0.5-5.fc38.aarch64.rpm"
+          },
+          "sha256:e0ae3b4f311fd33c715a6805dcfa2779f6f44b596506cf0f6ff36af409d506ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/container-selinux-2.190.0-2.fc38.noarch.rpm"
+          },
+          "sha256:e1a639fc3080b7266b470b39ddb038e711b1c758e522b5cda2618fa3cc22c433": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm"
+          },
+          "sha256:e1e11cf874a9ce02555a090a5bb783562854fbd037216e4c23cfbd1fa7f11ce0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-libs-4.18.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:e2038e0d7d9f572dc7cf4316a026580021b45374e189cf155849f292558e799b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/audit-libs-3.0.9-1.fc38.aarch64.rpm"
+          },
+          "sha256:e3d8c2aff54c19cd260a210a1d077077e304f1396f13ad8ebba91c0c5a367d9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/ostree-2022.6-1.fc38.aarch64.rpm"
+          },
+          "sha256:e5f8a73efcea92b3d5df1e23cbbbf19dc32382bc367632850c3bdb717566beb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:e5fa3bc538b9b2cd12fc597400a656a60772c2874637d4932ae8db60082291d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-networkd-252~rc2-612.fc38.aarch64.rpm"
+          },
+          "sha256:e6164c42552319cacc4226dbb680be091ac0e0853a91b63c496822daff175b68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:e7a61dd5759669ca441ff0023eabd9af78d1455d4931ab0a31db0107a54b3fc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cracklib-2.9.7-30.fc38.aarch64.rpm"
+          },
+          "sha256:e915e3507eb1e877251ac175df26c3be8022b31daedc39fcfa2e05c1ef190911": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-setuptools-wheel-65.3.0-1.fc38.noarch.rpm"
+          },
+          "sha256:eb62b4c7c08929750ed58268b2552105c360e8c0e8adfc4e1a53bb398e69333c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:eb820f40785631e37e1a023f8494c75feb743e4a172a503ff3feccad1d24f391": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glib2-2.74.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:ec60544d1423d5ea064e6edbd7beb3cf98e78fe5de2980cc9200428aa3452516": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm"
+          },
+          "sha256:f295d316d8aaa426972fd9fff029497b28f9a7572da5faf7e1b121fc0868bd23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-38-0.3.noarch.rpm"
+          },
+          "sha256:f35d38bf1a573e6dec25fab79a39f29dce274b3e617f5628999a3a6ff0bea009": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxcrypt-4.4.28-3.fc38.aarch64.rpm"
+          },
+          "sha256:f3baa568b572643be26056e5f5bebdbb061d726c635c78fc2a8970335c724064": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-libelf-0.187-8.fc38.aarch64.rpm"
+          },
+          "sha256:f45f46be9bfa2ed73829988839fd2ceca36600e3597605205841255b4556371c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-2.5.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:f4cfae4f2e8ebb6772c7c5d6ca6212f776c36e5da5c47bb0ef51f444e4a68d3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc38.noarch.rpm"
+          },
+          "sha256:f54c232b4713ac362a343800003ff7deff1c5e7c75710235b9cab5df55ef94a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm"
+          },
+          "sha256:f811cc8fc811d631471eb6adabcc1014ea329258cf37c2a5f7b936830e3b2e57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm"
+          },
+          "sha256:fa38c933e194c67185d9982e700bd67f65b9c8fbe23f0146a3a96987516eb668": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zlib-1.2.12-5.fc38.aarch64.rpm"
+          },
+          "sha256:fcaa481098470611f671e0b36520106c1f362cdb4ec709d8405b1f77d6c8c45f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse3-3.12.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:fd15bba53fc3e0c82c546a080c6f5441bed7d87587195843516949e230faf66a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:fdc0d4aeb8f58c2ff8afdd4e4716145c0f6dcf1d71ccc44e3e0c4986e0054913": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:fe3273344f14113724d991eadf8ccfbc945ce7be74c80bfe667d33c0741f5eb3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-resolved-252~rc2-612.fc38.aarch64.rpm"
+          },
+          "sha256:fe44f2c8c66aa23acee69b313fae5e001b28d139319677ea4aa6a4d3dc2f134d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kpartx-0.9.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:ff3cb745172d9bd639d22e13dc66e94b2df4dae847cbc55d63ae6a6c1b69bf49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm"
+          },
+          "sha256:ffa79d41f91cf48696bb9845b87eb8888efad8e52d914087d94de139363012a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxml2-2.10.3-1.fc38.aarch64.rpm"
+          }
+        }
+      },
+      "org.osbuild.inline": {
+        "items": {
+          "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+            "encoding": "base64",
+            "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+          },
+          "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+            "encoding": "base64",
+            "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+          },
+          "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+            "encoding": "base64",
+            "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+          },
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+            "encoding": "base64",
+            "data": ""
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/alternatives-1.21-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ba72fbb32b033ac001d8a410f864e6e2e456dbcb2fba09a4849efc1205e6d0ab",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.9",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/audit-libs-3.0.9-1.fc38.aarch64.rpm",
+        "checksum": "sha256:e2038e0d7d9f572dc7cf4316a026580021b45374e189cf155849f292558e799b",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:fd15bba53fc3e0c82c546a080c6f5441bed7d87587195843516949e230faf66a",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:7347986518175c4c649d2cdab6378d55a565fdedc1cd6519fc5e8140e06f8ca4",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bash-5.2.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:48897ef50d1d7fceced43f3fb3a8159e4aa4eacf87d4ed2a13880a9f6dcec6bc",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bubblewrap-0.5.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:86e5cb2ff99e096a1d7a31bdd0a0038ba0aa6831ccd8804f5a04b262e2772dda",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm",
+        "checksum": "sha256:bbfa023e35aa0c917ca8b0f451b24af4582c769c65571e4c0d90c7dbbef92615",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.190.0",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/container-selinux-2.190.0-2.fc38.noarch.rpm",
+        "checksum": "sha256:e0ae3b4f311fd33c715a6805dcfa2779f6f44b596506cf0f6ff36af409d506ec",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "78.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/containers-common-1-78.fc38.noarch.rpm",
+        "checksum": "sha256:40ec41204bdb8ce3dfa256a2f0c12b26ec0cb87a863fddda1cb5c5ac17b248b5",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/coreutils-9.1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:24ef51235db87f815528627f58d9b7a1720e3984ecc382ec5d5833d2852d5c60",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/coreutils-common-9.1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:6f5b6b7d0c17fb19292cd8fbb5fd4def006eb8ad7b24d8117c1e975322d05891",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cpio-2.13-13.fc38.aarch64.rpm",
+        "checksum": "sha256:13a5171648e217e0d3b3f7021dff491e736a39b5f7162a1c2bd3779bd3bcbd17",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cracklib-2.9.7-30.fc38.aarch64.rpm",
+        "checksum": "sha256:e7a61dd5759669ca441ff0023eabd9af78d1455d4931ab0a31db0107a54b3fc7",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20221003",
+        "release": "1.gitcb1ad32.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/crypto-policies-20221003-1.gitcb1ad32.fc38.noarch.rpm",
+        "checksum": "sha256:c09b8285b4fa856c472ff33e8220186fb35220161fcdd2b6054dc27574cf5066",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20221003",
+        "release": "1.gitcb1ad32.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/crypto-policies-scripts-20221003-1.gitcb1ad32.fc38.noarch.rpm",
+        "checksum": "sha256:df36f338c43b86547adf17d9bfdadcad07f1ac7d6456bc416c29d3373e6287c6",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ca5a06cd3eaa5701c9be12d3fabda97454e9a9e6aca9ffc586b9e14eb3952520",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/curl-7.85.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:1a4d8cc770e436919ebad73a32168e2cd4da3cad8781d3cce6c9d654a5d3fe59",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/cyrus-sasl-lib-2.1.28-8.fc38.aarch64.rpm",
+        "checksum": "sha256:d9828e6e75cd847a6cf4aa0d27d0f4884df5779546ff6b194a759a84e1894e85",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-1.14.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:de090ad42c7e36fa7bb2e4408a6bab45e216c0420ae055b9ba1f96c20f804463",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a3124d8a892116345eab8f50b79835214599ea061cf66665397e9a1cf0f05ba5",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dbus-common-1.14.4-1.fc38.noarch.rpm",
+        "checksum": "sha256:313910bb3c90cc31b7c82212fa71121c54b311f1d9af4eb78e50c7d39446ac86",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.185",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/device-mapper-1.02.185-1.fc38.aarch64.rpm",
+        "checksum": "sha256:9cf98847c92321215a42aa1061e143f35d10ac3e738943ce0ce00dafe1df9471",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.185",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/device-mapper-libs-1.02.185-1.fc38.aarch64.rpm",
+        "checksum": "sha256:04296a5d261f241802a92a70c9b000d98e11c0389d689af0bd19bb55abf75bbd",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:786cec3721ba9907a4c69620cee6bc3952de8f27dec33f57d9939619b8514f87",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:38e6676864f276c4364b6324b787b6e19ad4d160107e9867a57fbbf84530a7ef",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dracut-057-4.fc38.aarch64.rpm",
+        "checksum": "sha256:b25ce7686cc5c1cf3d59e8a9ac89156e9f4bb846de8a6fb44ad33c1a19179067",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "057",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/dracut-config-generic-057-4.fc38.aarch64.rpm",
+        "checksum": "sha256:15a878661b48b5b4613601eacfc195b812e069a839324dd7d963c7a43d03f1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "duktape",
+        "epoch": 0,
+        "version": "2.6.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/d/duktape-2.6.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:015477e0760f1cc1f080ca43716bcf05c9e40ff7394c26f25e5a4e5512f4074a",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:34eaff2e19c7ecf3be38670103a4ca8655c5670f42a3c32d4d1fd13de76be842",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:bdecabcb7a7e24b2c2d52220d2e958b42466e868416553a079a7f01c0d5ff0fa",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm",
+        "checksum": "sha256:433b6f621d595b607c4a9f73201e4be9b2a54535191b214b5905278e064c32cf",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:19a1bf0b6a02842ec4d86d9a26a0fafb3864b8a18a05eec266d52bb58f3d1feb",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/efivar-libs-38-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b11aea62a9e6e4295e33c6856c1a32b8f50af5ae98750836d1f97163a8a17bdf",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-debuginfod-client-0.187-8.fc38.aarch64.rpm",
+        "checksum": "sha256:df7f7e1774a64e458e4836972fc09673080e56490ec11b08327cb6137f1b9bd3",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-default-yama-scope-0.187-8.fc38.noarch.rpm",
+        "checksum": "sha256:f4cfae4f2e8ebb6772c7c5d6ca6212f776c36e5da5c47bb0ef51f444e4a68d3f",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-libelf-0.187-8.fc38.aarch64.rpm",
+        "checksum": "sha256:f3baa568b572643be26056e5f5bebdbb061d726c635c78fc2a8970335c724064",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/elfutils-libs-0.187-8.fc38.aarch64.rpm",
+        "checksum": "sha256:6dc8ec1d8f370cfb509220b23a418938f44280f4d7d4a92458a78a5980281062",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:503b9b7f3b947c4d1a50dfe8dac8064b726a09beade31f116c0e3fd5df5ad78a",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-gpg-keys-38-0.3.noarch.rpm",
+        "checksum": "sha256:89ef8e879fd7ae5dd9e54405accaf1b558bb98edb423eaf27cd44a45c7c443bf",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-38-0.4.noarch.rpm",
+        "checksum": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-common-38-0.4.noarch.rpm",
+        "checksum": "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-identity-basic-38-0.4.noarch.rpm",
+        "checksum": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-38-0.3.noarch.rpm",
+        "checksum": "sha256:f295d316d8aaa426972fd9fff029497b28f9a7572da5faf7e1b121fc0868bd23",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.3",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-repos-rawhide-38-0.3.noarch.rpm",
+        "checksum": "sha256:2be19d631bc2c3399af9c4a02a73c882cfc79a0296e3101304f5f41bdd5587a3",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/file-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3d7d9e4cc7520cba86f679322b635238761b4a8ffb443cb3b2e8228d88a5bdaa",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3a4df46e9482e6dd68f6ff70603e36aaf846d4767ecb69b034900813566f705d",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0ccaefa2ac125fc90c752808872eef3f72d0e159e4497a58a2b65ce0ca863ca0",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:bad9043c625b8d266cf0c817453af694b04d41e204270ce91b02013320e6a66d",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:9115d9bebae439ee8412571ca2c9815b6af517ac2b638fdd5365e291b3d428a5",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.12.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse-common-3.12.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:beadcf8d546a7a1b8feafe3e82fbd22efb5bf329c6277a12b01bc4b13d77a583",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:7c7b74094a5e268849ad2d86fbeb78b67b52c8aed96a88c855ac8fc7a274a569",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse-overlayfs-1.9-8.fc38.aarch64.rpm",
+        "checksum": "sha256:0e5d1f7f81bae3c55bba8678097db8cf76d25b6495b05c7ee471fe515f0ede60",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.12.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse3-3.12.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:fcaa481098470611f671e0b36520106c1f362cdb4ec709d8405b1f77d6c8c45f",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.12.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fuse3-libs-3.12.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:b3a5c06db2c5c85f759df7baae7f87b6390b9e126586a59fcdeaa68e23010e9a",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1b162d37fea25914e42e63e6483127b4ac8889e5587f461989e6be6769e5f694",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1520d5466cbb6f853828e3d8454a0a2a255247a2eb08315b35f5e8e147e6504d",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm",
+        "checksum": "sha256:7577f8eaa1171a15629ec06c438266b6ce586b59fdf65f8bce8f449a16faea7d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-envsubst-0.21.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ae88ef5dda0d2d000080a445ad51747a55df4fa94594fc11b1636639768e87be",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-libs-0.21.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:6605dc2f943b0b947a19c97fae4bca7608b59f1483c97882686c7ca05c4af7ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gettext-runtime-0.21.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:bd568ab6d1fcc43bf18bc353cbea23fe884c52f54079ee6ad5dfbc921cb72106",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.74.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glib2-2.74.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:eb820f40785631e37e1a023f8494c75feb743e4a172a503ff3feccad1d24f391",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-2.36.9000-10.fc38.aarch64.rpm",
+        "checksum": "sha256:0107618d15c26f2cd52d1c52825e02bb2fdead1fd6449bd670427f5cf880757a",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-common-2.36.9000-10.fc38.aarch64.rpm",
+        "checksum": "sha256:98204d9f002323eb100429184488ca9130659290c4446c974a9346a6e93df889",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-gconv-extra-2.36.9000-10.fc38.aarch64.rpm",
+        "checksum": "sha256:b2a8f241adc3298633c436f1ca4433a7cd7e9bbcf019865dab9d7e1c1c1094da",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/glibc-minimal-langpack-2.36.9000-10.fc38.aarch64.rpm",
+        "checksum": "sha256:07c102c24aaa0e06cccf2968b5da223961571b1a22931834db21295711f94de1",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:25a8c9a2d2b341f6aea2cac2dae0d1cdd01266fbd7cbbf4bc9a044039944f380",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.8",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gnupg2-2.3.8-1.fc38.aarch64.rpm",
+        "checksum": "sha256:92b25b91d7e69e1c9ee6dff32948d244776a1ff75cd2eee87c3665cb427a33b1",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.8",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gnupg2-smime-2.3.8-1.fc38.aarch64.rpm",
+        "checksum": "sha256:22672c886e6d1f1b49f962ff7258c12ac43b4b65cf60aa44651982ba36b0c973",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.8",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gnutls-3.7.8-8.fc38.aarch64.rpm",
+        "checksum": "sha256:7c4743682019a693624ede5af59d0eb4b112c3c493f91f0c59ffa7d3e171b301",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:12b45030df4dad11f26ed6e6d0c1c749941fcf96dffd72bbd4c122293f85994b",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grep-3.8-1.fc38.aarch64.rpm",
+        "checksum": "sha256:2d24979d1cf80f3906eab72efcac23bbbea35ef6eb10475631b5ffc32370621e",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-common-2.06-60.fc38.noarch.rpm",
+        "checksum": "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-efi-aa64-2.06-60.fc38.aarch64.rpm",
+        "checksum": "sha256:9e2717a19a4f68657b5b82fccfc85e9bbb6dc3a29d87496b9f96edd3023c029f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-tools-2.06-60.fc38.aarch64.rpm",
+        "checksum": "sha256:d1e2e146ad4254ab7bad7ea61acbc7318a9a3bcd254f8c5d06f15a2fa97c5c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "60.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-tools-minimal-2.06-60.fc38.aarch64.rpm",
+        "checksum": "sha256:114871e86a9e186ae8ff94ea02235f4d1eb98f7ef22a6945435beb0044f35d7a",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "67.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grubby-8.40-67.fc38.aarch64.rpm",
+        "checksum": "sha256:08fe4ae654a7c12bf80888ad0f52dc8d28ad7cd79c74c2466fcc98ef9b229908",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/gzip-1.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2b817b5ef5565a9190d29d77513dfbae65222fb156f80c4f64a03a12f0b8df52",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/j/json-c-0.16-2.fc37.aarch64.rpm",
+        "checksum": "sha256:b850dec7cc93073fd5c1dd6a86fcd4c300d046acb29c81d0cf1c0324a84a13ca",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm",
+        "checksum": "sha256:686fab2c75a3ecdc1573396c9dd97e7cdfc86da250bb0c01345ae0f0bb3831e7",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-2.5.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f45f46be9bfa2ed73829988839fd2ceca36600e3597605205841255b4556371c",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-legacy-2.5.1-3.fc38.noarch.rpm",
+        "checksum": "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kbd-misc-2.5.1-3.fc38.noarch.rpm",
+        "checksum": "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:73d3c84d2bd0f897c46f04fd4d3e816b0a77c5e1a5cb3e8b5a5ff22b86065351",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kmod-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a1fb07220d23a99fd4122fe207749d09122b7781719da301a6f43d5bb9f14ca7",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:821d92639d372d0a91b18587c5b9c698ab93aa47260f100531ee57cf2d0eb13c",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/kpartx-0.9.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:fe44f2c8c66aa23acee69b313fae5e001b28d139319677ea4aa6a4d3dc2f134d",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm",
+        "checksum": "sha256:48ff03b4055e7d41b519fb552410334f9702a955981b06ef9bedfb7ddcf8181b",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:fdc0d4aeb8f58c2ff8afdd4e4716145c0f6dcf1d71ccc44e3e0c4986e0054913",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:07041e5bfeb6f98229333d7a77210942f67a5e6bc82bec5af0f7a51d401a68be",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ad059e8b67b65d9a0c87f6dab6c27e710c1e232b880475538d7f300cf763855e",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:2cef5121f03115ec8c49b55f61ed2a990861b9cde76f89645df461e34478c1f2",
+        "check_gpg": true
+      },
+      {
+        "name": "libatomic",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libatomic-12.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:83d32dc63c203187bce8ff7534440260235d51e0e9f1b0101d3f01c8adf59a20",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b5c2231369227e12b0c9e380a8ea0b6459a34eb73469b8e424a7467d11bc125c",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:33445abbe9ea176b4a1f40a3ad3bdc7aa3efb8398a627cbdc25dacaf5f95a74f",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libblkid-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:df039113134ebe1450875b29e86003ba6d70fd29ad154d861c7df212e821007c",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:85a45ca1842eef2537163421043df629daf951705453a8a6ce4c6b4d80c45a31",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm",
+        "checksum": "sha256:b5319b25ee50ebf4c3e1f0e20a627110459179858455dfe4e5ea9ef98ac3a0f5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcap-2.48-5.fc37.aarch64.rpm",
+        "checksum": "sha256:35d5d6f894585c851435e1eba94c6fc5e9c7cea6eb689f40b560b98d2542ae20",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:640116bfdde14e93341912ea1624c7a54944ed5335f79669c8da3c865ef4f900",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm",
+        "checksum": "sha256:bdd1cffeb7fd0ce84ee0223c0fb1325505d96803a781c399181ee8f86a0bac8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1fa19567790fa568c37734961a36d3055308b0b640e67f58a5a25c0dd4c8e791",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libcurl-7.85.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:84d0d30b0bc33e35a1ba0d0b8d7421b7b66242d8a7dee7c0728633201eb8a441",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm",
+        "checksum": "sha256:659e775e54fc94630a050d8ad717ab4bf60ec1ce5771936233b01764456d8573",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:5d678daeae88dedc53e06a79694ac5917341c30f2500e5e09928d0ed74c08a59",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm",
+        "checksum": "sha256:0dc74a66395954759fab10903160f3643a43d6b26497c68c36588726e2a83e5a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libfdisk-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:53c7deb95ab9e9672f896a86ac4264d45a5ae6618f8aaa121d29acbca4aec9cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:0a38680aa5eb19d5f694ba4a6c15ba55a2439c29d2003ff7586f2268cb01f14a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.12.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libfido2-1.12.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:1f186cac7f4199f6927059b8adb3122c6c15e4f5ab92929aa25456164912c9ba",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgcc-12.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:23a74944220bbfc19d5d26ed1ecc24f6f0f3871a33c71569a15aa8d17101885b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a1eeea74b3fe8500ee50fb3ad828ee4b980d41f568ad31c441df42b2daeff71c",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgomp-12.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:b9618eabe91acefaa7406a01e8ea2033cf3cf5111ab9e1738b80212b6375d78c",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.46",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libgpg-error-1.46-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3dc4c94526a92526b1af09a991f588ec4b4143aeadc79866fbd7e1dd021107f1",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libidn2-2.3.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:65f0e543799ac1d7b993d4eb44e76e0562f180d0cd108d0bab6574240fca6ea9",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libkcapi-1.4.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:b3f83992a7dd875f0ab4cdc421e2f96f36ebcdd06077dcf3c685b349fa25a553",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:2396e128877a15edb4d75caa013a3bedd1bdc4f923aee8a967c687a702d72892",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libksba-1.6.2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:228736bb7c085e000a1c3b104bf5fb38ae2f60be99fe6a62ee67b44e9e571629",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmodulemd-2.14.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:bb473c20d69060ea166d4e111ac457230d35e8e5a440ed1fae3db4b6da5dc4b7",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libmount-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:329683a63e8ac4bbc810e06338f0257db0b231f90eb86b19e864d4036b3a7ae3",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.50.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnghttp2-1.50.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:8ce087df2a91fd49e8e796e215d04125eaae9a334d3c55fead4f4eac7142a91e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:2f04577c4ac4fa114df989e3ff36c69d10cb2e4fdbf75691ac1498c770bc28a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:a09e3668ccadb40503e28e2efd8ed3d0dec2946fc551856b25c845d8c6d08794",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm",
+        "checksum": "sha256:cbe6fe8f74c609ee672cfb35b75497ace1cdf17501a41f205bef49a806097e67",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/librepo-1.14.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:19ba66f8a1b897f620e4bfd5d66bd7e190460f5bc68288d4fda15f9a23063363",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:a685678a81eadc35331a74023672a94d7e8a71ebb15aa19ee3e0c2b79d4c625e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:01b4d4c566896c87ea8736a1a0406eb3480e5e9dec581a49c973ea30774cff52",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:2abcc292c06a17a25e60f0e8151c66943da7559c357e025f6acf0ece1cc1fea9",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:59035fd7df5f840f60fb189f96c5d12c2f0be34db6d91ba768358f797263d210",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a9b3c5a71bd562a3c71f6510b8562ae093a683db22448f03fdf91814123dedf8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:c6871fd28de18a80a42d8b5a1088210c32e9dbff12c5395d25c76cf8b4e65612",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:044b32d2bb74e2ad1bde221b87c476c83c8274fbf6f30e928c7ef721f59c518a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsmartcols-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:cc2566ef3de1b9983323341861fc4658422161e167eb29419deb2f438dd907e4",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ec60544d1423d5ea064e6edbd7beb3cf98e78fe5de2980cc9200428aa3452516",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:76382f66152a11217bfc5fa63aa8cc51ee0444bddab95f4810694eb83af21518",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libssh-0.10.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:9f7e876d7352b9857ca1421b5503d329f4198d287c2cb21d45e77e639f77ccd2",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libssh-config-0.10.4-2.fc38.noarch.rpm",
+        "checksum": "sha256:0f658f37cc911a0ed122c445ee07555c27d8f98ddf30424bdaa528cdf0cfe166",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libstdc++-12.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:a73dbf0bb7b043b8469fab0128420673cab87911f9af0befbb12c32123f0374f",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d63275a7fba7a2bf7a30df0e4a32f9955eb932bd32d80ccdf70b0ca45f138b90",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm",
+        "checksum": "sha256:89fdf49c17b8e2ddc9b8860ccd6ffddda6656589faa7adf9b0bd701ee89b0e04",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:8b21c89fe2abd9e577631d2541cd7cfb1af5e11e9493c90b354dc772bef35aa1",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.26",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libusb1-1.0.26-1.fc38.aarch64.rpm",
+        "checksum": "sha256:bf2e33036db5d364e097118c03b577f7296786cee248f1ff76a4228db48227c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:b81eff17b72f9d25482a25eee089dea76ee1c2f853deae9b65e0fcad01bb8b66",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libuuid-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:90c932fe01f11a1ac5bfeb956aa4bf45570101e0b899e00c9a452e2c5666bea4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxcrypt-4.4.28-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f35d38bf1a573e6dec25fab79a39f29dce274b3e617f5628999a3a6ff0bea009",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:56ec328ba2bc798113071cb36196e69fff2e5bc3abb48be4cf263bfa101c827c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libxml2-2.10.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ffa79d41f91cf48696bb9845b87eb8888efad8e52d914087d94de139363012a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm",
+        "checksum": "sha256:9a2b564a7855fd993a70efa5e5b2e8fdc1c5ae8635ab8314eb3a2df544764d60",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e5f8a73efcea92b3d5df1e23cbbbf19dc32382bc367632850c3bdb717566beb7",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/lua-libs-5.4.4-6.fc38.aarch64.rpm",
+        "checksum": "sha256:368d069f5630080a91013f51d3a4ecff6dbd4ffe29f667f6b73cfef681780190",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b8b26543b81a634855287185000dcefe6c0e09f35bd77347e8215969aeda5959",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:09f8de1e0c90ea397c7677df9e550a1296668a3e018bd58eb1f704b77d7e815c",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.14",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mkpasswd-5.5.14-1.fc38.aarch64.rpm",
+        "checksum": "sha256:25a5c9e303d5586812b4bd3ca7bc1b1af1e1fe80a1764dabd84409468c1acacd",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:e6164c42552319cacc4226dbb680be091ac0e0853a91b63c496822daff175b68",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a7bfc2e27dc453726495f11d21f2f4e79716be924d744a92d0a4e4fcb96acca8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:8753e26208dc659797cafc163c8fa06c3924d2dc9fdf6ccee94647ff4edde735",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:d3b7939b663a7c169c436d40adcbf78b20386928ffb620e951703ef5e20b3ed8",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/nettle-3.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a17d3ec2925c94030cf456e706bc96b7f4cccfc4119d5b1f5a89aa302da12ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "10.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/n/npth-1.6-10.fc38.aarch64.rpm",
+        "checksum": "sha256:c6c268d36a199f6173e6ecc5cdbbc38b0e203d034ecb91ab09cb87d2107f0534",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openldap-2.6.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:80947c794b006db9f11bc4b5eade078fb29fcd0f4c44819683b232936fa830bf",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssl-libs-3.0.5-5.fc38.aarch64.rpm",
+        "checksum": "sha256:dff1f45a48b30cbe5b38a98dc4eb38da373f1248dc35f2256d245eb1fa9cfaa5",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:cae55e7380b67c572cd4f793412c604707f77b2ae5e1bbb77133b17f35ab5e92",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f811cc8fc811d631471eb6adabcc1014ea329258cf37c2a5f7b936830e3b2e57",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2022.6",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/ostree-2022.6-1.fc38.aarch64.rpm",
+        "checksum": "sha256:e3d8c2aff54c19cd260a210a1d077077e304f1396f13ad8ebba91c0c5a367d9c",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2022.6",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/ostree-libs-2022.6-1.fc38.aarch64.rpm",
+        "checksum": "sha256:c67ee583c77d9afba9a8ed7e63f6afeab8c3b272c8c43eb3df6f31dfc83d9124",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:c568a007b9dae0d471d6badf723161e565f921c2b1eb04e19aee5fbf7dc6e61b",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f54c232b4713ac362a343800003ff7deff1c5e7c75710235b9cab5df55ef94a9",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:7c508a709e816951b3650e600925e691f180f25f92b68f2b0433ef3d787137f3",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:ff3cb745172d9bd639d22e13dc66e94b2df4dae847cbc55d63ae6a6c1b69bf49",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm",
+        "checksum": "sha256:6835ca1b00813eff887ef180d9a41f561f9f096a39a6446e5b25dc9da283f8e6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcsc-lite-1.9.9-1.fc38.aarch64.rpm",
+        "checksum": "sha256:11c6ef78372b52968cdea9fd2062bec3fd0cdd77209d5bff8c58da2dbb3f61ce",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:25930a2fdaa748fc28850dc1afd3e02a497b0e4aac518d36be8c80a9fee91a24",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pcsc-lite-libs-1.9.9-1.fc38.aarch64.rpm",
+        "checksum": "sha256:6ccad2fb8b08b10aff2cd6c5bee0d3bbaf839d28872090a616972f1161f1adbc",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pigz-2.7-2.fc37.aarch64.rpm",
+        "checksum": "sha256:40ee09498cf64c1474ab90c473c9f363bf51611b18d2a929bb57cb8b6be505f4",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/pinentry-1.2.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:315097bc4f6f543ef241fe82935e9e89ea9e3e35fdea84a9eeee6dcea75aad70",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:315ad79fbc53c6098168be87264263dd332e9b8df9fbc29a64b6fc44da182344",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/polkit-121-4.fc38.aarch64.rpm",
+        "checksum": "sha256:283b9a24381d643403c7957c5df4cb389890564082f1f16f9696ca8b35322930",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/polkit-libs-121-4.fc38.aarch64.rpm",
+        "checksum": "sha256:7d101e3624bb04eee8fedae8425964f6276d2b50badb75b6885ac255ad2101ee",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "22.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm",
+        "checksum": "sha256:e1a639fc3080b7266b470b39ddb038e711b1c758e522b5cda2618fa3cc22c433",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/popt-1.19-1.fc38.aarch64.rpm",
+        "checksum": "sha256:a7177fc17d2c1a947b971d5cc8528e477a19cca68000c30552f14f0a8e96b4ab",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/procps-ng-3.3.17-8.fc38.aarch64.rpm",
+        "checksum": "sha256:81982f4c377e24e62cc250654706f2236d8c714d3381c48704ba5ea5ebf2a139",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2.2",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-pip-wheel-22.2.2-2.fc38.noarch.rpm",
+        "checksum": "sha256:aca40dd03fc1eb93703ea43d9a96a70ad87792e1d675f7a9a762be71d8908c33",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "65.3.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-setuptools-wheel-65.3.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:e915e3507eb1e877251ac175df26c3be8022b31daedc39fcfa2e05c1ef190911",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python-unversioned-command-3.11.0~rc2-1.fc38.noarch.rpm",
+        "checksum": "sha256:310078572de43cf8be4ae7dd9041028fcdf4b4cba315ed3c97a53cf2049d6793",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-3.11.0~rc2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:0749ca93d398834c7e4f2c252100b1fc104a2f4461640ebe18928f2315ee0013",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/python3-libs-3.11.0~rc2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3ae21d35720ece7b6a01da963444603844d323a7d498b7bbcab2aa26aed1117a",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4a9ff34d2b8abc163eff8534a8798e95e077d77936838930240b6da876cf4c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/readline-8.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:29f0368744406e96a46faa1601aab4aa62107e232cb19ca72bca5116249acc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-4.18.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:2670a90b97a51893703b9617dc0368b4ec2aee9136f6351b3d06841dff284947",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-libs-4.18.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:e1e11cf874a9ce02555a090a5bb783562854fbd037216e4c23cfbd1fa7f11ce0",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2022.14",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-ostree-2022.14-1.fc38.aarch64.rpm",
+        "checksum": "sha256:69d7af8e50b97490006866fbedb5398419d1edf93376c2d70d4b159071ef8996",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2022.14",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-ostree-libs-2022.14-1.fc38.aarch64.rpm",
+        "checksum": "sha256:5534bf882d968556f232d9419fcdeaf717123fedf55dddaf115b34eabf382678",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/r/rpm-plugin-selinux-4.18.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:4f759215cd4075a109ac771993890b0e42dbdeacd14ffdbd8c81dce12e39dafa",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sed-4.8-11.fc37.aarch64.rpm",
+        "checksum": "sha256:b2c4f6d1944d3eee2fe5bbd79c89865cc89bde742fdb9538093048cc95ca6d71",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.13",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/selinux-policy-37.13-1.fc38.noarch.rpm",
+        "checksum": "sha256:dc7f1b56cadb7d7c1f4b1dba4bca9a87b22071d592f1e06e25d0be7106dd418f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.13",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/selinux-policy-targeted-37.13-1.fc38.noarch.rpm",
+        "checksum": "sha256:36e6835f02c897ea7d1929163cf0dba9317a9fe38637bfa349ecd291ba4b36ae",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.2",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/setup-2.14.2-1.fc38.noarch.rpm",
+        "checksum": "sha256:96f465090b634df32e8d5c1e95e915b82da5537f38c46f9eec88484b719786c8",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.12.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/shadow-utils-4.12.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:ccbd03bfb04069ba7c0400dd1b6ccd54a8dd83b5cd8881d0c75ed7d8468da1f6",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/shim-aa64-15.6-2.aarch64.rpm",
+        "checksum": "sha256:700764e38ea8bc1c019d0aec39542b1af5f0c00f169a2210ff8d80504d0ce2ee",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.10.0",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/skopeo-1.10.0-6.fc38.aarch64.rpm",
+        "checksum": "sha256:b476a1e74a3d193827e8a1d021b46847157a9faeae75d02e1a841a21895d4b38",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/sqlite-libs-3.39.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3cc37b098b36f89cdf93fc6eaf16bd650ab0b5e7040e789b567c42a934c5f03f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:0ffc6ebe5127bbc38080006a4fdeace052e8ca2765f41a8dd1190eee720b904d",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-libs-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:40ea98773d45bd6bd6a1e756afd183711ba5b4d4c1e56777551e9af16c4979b5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-networkd-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:e5fa3bc538b9b2cd12fc597400a656a60772c2874637d4932ae8db60082291d1",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-pam-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:decf31a52963be8f8735646a1b51a5e574a2123486ec6813f5ba6e728f5b00c2",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-resolved-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:fe3273344f14113724d991eadf8ccfbc945ce7be74c80bfe667d33c0741f5eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "252~rc2",
+        "release": "612.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/s/systemd-udev-252~rc2-612.fc38.aarch64.rpm",
+        "checksum": "sha256:430204db219fd88d828a7b1e4ab0f716034128d10226266aa2ec3517ff48c0da",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tpm2-tools-5.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3a7e6b04e4e03810cb47b3a028c089de84917b63c03bd8f1bc82322afa59c78f",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:eb62b4c7c08929750ed58268b2552105c360e8c0e8adfc4e1a53bb398e69333c",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022e",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/t/tzdata-2022e-1.fc38.noarch.rpm",
+        "checksum": "sha256:aa71f4f1c3cc79edc9343ea0fcf558bdfed408a094ddda0bbc7582a0c647fc7e",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/util-linux-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:30d5904ee6c1e49e2b78fd85c35202658945614fbd4f14b8e12dba342abaaf46",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/u/util-linux-core-2.38.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:6902ed20a768a81df117a0ceeb0b0494c17966ebec2a2a4fbcb426aa4de60357",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "35.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/w/which-2.21-35.fc37.aarch64.rpm",
+        "checksum": "sha256:057af6e3125eb236993510cd5173b01865b82068a199737264b41690ca0fa631",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.14",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/w/whois-nls-5.5.14-1.fc38.noarch.rpm",
+        "checksum": "sha256:a0527ff7d382107084ff5a8d5a5c9c95e4f2b526fbff98dfb251c947f4003efa",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.7",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xz-5.2.7-1.fc38.aarch64.rpm",
+        "checksum": "sha256:1257255c6b7842e0a8901cfc767dae55e22d642b920ef8250e6ded36a2b53615",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.7",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/x/xz-libs-5.2.7-1.fc38.aarch64.rpm",
+        "checksum": "sha256:109073906a2f705f857104e3505315c122e4faa14142ad90d0bbdabcba257bc9",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zchunk-libs-1.2.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:2b990ceb0f22e2147777ceace7f486a6021e9373a5ece97feee463bbc9793cb2",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zlib-1.2.12-5.fc38.aarch64.rpm",
+        "checksum": "sha256:fa38c933e194c67185d9982e700bd67f65b9c8fbe23f0146a3a96987516eb668",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_38-x86_64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_raw_image_customizations-boot.json
@@ -1,0 +1,5626 @@
+{
+  "compose-request": {
+    "distro": "fedora-38",
+    "arch": "x86_64",
+    "image-type": "iot-raw-image",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-modular-20230310",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "image.raw.xz",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {
+      "customizations": {
+        "user": [
+          {
+            "name": "user2",
+            "description": "description 2",
+            "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+            "home": "/home/home2",
+            "shell": "/bin/sh",
+            "groups": [
+              "group1"
+            ],
+            "uid": 1020,
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "uid": 1060,
+            "gid": 1060
+          }
+        ],
+        "group": [
+          {
+            "name": "group1",
+            "gid": 1030
+          },
+          {
+            "name": "group2",
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "gid": 1060
+          }
+        ],
+        "services": {
+          "enabled": [
+            "custom.service"
+          ]
+        },
+        "directories": [
+          {
+            "path": "/etc/systemd/system/custom.service.d"
+          },
+          {
+            "path": "/etc/custom_dir",
+            "user": 1020,
+            "group": 1050,
+            "mode": "0770"
+          }
+        ],
+        "files": [
+          {
+            "path": "/etc/systemd/system/custom.service",
+            "data": "[Unit]\nDescription=Custom service\n\n[Service]\nExecStart=/usr/bin/false\n\n[Install]\nWantedBy=multi-user.target\n"
+          },
+          {
+            "path": "/etc/systemd/system/custom.service.d/override.conf",
+            "data": "[Service]\nExecStart=\nExecStart=/usr/bin/cat /etc/custom_file.txt\n"
+          },
+          {
+            "path": "/etc/custom_file.txt",
+            "user": "root",
+            "group": "root",
+            "mode": "0644",
+            "data": "image builder is the best"
+          },
+          {
+            "path": "/etc/empty_file.txt",
+            "user": 0,
+            "group": 0
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora38",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e41d2d818abf5bf1209ed18ec6f28dad7b4ec49b6459d34c96104a93da329bd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1abdc7956a48e8f3d6a4ac91aa511123f55b1c876e8c664f78ae16b9195dcec3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66604d04522a860a1c755a9629b0cb1e25a2c24747945f1f69b41ab8522787b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dc70c4a90ddede4f38d96e8184da5d3113f9404d3cd4b98b45ffd40cc503249",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:718d95c40b41c2f0ecc8dc2290ebb91b529ba3be7accbad9c30c88e9ce408349",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:961883b6ac18ca54b525209adce0c593f81fd8a7e71bb75bc07724e4ef72bc5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbe3eb89df059162bda14c6f0c06e6251984d79502806c87ae4c6befc4e392ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95273426afa05a81e6cf77f941e1156f6a0a3305a7768a02c04a4164280cf876",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:738f573c50a537b556e2fbb8fa4a2c0d22fc2ce4a67344f89d478989cc323ab3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b57a6547661f257778026e4e69d0264ea58ba7d81d422efec31476db408931",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b0d680c4c2a36d9137c98a056683b456b6aba93838c3ade023ba78da937e8ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b879b130ab94cbe69d3a6fe1236934ae330c0b11d344c140b7de35acb075fff6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:664000d54ff291110ed9f350dbfd5e9cef78580a4c191846e08e29535b4103cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75ecf8c60bea53432b973d9391e3bdb1b6cdc1f1cad0a7b56aabfb8b70252832",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1262de076983a540ed42a33160a61cd2723a662c1680935379ccdb0894f60cee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f289b7726320f275730e28e3891a6f3fda76941876de4f643d486f3265a0a074",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6809fe060dc93dfed723bd8faca0f5d65e4f6c62aebd2f9f39f679413b260539",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1880b8f3e8a5fa943ba033c96dc964fac3e07c34cbd0bb8ac2b0fdcb57abcbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:070d86aca4548e9148901881a4ef64d98c5dfd4ea158e9208c650c7f4b225c47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b76ad6cde430264ecd88244255c44bae45a955da60b43ffc19fcefc3f98dacc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b570b4857289cf32ed57d0d84cb861677a649cef7c5cc2498a249d6593eb3614",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1812689be8bbc4ef39718dbb8ef862105225348310052ddaf0b1cb0f0a1bf296",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6652f5d40acfaeda20555bdd63e964f123e8ab4a52f8c8890e749e06b6bae3e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41cd0821eaa5887eab973a969bd1c8928567e655aacd851f37fd2026d95c7e4d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:695aab11fda4b6a396c3ca141fb3ccc48af757a70f36ea3a1be2292e90c40d6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e8600a8d7e7109de32df6cb6a619b9805f9335bf467a085009f6b82dda6e22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38c134f1c688e9c33ced36cf623e6ce1b0802ff0623b42c69b1cdffb5bea1b9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0a6768f0ca08572b79a265ba0d3fdeba09408431d9e717b8d45af9e1ae67cf6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f0fcb77e99894033474d4b8b5f27001cc8ef1aea7b80890a2d76a9eba71b891",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26f5be58bb251b4e4216c0d6c5b69ddea6afcd0a797121126da3ab4eb74e9b37",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8bcdb9b5ce9b5e19c4f772f52c2c40712491d2a953496e415c380a21a792b050",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b25a042f52c8cdc1ddab56fc726d98789ff902d5264d9835f5b910db3e565213",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ca049bff926a8ec9b6e0e69f23662934eab96c35d8eda1cf429a2a31f186045",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a007fe955a4fba751f211b4e8e16f916e9b7ba1c020b69d62ccb4d437a3ddd1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:575ba7ab8e3b6d5b7508a505694a37c390a64ec070659b9393c1a5283c19ce90",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbeb7a7a95051df0dfeb7c4ab379b77ccfb0bf0174a39dae4a423b9108627771",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32ff1d8ce057bca605a5ac7fabcbb66904158d66b889591b308c4489d041b116",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0fcc99133bac41153d6218c56b05b33016d00f302c4ff34549e2bbac196845d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e81ffc077d3cc1c27f34949cf1b473e2ffbebfdb6bd95d1a130fa8d13b9de61e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88fd2c9592332643f6cf361755a9d47a2fa4340973bd6c85a97eab6b24daaa11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c64fea958acfb77da5ee23ec1e8d0916c7809ce39987f219927e8f94e5f2755",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2fd7553527985aefe6b65216c9c4295ab0bac21551ad092e9d3e3229a5c73e5b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f828322655ab1b93de1972d8af71689ef239a160f13931e447b0ebcbb764cef9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e088cea3244085f9d19d2f1bcb171b9f0c3a4ffc2ff0c81932081fbb225e564",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5b52d9e252e7b653d54a2aee5ae1b9d45034ccd3d8f30e6af9b86952029c535",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84e6c8f8f6c538f3fb2a5bf233001b987e699ee6df22e27278d561477470ec70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8acc96dd96e696a41125c210f8552317315741c4084023befcaa847536a478d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a1cba4c2c846be11966bac9dbba02ec47a22920655a27b305f4881232b4af16",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0fc6c55f5989aebf6e71279541206070b32b3b28b708a249bd3bdeaa6c088a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79986f917ef1bae7ca2378b16515ba44c19160f5a5eae4f6b697eda160bc26c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c70948b04d05290d6441359d461d9f7ec45439b3c97430c41b8a862d59e7b60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbe79a864033502b6f2eb2de22a3801cefebe711769254f1b17a7026f7a4429d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56df47937646df892dad25c6b9ae63d111328febfe86eb93096b8b0a11700b60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:579f391b704753511bdd4f30840b5e07f178b6838042d3701a19c3cb7f9ccfac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:afffbd76e4c048e7fb12e411d0270fb1467e186a83d4b6d12bdb1eacbb54155b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37d97cf3e381bde43861a03858e9cbd097191b0d1a7e555ba82eddd06a5a56d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e607df61803999da46a199d23d4acadb45b290f29b5b644e583c5526d8081178",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:254c6789b4a98b96a53172e1b3fb866f71ea29a5b5fa7b39f072f33c27d897bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb376264750aae673aa2a3218c291756023dea980640b30a3efe0f2199ff3889",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:276c7af4b13262c0307cf2528c6d79c859ed348db68c0d2780869ea4b179dd02",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fb6fcf7eef64a48666ff9fe5a46344087979d9e8fd87be4d58a17cf9c3ef108",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3837cbe450ceb59e1f9e7469aeb6ec98e08150773b83463725acfb2ebb77a98a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03cb373a4cb9a43bbf71c0118573ce2db0ec1fa773d50adc9eed628a62acca01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b727de2c86a63fae0a59f7c85b6a2c6c35f52678ac47b66e617e35c974e3619",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48a787e140f7b35d53ef83b808dece8dd5954be79546a2a583d07f520ea3ea1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf999c05654fb860129d6211a6addace24e1477d543e3558b11ffcea15884c9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20122ec918b8abe671346ce40aa30fdc97b7dbf9e52451dfe6552c5309655286",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69e48c73d962e3798fbc84150dfd79258b32a4f9250ee801d8cdb9540edfc21a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:afad50ac8bea1986acaa72b119cbdf2fa8aa08dc0d4d93d26b8b70f1bfea8067",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86128c7bb4d73b0921687db30d724ef3abf9023a75cfac4c49f6b91b22a1e1ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ac3d3cb86a7515bd79c788930ce7d804bb39e84abe9261c4838bd35c669d8ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d5eb1e8f80ae1dddc082b58c387f8d7b66d48dbf1d9ab4bcf9c9c138996085b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60ed241ec381a23d03fac733a72132dbdc4ba04c412add78bfc67f1b9f1b4daa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71778e1007afac3d55fa2d85301ce035c7d14f31f852a22f97a07e29811b17a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f6baad418fc4f4da5db75e51e921dac6b313fad34f5f4901d772dfbfd9623537",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fadef9c94822d311c6f1092c2ff77e0485cb49d21171acef4012b15b35d1485d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1ac9f901c9bf96278c5959e024a0bbfe9aaf2581debee7ba5b608c319e8a132",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d48579aa97fba34dc3a4c4dd3fb10e8fd66186d970e37c2f7fc28bebbc2d31eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:166e842798813a72e4d075dcd9b6e814d7ad3fc8d1b5860281cffe7a68784b25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736182ae69e03a19be60ed57486990f9b88cd06eeecb5e06cebc7f4b64ab0f5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2ae86002363a331661c72eec5cad90a100216e46176d4bdbe2c20e465c1d73c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6bc9869c8ba8704f16fcec7543d4b029dd51213ff171fee7cb8e0a3da167b77a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b66376e78fe54024531d94036d10b22b5050d52a9e65682b36dc7fdf24405997",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7419671c64795b96be18231e2f5d3f95eca8e6a71771863ac035f961041c1d7c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19f873b67f23362074c03d5825e709ad521278c02e44bdeb30eba6d3bb3a8e0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac8a7628a2a4b1f742fc90719145f50cfad9ecf67e3309fcf623fb3d82c2a768",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e779fca5e3be85efabe2132bdaf87ac852d78187fbbb9e3d9b37eabccafb4e85",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b093be8a99bfbae03c2f3dd5435fc9508003f7ef21e4280ff72fe814c1d794e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d0890dba8274458d068b981164111f554b47632bf9c82d1ec41c14697f2b4af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd044973c572e64f505f3d00482249b2b4d71369babb5395a22861fd55b21d79",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b4892a7d8ff6e913ea16e1b26c4a3f7dd2bbed5893895b34ef3f02553be1a78",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d78d7bc485f099bb08c9de55dd12ea6a984b948face1f947de6ec805663a96c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e73a2b591ebf2915bfbe7f9479498a73c982a4c74e96cc555930022e3ef0aba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21b5a1a024c2d1877d2b7271fd3f82424eb0bd6b95395ad3a3dae5776eec8714",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd3f5e8edc77ce3e183134535ec838f033ed3bf0e6802e864c0a6c5fc94b22d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b6a2b3872182fe877fcd1dd85ef66282fdeec79fab87157327c9fc6cbd80ab15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e0bee6fd4e234796795cd45185b250d8cf894aef0bb95f2793d9453246e1a4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5922028bb5642faf00d781f34bf105ef30f1988932b4b80f6bb54e9f6eed0fd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ed3e7b6b0727b86ae9af17bd4839c06762a417a263a5d22eb7fcb39714bb480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8d84ce3922c932844043d6037ae880d18221e974fc7cf1fab58de48f0a851e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7030af9e9e0dd9afc5b9ee02839c94757d6a4f8ebd3b21e6d81ba6141a76d46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e57ebf25ad25e7a6809aa0d99b5692598fb009a5438e90a2005f9fae5fd3b13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9741c40e94cf45bdc699b950c238646c2d56b3ee7984e748b94d8e6f87ba3cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2fb7ee2d94f7ee34cff49ab28659c07b075ed67ac147f817e19d8ee8e0adbc9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:098e8ba05482205c70c3510907da71819faf5d40b588f865ad2a77d6eaf4af09",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a30628b39d9c5ca81c4e073dfbf64d543284f17d4ae1325e23e3eda55f92fd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:462e051734bc21a4ad5c661bfd5e3e333da41c60db0f971967212fd9f022ea69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f2d599ea016ff52203366dd6563006c0bd17e7c258b6de65580d44afb42c27e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c00645bab83992be045c24652c3f8f23f8d5d68dfdd80b6e64f01f2d4e6530f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7ce8eced4895a190f10e2e6afa566f2f4c7e7192b0801581d4e2a337fb51970",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3416e2b6c7565d7a607225d86b556398827316ae7ce43280b82630f0a022bc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75c0097330fa3c995e80b7791cbe7baf75d86f3523f67b3becaf37360fdb4b16",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e552fae193775507d8264f7a856fbdc51f7e594d7d8726f181312aeb9cf8b973",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34446f36355b415633037cdb983677288e4fb70b68d70a509fa2081b6b6e9f49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6ba30fafaf487f20f9c09d89803c578fca1cbe3226b497fedf202536da4f47e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:14541cda2a4516ad6a17f46be6b7ad85ef5f6508d36f209f2ba7bd45bc1504e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33631973ecf9e6b23e0b7d07d61100fdc2db33261f4a6c43b5a09791b9455291",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28697cf1b5cb4d62c3bd154fc24a23d91a84a5bda2f974fb64bdd04e91b6cec5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0bccc94a740acf317caa4fa1fae6b0d57442ef4be36341472b7db93d588ec13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aefb7d2d96af03f4d7ac5a132138d383faf858011b1740c48fcd152000f3c617",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:845f6731b9e784784494fe9711c116631fc9ceede2fd0fa15b5f9575dee25e10",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dec378b594b79258dd8b44836c5371f316bcf5e4596d53dd84badcb6d00090df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46ed6b8fee11c16bb8b58f698dfba9874a8f393c1e72eb7f9a7b6802ac68dd1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11187ca403cd3fdfd42e85380b086979ce093b2dd59c5f42b097b33d41ee361f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56e701bd74cff3301be1e47e8405dc582a94fd37e45afd782e03c335fc8714bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f55b1581a26bb9fd552ec5c3c97cf206b163f3f1b8b892baf432a6454e2df0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adaf981062abdef448f851efccf68875de288c388c31a4adcac66478bb16a0c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac0a6bf295151973d2e34392a134e246560b19b7351ced244abc1ed81dfe5b8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbf5c73c71c798533cbecfa54ba28c42878c455df8cb382087d8a758c3ffe290",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db9229087c86f9d5725daf2066e3a52c84dc44bb31ac940461fc8d7510681297",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:faccff819eecffcee9dad49bda930a007e78b905b775b4ac0103121d7a8100db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9815828233d84324f7e012dc1ac51a38b801159a00c2a3d7884c97f4b5cb9bf3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c54d4cbbb5e20ac926fb9b6f158eda6d991ef7cb4568cb962f842c4b74317776",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ca6440f9957d486bf78bd93185a1137365c7b74f77a2cc529792bf7671fa798",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b49dd88579f1c37e05780202e81022c9400422b830d9bdd9087161683628b22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbfe99034f05faee13e8a5fc4708909d83bb1fe4e4edcdc6238d0a9dc00bec92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4012952872a08b9662963b13e29f89388ce6e695e68fa8c37eb6e62bad62441",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd0e8eb5d983a985f7df99718fde6245997bdf088fb6086442a883ddb9ed03e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:805da27b46f0d8cca2cf21a30e52401ae61ca472ae7c2d096de1cfb4b7a0d15c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5c409a2d5f8890eeab48b27b9f4f02925a6bbabeb21ee5e45694c7c9009f037",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:876ef0556ddeca2c8f56536c80a2f6e0f64357f40bacb92f483adb8a0ff29af2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:292791eb37bc312e845e777b2e0e3173e2d951c2bfbbda125bc619dced7f40bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ac3b50011adb56391125a3b60bf05ae578af7209788cfdbfcf0ddc37d7b0ba2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4170497dedcf53248c18f7963b911aed445d8bc02a33aa27aadf3354b8dfd8ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:507ffdb912296768699a70c30169077b531b1612e47041551bfe523a4b7b6c7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b8094280c4a7e368f8f22938d801ec0dab148a6468a7624edb358f6c5db4cad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f531fbcc52871aace8fdcdb816207c4196d5ab30ba233c71adb41371fa47e19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de9cc9d18a66b22a8e0b984e7d337244aae1611b522d5f88e9f5cccb47fed456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0a48ec36269d83120425b269e47ba5c86d5a9a44e0de2665c1d55c10732d25b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96a8f495896c0ff7520c2cc5c9c173d134efc9ef6c6b0364bc7533aefb578d41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36a1f0412e495e618ccd8636de3dcac9ad37d5d4c287a1acf2c9af4baa7745e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a4e2b838b797ce2dfaf45d8af8692c158ec741b2c76d42e2bf9013c47b30981",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9196608152ec34832cc82d3cefa90748f30c75986f2250d8cd0fabc3d0ceba2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22f217f91fc2d2a666304c0b360520b13adde47761baa6fed1663bb514b6faf5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7c9b0c39f77c6fdf68ff04d8714c10532907a8a9c3e76fb377afe546247737f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:602145f27fd017858256c6ee880863ef5be17c6d3c6c1354f7f16f6f6348db57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6ce309d9fd208bfff831981ee4298ccb25fa72363cb7464f1da03b8214d4351f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:605d6710ba42104ce0434bb37b0ca9a922a8392c14175bc782f8acb70b94c3aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9e8b62c6af7a60a505f881d3cc35294d8b4f51c671c05401133b02ab229c2a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0fd8f2c66a30d3c9544dc47cdd8964bae72e4977dc9b49d1f02d40cd299640f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8dede21b5102b60649074d45da8523ded78b2c9203771b204ae0ba70d3988432",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cfa3d6feba480abdeb425bc045b525c641c7a864625b1864c2f5721903e364d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06d2101874ea4d14b4c73131c5c359d1a2e0ebe0c36a501250026e7b867a0a86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1b047b5f04c240dcf3222f62ca6acf24e46e532d53a768cdae3ea500073ee3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9311016f5f40113d366f17d6ab6f6175e65ebde29212a05eee28e886d5b2e564",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e4afbcb9488d9c6a9bf7d0739173b8757ce33a6f5e00f0ab7ccfcf605ed9273",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9030a26ff737b7bbb71d5208feebba1a0b2774d58dfb6016824a042e059642d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:065b99f3541fd5f1281be2082b77e48b835a591776e92f2327bb0462c67baed0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63e970f7b3f8c54e1dff90661c26519f32a4bf7486c40f2dd38d55e40660230e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb1caf3e9a4ddc8343c0757c7a2730bf5de2b5f0b4c9ee7d928609566f64f010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:756f64de1e4673f0f617a9f3f12f74cceef5fc093e309d1b1d5dffef287b7d67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48efa34ce50ae936ab9fe437aa59396d4557ff39fa22cf36c5460d3a986e502f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa02afed121e9f5fa9590d75c0b237b6c497ae58c91e0022844b38f594feaeb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07dc5536982278f38c89517465384ef9f376cd27f0b200806268723993da01ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7509cf0ec99ce89e8e88e9352f733eb9ad14a9c77e0bbfd64826a3de0e4a150",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e521385a42b3350c0d17e3cbddc0b69c9cf4052d1b77cc8bea2179e05b7d374a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:584a3843d52f90ed38819007083ea7e8327d23cd6203c8205b511054c2e24003",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef498b94191f926bf5a55c4e6ca3431cdee2595a9cbfccd1f82ca959ea7bedfa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dcdc3dfa37a687351a6969c037d67669e7e55ba0efa579f60392ecb566f9174",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ffa0438229228bf5ba18945936d52c3620c95f4a3ffc5c5f0f8774fececac0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb3fabd657b8f8603c6e19858beb0d506cf957bbca2f3feb827b64c94563b31f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdb3e6e4578d8bb90f1f917edf5a7f52432df2eb5b0fab000eab662b15476479",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2fd63c2deeb11acaf63cccb09722b34961722a4387d73faa01e14badd13a13f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee100ea7fe8bf26d44df719283554a36398d484eee28682694c9e7a249c2d49c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7417816bd96d7b49e5a98c85eba313afaa8b8802458d7cd9f5ba72ecc31933e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d1fa962cbc496f775065c66855ee74b7a335be8658783a8b846871d73d94ec6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e952487132d2b7fef68e3221f720872ad314cdf273085aea1e9ecbdff5948b9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18c287498ef558f247f328c7c4c9161caff395b5f57ddb593d509f2c4ee677e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49ec489f168c1671a2babb690edfb020a5252f38e8d0b2d96465070abd2b0d70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7099c322c45030738bdd90e3de4402c0c80c6ebd993a1749c2e582cf33ee6f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53dc032707ab6765dcad52ec579e53106d9826a81fb061d616e00afe702adc1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47447bdd06e43a9911aaf3335490cef9414a436440ca945a8f5ad4b29345eab1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f416899a04b543dcebf6bf7a6c9a65521c64c3916cd06793e5b5a7a5f9b71cf3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12e4d05a9407f3f78fa1928ce62449e9d227a3bd9bb68ef4352f083b4c1f7cc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2daee83cd0c6bd1210e7a547b0837acd1fe460901d55b8df2d47d312cf0b229c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:340d6564ad122b245fda35c873e91ec685e523f1fef6afa539a087b01d70fb48",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6e01b89e814ec42d1c2c6be79240a97a9bd151c857f82a11e129547e069e27f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78169acd52d9d936842dc326cb5ecdf92f7690ac7fa92a458ff83815e1a81b1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b7da6204d4db26f1896b5e0eb7b979c4934dbf48f33f91f30bdcb04d730d583",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7efb8634b62cdab9e8894174a8c70d20eb431482277231bc54fa8ca8c3681e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a80791ca462f0037c5438787081ab0161f14db6a4180113af618155d76f40a00",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85bb1aa32f6345349c9cf09c35217caae441dca6b2be8f21619ea6808d3c5af6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2871bb34038a71a4b766bddafd82135a2dc42ac0ee7b158b2378c1cd445f9d03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be6d9e9b98733494ee5901d45b849e2dc012a6b41c3ff09d0d212002dbe15dce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65c21b264dd2adc3b20a0dff9384d6d630e0ce98ab9eab77e9a33b360173238d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bae7f23fd0f7aed44a9081cbdbeb9cb922a694f09d21f564738f192e0e4d7f7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d31e41005fa66d22c5cb0010161b423e3f538713176e33b5c519b4b8139e5e5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:227a86de146b2ef85f7b3c7843ca48e0a498f51fee2975dad4b361426fae67a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f30e74df21de01e6ecb6bec0fe0748aa80cb49e597dbd694e0cc8b3b68c425e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f83ba3694aaa98e13c078b0c642c816033a9450105b30942f7c5f84199722b59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9dea5ef5fada9f1230590c0ca476c0da2b2fd228edba3dce81a9bac7c3a8df7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8adf29af85920514902bc4332ceb896a54f9cf89e08993c9345b62c4140f91d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:10e4fa175ae454832902cafa61ccc24f7690b5abe2c6935923cd90f123ebbc80",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0f8e33332df97afd911093f28c487bc84cbe4dcc7bb468eac5551d235acee62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b57dbbbee14301e89df618b398ef39b7fc841eaba6be1b6346cf37ed7695c26a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac6e86a36c90c7b75a2d1e30476b16c286b2cc29f958677ac0aaada2df72a316",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d559e22dc4dfc539d5455d76f446ecaf7d0dc9ef37ba762c45b01e069a19b56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59a7a5a775c196961cdc51fb89440a055295c767a632bfa684760e73650aa9a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e911703ffceee37ec1066344820ab0cf9ba8e43d7957395981ba68c4d411a0a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfce8ac2a2a78a23fb931531fb3d8f530a78f4d5b17f6199bf99b93ca21858c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e49dc59ac89b5b0a00384cba20a42e7238adc6cbc1471851980b1abbc1202705",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c26d4d161f8eddd7cb794075e383d0f4d3a77aa88e453a2db51e53346981f04c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "user2": {
+                  "uid": 1020,
+                  "gid": 1050,
+                  "groups": [
+                    "group1"
+                  ],
+                  "description": "description 2",
+                  "home": "/home/home2",
+                  "shell": "/bin/sh",
+                  "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                },
+                "user3": {
+                  "uid": 1060,
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.groups",
+            "options": {
+              "groups": {
+                "group1": {
+                  "gid": 1030
+                },
+                "group2": {
+                  "gid": 1050
+                },
+                "user3": {
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/etc/systemd/system/custom.service.d",
+                  "exist_ok": true
+                },
+                {
+                  "path": "/etc/custom_dir"
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "mode": "0770"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "user": 1020,
+                  "group": 1050
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                  }
+                ]
+              },
+              "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                  }
+                ]
+              },
+              "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                  }
+                ]
+              },
+              "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  }
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                  "to": "tree:///etc/systemd/system/custom.service",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                  "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                  "to": "tree:///etc/custom_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                  "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "mode": "0644"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "user": "root",
+                  "group": "root"
+                },
+                "/etc/empty_file.txt": {
+                  "user": 0,
+                  "group": 0
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.systemd",
+            "options": {
+              "enabled_services": [
+                "custom.service"
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 5263327,
+                  "start": 3125248,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263327,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263327
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "xz",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.xz",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "image.raw.xz"
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:03cb373a4cb9a43bbf71c0118573ce2db0ec1fa773d50adc9eed628a62acca01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/glib2-2.75.3-4.fc38.x86_64.rpm"
+          },
+          "sha256:065b99f3541fd5f1281be2082b77e48b835a591776e92f2327bb0462c67baed0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pam-1.5.2-16.fc38.x86_64.rpm"
+          },
+          "sha256:06d2101874ea4d14b4c73131c5c359d1a2e0ebe0c36a501250026e7b867a0a86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/o/os-prober-1.81-3.fc38.x86_64.rpm"
+          },
+          "sha256:070d86aca4548e9148901881a4ef64d98c5dfd4ea158e9208c650c7f4b225c47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/cryptsetup-libs-2.6.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:07dc5536982278f38c89517465384ef9f376cd27f0b200806268723993da01ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.x86_64.rpm"
+          },
+          "sha256:098e8ba05482205c70c3510907da71819faf5d40b588f865ad2a77d6eaf4af09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libffi-3.4.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:0a30628b39d9c5ca81c4e073dfbf64d543284f17d4ae1325e23e3eda55f92fd9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libfido2-1.12.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:0b8094280c4a7e368f8f22938d801ec0dab148a6468a7624edb358f6c5db4cad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libxml2-2.10.3-3.fc38.x86_64.rpm"
+          },
+          "sha256:0d0890dba8274458d068b981164111f554b47632bf9c82d1ec41c14697f2b4af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libarchive-3.6.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:10e4fa175ae454832902cafa61ccc24f7690b5abe2c6935923cd90f123ebbc80": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/t/tzdata-2022g-2.fc38.noarch.rpm"
+          },
+          "sha256:11187ca403cd3fdfd42e85380b086979ce093b2dd59c5f42b097b33d41ee361f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libselinux-3.5-0.rc3.1.fc38.x86_64.rpm"
+          },
+          "sha256:1262de076983a540ed42a33160a61cd2723a662c1680935379ccdb0894f60cee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/cracklib-2.9.7-31.fc38.x86_64.rpm"
+          },
+          "sha256:12e4d05a9407f3f78fa1928ce62449e9d227a3bd9bb68ef4352f083b4c1f7cc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/rpm-ostree-libs-2023.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:14541cda2a4516ad6a17f46be6b7ad85ef5f6508d36f209f2ba7bd45bc1504e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libmount-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:166e842798813a72e4d075dcd9b6e814d7ad3fc8d1b5860281cffe7a68784b25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gzip-1.12-3.fc38.x86_64.rpm"
+          },
+          "sha256:1812689be8bbc4ef39718dbb8ef862105225348310052ddaf0b1cb0f0a1bf296": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/dbus-1.14.6-1.fc38.x86_64.rpm"
+          },
+          "sha256:18c287498ef558f247f328c7c4c9161caff395b5f57ddb593d509f2c4ee677e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/python3-libs-3.11.2-1.fc38.x86_64.rpm"
+          },
+          "sha256:19f873b67f23362074c03d5825e709ad521278c02e44bdeb30eba6d3bb3a8e0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/kmod-libs-30-4.fc38.x86_64.rpm"
+          },
+          "sha256:1abdc7956a48e8f3d6a4ac91aa511123f55b1c876e8c664f78ae16b9195dcec3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/a/audit-libs-3.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:1ac3d3cb86a7515bd79c788930ce7d804bb39e84abe9261c4838bd35c669d8ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gnutls-3.7.8-11.fc38.x86_64.rpm"
+          },
+          "sha256:1b727de2c86a63fae0a59f7c85b6a2c6c35f52678ac47b66e617e35c974e3619": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/glibc-2.37-1.fc38.x86_64.rpm"
+          },
+          "sha256:1b7da6204d4db26f1896b5e0eb7b979c4934dbf48f33f91f30bdcb04d730d583": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/selinux-policy-targeted-38.6-1.fc38.noarch.rpm"
+          },
+          "sha256:1ca049bff926a8ec9b6e0e69f23662934eab96c35d8eda1cf429a2a31f186045": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/e2fsprogs-libs-1.46.5-4.fc38.x86_64.rpm"
+          },
+          "sha256:1e0bee6fd4e234796795cd45185b250d8cf894aef0bb95f2793d9453246e1a4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libcap-ng-0.8.3-5.fc38.x86_64.rpm"
+          },
+          "sha256:20122ec918b8abe671346ce40aa30fdc97b7dbf9e52451dfe6552c5309655286": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/glibc-minimal-langpack-2.37-1.fc38.x86_64.rpm"
+          },
+          "sha256:21b5a1a024c2d1877d2b7271fd3f82424eb0bd6b95395ad3a3dae5776eec8714": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libblkid-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:227a86de146b2ef85f7b3c7843ca48e0a498f51fee2975dad4b361426fae67a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/systemd-pam-253-1.fc38.x86_64.rpm"
+          },
+          "sha256:22f217f91fc2d2a666304c0b360520b13adde47761baa6fed1663bb514b6faf5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/m/mpdecimal-2.5.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:254c6789b4a98b96a53172e1b3fb866f71ea29a5b5fa7b39f072f33c27d897bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gawk-all-langpacks-5.1.1-5.fc38.x86_64.rpm"
+          },
+          "sha256:26f5be58bb251b4e4216c0d6c5b69ddea6afcd0a797121126da3ab4eb74e9b37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/dracut-config-generic-057-6.fc38.x86_64.rpm"
+          },
+          "sha256:276c7af4b13262c0307cf2528c6d79c859ed348db68c0d2780869ea4b179dd02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gettext-envsubst-0.21.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:28697cf1b5cb4d62c3bd154fc24a23d91a84a5bda2f974fb64bdd04e91b6cec5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libnsl2-2.0.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:2871bb34038a71a4b766bddafd82135a2dc42ac0ee7b158b2378c1cd445f9d03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/skopeo-1.11.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:292791eb37bc312e845e777b2e0e3173e2d951c2bfbbda125bc619dced7f40bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libverto-0.3.2-5.fc38.x86_64.rpm"
+          },
+          "sha256:2daee83cd0c6bd1210e7a547b0837acd1fe460901d55b8df2d47d312cf0b229c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/rpm-plugin-selinux-4.18.0-10.fc38.x86_64.rpm"
+          },
+          "sha256:2dcdc3dfa37a687351a6969c037d67669e7e55ba0efa579f60392ecb566f9174": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/polkit-libs-122-3.fc38.x86_64.rpm"
+          },
+          "sha256:2f55b1581a26bb9fd552ec5c3c97cf206b163f3f1b8b892baf432a6454e2df0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libsemanage-3.5-0.rc3.1.fc38.x86_64.rpm"
+          },
+          "sha256:2fb7ee2d94f7ee34cff49ab28659c07b075ed67ac147f817e19d8ee8e0adbc9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libfdisk-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:2fd63c2deeb11acaf63cccb09722b34961722a4387d73faa01e14badd13a13f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/publicsuffix-list-dafsa-20221208-2.fc38.noarch.rpm"
+          },
+          "sha256:2fd7553527985aefe6b65216c9c4295ab0bac21551ad092e9d3e3229a5c73e5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-gpg-keys-38-0.5.noarch.rpm"
+          },
+          "sha256:32ff1d8ce057bca605a5ac7fabcbb66904158d66b889591b308c4489d041b116": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/elfutils-debuginfod-client-0.188-5.fc38.x86_64.rpm"
+          },
+          "sha256:33631973ecf9e6b23e0b7d07d61100fdc2db33261f4a6c43b5a09791b9455291": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libnghttp2-1.52.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:340d6564ad122b245fda35c873e91ec685e523f1fef6afa539a087b01d70fb48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/rpm-sequoia-1.3.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:34446f36355b415633037cdb983677288e4fb70b68d70a509fa2081b6b6e9f49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libksba-1.6.3-2.fc38.x86_64.rpm"
+          },
+          "sha256:36a1f0412e495e618ccd8636de3dcac9ad37d5d4c287a1acf2c9af4baa7745e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/m/memstrack-0.2.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:37d97cf3e381bde43861a03858e9cbd097191b0d1a7e555ba82eddd06a5a56d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fuse3-libs-3.13.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:3837cbe450ceb59e1f9e7469aeb6ec98e08150773b83463725acfb2ebb77a98a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gettext-runtime-0.21.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:38c134f1c688e9c33ced36cf623e6ce1b0802ff0623b42c69b1cdffb5bea1b9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/diffutils-3.9-1.fc38.x86_64.rpm"
+          },
+          "sha256:4170497dedcf53248c18f7963b911aed445d8bc02a33aa27aadf3354b8dfd8ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libxcrypt-compat-4.4.33-7.fc38.x86_64.rpm"
+          },
+          "sha256:41cd0821eaa5887eab973a969bd1c8928567e655aacd851f37fd2026d95c7e4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm"
+          },
+          "sha256:42e8600a8d7e7109de32df6cb6a619b9805f9335bf467a085009f6b82dda6e22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/device-mapper-libs-1.02.189-2.fc38.x86_64.rpm"
+          },
+          "sha256:462e051734bc21a4ad5c661bfd5e3e333da41c60db0f971967212fd9f022ea69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libgcc-13.0.1-0.5.fc38.x86_64.rpm"
+          },
+          "sha256:46ed6b8fee11c16bb8b58f698dfba9874a8f393c1e72eb7f9a7b6802ac68dd1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libsecret-0.20.5-3.fc38.x86_64.rpm"
+          },
+          "sha256:47447bdd06e43a9911aaf3335490cef9414a436440ca945a8f5ad4b29345eab1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/rpm-libs-4.18.0-10.fc38.x86_64.rpm"
+          },
+          "sha256:48a787e140f7b35d53ef83b808dece8dd5954be79546a2a583d07f520ea3ea1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/glibc-common-2.37-1.fc38.x86_64.rpm"
+          },
+          "sha256:48efa34ce50ae936ab9fe437aa59396d4557ff39fa22cf36c5460d3a986e502f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pcsc-lite-1.9.9-3.fc38.x86_64.rpm"
+          },
+          "sha256:49ec489f168c1671a2babb690edfb020a5252f38e8d0b2d96465070abd2b0d70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/q/qrencode-libs-4.1.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:4b0d680c4c2a36d9137c98a056683b456b6aba93838c3ade023ba78da937e8ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/containers-common-1-86.fc38.noarch.rpm"
+          },
+          "sha256:4c00645bab83992be045c24652c3f8f23f8d5d68dfdd80b6e64f01f2d4e6530f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libgomp-13.0.1-0.5.fc38.x86_64.rpm"
+          },
+          "sha256:4d559e22dc4dfc539d5455d76f446ecaf7d0dc9ef37ba762c45b01e069a19b56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/w/whois-nls-5.5.15-3.fc38.noarch.rpm"
+          },
+          "sha256:4dc70c4a90ddede4f38d96e8184da5d3113f9404d3cd4b98b45ffd40cc503249": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/a/authselect-libs-1.4.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:4ed3e7b6b0727b86ae9af17bd4839c06762a417a263a5d22eb7fcb39714bb480": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libcom_err-1.46.5-4.fc38.x86_64.rpm"
+          },
+          "sha256:4fb6fcf7eef64a48666ff9fe5a46344087979d9e8fd87be4d58a17cf9c3ef108": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gettext-libs-0.21.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:507ffdb912296768699a70c30169077b531b1612e47041551bfe523a4b7b6c7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libxkbcommon-1.5.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:53dc032707ab6765dcad52ec579e53106d9826a81fb061d616e00afe702adc1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/rpm-4.18.0-10.fc38.x86_64.rpm"
+          },
+          "sha256:56df47937646df892dad25c6b9ae63d111328febfe86eb93096b8b0a11700b60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fuse-libs-2.9.9-16.fc38.x86_64.rpm"
+          },
+          "sha256:56e701bd74cff3301be1e47e8405dc582a94fd37e45afd782e03c335fc8714bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libselinux-utils-3.5-0.rc3.1.fc38.x86_64.rpm"
+          },
+          "sha256:575ba7ab8e3b6d5b7508a505694a37c390a64ec070659b9393c1a5283c19ce90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/efibootmgr-18-3.fc38.x86_64.rpm"
+          },
+          "sha256:579f391b704753511bdd4f30840b5e07f178b6838042d3701a19c3cb7f9ccfac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fuse-overlayfs-1.10-3.fc38.x86_64.rpm"
+          },
+          "sha256:584a3843d52f90ed38819007083ea7e8327d23cd6203c8205b511054c2e24003": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/policycoreutils-3.5-0.rc3.1.fc38.x86_64.rpm"
+          },
+          "sha256:58b57a6547661f257778026e4e69d0264ea58ba7d81d422efec31476db408931": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/container-selinux-2.200.0-1.fc38.noarch.rpm"
+          },
+          "sha256:5922028bb5642faf00d781f34bf105ef30f1988932b4b80f6bb54e9f6eed0fd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libcbor-0.7.0-9.fc38.x86_64.rpm"
+          },
+          "sha256:59a7a5a775c196961cdc51fb89440a055295c767a632bfa684760e73650aa9a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm"
+          },
+          "sha256:5ac3b50011adb56391125a3b60bf05ae578af7209788cfdbfcf0ddc37d7b0ba2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libxcrypt-4.4.33-7.fc38.x86_64.rpm"
+          },
+          "sha256:5d1fa962cbc496f775065c66855ee74b7a335be8658783a8b846871d73d94ec6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/python-unversioned-command-3.11.2-1.fc38.noarch.rpm"
+          },
+          "sha256:5e088cea3244085f9d19d2f1bcb171b9f0c3a4ffc2ff0c81932081fbb225e564": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-common-38-0.26.noarch.rpm"
+          },
+          "sha256:602145f27fd017858256c6ee880863ef5be17c6d3c6c1354f7f16f6f6348db57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/n/ncurses-base-6.4-3.20230114.fc38.noarch.rpm"
+          },
+          "sha256:605d6710ba42104ce0434bb37b0ca9a922a8392c14175bc782f8acb70b94c3aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/n/nettle-3.8-3.fc38.x86_64.rpm"
+          },
+          "sha256:60ed241ec381a23d03fac733a72132dbdc4ba04c412add78bfc67f1b9f1b4daa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/grep-3.8-3.fc38.x86_64.rpm"
+          },
+          "sha256:63e970f7b3f8c54e1dff90661c26519f32a4bf7486c40f2dd38d55e40660230e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pam-libs-1.5.2-16.fc38.x86_64.rpm"
+          },
+          "sha256:65c21b264dd2adc3b20a0dff9384d6d630e0ce98ab9eab77e9a33b360173238d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/systemd-253-1.fc38.x86_64.rpm"
+          },
+          "sha256:664000d54ff291110ed9f350dbfd5e9cef78580a4c191846e08e29535b4103cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/coreutils-common-9.1-11.fc38.x86_64.rpm"
+          },
+          "sha256:6652f5d40acfaeda20555bdd63e964f123e8ab4a52f8c8890e749e06b6bae3e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/dbus-broker-33-1.fc38.x86_64.rpm"
+          },
+          "sha256:66604d04522a860a1c755a9629b0cb1e25a2c24747945f1f69b41ab8522787b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/a/authselect-1.4.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:6809fe060dc93dfed723bd8faca0f5d65e4f6c62aebd2f9f39f679413b260539": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/crypto-policies-20230301-1.gita12f7b2.fc38.noarch.rpm"
+          },
+          "sha256:695aab11fda4b6a396c3ca141fb3ccc48af757a70f36ea3a1be2292e90c40d6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/device-mapper-1.02.189-2.fc38.x86_64.rpm"
+          },
+          "sha256:69e48c73d962e3798fbc84150dfd79258b32a4f9250ee801d8cdb9540edfc21a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gmp-6.2.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:6bc9869c8ba8704f16fcec7543d4b029dd51213ff171fee7cb8e0a3da167b77a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/kbd-2.5.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:6c64fea958acfb77da5ee23ec1e8d0916c7809ce39987f219927e8f94e5f2755": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/expat-2.5.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:6ce309d9fd208bfff831981ee4298ccb25fa72363cb7464f1da03b8214d4351f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/n/ncurses-libs-6.4-3.20230114.fc38.x86_64.rpm"
+          },
+          "sha256:6e57ebf25ad25e7a6809aa0d99b5692598fb009a5438e90a2005f9fae5fd3b13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libeconf-0.4.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:6f2d599ea016ff52203366dd6563006c0bd17e7c258b6de65580d44afb42c27e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libgcrypt-1.10.1-7.fc38.x86_64.rpm"
+          },
+          "sha256:71778e1007afac3d55fa2d85301ce035c7d14f31f852a22f97a07e29811b17a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/grub2-common-2.06-88.fc38.noarch.rpm"
+          },
+          "sha256:718d95c40b41c2f0ecc8dc2290ebb91b529ba3be7accbad9c30c88e9ce408349": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/b/basesystem-11-15.fc38.noarch.rpm"
+          },
+          "sha256:736182ae69e03a19be60ed57486990f9b88cd06eeecb5e06cebc7f4b64ab0f5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/j/json-c-0.16-4.fc38.x86_64.rpm"
+          },
+          "sha256:738f573c50a537b556e2fbb8fa4a2c0d22fc2ce4a67344f89d478989cc323ab3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm"
+          },
+          "sha256:7417816bd96d7b49e5a98c85eba313afaa8b8802458d7cd9f5ba72ecc31933e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/python-setuptools-wheel-65.5.1-2.fc38.noarch.rpm"
+          },
+          "sha256:7419671c64795b96be18231e2f5d3f95eca8e6a71771863ac035f961041c1d7c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/kmod-30-4.fc38.x86_64.rpm"
+          },
+          "sha256:756f64de1e4673f0f617a9f3f12f74cceef5fc093e309d1b1d5dffef287b7d67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm"
+          },
+          "sha256:75c0097330fa3c995e80b7791cbe7baf75d86f3523f67b3becaf37360fdb4b16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libkcapi-1.4.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:75ecf8c60bea53432b973d9391e3bdb1b6cdc1f1cad0a7b56aabfb8b70252832": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/cpio-2.13-14.fc38.x86_64.rpm"
+          },
+          "sha256:78169acd52d9d936842dc326cb5ecdf92f7690ac7fa92a458ff83815e1a81b1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/selinux-policy-38.6-1.fc38.noarch.rpm"
+          },
+          "sha256:79986f917ef1bae7ca2378b16515ba44c19160f5a5eae4f6b697eda160bc26c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/findutils-4.9.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:7ca6440f9957d486bf78bd93185a1137365c7b74f77a2cc529792bf7671fa798": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libstdc++-13.0.1-0.5.fc38.x86_64.rpm"
+          },
+          "sha256:7d5eb1e8f80ae1dddc082b58c387f8d7b66d48dbf1d9ab4bcf9c9c138996085b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gpgme-1.17.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/kbd-misc-2.5.1-3.fc38.noarch.rpm"
+          },
+          "sha256:7f0fcb77e99894033474d4b8b5f27001cc8ef1aea7b80890a2d76a9eba71b891": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/dracut-057-6.fc38.x86_64.rpm"
+          },
+          "sha256:7ffa0438229228bf5ba18945936d52c3620c95f4a3ffc5c5f0f8774fececac0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/polkit-pkla-compat-0.1-23.fc38.x86_64.rpm"
+          },
+          "sha256:805da27b46f0d8cca2cf21a30e52401ae61ca472ae7c2d096de1cfb4b7a0d15c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libusb1-1.0.26-2.fc38.x86_64.rpm"
+          },
+          "sha256:845f6731b9e784784494fe9711c116631fc9ceede2fd0fa15b5f9575dee25e10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/librepo-1.15.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:84e6c8f8f6c538f3fb2a5bf233001b987e699ee6df22e27278d561477470ec70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-repos-38-0.5.noarch.rpm"
+          },
+          "sha256:85bb1aa32f6345349c9cf09c35217caae441dca6b2be8f21619ea6808d3c5af6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/shim-x64-15.6-2.x86_64.rpm"
+          },
+          "sha256:86128c7bb4d73b0921687db30d724ef3abf9023a75cfac4c49f6b91b22a1e1ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gnupg2-smime-2.4.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:876ef0556ddeca2c8f56536c80a2f6e0f64357f40bacb92f483adb8a0ff29af2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libuuid-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:88fd2c9592332643f6cf361755a9d47a2fa4340973bd6c85a97eab6b24daaa11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/elfutils-libs-0.188-5.fc38.x86_64.rpm"
+          },
+          "sha256:8acc96dd96e696a41125c210f8552317315741c4084023befcaa847536a478d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/file-5.44-2.fc38.x86_64.rpm"
+          },
+          "sha256:8adf29af85920514902bc4332ceb896a54f9cf89e08993c9345b62c4140f91d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/t/tpm2-tss-4.0.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:8b4892a7d8ff6e913ea16e1b26c4a3f7dd2bbed5893895b34ef3f02553be1a78": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libassuan-2.5.5-6.fc38.x86_64.rpm"
+          },
+          "sha256:8b49dd88579f1c37e05780202e81022c9400422b830d9bdd9087161683628b22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libtasn1-4.19.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:8bcdb9b5ce9b5e19c4f772f52c2c40712491d2a953496e415c380a21a792b050": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/duktape-2.7.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:8c70948b04d05290d6441359d461d9f7ec45439b3c97430c41b8a862d59e7b60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fuse-2.9.9-16.fc38.x86_64.rpm"
+          },
+          "sha256:8dede21b5102b60649074d45da8523ded78b2c9203771b204ae0ba70d3988432": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/o/openssl-libs-3.0.8-1.fc38.x86_64.rpm"
+          },
+          "sha256:8e4afbcb9488d9c6a9bf7d0739173b8757ce33a6f5e00f0ab7ccfcf605ed9273": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/p11-kit-0.24.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:9030a26ff737b7bbb71d5208feebba1a0b2774d58dfb6016824a042e059642d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/p11-kit-trust-0.24.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:9311016f5f40113d366f17d6ab6f6175e65ebde29212a05eee28e886d5b2e564": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/o/ostree-libs-2023.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:95273426afa05a81e6cf77f941e1156f6a0a3305a7768a02c04a4164280cf876": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/b/bzip2-libs-1.0.8-13.fc38.x86_64.rpm"
+          },
+          "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/kbd-legacy-2.5.1-3.fc38.noarch.rpm"
+          },
+          "sha256:961883b6ac18ca54b525209adce0c593f81fd8a7e71bb75bc07724e4ef72bc5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/b/bash-5.2.15-3.fc38.x86_64.rpm"
+          },
+          "sha256:96a8f495896c0ff7520c2cc5c9c173d134efc9ef6c6b0364bc7533aefb578d41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/lz4-libs-1.9.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:9815828233d84324f7e012dc1ac51a38b801159a00c2a3d7884c97f4b5cb9bf3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libssh-0.10.4-3.fc38.x86_64.rpm"
+          },
+          "sha256:9a1cba4c2c846be11966bac9dbba02ec47a22920655a27b305f4881232b4af16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/file-libs-5.44-2.fc38.x86_64.rpm"
+          },
+          "sha256:9a4e2b838b797ce2dfaf45d8af8692c158ec741b2c76d42e2bf9013c47b30981": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/m/mkpasswd-5.5.15-3.fc38.x86_64.rpm"
+          },
+          "sha256:9b093be8a99bfbae03c2f3dd5435fc9508003f7ef21e4280ff72fe814c1d794e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libacl-2.3.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:9b76ad6cde430264ecd88244255c44bae45a955da60b43ffc19fcefc3f98dacc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/curl-7.87.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:9dea5ef5fada9f1230590c0ca476c0da2b2fd228edba3dce81a9bac7c3a8df7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/t/tpm2-tools-5.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:9e73a2b591ebf2915bfbe7f9479498a73c982a4c74e96cc555930022e3ef0aba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libb2-0.98.1-8.fc38.x86_64.rpm"
+          },
+          "sha256:9f531fbcc52871aace8fdcdb816207c4196d5ab30ba233c71adb41371fa47e19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libyaml-0.2.5-9.fc38.x86_64.rpm"
+          },
+          "sha256:a007fe955a4fba751f211b4e8e16f916e9b7ba1c020b69d62ccb4d437a3ddd1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm"
+          },
+          "sha256:a5b52d9e252e7b653d54a2aee5ae1b9d45034ccd3d8f30e6af9b86952029c535": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-identity-basic-38-0.26.noarch.rpm"
+          },
+          "sha256:a6e01b89e814ec42d1c2c6be79240a97a9bd151c857f82a11e129547e069e27f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/sed-4.8-12.fc38.x86_64.rpm"
+          },
+          "sha256:a7099c322c45030738bdd90e3de4402c0c80c6ebd993a1749c2e582cf33ee6f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/readline-8.2-3.fc38.x86_64.rpm"
+          },
+          "sha256:a7ce8eced4895a190f10e2e6afa566f2f4c7e7192b0801581d4e2a337fb51970": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libgpg-error-1.46-2.fc38.x86_64.rpm"
+          },
+          "sha256:a80791ca462f0037c5438787081ab0161f14db6a4180113af618155d76f40a00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/shadow-utils-4.13-4.fc38.x86_64.rpm"
+          },
+          "sha256:aa02afed121e9f5fa9590d75c0b237b6c497ae58c91e0022844b38f594feaeb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.x86_64.rpm"
+          },
+          "sha256:ac0a6bf295151973d2e34392a134e246560b19b7351ced244abc1ed81dfe5b8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libsigsegv-2.14-4.fc38.x86_64.rpm"
+          },
+          "sha256:ac6e86a36c90c7b75a2d1e30476b16c286b2cc29f958677ac0aaada2df72a316": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/w/which-2.21-37.fc38.x86_64.rpm"
+          },
+          "sha256:ac8a7628a2a4b1f742fc90719145f50cfad9ecf67e3309fcf623fb3d82c2a768": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/kpartx-0.9.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:adaf981062abdef448f851efccf68875de288c388c31a4adcac66478bb16a0c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libsepol-3.5-0.rc3.1.fc38.x86_64.rpm"
+          },
+          "sha256:aefb7d2d96af03f4d7ac5a132138d383faf858011b1740c48fcd152000f3c617": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libpwquality-1.4.5-3.fc38.x86_64.rpm"
+          },
+          "sha256:afad50ac8bea1986acaa72b119cbdf2fa8aa08dc0d4d93d26b8b70f1bfea8067": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gnupg2-2.4.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:afffbd76e4c048e7fb12e411d0270fb1467e186a83d4b6d12bdb1eacbb54155b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fuse3-3.13.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:b0fc6c55f5989aebf6e71279541206070b32b3b28b708a249bd3bdeaa6c088a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/filesystem-3.18-3.fc38.x86_64.rpm"
+          },
+          "sha256:b25a042f52c8cdc1ddab56fc726d98789ff902d5264d9835f5b910db3e565213": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/e2fsprogs-1.46.5-4.fc38.x86_64.rpm"
+          },
+          "sha256:b570b4857289cf32ed57d0d84cb861677a649cef7c5cc2498a249d6593eb3614": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/cyrus-sasl-lib-2.1.28-9.fc38.x86_64.rpm"
+          },
+          "sha256:b57dbbbee14301e89df618b398ef39b7fc841eaba6be1b6346cf37ed7695c26a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/u/util-linux-core-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:b66376e78fe54024531d94036d10b22b5050d52a9e65682b36dc7fdf24405997": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/keyutils-libs-1.6.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:b6a2b3872182fe877fcd1dd85ef66282fdeec79fab87157327c9fc6cbd80ab15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libcap-2.48-6.fc38.x86_64.rpm"
+          },
+          "sha256:b879b130ab94cbe69d3a6fe1236934ae330c0b11d344c140b7de35acb075fff6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/coreutils-9.1-11.fc38.x86_64.rpm"
+          },
+          "sha256:bae7f23fd0f7aed44a9081cbdbeb9cb922a694f09d21f564738f192e0e4d7f7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/systemd-libs-253-1.fc38.x86_64.rpm"
+          },
+          "sha256:bbe3eb89df059162bda14c6f0c06e6251984d79502806c87ae4c6befc4e392ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/b/bubblewrap-0.7.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:bdd3f5e8edc77ce3e183134535ec838f033ed3bf0e6802e864c0a6c5fc94b22d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libbrotli-1.0.9-11.fc38.x86_64.rpm"
+          },
+          "sha256:be6d9e9b98733494ee5901d45b849e2dc012a6b41c3ff09d0d212002dbe15dce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/sqlite-libs-3.40.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:bf999c05654fb860129d6211a6addace24e1477d543e3558b11ffcea15884c9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/glibc-gconv-extra-2.37-1.fc38.x86_64.rpm"
+          },
+          "sha256:bfce8ac2a2a78a23fb931531fb3d8f530a78f4d5b17f6199bf99b93ca21858c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/x/xz-libs-5.4.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:c1ac9f901c9bf96278c5959e024a0bbfe9aaf2581debee7ba5b608c319e8a132": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/grub2-tools-minimal-2.06-88.fc38.x86_64.rpm"
+          },
+          "sha256:c26d4d161f8eddd7cb794075e383d0f4d3a77aa88e453a2db51e53346981f04c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm"
+          },
+          "sha256:c2ae86002363a331661c72eec5cad90a100216e46176d4bdbe2c20e465c1d73c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/j/json-glib-1.6.6-4.fc38.x86_64.rpm"
+          },
+          "sha256:c4012952872a08b9662963b13e29f89388ce6e695e68fa8c37eb6e62bad62441": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libunistring-1.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:c54d4cbbb5e20ac926fb9b6f158eda6d991ef7cb4568cb962f842c4b74317776": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libssh-config-0.10.4-3.fc38.noarch.rpm"
+          },
+          "sha256:c5c409a2d5f8890eeab48b27b9f4f02925a6bbabeb21ee5e45694c7c9009f037": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libutempter-1.2.1-8.fc38.x86_64.rpm"
+          },
+          "sha256:c7efb8634b62cdab9e8894174a8c70d20eb431482277231bc54fa8ca8c3681e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/setup-2.14.3-2.fc38.noarch.rpm"
+          },
+          "sha256:c9e8b62c6af7a60a505f881d3cc35294d8b4f51c671c05401133b02ab229c2a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/n/npth-1.6-12.fc38.x86_64.rpm"
+          },
+          "sha256:cb1caf3e9a4ddc8343c0757c7a2730bf5de2b5f0b4c9ee7d928609566f64f010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pcre2-10.42-1.fc38.1.x86_64.rpm"
+          },
+          "sha256:cbfe99034f05faee13e8a5fc4708909d83bb1fe4e4edcdc6238d0a9dc00bec92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libtirpc-1.3.3-1.fc38.x86_64.rpm"
+          },
+          "sha256:cd0e8eb5d983a985f7df99718fde6245997bdf088fb6086442a883ddb9ed03e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libunistring1.0-1.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:cfa3d6feba480abdeb425bc045b525c641c7a864625b1864c2f5721903e364d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/o/openssl-pkcs11-0.4.12-3.fc38.x86_64.rpm"
+          },
+          "sha256:d1880b8f3e8a5fa943ba033c96dc964fac3e07c34cbd0bb8ac2b0fdcb57abcbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/crypto-policies-scripts-20230301-1.gita12f7b2.fc38.noarch.rpm"
+          },
+          "sha256:d31e41005fa66d22c5cb0010161b423e3f538713176e33b5c519b4b8139e5e5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/systemd-networkd-253-1.fc38.x86_64.rpm"
+          },
+          "sha256:d3416e2b6c7565d7a607225d86b556398827316ae7ce43280b82630f0a022bc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libidn2-2.3.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:d48579aa97fba34dc3a4c4dd3fb10e8fd66186d970e37c2f7fc28bebbc2d31eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/grubby-8.40-69.fc38.x86_64.rpm"
+          },
+          "sha256:d7030af9e9e0dd9afc5b9ee02839c94757d6a4f8ebd3b21e6d81ba6141a76d46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libdb-5.3.28-55.fc38.x86_64.rpm"
+          },
+          "sha256:d78d7bc485f099bb08c9de55dd12ea6a984b948face1f947de6ec805663a96c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libattr-2.5.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:d9196608152ec34832cc82d3cefa90748f30c75986f2250d8cd0fabc3d0ceba2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/m/mokutil-0.6.0-6.fc38.x86_64.rpm"
+          },
+          "sha256:db9229087c86f9d5725daf2066e3a52c84dc44bb31ac940461fc8d7510681297": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libsolv-0.7.22-4.fc38.x86_64.rpm"
+          },
+          "sha256:dbe79a864033502b6f2eb2de22a3801cefebe711769254f1b17a7026f7a4429d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fuse-common-3.13.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:dbf5c73c71c798533cbecfa54ba28c42878c455df8cb382087d8a758c3ffe290": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libsmartcols-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:dd044973c572e64f505f3d00482249b2b4d71369babb5395a22861fd55b21d79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libargon2-20190702-2.fc38.x86_64.rpm"
+          },
+          "sha256:de9cc9d18a66b22a8e0b984e7d337244aae1611b522d5f88e9f5cccb47fed456": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libzstd-1.5.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:dec378b594b79258dd8b44836c5371f316bcf5e4596d53dd84badcb6d00090df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libseccomp-2.5.3-4.fc38.x86_64.rpm"
+          },
+          "sha256:e0a6768f0ca08572b79a265ba0d3fdeba09408431d9e717b8d45af9e1ae67cf6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/dosfstools-4.2-6.fc38.x86_64.rpm"
+          },
+          "sha256:e0bccc94a740acf317caa4fa1fae6b0d57442ef4be36341472b7db93d588ec13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libpsl-0.21.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:e0fcc99133bac41153d6218c56b05b33016d00f302c4ff34549e2bbac196845d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/elfutils-default-yama-scope-0.188-5.fc38.noarch.rpm"
+          },
+          "sha256:e41d2d818abf5bf1209ed18ec6f28dad7b4ec49b6459d34c96104a93da329bd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/a/alternatives-1.21-2.fc38.x86_64.rpm"
+          },
+          "sha256:e49dc59ac89b5b0a00384cba20a42e7238adc6cbc1471851980b1abbc1202705": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/z/zchunk-libs-1.2.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:e521385a42b3350c0d17e3cbddc0b69c9cf4052d1b77cc8bea2179e05b7d374a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pinentry-1.2.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:e552fae193775507d8264f7a856fbdc51f7e594d7d8726f181312aeb9cf8b973": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:e607df61803999da46a199d23d4acadb45b290f29b5b644e583c5526d8081178": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gawk-5.1.1-5.fc38.x86_64.rpm"
+          },
+          "sha256:e6ba30fafaf487f20f9c09d89803c578fca1cbe3226b497fedf202536da4f47e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libmodulemd-2.14.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:e7509cf0ec99ce89e8e88e9352f733eb9ad14a9c77e0bbfd64826a3de0e4a150": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pigz-2.7-3.fc38.x86_64.rpm"
+          },
+          "sha256:e779fca5e3be85efabe2132bdaf87ac852d78187fbbb9e3d9b37eabccafb4e85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/krb5-libs-1.20.1-8.fc38.x86_64.rpm"
+          },
+          "sha256:e7c9b0c39f77c6fdf68ff04d8714c10532907a8a9c3e76fb377afe546247737f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/m/mpfr-4.1.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:e81ffc077d3cc1c27f34949cf1b473e2ffbebfdb6bd95d1a130fa8d13b9de61e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/elfutils-libelf-0.188-5.fc38.x86_64.rpm"
+          },
+          "sha256:e911703ffceee37ec1066344820ab0cf9ba8e43d7957395981ba68c4d411a0a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/x/xz-5.4.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:e952487132d2b7fef68e3221f720872ad314cdf273085aea1e9ecbdff5948b9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/python3-3.11.2-1.fc38.x86_64.rpm"
+          },
+          "sha256:e9741c40e94cf45bdc699b950c238646c2d56b3ee7984e748b94d8e6f87ba3cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libevent-2.1.12-8.fc38.x86_64.rpm"
+          },
+          "sha256:eb376264750aae673aa2a3218c291756023dea980640b30a3efe0f2199ff3889": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gdbm-libs-1.23-3.fc38.x86_64.rpm"
+          },
+          "sha256:ee100ea7fe8bf26d44df719283554a36398d484eee28682694c9e7a249c2d49c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/python-pip-wheel-22.3.1-2.fc38.noarch.rpm"
+          },
+          "sha256:ef498b94191f926bf5a55c4e6ca3431cdee2595a9cbfccd1f82ca959ea7bedfa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/polkit-122-3.fc38.x86_64.rpm"
+          },
+          "sha256:f0a48ec36269d83120425b269e47ba5c86d5a9a44e0de2665c1d55c10732d25b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/lua-libs-5.4.4-9.fc38.x86_64.rpm"
+          },
+          "sha256:f0f8e33332df97afd911093f28c487bc84cbe4dcc7bb468eac5551d235acee62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/u/util-linux-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:f0fd8f2c66a30d3c9544dc47cdd8964bae72e4977dc9b49d1f02d40cd299640f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/o/openldap-2.6.3-2.fc38.x86_64.rpm"
+          },
+          "sha256:f1b047b5f04c240dcf3222f62ca6acf24e46e532d53a768cdae3ea500073ee3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/o/ostree-2023.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:f289b7726320f275730e28e3891a6f3fda76941876de4f643d486f3265a0a074": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/cracklib-dicts-2.9.7-31.fc38.x86_64.rpm"
+          },
+          "sha256:f30e74df21de01e6ecb6bec0fe0748aa80cb49e597dbd694e0cc8b3b68c425e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/systemd-resolved-253-1.fc38.x86_64.rpm"
+          },
+          "sha256:f416899a04b543dcebf6bf7a6c9a65521c64c3916cd06793e5b5a7a5f9b71cf3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/rpm-ostree-2023.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:f6baad418fc4f4da5db75e51e921dac6b313fad34f5f4901d772dfbfd9623537": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/grub2-efi-x64-2.06-88.fc38.x86_64.rpm"
+          },
+          "sha256:f828322655ab1b93de1972d8af71689ef239a160f13931e447b0ebcbb764cef9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-38-0.26.noarch.rpm"
+          },
+          "sha256:f83ba3694aaa98e13c078b0c642c816033a9450105b30942f7c5f84199722b59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/systemd-udev-253-1.fc38.x86_64.rpm"
+          },
+          "sha256:f8d84ce3922c932844043d6037ae880d18221e974fc7cf1fab58de48f0a851e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libcurl-7.87.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:faccff819eecffcee9dad49bda930a007e78b905b775b4ac0103121d7a8100db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libss-1.46.5-4.fc38.x86_64.rpm"
+          },
+          "sha256:fadef9c94822d311c6f1092c2ff77e0485cb49d21171acef4012b15b35d1485d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/grub2-tools-2.06-88.fc38.x86_64.rpm"
+          },
+          "sha256:fb3fabd657b8f8603c6e19858beb0d506cf957bbca2f3feb827b64c94563b31f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/popt-1.19-2.fc38.x86_64.rpm"
+          },
+          "sha256:fbeb7a7a95051df0dfeb7c4ab379b77ccfb0bf0174a39dae4a423b9108627771": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/efivar-libs-38-7.fc38.x86_64.rpm"
+          },
+          "sha256:fdb3e6e4578d8bb90f1f917edf5a7f52432df2eb5b0fab000eab662b15476479": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/procps-ng-3.3.17-9.fc38.x86_64.rpm"
+          }
+        }
+      },
+      "org.osbuild.inline": {
+        "items": {
+          "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+            "encoding": "base64",
+            "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+          },
+          "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+            "encoding": "base64",
+            "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+          },
+          "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+            "encoding": "base64",
+            "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+          },
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+            "encoding": "base64",
+            "data": ""
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/a/alternatives-1.21-2.fc38.x86_64.rpm",
+        "checksum": "sha256:e41d2d818abf5bf1209ed18ec6f28dad7b4ec49b6459d34c96104a93da329bd6",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/a/audit-libs-3.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:1abdc7956a48e8f3d6a4ac91aa511123f55b1c876e8c664f78ae16b9195dcec3",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/a/authselect-1.4.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:66604d04522a860a1c755a9629b0cb1e25a2c24747945f1f69b41ab8522787b3",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/a/authselect-libs-1.4.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:4dc70c4a90ddede4f38d96e8184da5d3113f9404d3cd4b98b45ffd40cc503249",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "15.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/b/basesystem-11-15.fc38.noarch.rpm",
+        "checksum": "sha256:718d95c40b41c2f0ecc8dc2290ebb91b529ba3be7accbad9c30c88e9ce408349",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.15",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/b/bash-5.2.15-3.fc38.x86_64.rpm",
+        "checksum": "sha256:961883b6ac18ca54b525209adce0c593f81fd8a7e71bb75bc07724e4ef72bc5f",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/b/bubblewrap-0.7.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:bbe3eb89df059162bda14c6f0c06e6251984d79502806c87ae4c6befc4e392ab",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "13.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/b/bzip2-libs-1.0.8-13.fc38.x86_64.rpm",
+        "checksum": "sha256:95273426afa05a81e6cf77f941e1156f6a0a3305a7768a02c04a4164280cf876",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2023.2.60",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm",
+        "checksum": "sha256:738f573c50a537b556e2fbb8fa4a2c0d22fc2ce4a67344f89d478989cc323ab3",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.200.0",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/container-selinux-2.200.0-1.fc38.noarch.rpm",
+        "checksum": "sha256:58b57a6547661f257778026e4e69d0264ea58ba7d81d422efec31476db408931",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "86.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/containers-common-1-86.fc38.noarch.rpm",
+        "checksum": "sha256:4b0d680c4c2a36d9137c98a056683b456b6aba93838c3ade023ba78da937e8ab",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "11.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/coreutils-9.1-11.fc38.x86_64.rpm",
+        "checksum": "sha256:b879b130ab94cbe69d3a6fe1236934ae330c0b11d344c140b7de35acb075fff6",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "11.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/coreutils-common-9.1-11.fc38.x86_64.rpm",
+        "checksum": "sha256:664000d54ff291110ed9f350dbfd5e9cef78580a4c191846e08e29535b4103cc",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "14.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/cpio-2.13-14.fc38.x86_64.rpm",
+        "checksum": "sha256:75ecf8c60bea53432b973d9391e3bdb1b6cdc1f1cad0a7b56aabfb8b70252832",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/cracklib-2.9.7-31.fc38.x86_64.rpm",
+        "checksum": "sha256:1262de076983a540ed42a33160a61cd2723a662c1680935379ccdb0894f60cee",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/cracklib-dicts-2.9.7-31.fc38.x86_64.rpm",
+        "checksum": "sha256:f289b7726320f275730e28e3891a6f3fda76941876de4f643d486f3265a0a074",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20230301",
+        "release": "1.gita12f7b2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/crypto-policies-20230301-1.gita12f7b2.fc38.noarch.rpm",
+        "checksum": "sha256:6809fe060dc93dfed723bd8faca0f5d65e4f6c62aebd2f9f39f679413b260539",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20230301",
+        "release": "1.gita12f7b2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/crypto-policies-scripts-20230301-1.gita12f7b2.fc38.noarch.rpm",
+        "checksum": "sha256:d1880b8f3e8a5fa943ba033c96dc964fac3e07c34cbd0bb8ac2b0fdcb57abcbc",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/cryptsetup-libs-2.6.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:070d86aca4548e9148901881a4ef64d98c5dfd4ea158e9208c650c7f4b225c47",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.87.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/curl-7.87.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:9b76ad6cde430264ecd88244255c44bae45a955da60b43ffc19fcefc3f98dacc",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/c/cyrus-sasl-lib-2.1.28-9.fc38.x86_64.rpm",
+        "checksum": "sha256:b570b4857289cf32ed57d0d84cb861677a649cef7c5cc2498a249d6593eb3614",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/dbus-1.14.6-1.fc38.x86_64.rpm",
+        "checksum": "sha256:1812689be8bbc4ef39718dbb8ef862105225348310052ddaf0b1cb0f0a1bf296",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "33",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/dbus-broker-33-1.fc38.x86_64.rpm",
+        "checksum": "sha256:6652f5d40acfaeda20555bdd63e964f123e8ab4a52f8c8890e749e06b6bae3e0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm",
+        "checksum": "sha256:41cd0821eaa5887eab973a969bd1c8928567e655aacd851f37fd2026d95c7e4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.189",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/device-mapper-1.02.189-2.fc38.x86_64.rpm",
+        "checksum": "sha256:695aab11fda4b6a396c3ca141fb3ccc48af757a70f36ea3a1be2292e90c40d6f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.189",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/device-mapper-libs-1.02.189-2.fc38.x86_64.rpm",
+        "checksum": "sha256:42e8600a8d7e7109de32df6cb6a619b9805f9335bf467a085009f6b82dda6e22",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/diffutils-3.9-1.fc38.x86_64.rpm",
+        "checksum": "sha256:38c134f1c688e9c33ced36cf623e6ce1b0802ff0623b42c69b1cdffb5bea1b9d",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/dosfstools-4.2-6.fc38.x86_64.rpm",
+        "checksum": "sha256:e0a6768f0ca08572b79a265ba0d3fdeba09408431d9e717b8d45af9e1ae67cf6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/dracut-057-6.fc38.x86_64.rpm",
+        "checksum": "sha256:7f0fcb77e99894033474d4b8b5f27001cc8ef1aea7b80890a2d76a9eba71b891",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "057",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/dracut-config-generic-057-6.fc38.x86_64.rpm",
+        "checksum": "sha256:26f5be58bb251b4e4216c0d6c5b69ddea6afcd0a797121126da3ab4eb74e9b37",
+        "check_gpg": true
+      },
+      {
+        "name": "duktape",
+        "epoch": 0,
+        "version": "2.7.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/duktape-2.7.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:8bcdb9b5ce9b5e19c4f772f52c2c40712491d2a953496e415c380a21a792b050",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/e2fsprogs-1.46.5-4.fc38.x86_64.rpm",
+        "checksum": "sha256:b25a042f52c8cdc1ddab56fc726d98789ff902d5264d9835f5b910db3e565213",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/e2fsprogs-libs-1.46.5-4.fc38.x86_64.rpm",
+        "checksum": "sha256:1ca049bff926a8ec9b6e0e69f23662934eab96c35d8eda1cf429a2a31f186045",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "7.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm",
+        "checksum": "sha256:a007fe955a4fba751f211b4e8e16f916e9b7ba1c020b69d62ccb4d437a3ddd1d",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/efibootmgr-18-3.fc38.x86_64.rpm",
+        "checksum": "sha256:575ba7ab8e3b6d5b7508a505694a37c390a64ec070659b9393c1a5283c19ce90",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "7.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/efivar-libs-38-7.fc38.x86_64.rpm",
+        "checksum": "sha256:fbeb7a7a95051df0dfeb7c4ab379b77ccfb0bf0174a39dae4a423b9108627771",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.188",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/elfutils-debuginfod-client-0.188-5.fc38.x86_64.rpm",
+        "checksum": "sha256:32ff1d8ce057bca605a5ac7fabcbb66904158d66b889591b308c4489d041b116",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.188",
+        "release": "5.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/elfutils-default-yama-scope-0.188-5.fc38.noarch.rpm",
+        "checksum": "sha256:e0fcc99133bac41153d6218c56b05b33016d00f302c4ff34549e2bbac196845d",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.188",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/elfutils-libelf-0.188-5.fc38.x86_64.rpm",
+        "checksum": "sha256:e81ffc077d3cc1c27f34949cf1b473e2ffbebfdb6bd95d1a130fa8d13b9de61e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.188",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/elfutils-libs-0.188-5.fc38.x86_64.rpm",
+        "checksum": "sha256:88fd2c9592332643f6cf361755a9d47a2fa4340973bd6c85a97eab6b24daaa11",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/e/expat-2.5.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:6c64fea958acfb77da5ee23ec1e8d0916c7809ce39987f219927e8f94e5f2755",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.5",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-gpg-keys-38-0.5.noarch.rpm",
+        "checksum": "sha256:2fd7553527985aefe6b65216c9c4295ab0bac21551ad092e9d3e3229a5c73e5b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.26",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-38-0.26.noarch.rpm",
+        "checksum": "sha256:f828322655ab1b93de1972d8af71689ef239a160f13931e447b0ebcbb764cef9",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.26",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-common-38-0.26.noarch.rpm",
+        "checksum": "sha256:5e088cea3244085f9d19d2f1bcb171b9f0c3a4ffc2ff0c81932081fbb225e564",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.26",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-identity-basic-38-0.26.noarch.rpm",
+        "checksum": "sha256:a5b52d9e252e7b653d54a2aee5ae1b9d45034ccd3d8f30e6af9b86952029c535",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.5",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-repos-38-0.5.noarch.rpm",
+        "checksum": "sha256:84e6c8f8f6c538f3fb2a5bf233001b987e699ee6df22e27278d561477470ec70",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/file-5.44-2.fc38.x86_64.rpm",
+        "checksum": "sha256:8acc96dd96e696a41125c210f8552317315741c4084023befcaa847536a478d6",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/file-libs-5.44-2.fc38.x86_64.rpm",
+        "checksum": "sha256:9a1cba4c2c846be11966bac9dbba02ec47a22920655a27b305f4881232b4af16",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/filesystem-3.18-3.fc38.x86_64.rpm",
+        "checksum": "sha256:b0fc6c55f5989aebf6e71279541206070b32b3b28b708a249bd3bdeaa6c088a4",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/findutils-4.9.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:79986f917ef1bae7ca2378b16515ba44c19160f5a5eae4f6b697eda160bc26c1",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fuse-2.9.9-16.fc38.x86_64.rpm",
+        "checksum": "sha256:8c70948b04d05290d6441359d461d9f7ec45439b3c97430c41b8a862d59e7b60",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fuse-common-3.13.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:dbe79a864033502b6f2eb2de22a3801cefebe711769254f1b17a7026f7a4429d",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fuse-libs-2.9.9-16.fc38.x86_64.rpm",
+        "checksum": "sha256:56df47937646df892dad25c6b9ae63d111328febfe86eb93096b8b0a11700b60",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fuse-overlayfs-1.10-3.fc38.x86_64.rpm",
+        "checksum": "sha256:579f391b704753511bdd4f30840b5e07f178b6838042d3701a19c3cb7f9ccfac",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fuse3-3.13.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:afffbd76e4c048e7fb12e411d0270fb1467e186a83d4b6d12bdb1eacbb54155b",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fuse3-libs-3.13.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:37d97cf3e381bde43861a03858e9cbd097191b0d1a7e555ba82eddd06a5a56d0",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gawk-5.1.1-5.fc38.x86_64.rpm",
+        "checksum": "sha256:e607df61803999da46a199d23d4acadb45b290f29b5b644e583c5526d8081178",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gawk-all-langpacks-5.1.1-5.fc38.x86_64.rpm",
+        "checksum": "sha256:254c6789b4a98b96a53172e1b3fb866f71ea29a5b5fa7b39f072f33c27d897bc",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gdbm-libs-1.23-3.fc38.x86_64.rpm",
+        "checksum": "sha256:eb376264750aae673aa2a3218c291756023dea980640b30a3efe0f2199ff3889",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gettext-envsubst-0.21.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:276c7af4b13262c0307cf2528c6d79c859ed348db68c0d2780869ea4b179dd02",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gettext-libs-0.21.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:4fb6fcf7eef64a48666ff9fe5a46344087979d9e8fd87be4d58a17cf9c3ef108",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gettext-runtime-0.21.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:3837cbe450ceb59e1f9e7469aeb6ec98e08150773b83463725acfb2ebb77a98a",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.75.3",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/glib2-2.75.3-4.fc38.x86_64.rpm",
+        "checksum": "sha256:03cb373a4cb9a43bbf71c0118573ce2db0ec1fa773d50adc9eed628a62acca01",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/glibc-2.37-1.fc38.x86_64.rpm",
+        "checksum": "sha256:1b727de2c86a63fae0a59f7c85b6a2c6c35f52678ac47b66e617e35c974e3619",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/glibc-common-2.37-1.fc38.x86_64.rpm",
+        "checksum": "sha256:48a787e140f7b35d53ef83b808dece8dd5954be79546a2a583d07f520ea3ea1e",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/glibc-gconv-extra-2.37-1.fc38.x86_64.rpm",
+        "checksum": "sha256:bf999c05654fb860129d6211a6addace24e1477d543e3558b11ffcea15884c9c",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/glibc-minimal-langpack-2.37-1.fc38.x86_64.rpm",
+        "checksum": "sha256:20122ec918b8abe671346ce40aa30fdc97b7dbf9e52451dfe6552c5309655286",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gmp-6.2.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:69e48c73d962e3798fbc84150dfd79258b32a4f9250ee801d8cdb9540edfc21a",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gnupg2-2.4.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:afad50ac8bea1986acaa72b119cbdf2fa8aa08dc0d4d93d26b8b70f1bfea8067",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gnupg2-smime-2.4.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:86128c7bb4d73b0921687db30d724ef3abf9023a75cfac4c49f6b91b22a1e1ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.8",
+        "release": "11.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gnutls-3.7.8-11.fc38.x86_64.rpm",
+        "checksum": "sha256:1ac3d3cb86a7515bd79c788930ce7d804bb39e84abe9261c4838bd35c669d8ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gpgme-1.17.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:7d5eb1e8f80ae1dddc082b58c387f8d7b66d48dbf1d9ab4bcf9c9c138996085b",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/grep-3.8-3.fc38.x86_64.rpm",
+        "checksum": "sha256:60ed241ec381a23d03fac733a72132dbdc4ba04c412add78bfc67f1b9f1b4daa",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "88.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/grub2-common-2.06-88.fc38.noarch.rpm",
+        "checksum": "sha256:71778e1007afac3d55fa2d85301ce035c7d14f31f852a22f97a07e29811b17a4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "88.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/grub2-efi-x64-2.06-88.fc38.x86_64.rpm",
+        "checksum": "sha256:f6baad418fc4f4da5db75e51e921dac6b313fad34f5f4901d772dfbfd9623537",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "88.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/grub2-tools-2.06-88.fc38.x86_64.rpm",
+        "checksum": "sha256:fadef9c94822d311c6f1092c2ff77e0485cb49d21171acef4012b15b35d1485d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "88.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/grub2-tools-minimal-2.06-88.fc38.x86_64.rpm",
+        "checksum": "sha256:c1ac9f901c9bf96278c5959e024a0bbfe9aaf2581debee7ba5b608c319e8a132",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "69.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/grubby-8.40-69.fc38.x86_64.rpm",
+        "checksum": "sha256:d48579aa97fba34dc3a4c4dd3fb10e8fd66186d970e37c2f7fc28bebbc2d31eb",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gzip-1.12-3.fc38.x86_64.rpm",
+        "checksum": "sha256:166e842798813a72e4d075dcd9b6e814d7ad3fc8d1b5860281cffe7a68784b25",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/j/json-c-0.16-4.fc38.x86_64.rpm",
+        "checksum": "sha256:736182ae69e03a19be60ed57486990f9b88cd06eeecb5e06cebc7f4b64ab0f5d",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/j/json-glib-1.6.6-4.fc38.x86_64.rpm",
+        "checksum": "sha256:c2ae86002363a331661c72eec5cad90a100216e46176d4bdbe2c20e465c1d73c",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/kbd-2.5.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:6bc9869c8ba8704f16fcec7543d4b029dd51213ff171fee7cb8e0a3da167b77a",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/kbd-legacy-2.5.1-3.fc38.noarch.rpm",
+        "checksum": "sha256:95efa1dee7e2925ec915e6960be9e003a042e8f82e66efa7f60c1a01729f1a4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/kbd-misc-2.5.1-3.fc38.noarch.rpm",
+        "checksum": "sha256:7dca1f4e54c68002e58ab57bc832963816a4ccd5d827094d8b9d407f8ee02853",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/keyutils-libs-1.6.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:b66376e78fe54024531d94036d10b22b5050d52a9e65682b36dc7fdf24405997",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/kmod-30-4.fc38.x86_64.rpm",
+        "checksum": "sha256:7419671c64795b96be18231e2f5d3f95eca8e6a71771863ac035f961041c1d7c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/kmod-libs-30-4.fc38.x86_64.rpm",
+        "checksum": "sha256:19f873b67f23362074c03d5825e709ad521278c02e44bdeb30eba6d3bb3a8e0f",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/kpartx-0.9.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:ac8a7628a2a4b1f742fc90719145f50cfad9ecf67e3309fcf623fb3d82c2a768",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.20.1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/k/krb5-libs-1.20.1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:e779fca5e3be85efabe2132bdaf87ac852d78187fbbb9e3d9b37eabccafb4e85",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libacl-2.3.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:9b093be8a99bfbae03c2f3dd5435fc9508003f7ef21e4280ff72fe814c1d794e",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libarchive-3.6.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:0d0890dba8274458d068b981164111f554b47632bf9c82d1ec41c14697f2b4af",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libargon2-20190702-2.fc38.x86_64.rpm",
+        "checksum": "sha256:dd044973c572e64f505f3d00482249b2b4d71369babb5395a22861fd55b21d79",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libassuan-2.5.5-6.fc38.x86_64.rpm",
+        "checksum": "sha256:8b4892a7d8ff6e913ea16e1b26c4a3f7dd2bbed5893895b34ef3f02553be1a78",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libattr-2.5.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:d78d7bc485f099bb08c9de55dd12ea6a984b948face1f947de6ec805663a96c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libb2-0.98.1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:9e73a2b591ebf2915bfbe7f9479498a73c982a4c74e96cc555930022e3ef0aba",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libblkid-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:21b5a1a024c2d1877d2b7271fd3f82424eb0bd6b95395ad3a3dae5776eec8714",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "11.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libbrotli-1.0.9-11.fc38.x86_64.rpm",
+        "checksum": "sha256:bdd3f5e8edc77ce3e183134535ec838f033ed3bf0e6802e864c0a6c5fc94b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libcap-2.48-6.fc38.x86_64.rpm",
+        "checksum": "sha256:b6a2b3872182fe877fcd1dd85ef66282fdeec79fab87157327c9fc6cbd80ab15",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libcap-ng-0.8.3-5.fc38.x86_64.rpm",
+        "checksum": "sha256:1e0bee6fd4e234796795cd45185b250d8cf894aef0bb95f2793d9453246e1a4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libcbor-0.7.0-9.fc38.x86_64.rpm",
+        "checksum": "sha256:5922028bb5642faf00d781f34bf105ef30f1988932b4b80f6bb54e9f6eed0fd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libcom_err-1.46.5-4.fc38.x86_64.rpm",
+        "checksum": "sha256:4ed3e7b6b0727b86ae9af17bd4839c06762a417a263a5d22eb7fcb39714bb480",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.87.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libcurl-7.87.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:f8d84ce3922c932844043d6037ae880d18221e974fc7cf1fab58de48f0a851e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "55.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libdb-5.3.28-55.fc38.x86_64.rpm",
+        "checksum": "sha256:d7030af9e9e0dd9afc5b9ee02839c94757d6a4f8ebd3b21e6d81ba6141a76d46",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libeconf-0.4.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:6e57ebf25ad25e7a6809aa0d99b5692598fb009a5438e90a2005f9fae5fd3b13",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libevent-2.1.12-8.fc38.x86_64.rpm",
+        "checksum": "sha256:e9741c40e94cf45bdc699b950c238646c2d56b3ee7984e748b94d8e6f87ba3cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libfdisk-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:2fb7ee2d94f7ee34cff49ab28659c07b075ed67ac147f817e19d8ee8e0adbc9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libffi-3.4.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:098e8ba05482205c70c3510907da71819faf5d40b588f865ad2a77d6eaf4af09",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.12.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libfido2-1.12.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:0a30628b39d9c5ca81c4e073dfbf64d543284f17d4ae1325e23e3eda55f92fd9",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "13.0.1",
+        "release": "0.5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libgcc-13.0.1-0.5.fc38.x86_64.rpm",
+        "checksum": "sha256:462e051734bc21a4ad5c661bfd5e3e333da41c60db0f971967212fd9f022ea69",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "7.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libgcrypt-1.10.1-7.fc38.x86_64.rpm",
+        "checksum": "sha256:6f2d599ea016ff52203366dd6563006c0bd17e7c258b6de65580d44afb42c27e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "13.0.1",
+        "release": "0.5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libgomp-13.0.1-0.5.fc38.x86_64.rpm",
+        "checksum": "sha256:4c00645bab83992be045c24652c3f8f23f8d5d68dfdd80b6e64f01f2d4e6530f",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.46",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libgpg-error-1.46-2.fc38.x86_64.rpm",
+        "checksum": "sha256:a7ce8eced4895a190f10e2e6afa566f2f4c7e7192b0801581d4e2a337fb51970",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libidn2-2.3.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:d3416e2b6c7565d7a607225d86b556398827316ae7ce43280b82630f0a022bc0",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libkcapi-1.4.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:75c0097330fa3c995e80b7791cbe7baf75d86f3523f67b3becaf37360fdb4b16",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:e552fae193775507d8264f7a856fbdc51f7e594d7d8726f181312aeb9cf8b973",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libksba-1.6.3-2.fc38.x86_64.rpm",
+        "checksum": "sha256:34446f36355b415633037cdb983677288e4fb70b68d70a509fa2081b6b6e9f49",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libmodulemd-2.14.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:e6ba30fafaf487f20f9c09d89803c578fca1cbe3226b497fedf202536da4f47e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libmount-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:14541cda2a4516ad6a17f46be6b7ad85ef5f6508d36f209f2ba7bd45bc1504e2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.52.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libnghttp2-1.52.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:33631973ecf9e6b23e0b7d07d61100fdc2db33261f4a6c43b5a09791b9455291",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libnsl2-2.0.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:28697cf1b5cb4d62c3bd154fc24a23d91a84a5bda2f974fb64bdd04e91b6cec5",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libpsl-0.21.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:e0bccc94a740acf317caa4fa1fae6b0d57442ef4be36341472b7db93d588ec13",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.5",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libpwquality-1.4.5-3.fc38.x86_64.rpm",
+        "checksum": "sha256:aefb7d2d96af03f4d7ac5a132138d383faf858011b1740c48fcd152000f3c617",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/librepo-1.15.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:845f6731b9e784784494fe9711c116631fc9ceede2fd0fa15b5f9575dee25e10",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libseccomp-2.5.3-4.fc38.x86_64.rpm",
+        "checksum": "sha256:dec378b594b79258dd8b44836c5371f316bcf5e4596d53dd84badcb6d00090df",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libsecret-0.20.5-3.fc38.x86_64.rpm",
+        "checksum": "sha256:46ed6b8fee11c16bb8b58f698dfba9874a8f393c1e72eb7f9a7b6802ac68dd1a",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "0.rc3.1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libselinux-3.5-0.rc3.1.fc38.x86_64.rpm",
+        "checksum": "sha256:11187ca403cd3fdfd42e85380b086979ce093b2dd59c5f42b097b33d41ee361f",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "0.rc3.1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libselinux-utils-3.5-0.rc3.1.fc38.x86_64.rpm",
+        "checksum": "sha256:56e701bd74cff3301be1e47e8405dc582a94fd37e45afd782e03c335fc8714bf",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "0.rc3.1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libsemanage-3.5-0.rc3.1.fc38.x86_64.rpm",
+        "checksum": "sha256:2f55b1581a26bb9fd552ec5c3c97cf206b163f3f1b8b892baf432a6454e2df0d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "0.rc3.1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libsepol-3.5-0.rc3.1.fc38.x86_64.rpm",
+        "checksum": "sha256:adaf981062abdef448f851efccf68875de288c388c31a4adcac66478bb16a0c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libsigsegv-2.14-4.fc38.x86_64.rpm",
+        "checksum": "sha256:ac0a6bf295151973d2e34392a134e246560b19b7351ced244abc1ed81dfe5b8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libsmartcols-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:dbf5c73c71c798533cbecfa54ba28c42878c455df8cb382087d8a758c3ffe290",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libsolv-0.7.22-4.fc38.x86_64.rpm",
+        "checksum": "sha256:db9229087c86f9d5725daf2066e3a52c84dc44bb31ac940461fc8d7510681297",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libss-1.46.5-4.fc38.x86_64.rpm",
+        "checksum": "sha256:faccff819eecffcee9dad49bda930a007e78b905b775b4ac0103121d7a8100db",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libssh-0.10.4-3.fc38.x86_64.rpm",
+        "checksum": "sha256:9815828233d84324f7e012dc1ac51a38b801159a00c2a3d7884c97f4b5cb9bf3",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libssh-config-0.10.4-3.fc38.noarch.rpm",
+        "checksum": "sha256:c54d4cbbb5e20ac926fb9b6f158eda6d991ef7cb4568cb962f842c4b74317776",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "13.0.1",
+        "release": "0.5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libstdc++-13.0.1-0.5.fc38.x86_64.rpm",
+        "checksum": "sha256:7ca6440f9957d486bf78bd93185a1137365c7b74f77a2cc529792bf7671fa798",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.19.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libtasn1-4.19.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:8b49dd88579f1c37e05780202e81022c9400422b830d9bdd9087161683628b22",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libtirpc-1.3.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:cbfe99034f05faee13e8a5fc4708909d83bb1fe4e4edcdc6238d0a9dc00bec92",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libunistring-1.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:c4012952872a08b9662963b13e29f89388ce6e695e68fa8c37eb6e62bad62441",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring1.0",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libunistring1.0-1.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:cd0e8eb5d983a985f7df99718fde6245997bdf088fb6086442a883ddb9ed03e3",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.26",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libusb1-1.0.26-2.fc38.x86_64.rpm",
+        "checksum": "sha256:805da27b46f0d8cca2cf21a30e52401ae61ca472ae7c2d096de1cfb4b7a0d15c",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libutempter-1.2.1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:c5c409a2d5f8890eeab48b27b9f4f02925a6bbabeb21ee5e45694c7c9009f037",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libuuid-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:876ef0556ddeca2c8f56536c80a2f6e0f64357f40bacb92f483adb8a0ff29af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libverto-0.3.2-5.fc38.x86_64.rpm",
+        "checksum": "sha256:292791eb37bc312e845e777b2e0e3173e2d951c2bfbbda125bc619dced7f40bc",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "7.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libxcrypt-4.4.33-7.fc38.x86_64.rpm",
+        "checksum": "sha256:5ac3b50011adb56391125a3b60bf05ae578af7209788cfdbfcf0ddc37d7b0ba2",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "7.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libxcrypt-compat-4.4.33-7.fc38.x86_64.rpm",
+        "checksum": "sha256:4170497dedcf53248c18f7963b911aed445d8bc02a33aa27aadf3354b8dfd8ec",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libxkbcommon-1.5.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:507ffdb912296768699a70c30169077b531b1612e47041551bfe523a4b7b6c7d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libxml2-2.10.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:0b8094280c4a7e368f8f22938d801ec0dab148a6468a7624edb358f6c5db4cad",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libyaml-0.2.5-9.fc38.x86_64.rpm",
+        "checksum": "sha256:9f531fbcc52871aace8fdcdb816207c4196d5ab30ba233c71adb41371fa47e19",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libzstd-1.5.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:de9cc9d18a66b22a8e0b984e7d337244aae1611b522d5f88e9f5cccb47fed456",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/lua-libs-5.4.4-9.fc38.x86_64.rpm",
+        "checksum": "sha256:f0a48ec36269d83120425b269e47ba5c86d5a9a44e0de2665c1d55c10732d25b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/lz4-libs-1.9.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:96a8f495896c0ff7520c2cc5c9c173d134efc9ef6c6b0364bc7533aefb578d41",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/m/memstrack-0.2.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:36a1f0412e495e618ccd8636de3dcac9ad37d5d4c287a1acf2c9af4baa7745e0",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.15",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/m/mkpasswd-5.5.15-3.fc38.x86_64.rpm",
+        "checksum": "sha256:9a4e2b838b797ce2dfaf45d8af8692c158ec741b2c76d42e2bf9013c47b30981",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/m/mokutil-0.6.0-6.fc38.x86_64.rpm",
+        "checksum": "sha256:d9196608152ec34832cc82d3cefa90748f30c75986f2250d8cd0fabc3d0ceba2",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/m/mpdecimal-2.5.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:22f217f91fc2d2a666304c0b360520b13adde47761baa6fed1663bb514b6faf5",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/m/mpfr-4.1.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:e7c9b0c39f77c6fdf68ff04d8714c10532907a8a9c3e76fb377afe546247737f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "3.20230114.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/n/ncurses-base-6.4-3.20230114.fc38.noarch.rpm",
+        "checksum": "sha256:602145f27fd017858256c6ee880863ef5be17c6d3c6c1354f7f16f6f6348db57",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "3.20230114.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/n/ncurses-libs-6.4-3.20230114.fc38.x86_64.rpm",
+        "checksum": "sha256:6ce309d9fd208bfff831981ee4298ccb25fa72363cb7464f1da03b8214d4351f",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/n/nettle-3.8-3.fc38.x86_64.rpm",
+        "checksum": "sha256:605d6710ba42104ce0434bb37b0ca9a922a8392c14175bc782f8acb70b94c3aa",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "12.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/n/npth-1.6-12.fc38.x86_64.rpm",
+        "checksum": "sha256:c9e8b62c6af7a60a505f881d3cc35294d8b4f51c671c05401133b02ab229c2a7",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/o/openldap-2.6.3-2.fc38.x86_64.rpm",
+        "checksum": "sha256:f0fd8f2c66a30d3c9544dc47cdd8964bae72e4977dc9b49d1f02d40cd299640f",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.8",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/o/openssl-libs-3.0.8-1.fc38.x86_64.rpm",
+        "checksum": "sha256:8dede21b5102b60649074d45da8523ded78b2c9203771b204ae0ba70d3988432",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/o/openssl-pkcs11-0.4.12-3.fc38.x86_64.rpm",
+        "checksum": "sha256:cfa3d6feba480abdeb425bc045b525c641c7a864625b1864c2f5721903e364d8",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/o/os-prober-1.81-3.fc38.x86_64.rpm",
+        "checksum": "sha256:06d2101874ea4d14b4c73131c5c359d1a2e0ebe0c36a501250026e7b867a0a86",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2023.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/o/ostree-2023.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:f1b047b5f04c240dcf3222f62ca6acf24e46e532d53a768cdae3ea500073ee3e",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2023.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/o/ostree-libs-2023.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:9311016f5f40113d366f17d6ab6f6175e65ebde29212a05eee28e886d5b2e564",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/p11-kit-0.24.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:8e4afbcb9488d9c6a9bf7d0739173b8757ce33a6f5e00f0ab7ccfcf605ed9273",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/p11-kit-trust-0.24.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:9030a26ff737b7bbb71d5208feebba1a0b2774d58dfb6016824a042e059642d8",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "16.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pam-1.5.2-16.fc38.x86_64.rpm",
+        "checksum": "sha256:065b99f3541fd5f1281be2082b77e48b835a591776e92f2327bb0462c67baed0",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "16.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pam-libs-1.5.2-16.fc38.x86_64.rpm",
+        "checksum": "sha256:63e970f7b3f8c54e1dff90661c26519f32a4bf7486c40f2dd38d55e40660230e",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pcre2-10.42-1.fc38.1.x86_64.rpm",
+        "checksum": "sha256:cb1caf3e9a4ddc8343c0757c7a2730bf5de2b5f0b4c9ee7d928609566f64f010",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm",
+        "checksum": "sha256:756f64de1e4673f0f617a9f3f12f74cceef5fc093e309d1b1d5dffef287b7d67",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pcsc-lite-1.9.9-3.fc38.x86_64.rpm",
+        "checksum": "sha256:48efa34ce50ae936ab9fe437aa59396d4557ff39fa22cf36c5460d3a986e502f",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:aa02afed121e9f5fa9590d75c0b237b6c497ae58c91e0022844b38f594feaeb7",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.x86_64.rpm",
+        "checksum": "sha256:07dc5536982278f38c89517465384ef9f376cd27f0b200806268723993da01ad",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pigz-2.7-3.fc38.x86_64.rpm",
+        "checksum": "sha256:e7509cf0ec99ce89e8e88e9352f733eb9ad14a9c77e0bbfd64826a3de0e4a150",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/pinentry-1.2.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:e521385a42b3350c0d17e3cbddc0b69c9cf4052d1b77cc8bea2179e05b7d374a",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "0.rc3.1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/policycoreutils-3.5-0.rc3.1.fc38.x86_64.rpm",
+        "checksum": "sha256:584a3843d52f90ed38819007083ea7e8327d23cd6203c8205b511054c2e24003",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "122",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/polkit-122-3.fc38.x86_64.rpm",
+        "checksum": "sha256:ef498b94191f926bf5a55c4e6ca3431cdee2595a9cbfccd1f82ca959ea7bedfa",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "122",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/polkit-libs-122-3.fc38.x86_64.rpm",
+        "checksum": "sha256:2dcdc3dfa37a687351a6969c037d67669e7e55ba0efa579f60392ecb566f9174",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "23.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/polkit-pkla-compat-0.1-23.fc38.x86_64.rpm",
+        "checksum": "sha256:7ffa0438229228bf5ba18945936d52c3620c95f4a3ffc5c5f0f8774fececac0a",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/popt-1.19-2.fc38.x86_64.rpm",
+        "checksum": "sha256:fb3fabd657b8f8603c6e19858beb0d506cf957bbca2f3feb827b64c94563b31f",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/procps-ng-3.3.17-9.fc38.x86_64.rpm",
+        "checksum": "sha256:fdb3e6e4578d8bb90f1f917edf5a7f52432df2eb5b0fab000eab662b15476479",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20221208",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/publicsuffix-list-dafsa-20221208-2.fc38.noarch.rpm",
+        "checksum": "sha256:2fd63c2deeb11acaf63cccb09722b34961722a4387d73faa01e14badd13a13f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.3.1",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/python-pip-wheel-22.3.1-2.fc38.noarch.rpm",
+        "checksum": "sha256:ee100ea7fe8bf26d44df719283554a36398d484eee28682694c9e7a249c2d49c",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "65.5.1",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/python-setuptools-wheel-65.5.1-2.fc38.noarch.rpm",
+        "checksum": "sha256:7417816bd96d7b49e5a98c85eba313afaa8b8802458d7cd9f5ba72ecc31933e3",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.2",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/python-unversioned-command-3.11.2-1.fc38.noarch.rpm",
+        "checksum": "sha256:5d1fa962cbc496f775065c66855ee74b7a335be8658783a8b846871d73d94ec6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/python3-3.11.2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:e952487132d2b7fef68e3221f720872ad314cdf273085aea1e9ecbdff5948b9d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/p/python3-libs-3.11.2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:18c287498ef558f247f328c7c4c9161caff395b5f57ddb593d509f2c4ee677e5",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/q/qrencode-libs-4.1.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:49ec489f168c1671a2babb690edfb020a5252f38e8d0b2d96465070abd2b0d70",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/readline-8.2-3.fc38.x86_64.rpm",
+        "checksum": "sha256:a7099c322c45030738bdd90e3de4402c0c80c6ebd993a1749c2e582cf33ee6f2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "10.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/rpm-4.18.0-10.fc38.x86_64.rpm",
+        "checksum": "sha256:53dc032707ab6765dcad52ec579e53106d9826a81fb061d616e00afe702adc1e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "10.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/rpm-libs-4.18.0-10.fc38.x86_64.rpm",
+        "checksum": "sha256:47447bdd06e43a9911aaf3335490cef9414a436440ca945a8f5ad4b29345eab1",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2023.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/rpm-ostree-2023.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:f416899a04b543dcebf6bf7a6c9a65521c64c3916cd06793e5b5a7a5f9b71cf3",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2023.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/rpm-ostree-libs-2023.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:12e4d05a9407f3f78fa1928ce62449e9d227a3bd9bb68ef4352f083b4c1f7cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "10.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/rpm-plugin-selinux-4.18.0-10.fc38.x86_64.rpm",
+        "checksum": "sha256:2daee83cd0c6bd1210e7a547b0837acd1fe460901d55b8df2d47d312cf0b229c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sequoia",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/r/rpm-sequoia-1.3.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:340d6564ad122b245fda35c873e91ec685e523f1fef6afa539a087b01d70fb48",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "12.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/sed-4.8-12.fc38.x86_64.rpm",
+        "checksum": "sha256:a6e01b89e814ec42d1c2c6be79240a97a9bd151c857f82a11e129547e069e27f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "38.6",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/selinux-policy-38.6-1.fc38.noarch.rpm",
+        "checksum": "sha256:78169acd52d9d936842dc326cb5ecdf92f7690ac7fa92a458ff83815e1a81b1c",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "38.6",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/selinux-policy-targeted-38.6-1.fc38.noarch.rpm",
+        "checksum": "sha256:1b7da6204d4db26f1896b5e0eb7b979c4934dbf48f33f91f30bdcb04d730d583",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.3",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/setup-2.14.3-2.fc38.noarch.rpm",
+        "checksum": "sha256:c7efb8634b62cdab9e8894174a8c70d20eb431482277231bc54fa8ca8c3681e3",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.13",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/shadow-utils-4.13-4.fc38.x86_64.rpm",
+        "checksum": "sha256:a80791ca462f0037c5438787081ab0161f14db6a4180113af618155d76f40a00",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/shim-x64-15.6-2.x86_64.rpm",
+        "checksum": "sha256:85bb1aa32f6345349c9cf09c35217caae441dca6b2be8f21619ea6808d3c5af6",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.11.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/skopeo-1.11.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:2871bb34038a71a4b766bddafd82135a2dc42ac0ee7b158b2378c1cd445f9d03",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.40.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/sqlite-libs-3.40.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:be6d9e9b98733494ee5901d45b849e2dc012a6b41c3ff09d0d212002dbe15dce",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "253",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/systemd-253-1.fc38.x86_64.rpm",
+        "checksum": "sha256:65c21b264dd2adc3b20a0dff9384d6d630e0ce98ab9eab77e9a33b360173238d",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "253",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/systemd-libs-253-1.fc38.x86_64.rpm",
+        "checksum": "sha256:bae7f23fd0f7aed44a9081cbdbeb9cb922a694f09d21f564738f192e0e4d7f7f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "253",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/systemd-networkd-253-1.fc38.x86_64.rpm",
+        "checksum": "sha256:d31e41005fa66d22c5cb0010161b423e3f538713176e33b5c519b4b8139e5e5d",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "253",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/systemd-pam-253-1.fc38.x86_64.rpm",
+        "checksum": "sha256:227a86de146b2ef85f7b3c7843ca48e0a498f51fee2975dad4b361426fae67a0",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "253",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/systemd-resolved-253-1.fc38.x86_64.rpm",
+        "checksum": "sha256:f30e74df21de01e6ecb6bec0fe0748aa80cb49e597dbd694e0cc8b3b68c425e6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "253",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/systemd-udev-253-1.fc38.x86_64.rpm",
+        "checksum": "sha256:f83ba3694aaa98e13c078b0c642c816033a9450105b30942f7c5f84199722b59",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/t/tpm2-tools-5.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:9dea5ef5fada9f1230590c0ca476c0da2b2fd228edba3dce81a9bac7c3a8df7b",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "4.0.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/t/tpm2-tss-4.0.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:8adf29af85920514902bc4332ceb896a54f9cf89e08993c9345b62c4140f91d9",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022g",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/t/tzdata-2022g-2.fc38.noarch.rpm",
+        "checksum": "sha256:10e4fa175ae454832902cafa61ccc24f7690b5abe2c6935923cd90f123ebbc80",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/u/util-linux-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:f0f8e33332df97afd911093f28c487bc84cbe4dcc7bb468eac5551d235acee62",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/u/util-linux-core-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:b57dbbbee14301e89df618b398ef39b7fc841eaba6be1b6346cf37ed7695c26a",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "37.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/w/which-2.21-37.fc38.x86_64.rpm",
+        "checksum": "sha256:ac6e86a36c90c7b75a2d1e30476b16c286b2cc29f958677ac0aaada2df72a316",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.15",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/w/whois-nls-5.5.15-3.fc38.noarch.rpm",
+        "checksum": "sha256:4d559e22dc4dfc539d5455d76f446ecaf7d0dc9ef37ba762c45b01e069a19b56",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm",
+        "checksum": "sha256:59a7a5a775c196961cdc51fb89440a055295c767a632bfa684760e73650aa9a0",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/x/xz-5.4.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:e911703ffceee37ec1066344820ab0cf9ba8e43d7957395981ba68c4d411a0a4",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/x/xz-libs-5.4.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:bfce8ac2a2a78a23fb931531fb3d8f530a78f4d5b17f6199bf99b93ca21858c0",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/z/zchunk-libs-1.2.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:e49dc59ac89b5b0a00384cba20a42e7238adc6cbc1471851980b1abbc1202705",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.13",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
+        "checksum": "sha256:c26d4d161f8eddd7cb794075e383d0f4d3a77aa88e453a2db51e53346981f04c",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_39-aarch64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-iot_raw_image_customizations-boot.json
@@ -1,0 +1,5827 @@
+{
+  "compose-request": {
+    "distro": "fedora-39",
+    "arch": "aarch64",
+    "image-type": "iot-raw-image",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-modular-20230310/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "image.raw.xz",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {
+      "customizations": {
+        "user": [
+          {
+            "name": "user2",
+            "description": "description 2",
+            "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+            "home": "/home/home2",
+            "shell": "/bin/sh",
+            "groups": [
+              "group1"
+            ],
+            "uid": 1020,
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "uid": 1060,
+            "gid": 1060
+          }
+        ],
+        "group": [
+          {
+            "name": "group1",
+            "gid": 1030
+          },
+          {
+            "name": "group2",
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "gid": 1060
+          }
+        ],
+        "services": {
+          "enabled": [
+            "custom.service"
+          ]
+        },
+        "directories": [
+          {
+            "path": "/etc/systemd/system/custom.service.d"
+          },
+          {
+            "path": "/etc/custom_dir",
+            "user": 1020,
+            "group": 1050,
+            "mode": "0770"
+          }
+        ],
+        "files": [
+          {
+            "path": "/etc/systemd/system/custom.service",
+            "data": "[Unit]\nDescription=Custom service\n\n[Service]\nExecStart=/usr/bin/false\n\n[Install]\nWantedBy=multi-user.target\n"
+          },
+          {
+            "path": "/etc/systemd/system/custom.service.d/override.conf",
+            "data": "[Service]\nExecStart=\nExecStart=/usr/bin/cat /etc/custom_file.txt\n"
+          },
+          {
+            "path": "/etc/custom_file.txt",
+            "user": "root",
+            "group": "root",
+            "mode": "0644",
+            "data": "image builder is the best"
+          },
+          {
+            "path": "/etc/empty_file.txt",
+            "user": 0,
+            "group": 0
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora39",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:d01c3be7e2f5773d0161ea7c01c01b696b979fb658de4bb59474b4a3998b70a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:112df1c64fb363c72ef1ac26957bd84a588ba13daabafaa03a29da307ef1e1ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db7a0a01b05d540e8f7f4bc9e967ceb27647f710beff3a33bceeba56381517f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41a149bfa3edb610eb47716c7e433cade50e898bc71ef0dac39f5390916eb500",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:16d1843cdac488ad04bdc654dd6b8dfbfeafe33a7728695070481302a7e54345",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:743c19b00671966ad2f10a08127e52f865e66318e2e538a17afe0de30b5a021d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:047b9b3feb3a7c8f4fd26ddd908e6c0a436827b7e73a3fe7af6a0bac9857887c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d071598ec4b502e566d62d160b0f62f2c97a6cd1c9b14a8a238358ae3efc169",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ed298c957602edb7ce91e0d06c4cc876c645d5e9848cd9553b5521ab1dba8a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cbad3c0b6b1b8c73ac219d5ed3772c89331e46a5fd8e4be3dc065e2021ef904",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b14738a69996f820a42c8857412d1fa62284932da5874d3d2eb39f0f356714b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d10f28a9f7871450d5c4b8f365a6204a35c29f4616d1d151147b717ea33c6b32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f48744c52212ec825e84bb98025f2f669202aa8eb34d3cce2402a0bce55d78b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e88ebc8a444689e1d8909071e59e6ba7625e700e05160a48dfef197ed315dd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:759661a23273cb8a1fbfd9885aa8e596b4787431701cd2cda75ed91d184ec4c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dcb34a02699a1d5363abfe91b6f485c58fbf11bd4b67ae7c94779972156d8d2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67b6c981dbc626378729138b7eec77198053d6c4c354a5c638901afa30c5a847",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73e923d9adbba6384840bac86c7664169fdd74f61a3db9407840f41f91e63d9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aefb3f2011381702ef4f32b6c0f7fcdd44b81fea883fea01f514d0219f6f2447",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c28bb675110f9884d0250077186cfaad0019cbfe43464d6b82cf31b864bf570d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50bcbb893527129117ecd5f3b7b72ea431d6c129e2dfeed7f1f02a8d65020c05",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a1609cfe80410fe13237771548eea4631ccbac69f6915e4d21918016f8a8677",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e44b1735f41ec275ccf5c8718c1cc718f2cb7ff7c16d1868fb0521d862a407fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42a6fa3db480f36554e51af9ca2c25a523e005ea09dfe3489403254496934e66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676a082be2f67a4a4c5bd0e6169e07a8bb4373f12bbac806ab1bb24a4b2c52b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:544c2f28235f316c56969f415db1a7b9928d9f8d22deed5c147a9f7e405b7054",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f75e48a0bf1a3f957d356727daf0773868104d98faeca73aa86955e15dcfd01c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c11e634fc2571a811eded10a912538838093706011e1785b9cc7b17a940b432",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7dfdcae92d385722866d220d79fed574af730eab1102fcfa5405f4dddcf6533",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a9bbc5b246511981636eacbe31612d9f7c1573bf6aaae277b1ef45c2982396c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58908e17a3f25173832301e604aaf51fb25c618b1ad1f0ffe64f1f8ae9346a34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83319103222ca364d7987d80b6d62d1b7cb957a19e1647793bb7e35584096057",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f4d3faf343835b02699666ad813316f7fa769b21e474006b55cbf0cd01e27ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bba199cbc2d5363334072bc40d868c9c0ff301d67dddd14a55f032043c9dc824",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c01590f3d237e302c0a9b8dac586469d1b58f37da29b1b815b1b2ae083944470",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bab8311915e4fdfcc2749558770cfbe63c7a1fad686094d116301c2b42a8109",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97f90c6b562ed91f0964ef8f5fc74136a19132e6ef86f2b40748928e36c8195b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f33f41efdeb7ed371ca73539df63e0a24e1ba6f1c08eb6b3a13efeee143c22cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c97f56b7531d2779d7c8adacc7fe34ec04077d1b86874afe621ca81fabbdbe2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:668e8d6d207ae1d40e11fce1637eae01bec8eb4cee770f29750b197e2b86926a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d7d603328d401296327ee05b8fc308cd7a781f71188f6c0e0e4bb3b967624fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04db736a77296edd4099a9165d68560d52dbf2484d959f668b3b676d68581f97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69c9711600ede5bd00494ae8dafa400121de28f70cb4784f4546b8810c4b4cd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ecb72298a8b662ee1a17e7fb4e1d279d7fc64b358c9fdf9a568a965022b3f97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3908078cd7debb2b2e081a7ea30fdf598f702ba7e65db7159836403940ed2421",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8284f25f53cfabed300f93598bc16a478b01650066a1b25db8fa2030e9f92b9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:197e34b18cf79c81342485457adb84ae7e111cc0fb0f9391b4c9428208433e84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:afe5493369ba96307895e423c10e3c6689a56541c7cc794f5ccd0e79387d8220",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9afb2acd6fe8a4d40fba4fee0ad87171b07ac6bd98be1c7b0319312872a67306",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3aa089143e2c45970439dc09f3cfc3c4500319a2f5785b6068899cdb02a1f83f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0b4d0383998437ac5af31fd5c88b2f1de632971f2a38b8cc04201fac7bf5450",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ebde9d7dd013fdb8e8f3ffa45638f394de1202facbbe81eac6c23c1dec068c85",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:761a0f650fbbfb1ace613cdd42ba5f16f4737c93b3bbb23a7792df444027dfa2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8462017b0d07c30506328d18f4b8c4ef60e5e53c9f9b2f6e53c1223b765f955",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41cabf9fc1ff8f073ed7b7760cf92bcaeaac1816e0fc1818f771e611dc11bc58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b22812b369fa7c7f63dc2a9847a893073f6344d21990d9df57b12666b9739f75",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25de7b2c0838b1c5c14d73ee0ebd9e2e9fdce428e276f0eaa7c6979791be8490",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70a8414ed24797eba9fa8cde6224ac222774ce808537abd5bdc8763484d6c146",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd4ca78530d858c1e084bc647181f589f156179a89ec0d949f0fd5550b8ba9ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0370d617744ed39409d0cf7177faa39f712fc88d8a44c465e624fe91b03120a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:697a1db85006f84026632c9b40fb41b03c5aa7cd41c72f6bb7232002f89d16b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1986f592f87e9f4027b726ec89627f707dcdd93af302dd251049915747819957",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a84a1855158cb046f471d4f5766a2aa564662caa47dcbed418181856fed92c6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a4bf51d3c2401fd612d9cbb04c6677b2ac74196af1ba36f4f39ef864ae47ad0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:510e948c49041b4481f4e749066ca1d52dae50294c182b92d281e1652c185d16",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f43c1499f87baf84bc6d298497fb8c323258cd9052573ae9ba6880d940bac4e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fce9ea5c004b04b39bceb83069c2791f4f725639be52f94a0eb438bd1087be3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53b418b81b706324137460ab14b73af13c71587b9d5189e5018a242991970915",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:767f4aea7eb5fba311b11f13eb22c71b40c31ccaca8bd07cc4b3b18dffa4d21f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5489b5688cf6e05405dd49f2096652686d3c83dd0666ce0d8de422100cc4d0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fb14724ad07464e9da98e15badb7523c299f6188a39bf65e02bbccfde8b44a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37bbecfe2755c8fe18722b8ce7a939bbaad2e9d1bf21e4d74b81041ca64df00f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2101508acd9f16f43fb1781e7242fd5ea1570275ab9f596ec1fdd622ac947d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dc3519e436d1a3551ea1201d786a503797c3d817805b5fc72a47febce816dc3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ce085a7077df5c5969c018d1c242fa6546bf57353132a786bae06183b892836",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61c40ecfc56c4667221bd6254024268d1295514ec93447976c40dfbe696e9863",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:91a4beb90b9cd9bfcc46d5262116e682ffe2be99591759a2a0437bfd3c9b394e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ff4a903b24533b661ca8d5f40d1fc0087da8de2cfad3a544adeb8037ae7e8e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47edf9a5d80e60334b0523f36a86b40b430a55c1afc91232181961152a3c8f25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b91df9b6fbeec00604181db29069eda114926e290e0acc3cfc8d7f74118db0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ca4acd8f26f010ebf04411a651df7bf3a5111881d7cbeffbe056367a2347ba6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9858eb4e6a8aca2d0e69a57d3db25f1a561e117e6c6221ccd0b3518f7db7f01e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58f75a8368b74d16380f7eeb1c506c3907ab4d168a91bb092c96da81bd27f59f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6810adc621e586b0cefd779767e2a962ed18f4f1267a05fab8a94a1593e12be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51ac501495ce47ed0204bc06ff012476e655a100c9f21d7889dbbf9747404a74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0c00f1f7adec2ad2ec68b320585aa34c52b911d9565518b25c8633b39a55cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:093fda317974455beb2b64f877902ffda898977e506c6ec4c6c18974b8f14ec7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5d131c1a4b194e5aab7e7925c524562d20b6e7b08a0e24045b0d11634c59c12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7adca8bd302126014d8d1721189422747a9a480f2e2d9abbf5b85f3d9c07804f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c49f0eb53cb43c935cc6d155ebd3d6353d17b23e0e8f69f8a984d7dc65f6ba5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0061480328390c3954b9e497aa6ab8bc62eb279e6efd050965661fd79a70e3b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d164fbd54f9921913cc39b71fc00d2a27b24f796e385e6e6a86502f6357958da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dfeaaaf4b49fd68b4b17aef47fefcfd6aedb83f7551123182dec1ba30f4eb48",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e28b42b8fcb1771c9ef3bd78045ffdceb00f4255fa8a08f5aa90399b4f8a1414",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e9cec829b408d471e732cd8a9e54babefded5234a31b2b6e81b8907e9bd9fd8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e6ea4123e4777b1d66c46d919934ba6d3a95cb6cbc6ac797d88f1ac21bb1b06",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea903340bb561eb07e43a9d3659badceb2992696015f1869b42e2c8932158d5c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a63abb2c9c20877409f8b7a74c7fef52c8ad701219a206e52ba20c9fe03da376",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:487fb0cea28d207da310d7d8e7e298ed4784e21bc198cf44b4f8ae1303c9abe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b799e33ca82fca0be8ffe86202c725912e46ea61d160a957502424a40f095e1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb8e22f358ffa431a7e4e13e564089af70de3dd009421bb12299227ceb5348be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7859fa38c737344f1dfa05c31143db413f14704908feec07b3a67a2a487e30a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db3f92441621b09e664be6790e6a279c036688093e7a5175927cda394756c214",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bcccd2b110d8a6a3d07a7aeed82b4416db762a22239346839838445a0a870d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7a71bdfdb966bbc2166e214aca99d324e16e8a0623246ed8664be8be7a56aa0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1235525527c3615d54e069b5df00c6528f6b359196cf8bff2e6703bb46a786a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdcd3745c2206fed259467bd49a96344c15a192952bc6f04b070e8b2995085dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3b9a49762bbfa7832b11514eaf441eec3431a174ec257607cbb221d7014cf44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d630a00ff5c09a3ccfcb2f40d1317b2b75cb97650840df6cd5b1c436c984747",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79fecda5af50e235d6b4ee9bc20834bf046cb15cb6f8f71ebf3b534759a78649",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bca2d927fe01ab25b2cc591bdb9f494397d99ec9eb72a93bcc53d1b8173da14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de3b9ad8d5651675a2293e93fd88fcb3f6eb0f269f255494898d40fa9c3cdf34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55756638296d53fdc9dd8c6b46c29bac98c890cfd9d558fec3aefa3406b358a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b676e51dda545d40276b27e5b39adb68a26611ee2f2881efca9a63a99dbc5674",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d79bd2d236c80c08037c820c56ecfd85faaa227af10b08ef96540e1fbb5623b6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19ca5402cac14d896f0422469446a4ad2157909ac383d611918f0436be1aa7b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00dec4b42cc8db4401eccc6a71353313a8f1c9e85b8237ae74bcb67a1f4415b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fac4d4b98282f5defc0802b2468bec30e5e6748c93719773b80da15e5567934f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb127da21f77c89e9e892b657018961ed54ffb43e55693482f1aaff06690f521",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b9f156faebae07f512e2e22a6d104e86bc9fc86056dcde54ae1eb87ca057eb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e266ae94a5854f59791cb040dd6e3ecc89a7c87590122a5161991b351d5408b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52b8c81f48a48855c95c65eb166dff0130d80948d3128ad3cd295e643b278d74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e7220bd2de39708cd2be2788c4c3bd95bf12590260ced37673849b892dec309",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5bb6e5af81ec4523bda8aa99eff6940eec288d9e45ed354796a1aba58a8f531d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6dd14c7a6678bca18e33694e37d8e26cd6cb165165a4acb04fbeb019d0edf05f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0667adcc1838d0193392fbded9d354955b2c591d5526930e30f2b083215975af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a78cc23b4f327c88acfe7a57fc24419563efd94e44987ed7b23ffaad3c0cfea7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09dc9676b44df287dfa05d9bc7b14c83b8474fb44c48e10c1e244d23017b5656",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:529bcb4c6d2060c8fce9b52bd8fb4cfbb807df374281a4e0d69e7c905df662e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b1a20e0fc39a72fd9e555ee7aa9975276427524508d48250d0bcf1f8f8de0f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e067c951e005c0d2c6e8153828eeaec0cc8f50aad60a3af56764eeb79128dec8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02a1eb4105799bbbc62d2a5964a29ab0e2c89d8e07932609af067152e358ec56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5828fe90bb4659e9373383d381c73a0232cb5dc6abb4144ebf0d194c81176c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e85faea7d600be67caa99decaa81a248fbfe90a629a38a66bb3a43f2a8050bd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bc707f6df0aac3eb69be6e32be2edb32c772c1afb63300577e72fcec472af54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24152292f7b94c35e36aa896f1cdf79b67e9804b8f69dcae79d69232233442e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:301dfc48d40ab87f54178c1805bc3ddf40daa666f72a9c986442dd3e3febe657",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24a4231bde0e44e99eaafa9ae7fc65940170e9df0654e81c3a85ae8979ff61b8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45ad13f2e16525392a44e438a549c2244b0ed6f91f8053c7780bd381a3448c25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:342b090523748dbd93de4d39adc5b059f388893bd086b3c11f1c3dc16770a520",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9f260ba16734b6d1be9672e6fe2c7b77f6e868a627d56e0c0664bf32388dfad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d2895e8e2c0f843631a268130c1d24dca9c78bc29151ba9052c717bf9cf945c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec754b5d6d177e9a91469c45729b7849c231d06a7dd004f8e5eb0c8cc304fe28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1bfcaeb6e03a843aa6a06c064737c4a3e48ace9e5353328aea3754eb0d489bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:141e746033217535d30b989e20cb565aad275e05e7971067f4a11913d2fc499d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86aa1169ef9757e59ca01b1557482b04d08d9436ac08e880c81efda71a26f346",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6842664d722aa02d086ee369f12831e614cf7d3bb022620d201271a26372915",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4644a24bef92e3c236f2273a2771e6172ad32a6ef23e274aed537285ff934cd5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6dfece5f9bdcefd5e881bfe85239bf0b662ef45af238827620653519142cc28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:267735e6b9efc4cc058fa926a9e432fb6c44b97b0c6e5037e24ae7bab75fa53a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1885d9d961bd04783d3c34309883c96eb041c0a5b3ce287892765444247cc8d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f2f2310459ef50d0bb8504f6744608abd949c46f7d798937bc129ef5153d647",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0bf5be760140e4d27eccc9ba1c45c1db070ac1b03420e8677000f82e6eeb107",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d63c198d35e144112b2bb3fff5918c56967a1a764478584e79be0967c71c35d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d94deb4d35588d4c8e91242266b2d7b776b94ecc3234bc7b94ef5ff786bfdad1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba9f5eeb8b85d79e215f70369aaca0c441073ef0a4bc94833842395c0ea8c8f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5c2b7e34cd518428e2b57b97d53038a35112bfd7dcf70b99a362edf6df03174",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f00be46cf33948f4608beb6e3a08cc4aa33bdd4ca53dd66cc1995ac82529967c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d41ee6bf1cf3506dc2e686da05fa297abda41b0aca14c1df121f9e788719ee5c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70e7c2d53e2d87ceb220bc6d1c06535d4a11ab3c8d1ff964a498d058698aeb36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24602018d0132dd1b8fa5e703844d8a732d7715b82949784f886128985f61646",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e89e25b52a60c39da1a2bed8d386572c3dfa5f06b7659c5ba52d45745336355d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a487be4156533f0d60db98bfd3459c2bef15bbf231f9d474d0ebf123d3ddfc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c500caab153179a9c7c4ecb6defe2d925cac2ba56621541db5afc576ed3230a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed631d2c111797912e1ac855d02ef78296d1853e4d1957f72f19c83afae02079",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a518527771195f92ff52297a56da79ce282d4a658ec610e159c9a6be97cc2e17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8458439742e626901956a5c65347e23af571fddca04e2987e1e25320811e31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4883bcb01e87f0dd5182e3200b24640424fdd55c3a18e46b4164eb92af904c3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9e0f5c2291d5cc4818f014caa6dd5c465d873e4d958d85d9bf7be04a8d9fa91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea126779940d8cfd1f0f0b8428c1d8ce2ca07a6d21e3db77a00f036f15004f9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9628ab6436ad123ff03b6d1ba703218604f5f1b9845f8cc835614df30341c678",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f19a70d3fbf30ac298700d3918d7fb483a387adf3d08b96efaa07d51dd0b156",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4a95381f9f9aa1228c429aa9cb25502a448632b344f16bb693e5b8993f4d1c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89b0edd10bdd990197605b7a938a0e25070524d83ffd986232817ca436874719",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcd6ad8c1b3550477db0783a1b5e59c74ce21909bae128259f4215aac4b03e9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5892ae6b2d9f370615dc668f1b4d4de7fe5067c192939e1f9c5648181198369",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7787ae522c7e74b912d13598e199c523d7ded171f9bc872f1f2656b393b6db19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76fa76c9c989b54d0677e3bb8eb89805083d6c2c4475325fdb57d2db23c45275",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4278312d7fa6c806c42a56c332f68a95cdabc86450ac3c0ebd8f2ff696c8c19c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1fb1418b8643edbbede7ae066d929946118a35832e4ee58676e7f65303ee781",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7fb924a539d5f6a8d9656886a2ffcc4850e6674e37d427d424623fbbcb64fc65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67bfe5c18c4eebe6cb28ade72b9af54d0f377b311da527a6cc7d133bf02a5e99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27df4c19fd4e7b72e35493f84f0f79ed809e02e9e628615583fc44973ca2d493",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cf03283e8e07e37763931446a599809c069fe25c20a0eb6dd6386f447673e06",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0d44fc3728295b16ee16e3eea5981c56115ef494e0e1dbabc04670c3a99aad9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54aa1a0699326aae0137529166df648a393331e99280ca10f77f6fc904caf9e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d54836133ed06083473cb58977db4422dfb201cb73f18e730d4691eebfa5414",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8207759999dd01b23b25e81cfa591a9f51c60cffd59c62c095f4bae948d1063",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:133e62a07a3424a90352289359aeaefa078a1657d12329f97f24c86799230c53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8b227c1cd6fb8987ef5885853349f2521fa2103c4c8577bbb77893589559a3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f198fa50d35112320ae2f81bfe83d4d626160ef3e8dbba16285183a747a96655",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e932e568356dee94c58e0c59ac0a825d11a89f45e8b82c5dd17b046acf8c9f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8005fb24037a3c7c4940bef13fb0b37df42581e567e935c86281a5ea30a01d82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:87f3fc51ecc7dbbebcf9c1290d1d959d483cc171552bdff4194ad741e34bc0e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:154d5875948c1aae996881b55ed71d42a51f9c138abc65950657cadff707269d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c812941dda067452d42b3820ac7b56a1edd0cdcd3df4002f17ecc1c69ba630f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb71e84c6261a71b49cc96be5305c71c54598c602c58dc7f709fc5755dba2af7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06c58a3605d3cafc7c442d2bb39ed2c944ea988fcdbe9b62dfb0b123f368c7d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f894df6361e474e904a667bbe9ab110af509541462932ffaa2cd1ca6b550c726",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f6d14f22f3b4e8bb3428d2cbef4e75821ec5c132a08816f159d82025be36f774",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e10c0ec1a70226866cd13c044cdb398d519fa28ae3f2cf5747b6ce799d3bd0c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb3ca377066ec35b4e93c52dd47625dc371d6ebfc5fe1da28b4e6c97186eda67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3aa9b7d8bf7c0d00e83d52180b24b2660ab3f4d72b454d82ecd0bc5e5aed4263",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8cd25bf3b1e71ea95424a8a2c9e1b608bc6fc22a0be1b2915824a9f133924731",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea43195642f245445df81cb11388ba262834e84643cf4cdf325e15c90014eb82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b12f7396d7bc5071ea8551cb8f6c28fb6fbe716ea38a7d5b73fb3d5b30948ab2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a743bc050a18d34091325448e5e7f7ea9baee51045d3485ea13f27f7459671e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b662e452c110095492b561a02bc1b96088e2e25b9cb925239b5f81358a58cacd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de66d62ae7c16f6e74a20b0dd8635c7dbe77c7ebc4e6bdc23cc234329c2676ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2122d4c0d41ac42bd3a7cb365d199bc462203fe443e403ca470784a1e02ac17a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0feebfa4ef016fd8645cd1f75291a97a79769957347d4b5c2f13042a11a9670",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:517b9d47e7b4ec7b8d1856f4525a6a60feed38617fa47767bee1140f812d5214",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33132e2cfc1552b6429ddfde328d8e350294cad519a34860c3021b4e4289bccc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9f81f7b77e1011de9e9cf4c68a149aa70f4f33e2bfa394213396115eaf9a2d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60245c3414a8c444103e937dfb1251cd1b18afc5f3c811daff1faa6f4b8875b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c15357e1e23afd9e156eeb8955b08a68c0be3ef65089d2aa4beb4aaefca3300e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5349c5841c28e67a4f1ac33c0e83ab7029a2aa16ec323dad176b3543e65006e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05cee3fe2968c1f5e507a7c0908e40ab2337f03df07292d9743578a7069af40b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c77fd27cb1dc592a2d9ba9238b80aafdf340749d690f15db59e8483609da884c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:14dccf84910696379b89995cb513cca8e2f7b7367989b3263045b299286b9234",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:278c8a31a736d96b08f1042eb801290c7e3b28d899364d9bb7c300762f2bc313",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06579903320ca98b1290fbf773743cc464df3af43bb64e92c735b455f2b4ff26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1f3751a9fdaf0c918bad3ca42a0984bea6d94d382995c3162bf6b391e53e21d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "user2": {
+                  "uid": 1020,
+                  "gid": 1050,
+                  "groups": [
+                    "group1"
+                  ],
+                  "description": "description 2",
+                  "home": "/home/home2",
+                  "shell": "/bin/sh",
+                  "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                },
+                "user3": {
+                  "uid": 1060,
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.groups",
+            "options": {
+              "groups": {
+                "group1": {
+                  "gid": 1030
+                },
+                "group2": {
+                  "gid": 1050
+                },
+                "user3": {
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/etc/systemd/system/custom.service.d",
+                  "exist_ok": true
+                },
+                {
+                  "path": "/etc/custom_dir"
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "mode": "0770"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "user": 1020,
+                  "group": 1050
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                  }
+                ]
+              },
+              "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                  }
+                ]
+              },
+              "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                  }
+                ]
+              },
+              "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  }
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                  "to": "tree:///etc/systemd/system/custom.service",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                  "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                  "to": "tree:///etc/custom_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                  "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "mode": "0644"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "user": "root",
+                  "group": "root"
+                },
+                "/etc/empty_file.txt": {
+                  "user": 0,
+                  "group": 0
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.systemd",
+            "options": {
+              "enabled_services": [
+                "custom.service"
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "dos",
+              "uuid": "0xc1748067",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "06"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "83"
+                },
+                {
+                  "size": 5263360,
+                  "start": 3125248,
+                  "type": "83"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263360,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263360
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "ostree-tree": {
+                "type": "org.osbuild.ostree.checkout",
+                "origin": "org.osbuild.source",
+                "references": [
+                  ""
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "to": "mount://root/boot/efi/config.txt"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "to": "mount://root/boot/efi/rpi-u-boot.bin"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "to": "mount://root/boot/efi/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263360
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "xz",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.xz",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "image.raw.xz"
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:0061480328390c3954b9e497aa6ab8bc62eb279e6efd050965661fd79a70e3b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libargon2-20190702-2.fc38.aarch64.rpm"
+          },
+          "sha256:00dec4b42cc8db4401eccc6a71353313a8f1c9e85b8237ae74bcb67a1f4415b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libmodulemd-2.14.0-5.fc38.aarch64.rpm"
+          },
+          "sha256:02a1eb4105799bbbc62d2a5964a29ab0e2c89d8e07932609af067152e358ec56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libsolv-0.7.22-4.fc38.aarch64.rpm"
+          },
+          "sha256:0370d617744ed39409d0cf7177faa39f712fc88d8a44c465e624fe91b03120a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gettext-libs-0.21.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:047b9b3feb3a7c8f4fd26ddd908e6c0a436827b7e73a3fe7af6a0bac9857887c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/b/bubblewrap-0.7.0-1.fc39.aarch64.rpm"
+          },
+          "sha256:04db736a77296edd4099a9165d68560d52dbf2484d959f668b3b676d68581f97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-gpg-keys-39-0.1.noarch.rpm"
+          },
+          "sha256:05cee3fe2968c1f5e507a7c0908e40ab2337f03df07292d9743578a7069af40b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/w/whois-nls-5.5.15-3.fc38.noarch.rpm"
+          },
+          "sha256:06579903320ca98b1290fbf773743cc464df3af43bb64e92c735b455f2b4ff26": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/z/zchunk-libs-1.3.0-1.fc39.aarch64.rpm"
+          },
+          "sha256:0667adcc1838d0193392fbded9d354955b2c591d5526930e30f2b083215975af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libselinux-3.5-1.fc39.aarch64.rpm"
+          },
+          "sha256:06c58a3605d3cafc7c442d2bb39ed2c944ea988fcdbe9b62dfb0b123f368c7d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/sed-4.8-12.fc38.aarch64.rpm"
+          },
+          "sha256:093fda317974455beb2b64f877902ffda898977e506c6ec4c6c18974b8f14ec7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/kpartx-0.9.4-2.fc38.aarch64.rpm"
+          },
+          "sha256:09dc9676b44df287dfa05d9bc7b14c83b8474fb44c48e10c1e244d23017b5656": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libsemanage-3.5-1.fc39.aarch64.rpm"
+          },
+          "sha256:0c11e634fc2571a811eded10a912538838093706011e1785b9cc7b17a940b432": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/dosfstools-4.2-6.fc38.aarch64.rpm"
+          },
+          "sha256:0cbad3c0b6b1b8c73ac219d5ed3772c89331e46a5fd8e4be3dc065e2021ef904": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/container-selinux-2.203.0-1.fc39.noarch.rpm"
+          },
+          "sha256:112df1c64fb363c72ef1ac26957bd84a588ba13daabafaa03a29da307ef1e1ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/a/audit-libs-3.1-2.fc39.aarch64.rpm"
+          },
+          "sha256:1235525527c3615d54e069b5df00c6528f6b359196cf8bff2e6703bb46a786a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libfdisk-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:133e62a07a3424a90352289359aeaefa078a1657d12329f97f24c86799230c53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/python3-libs-3.11.2-1.fc39.aarch64.rpm"
+          },
+          "sha256:141e746033217535d30b989e20cb565aad275e05e7971067f4a11913d2fc499d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libxcrypt-4.4.33-7.fc39.aarch64.rpm"
+          },
+          "sha256:14dccf84910696379b89995cb513cca8e2f7b7367989b3263045b299286b9234": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/x/xz-5.4.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:154d5875948c1aae996881b55ed71d42a51f9c138abc65950657cadff707269d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-ostree-libs-2023.2-1.fc39.aarch64.rpm"
+          },
+          "sha256:16d1843cdac488ad04bdc654dd6b8dfbfeafe33a7728695070481302a7e54345": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/b/basesystem-11-15.fc38.noarch.rpm"
+          },
+          "sha256:1885d9d961bd04783d3c34309883c96eb041c0a5b3ce287892765444247cc8d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/lz4-libs-1.9.4-2.fc38.aarch64.rpm"
+          },
+          "sha256:197e34b18cf79c81342485457adb84ae7e111cc0fb0f9391b4c9428208433e84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/file-libs-5.44-2.fc39.aarch64.rpm"
+          },
+          "sha256:1986f592f87e9f4027b726ec89627f707dcdd93af302dd251049915747819957": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/glib2-2.75.4-2.fc39.aarch64.rpm"
+          },
+          "sha256:19ca5402cac14d896f0422469446a4ad2157909ac383d611918f0436be1aa7b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libksba-1.6.3-2.fc38.aarch64.rpm"
+          },
+          "sha256:1bc707f6df0aac3eb69be6e32be2edb32c772c1afb63300577e72fcec472af54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libssh-config-0.10.4-4.fc39.noarch.rpm"
+          },
+          "sha256:1bca2d927fe01ab25b2cc591bdb9f494397d99ec9eb72a93bcc53d1b8173da14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libgomp-13.0.1-0.6.fc39.aarch64.rpm"
+          },
+          "sha256:1c49f0eb53cb43c935cc6d155ebd3d6353d17b23e0e8f69f8a984d7dc65f6ba5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libarchive-3.6.1-5.fc39.aarch64.rpm"
+          },
+          "sha256:1dc3519e436d1a3551ea1201d786a503797c3d817805b5fc72a47febce816dc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/grub2-efi-aa64-2.06-88.fc39.aarch64.rpm"
+          },
+          "sha256:1fce9ea5c004b04b39bceb83069c2791f4f725639be52f94a0eb438bd1087be3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gmp-6.2.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:1ff4a903b24533b661ca8d5f40d1fc0087da8de2cfad3a544adeb8037ae7e8e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gzip-1.12-3.fc38.aarch64.rpm"
+          },
+          "sha256:2122d4c0d41ac42bd3a7cb365d199bc462203fe443e403ca470784a1e02ac17a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/systemd-resolved-253.1-4.fc39.aarch64.rpm"
+          },
+          "sha256:24152292f7b94c35e36aa896f1cdf79b67e9804b8f69dcae79d69232233442e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libstdc++-13.0.1-0.6.fc39.aarch64.rpm"
+          },
+          "sha256:24602018d0132dd1b8fa5e703844d8a732d7715b82949784f886128985f61646": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/o/openldap-2.6.4-1.fc39.aarch64.rpm"
+          },
+          "sha256:24a4231bde0e44e99eaafa9ae7fc65940170e9df0654e81c3a85ae8979ff61b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libtirpc-1.3.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:25de7b2c0838b1c5c14d73ee0ebd9e2e9fdce428e276f0eaa7c6979791be8490": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gawk-all-langpacks-5.1.1-5.fc38.aarch64.rpm"
+          },
+          "sha256:267735e6b9efc4cc058fa926a9e432fb6c44b97b0c6e5037e24ae7bab75fa53a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/lua-libs-5.4.4-9.fc39.aarch64.rpm"
+          },
+          "sha256:278c8a31a736d96b08f1042eb801290c7e3b28d899364d9bb7c300762f2bc313": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/x/xz-libs-5.4.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:27df4c19fd4e7b72e35493f84f0f79ed809e02e9e628615583fc44973ca2d493": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/procps-ng-3.3.17-9.fc38.aarch64.rpm"
+          },
+          "sha256:2a487be4156533f0d60db98bfd3459c2bef15bbf231f9d474d0ebf123d3ddfc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/o/openssl-pkcs11-0.4.12-3.fc38.aarch64.rpm"
+          },
+          "sha256:2bab8311915e4fdfcc2749558770cfbe63c7a1fad686094d116301c2b42a8109": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/efivar-libs-38-7.fc38.aarch64.rpm"
+          },
+          "sha256:301dfc48d40ab87f54178c1805bc3ddf40daa666f72a9c986442dd3e3febe657": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libtasn1-4.19.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:33132e2cfc1552b6429ddfde328d8e350294cad519a34860c3021b4e4289bccc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/t/tpm2-tss-4.0.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:342b090523748dbd93de4d39adc5b059f388893bd086b3c11f1c3dc16770a520": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libunistring1.0-1.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:37bbecfe2755c8fe18722b8ce7a939bbaad2e9d1bf21e4d74b81041ca64df00f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/grep-3.9-1.fc39.aarch64.rpm"
+          },
+          "sha256:3908078cd7debb2b2e081a7ea30fdf598f702ba7e65db7159836403940ed2421": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-repos-rawhide-39-0.1.noarch.rpm"
+          },
+          "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-39-0.5.noarch.rpm"
+          },
+          "sha256:3aa089143e2c45970439dc09f3cfc3c4500319a2f5785b6068899cdb02a1f83f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fuse-2.9.9-16.fc38.aarch64.rpm"
+          },
+          "sha256:3aa9b7d8bf7c0d00e83d52180b24b2660ab3f4d72b454d82ecd0bc5e5aed4263": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/shim-aa64-15.6-2.aarch64.rpm"
+          },
+          "sha256:3cf03283e8e07e37763931446a599809c069fe25c20a0eb6dd6386f447673e06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/publicsuffix-list-dafsa-20221208-2.fc38.noarch.rpm"
+          },
+          "sha256:3ed298c957602edb7ce91e0d06c4cc876c645d5e9848cd9553b5521ab1dba8a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm"
+          },
+          "sha256:41a149bfa3edb610eb47716c7e433cade50e898bc71ef0dac39f5390916eb500": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/a/authselect-libs-1.4.2-2.fc38.aarch64.rpm"
+          },
+          "sha256:41cabf9fc1ff8f073ed7b7760cf92bcaeaac1816e0fc1818f771e611dc11bc58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fuse3-libs-3.14.0-1.fc39.aarch64.rpm"
+          },
+          "sha256:4278312d7fa6c806c42a56c332f68a95cdabc86450ac3c0ebd8f2ff696c8c19c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/polkit-122-4.fc39.aarch64.rpm"
+          },
+          "sha256:42a6fa3db480f36554e51af9ca2c25a523e005ea09dfe3489403254496934e66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm"
+          },
+          "sha256:45ad13f2e16525392a44e438a549c2244b0ed6f91f8053c7780bd381a3448c25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libunistring-1.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:4644a24bef92e3c236f2273a2771e6172ad32a6ef23e274aed537285ff934cd5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libyaml-0.2.5-9.fc38.aarch64.rpm"
+          },
+          "sha256:47edf9a5d80e60334b0523f36a86b40b430a55c1afc91232181961152a3c8f25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/j/json-c-0.16-4.fc38.aarch64.rpm"
+          },
+          "sha256:487fb0cea28d207da310d7d8e7e298ed4784e21bc198cf44b4f8ae1303c9abe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libcap-ng-0.8.3-5.fc38.aarch64.rpm"
+          },
+          "sha256:4883bcb01e87f0dd5182e3200b24640424fdd55c3a18e46b4164eb92af904c3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/p11-kit-trust-0.24.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:4a1609cfe80410fe13237771548eea4631ccbac69f6915e4d21918016f8a8677": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/dbus-1.14.6-1.fc38.aarch64.rpm"
+          },
+          "sha256:4b9f156faebae07f512e2e22a6d104e86bc9fc86056dcde54ae1eb87ca057eb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libnsl2-2.0.0-5.fc38.aarch64.rpm"
+          },
+          "sha256:4c812941dda067452d42b3820ac7b56a1edd0cdcd3df4002f17ecc1c69ba630f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-plugin-selinux-4.18.0-11.fc39.aarch64.rpm"
+          },
+          "sha256:4e266ae94a5854f59791cb040dd6e3ecc89a7c87590122a5161991b351d5408b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libpsl-0.21.2-2.fc38.aarch64.rpm"
+          },
+          "sha256:4f19a70d3fbf30ac298700d3918d7fb483a387adf3d08b96efaa07d51dd0b156": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm"
+          },
+          "sha256:50bcbb893527129117ecd5f3b7b72ea431d6c129e2dfeed7f1f02a8d65020c05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/cyrus-sasl-lib-2.1.28-9.fc38.aarch64.rpm"
+          },
+          "sha256:510e948c49041b4481f4e749066ca1d52dae50294c182b92d281e1652c185d16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/glibc-gconv-extra-2.37.9000-3.fc39.aarch64.rpm"
+          },
+          "sha256:517b9d47e7b4ec7b8d1856f4525a6a60feed38617fa47767bee1140f812d5214": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/t/tpm2-tools-5.5-1.fc39.aarch64.rpm"
+          },
+          "sha256:51ac501495ce47ed0204bc06ff012476e655a100c9f21d7889dbbf9747404a74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/kmod-30-4.fc38.aarch64.rpm"
+          },
+          "sha256:529bcb4c6d2060c8fce9b52bd8fb4cfbb807df374281a4e0d69e7c905df662e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libsepol-3.5-1.fc39.aarch64.rpm"
+          },
+          "sha256:52b8c81f48a48855c95c65eb166dff0130d80948d3128ad3cd295e643b278d74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libpwquality-1.4.5-3.fc38.aarch64.rpm"
+          },
+          "sha256:5349c5841c28e67a4f1ac33c0e83ab7029a2aa16ec323dad176b3543e65006e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/w/which-2.21-39.fc39.aarch64.rpm"
+          },
+          "sha256:53b418b81b706324137460ab14b73af13c71587b9d5189e5018a242991970915": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gnupg2-2.4.0-3.fc39.aarch64.rpm"
+          },
+          "sha256:544c2f28235f316c56969f415db1a7b9928d9f8d22deed5c147a9f7e405b7054": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/device-mapper-libs-1.02.191-2.fc39.aarch64.rpm"
+          },
+          "sha256:54aa1a0699326aae0137529166df648a393331e99280ca10f77f6fc904caf9e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/python-setuptools-wheel-65.5.1-2.fc38.noarch.rpm"
+          },
+          "sha256:55756638296d53fdc9dd8c6b46c29bac98c890cfd9d558fec3aefa3406b358a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libidn2-2.3.4-2.fc38.aarch64.rpm"
+          },
+          "sha256:58908e17a3f25173832301e604aaf51fb25c618b1ad1f0ffe64f1f8ae9346a34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/duktape-2.7.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:58f75a8368b74d16380f7eeb1c506c3907ab4d168a91bb092c96da81bd27f59f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/kbd-misc-2.5.1-5.fc39.noarch.rpm"
+          },
+          "sha256:5bb6e5af81ec4523bda8aa99eff6940eec288d9e45ed354796a1aba58a8f531d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libseccomp-2.5.3-4.fc38.aarch64.rpm"
+          },
+          "sha256:5ce085a7077df5c5969c018d1c242fa6546bf57353132a786bae06183b892836": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/grub2-tools-2.06-88.fc39.aarch64.rpm"
+          },
+          "sha256:5d2895e8e2c0f843631a268130c1d24dca9c78bc29151ba9052c717bf9cf945c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libutempter-1.2.1-8.fc38.aarch64.rpm"
+          },
+          "sha256:5e8458439742e626901956a5c65347e23af571fddca04e2987e1e25320811e31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/p11-kit-0.24.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:5f2f2310459ef50d0bb8504f6744608abd949c46f7d798937bc129ef5153d647": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/m/memstrack-0.2.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:60245c3414a8c444103e937dfb1251cd1b18afc5f3c811daff1faa6f4b8875b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/u/util-linux-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:61c40ecfc56c4667221bd6254024268d1295514ec93447976c40dfbe696e9863": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/grub2-tools-minimal-2.06-88.fc39.aarch64.rpm"
+          },
+          "sha256:668e8d6d207ae1d40e11fce1637eae01bec8eb4cee770f29750b197e2b86926a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/elfutils-libs-0.189-1.fc39.aarch64.rpm"
+          },
+          "sha256:676a082be2f67a4a4c5bd0e6169e07a8bb4373f12bbac806ab1bb24a4b2c52b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/device-mapper-1.02.191-2.fc39.aarch64.rpm"
+          },
+          "sha256:67b6c981dbc626378729138b7eec77198053d6c4c354a5c638901afa30c5a847": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/crypto-policies-20230301-1.gita12f7b2.fc39.noarch.rpm"
+          },
+          "sha256:67bfe5c18c4eebe6cb28ade72b9af54d0f377b311da527a6cc7d133bf02a5e99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/popt-1.19-2.fc38.aarch64.rpm"
+          },
+          "sha256:697a1db85006f84026632c9b40fb41b03c5aa7cd41c72f6bb7232002f89d16b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gettext-runtime-0.21.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:69c9711600ede5bd00494ae8dafa400121de28f70cb4784f4546b8810c4b4cd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-common-39-0.5.noarch.rpm"
+          },
+          "sha256:6b14738a69996f820a42c8857412d1fa62284932da5874d3d2eb39f0f356714b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/containers-common-1-87.fc39.noarch.rpm"
+          },
+          "sha256:6b1a20e0fc39a72fd9e555ee7aa9975276427524508d48250d0bcf1f8f8de0f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libsigsegv-2.14-4.fc38.aarch64.rpm"
+          },
+          "sha256:6d630a00ff5c09a3ccfcb2f40d1317b2b75cb97650840df6cd5b1c436c984747": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libgcc-13.0.1-0.6.fc39.aarch64.rpm"
+          },
+          "sha256:6dd14c7a6678bca18e33694e37d8e26cd6cb165165a4acb04fbeb019d0edf05f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libsecret-0.20.5-3.fc38.aarch64.rpm"
+          },
+          "sha256:6e6ea4123e4777b1d66c46d919934ba6d3a95cb6cbc6ac797d88f1ac21bb1b06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libblkid-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:70a8414ed24797eba9fa8cde6224ac222774ce808537abd5bdc8763484d6c146": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gdbm-libs-1.23-3.fc38.aarch64.rpm"
+          },
+          "sha256:70e7c2d53e2d87ceb220bc6d1c06535d4a11ab3c8d1ff964a498d058698aeb36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/n/npth-1.6-12.fc38.aarch64.rpm"
+          },
+          "sha256:73e923d9adbba6384840bac86c7664169fdd74f61a3db9407840f41f91e63d9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/crypto-policies-scripts-20230301-1.gita12f7b2.fc39.noarch.rpm"
+          },
+          "sha256:743c19b00671966ad2f10a08127e52f865e66318e2e538a17afe0de30b5a021d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/b/bash-5.2.15-3.fc38.aarch64.rpm"
+          },
+          "sha256:759661a23273cb8a1fbfd9885aa8e596b4787431701cd2cda75ed91d184ec4c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/cracklib-2.9.7-31.fc38.aarch64.rpm"
+          },
+          "sha256:761a0f650fbbfb1ace613cdd42ba5f16f4737c93b3bbb23a7792df444027dfa2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fuse-overlayfs-1.10-4.fc39.aarch64.rpm"
+          },
+          "sha256:767f4aea7eb5fba311b11f13eb22c71b40c31ccaca8bd07cc4b3b18dffa4d21f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gnupg2-smime-2.4.0-3.fc39.aarch64.rpm"
+          },
+          "sha256:76fa76c9c989b54d0677e3bb8eb89805083d6c2c4475325fdb57d2db23c45275": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/policycoreutils-3.5-1.fc39.aarch64.rpm"
+          },
+          "sha256:7787ae522c7e74b912d13598e199c523d7ded171f9bc872f1f2656b393b6db19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pinentry-1.2.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:7859fa38c737344f1dfa05c31143db413f14704908feec07b3a67a2a487e30a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libcurl-7.88.1-1.fc39.aarch64.rpm"
+          },
+          "sha256:79fecda5af50e235d6b4ee9bc20834bf046cb15cb6f8f71ebf3b534759a78649": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libgcrypt-1.10.1-7.fc38.aarch64.rpm"
+          },
+          "sha256:7adca8bd302126014d8d1721189422747a9a480f2e2d9abbf5b85f3d9c07804f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libacl-2.3.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:7b91df9b6fbeec00604181db29069eda114926e290e0acc3cfc8d7f74118db0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/j/json-glib-1.6.6-4.fc38.aarch64.rpm"
+          },
+          "sha256:7c97f56b7531d2779d7c8adacc7fe34ec04077d1b86874afe621ca81fabbdbe2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/elfutils-libelf-0.189-1.fc39.aarch64.rpm"
+          },
+          "sha256:7ca4acd8f26f010ebf04411a651df7bf3a5111881d7cbeffbe056367a2347ba6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/kbd-2.5.1-5.fc39.aarch64.rpm"
+          },
+          "sha256:7d54836133ed06083473cb58977db4422dfb201cb73f18e730d4691eebfa5414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/python-unversioned-command-3.11.2-1.fc39.noarch.rpm"
+          },
+          "sha256:7d7d603328d401296327ee05b8fc308cd7a781f71188f6c0e0e4bb3b967624fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/expat-2.5.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:7dfeaaaf4b49fd68b4b17aef47fefcfd6aedb83f7551123182dec1ba30f4eb48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libatomic-13.0.1-0.6.fc39.aarch64.rpm"
+          },
+          "sha256:7e88ebc8a444689e1d8909071e59e6ba7625e700e05160a48dfef197ed315dd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/cpio-2.13-14.fc38.aarch64.rpm"
+          },
+          "sha256:7fb924a539d5f6a8d9656886a2ffcc4850e6674e37d427d424623fbbcb64fc65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/polkit-pkla-compat-0.1-23.fc38.aarch64.rpm"
+          },
+          "sha256:8005fb24037a3c7c4940bef13fb0b37df42581e567e935c86281a5ea30a01d82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-libs-4.18.0-11.fc39.aarch64.rpm"
+          },
+          "sha256:8284f25f53cfabed300f93598bc16a478b01650066a1b25db8fa2030e9f92b9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/file-5.44-2.fc39.aarch64.rpm"
+          },
+          "sha256:83319103222ca364d7987d80b6d62d1b7cb957a19e1647793bb7e35584096057": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/e2fsprogs-1.46.5-4.fc38.aarch64.rpm"
+          },
+          "sha256:86aa1169ef9757e59ca01b1557482b04d08d9436ac08e880c81efda71a26f346": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libxkbcommon-1.5.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:87f3fc51ecc7dbbebcf9c1290d1d959d483cc171552bdff4194ad741e34bc0e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-ostree-2023.2-1.fc39.aarch64.rpm"
+          },
+          "sha256:89b0edd10bdd990197605b7a938a0e25070524d83ffd986232817ca436874719": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.aarch64.rpm"
+          },
+          "sha256:8cd25bf3b1e71ea95424a8a2c9e1b608bc6fc22a0be1b2915824a9f133924731": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/skopeo-1.11.1-2.fc39.aarch64.rpm"
+          },
+          "sha256:8d071598ec4b502e566d62d160b0f62f2c97a6cd1c9b14a8a238358ae3efc169": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/b/bzip2-libs-1.0.8-13.fc38.aarch64.rpm"
+          },
+          "sha256:8e7220bd2de39708cd2be2788c4c3bd95bf12590260ced37673849b892dec309": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/librepo-1.15.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:8ecb72298a8b662ee1a17e7fb4e1d279d7fc64b358c9fdf9a568a965022b3f97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-repos-39-0.1.noarch.rpm"
+          },
+          "sha256:8f4d3faf343835b02699666ad813316f7fa769b21e474006b55cbf0cd01e27ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/e2fsprogs-libs-1.46.5-4.fc38.aarch64.rpm"
+          },
+          "sha256:8fb14724ad07464e9da98e15badb7523c299f6188a39bf65e02bbccfde8b44a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gpgme-1.17.1-5.fc39.aarch64.rpm"
+          },
+          "sha256:91a4beb90b9cd9bfcc46d5262116e682ffe2be99591759a2a0437bfd3c9b394e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/grubby-8.40-70.fc39.aarch64.rpm"
+          },
+          "sha256:9628ab6436ad123ff03b6d1ba703218604f5f1b9845f8cc835614df30341c678": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pcre2-10.42-1.fc38.1.aarch64.rpm"
+          },
+          "sha256:97f90c6b562ed91f0964ef8f5fc74136a19132e6ef86f2b40748928e36c8195b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/elfutils-debuginfod-client-0.189-1.fc39.aarch64.rpm"
+          },
+          "sha256:9858eb4e6a8aca2d0e69a57d3db25f1a561e117e6c6221ccd0b3518f7db7f01e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/kbd-legacy-2.5.1-5.fc39.noarch.rpm"
+          },
+          "sha256:9a9bbc5b246511981636eacbe31612d9f7c1573bf6aaae277b1ef45c2982396c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/dracut-config-generic-059-3.fc39.aarch64.rpm"
+          },
+          "sha256:9afb2acd6fe8a4d40fba4fee0ad87171b07ac6bd98be1c7b0319312872a67306": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/findutils-4.9.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:9bcccd2b110d8a6a3d07a7aeed82b4416db762a22239346839838445a0a870d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libeconf-0.4.0-5.fc38.aarch64.rpm"
+          },
+          "sha256:9e932e568356dee94c58e0c59ac0a825d11a89f45e8b82c5dd17b046acf8c9f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-4.18.0-11.fc39.aarch64.rpm"
+          },
+          "sha256:9e9cec829b408d471e732cd8a9e54babefded5234a31b2b6e81b8907e9bd9fd8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libb2-0.98.1-8.fc38.aarch64.rpm"
+          },
+          "sha256:a4bf51d3c2401fd612d9cbb04c6677b2ac74196af1ba36f4f39ef864ae47ad0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/glibc-common-2.37.9000-3.fc39.aarch64.rpm"
+          },
+          "sha256:a518527771195f92ff52297a56da79ce282d4a658ec610e159c9a6be97cc2e17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/o/ostree-libs-2023.1-2.fc39.aarch64.rpm"
+          },
+          "sha256:a5d131c1a4b194e5aab7e7925c524562d20b6e7b08a0e24045b0d11634c59c12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/krb5-libs-1.20.1-9.fc39.aarch64.rpm"
+          },
+          "sha256:a63abb2c9c20877409f8b7a74c7fef52c8ad701219a206e52ba20c9fe03da376": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libcap-2.48-6.fc38.aarch64.rpm"
+          },
+          "sha256:a6810adc621e586b0cefd779767e2a962ed18f4f1267a05fab8a94a1593e12be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/keyutils-libs-1.6.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:a6842664d722aa02d086ee369f12831e614cf7d3bb022620d201271a26372915": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libxml2-2.10.3-3.fc38.aarch64.rpm"
+          },
+          "sha256:a743bc050a18d34091325448e5e7f7ea9baee51045d3485ea13f27f7459671e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/systemd-libs-253.1-4.fc39.aarch64.rpm"
+          },
+          "sha256:a78cc23b4f327c88acfe7a57fc24419563efd94e44987ed7b23ffaad3c0cfea7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libselinux-utils-3.5-1.fc39.aarch64.rpm"
+          },
+          "sha256:a8207759999dd01b23b25e81cfa591a9f51c60cffd59c62c095f4bae948d1063": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/python3-3.11.2-1.fc39.aarch64.rpm"
+          },
+          "sha256:a8462017b0d07c30506328d18f4b8c4ef60e5e53c9f9b2f6e53c1223b765f955": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fuse3-3.14.0-1.fc39.aarch64.rpm"
+          },
+          "sha256:a84a1855158cb046f471d4f5766a2aa564662caa47dcbed418181856fed92c6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/glibc-2.37.9000-3.fc39.aarch64.rpm"
+          },
+          "sha256:a9f260ba16734b6d1be9672e6fe2c7b77f6e868a627d56e0c0664bf32388dfad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libusb1-1.0.26-2.fc38.aarch64.rpm"
+          },
+          "sha256:aefb3f2011381702ef4f32b6c0f7fcdd44b81fea883fea01f514d0219f6f2447": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/cryptsetup-libs-2.6.1-1.fc39.aarch64.rpm"
+          },
+          "sha256:afe5493369ba96307895e423c10e3c6689a56541c7cc794f5ccd0e79387d8220": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/filesystem-3.18-4.fc39.aarch64.rpm"
+          },
+          "sha256:b0d44fc3728295b16ee16e3eea5981c56115ef494e0e1dbabc04670c3a99aad9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/python-pip-wheel-23.0.1-1.fc39.noarch.rpm"
+          },
+          "sha256:b12f7396d7bc5071ea8551cb8f6c28fb6fbe716ea38a7d5b73fb3d5b30948ab2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/systemd-253.1-4.fc39.aarch64.rpm"
+          },
+          "sha256:b1f3751a9fdaf0c918bad3ca42a0984bea6d94d382995c3162bf6b391e53e21d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.aarch64.rpm"
+          },
+          "sha256:b1fb1418b8643edbbede7ae066d929946118a35832e4ee58676e7f65303ee781": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/polkit-libs-122-4.fc39.aarch64.rpm"
+          },
+          "sha256:b22812b369fa7c7f63dc2a9847a893073f6344d21990d9df57b12666b9739f75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gawk-5.1.1-5.fc38.aarch64.rpm"
+          },
+          "sha256:b4a95381f9f9aa1228c429aa9cb25502a448632b344f16bb693e5b8993f4d1c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pcsc-lite-1.9.9-3.fc38.aarch64.rpm"
+          },
+          "sha256:b662e452c110095492b561a02bc1b96088e2e25b9cb925239b5f81358a58cacd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/systemd-networkd-253.1-4.fc39.aarch64.rpm"
+          },
+          "sha256:b676e51dda545d40276b27e5b39adb68a26611ee2f2881efca9a63a99dbc5674": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libkcapi-1.4.0-5.fc38.aarch64.rpm"
+          },
+          "sha256:b799e33ca82fca0be8ffe86202c725912e46ea61d160a957502424a40f095e1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libcbor-0.10.2-1.fc39.aarch64.rpm"
+          },
+          "sha256:ba9f5eeb8b85d79e215f70369aaca0c441073ef0a4bc94833842395c0ea8c8f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/m/mpfr-4.1.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:bba199cbc2d5363334072bc40d868c9c0ff301d67dddd14a55f032043c9dc824": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm"
+          },
+          "sha256:c01590f3d237e302c0a9b8dac586469d1b58f37da29b1b815b1b2ae083944470": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/efibootmgr-18-3.fc38.aarch64.rpm"
+          },
+          "sha256:c0c00f1f7adec2ad2ec68b320585aa34c52b911d9565518b25c8633b39a55cdd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/kmod-libs-30-4.fc38.aarch64.rpm"
+          },
+          "sha256:c0feebfa4ef016fd8645cd1f75291a97a79769957347d4b5c2f13042a11a9670": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/systemd-udev-253.1-4.fc39.aarch64.rpm"
+          },
+          "sha256:c15357e1e23afd9e156eeb8955b08a68c0be3ef65089d2aa4beb4aaefca3300e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/u/util-linux-core-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:c28bb675110f9884d0250077186cfaad0019cbfe43464d6b82cf31b864bf570d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/curl-7.88.1-1.fc39.aarch64.rpm"
+          },
+          "sha256:c500caab153179a9c7c4ecb6defe2d925cac2ba56621541db5afc576ed3230a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/o/os-prober-1.81-3.fc38.aarch64.rpm"
+          },
+          "sha256:c5828fe90bb4659e9373383d381c73a0232cb5dc6abb4144ebf0d194c81176c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libss-1.46.5-4.fc38.aarch64.rpm"
+          },
+          "sha256:c6dfece5f9bdcefd5e881bfe85239bf0b662ef45af238827620653519142cc28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libzstd-1.5.4-1.fc39.aarch64.rpm"
+          },
+          "sha256:c77fd27cb1dc592a2d9ba9238b80aafdf340749d690f15db59e8483609da884c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm"
+          },
+          "sha256:c7a71bdfdb966bbc2166e214aca99d324e16e8a0623246ed8664be8be7a56aa0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libevent-2.1.12-8.fc38.aarch64.rpm"
+          },
+          "sha256:cd4ca78530d858c1e084bc647181f589f156179a89ec0d949f0fd5550b8ba9ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gettext-envsubst-0.21.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:d01c3be7e2f5773d0161ea7c01c01b696b979fb658de4bb59474b4a3998b70a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/a/alternatives-1.21-2.fc38.aarch64.rpm"
+          },
+          "sha256:d10f28a9f7871450d5c4b8f365a6204a35c29f4616d1d151147b717ea33c6b32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/coreutils-9.1-11.fc38.aarch64.rpm"
+          },
+          "sha256:d164fbd54f9921913cc39b71fc00d2a27b24f796e385e6e6a86502f6357958da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libassuan-2.5.5-6.fc38.aarch64.rpm"
+          },
+          "sha256:d41ee6bf1cf3506dc2e686da05fa297abda41b0aca14c1df121f9e788719ee5c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/n/nettle-3.8-3.fc38.aarch64.rpm"
+          },
+          "sha256:d5892ae6b2d9f370615dc668f1b4d4de7fe5067c192939e1f9c5648181198369": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pigz-2.7-3.fc38.aarch64.rpm"
+          },
+          "sha256:d63c198d35e144112b2bb3fff5918c56967a1a764478584e79be0967c71c35d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/m/mokutil-0.6.0-6.fc38.aarch64.rpm"
+          },
+          "sha256:d79bd2d236c80c08037c820c56ecfd85faaa227af10b08ef96540e1fbb5623b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.aarch64.rpm"
+          },
+          "sha256:d94deb4d35588d4c8e91242266b2d7b776b94ecc3234bc7b94ef5ff786bfdad1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/m/mpdecimal-2.5.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:d9e0f5c2291d5cc4818f014caa6dd5c465d873e4d958d85d9bf7be04a8d9fa91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pam-1.5.2-17.fc39.aarch64.rpm"
+          },
+          "sha256:db3f92441621b09e664be6790e6a279c036688093e7a5175927cda394756c214": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libdb-5.3.28-55.fc38.aarch64.rpm"
+          },
+          "sha256:db7a0a01b05d540e8f7f4bc9e967ceb27647f710beff3a33bceeba56381517f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/a/authselect-1.4.2-2.fc38.aarch64.rpm"
+          },
+          "sha256:dcb34a02699a1d5363abfe91b6f485c58fbf11bd4b67ae7c94779972156d8d2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/cracklib-dicts-2.9.7-31.fc38.aarch64.rpm"
+          },
+          "sha256:de3b9ad8d5651675a2293e93fd88fcb3f6eb0f269f255494898d40fa9c3cdf34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libgpg-error-1.46-2.fc38.aarch64.rpm"
+          },
+          "sha256:de66d62ae7c16f6e74a20b0dd8635c7dbe77c7ebc4e6bdc23cc234329c2676ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/systemd-pam-253.1-4.fc39.aarch64.rpm"
+          },
+          "sha256:e067c951e005c0d2c6e8153828eeaec0cc8f50aad60a3af56764eeb79128dec8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libsmartcols-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:e0b4d0383998437ac5af31fd5c88b2f1de632971f2a38b8cc04201fac7bf5450": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fuse-common-3.14.0-1.fc39.aarch64.rpm"
+          },
+          "sha256:e10c0ec1a70226866cd13c044cdb398d519fa28ae3f2cf5747b6ce799d3bd0c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/setup-2.14.3-3.fc39.noarch.rpm"
+          },
+          "sha256:e2101508acd9f16f43fb1781e7242fd5ea1570275ab9f596ec1fdd622ac947d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/grub2-common-2.06-88.fc39.noarch.rpm"
+          },
+          "sha256:e28b42b8fcb1771c9ef3bd78045ffdceb00f4255fa8a08f5aa90399b4f8a1414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libattr-2.5.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:e44b1735f41ec275ccf5c8718c1cc718f2cb7ff7c16d1868fb0521d862a407fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/dbus-broker-33-1.fc38.aarch64.rpm"
+          },
+          "sha256:e7dfdcae92d385722866d220d79fed574af730eab1102fcfa5405f4dddcf6533": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/dracut-059-3.fc39.aarch64.rpm"
+          },
+          "sha256:e85faea7d600be67caa99decaa81a248fbfe90a629a38a66bb3a43f2a8050bd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libssh-0.10.4-4.fc39.aarch64.rpm"
+          },
+          "sha256:e89e25b52a60c39da1a2bed8d386572c3dfa5f06b7659c5ba52d45745336355d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/o/openssl-libs-3.0.8-1.fc39.aarch64.rpm"
+          },
+          "sha256:e9f81f7b77e1011de9e9cf4c68a149aa70f4f33e2bfa394213396115eaf9a2d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/t/tzdata-2022g-2.fc38.noarch.rpm"
+          },
+          "sha256:ea126779940d8cfd1f0f0b8428c1d8ce2ca07a6d21e3db77a00f036f15004f9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pam-libs-1.5.2-17.fc39.aarch64.rpm"
+          },
+          "sha256:ea43195642f245445df81cb11388ba262834e84643cf4cdf325e15c90014eb82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/sqlite-libs-3.40.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:ea903340bb561eb07e43a9d3659badceb2992696015f1869b42e2c8932158d5c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libbrotli-1.0.9-11.fc38.aarch64.rpm"
+          },
+          "sha256:eb127da21f77c89e9e892b657018961ed54ffb43e55693482f1aaff06690f521": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libnghttp2-1.52.0-1.fc39.aarch64.rpm"
+          },
+          "sha256:eb8e22f358ffa431a7e4e13e564089af70de3dd009421bb12299227ceb5348be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libcom_err-1.46.5-4.fc38.aarch64.rpm"
+          },
+          "sha256:ebde9d7dd013fdb8e8f3ffa45638f394de1202facbbe81eac6c23c1dec068c85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fuse-libs-2.9.9-16.fc38.aarch64.rpm"
+          },
+          "sha256:ec754b5d6d177e9a91469c45729b7849c231d06a7dd004f8e5eb0c8cc304fe28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libuuid-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:ed631d2c111797912e1ac855d02ef78296d1853e4d1957f72f19c83afae02079": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/o/ostree-2023.1-2.fc39.aarch64.rpm"
+          },
+          "sha256:f00be46cf33948f4608beb6e3a08cc4aa33bdd4ca53dd66cc1995ac82529967c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/n/ncurses-libs-6.4-3.20230114.fc38.aarch64.rpm"
+          },
+          "sha256:f0bf5be760140e4d27eccc9ba1c45c1db070ac1b03420e8677000f82e6eeb107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/m/mkpasswd-5.5.15-3.fc38.aarch64.rpm"
+          },
+          "sha256:f198fa50d35112320ae2f81bfe83d4d626160ef3e8dbba16285183a747a96655": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/readline-8.2-3.fc38.aarch64.rpm"
+          },
+          "sha256:f1bfcaeb6e03a843aa6a06c064737c4a3e48ace9e5353328aea3754eb0d489bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libverto-0.3.2-5.fc38.aarch64.rpm"
+          },
+          "sha256:f33f41efdeb7ed371ca73539df63e0a24e1ba6f1c08eb6b3a13efeee143c22cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/elfutils-default-yama-scope-0.189-1.fc39.noarch.rpm"
+          },
+          "sha256:f3b9a49762bbfa7832b11514eaf441eec3431a174ec257607cbb221d7014cf44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libfido2-1.13.0-2.fc39.aarch64.rpm"
+          },
+          "sha256:f43c1499f87baf84bc6d298497fb8c323258cd9052573ae9ba6880d940bac4e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/glibc-minimal-langpack-2.37.9000-3.fc39.aarch64.rpm"
+          },
+          "sha256:f48744c52212ec825e84bb98025f2f669202aa8eb34d3cce2402a0bce55d78b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/coreutils-common-9.1-11.fc38.aarch64.rpm"
+          },
+          "sha256:f5489b5688cf6e05405dd49f2096652686d3c83dd0666ce0d8de422100cc4d0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gnutls-3.8.0-2.fc39.aarch64.rpm"
+          },
+          "sha256:f5c2b7e34cd518428e2b57b97d53038a35112bfd7dcf70b99a362edf6df03174": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/n/ncurses-base-6.4-3.20230114.fc38.noarch.rpm"
+          },
+          "sha256:f6d14f22f3b4e8bb3428d2cbef4e75821ec5c132a08816f159d82025be36f774": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/selinux-policy-targeted-38.8-1.fc39.noarch.rpm"
+          },
+          "sha256:f75e48a0bf1a3f957d356727daf0773868104d98faeca73aa86955e15dcfd01c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/diffutils-3.9-3.fc39.aarch64.rpm"
+          },
+          "sha256:f894df6361e474e904a667bbe9ab110af509541462932ffaa2cd1ca6b550c726": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/selinux-policy-38.8-1.fc39.noarch.rpm"
+          },
+          "sha256:f8b227c1cd6fb8987ef5885853349f2521fa2103c4c8577bbb77893589559a3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/q/qrencode-libs-4.1.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-identity-basic-39-0.5.noarch.rpm"
+          },
+          "sha256:fac4d4b98282f5defc0802b2468bec30e5e6748c93719773b80da15e5567934f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libmount-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:fb3ca377066ec35b4e93c52dd47625dc371d6ebfc5fe1da28b4e6c97186eda67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/shadow-utils-4.13-6.fc39.aarch64.rpm"
+          },
+          "sha256:fb71e84c6261a71b49cc96be5305c71c54598c602c58dc7f709fc5755dba2af7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-sequoia-1.3.0-1.fc39.aarch64.rpm"
+          },
+          "sha256:fcd6ad8c1b3550477db0783a1b5e59c74ce21909bae128259f4215aac4b03e9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.aarch64.rpm"
+          },
+          "sha256:fdcd3745c2206fed259467bd49a96344c15a192952bc6f04b070e8b2995085dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libffi-3.4.4-2.fc38.aarch64.rpm"
+          }
+        }
+      },
+      "org.osbuild.inline": {
+        "items": {
+          "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+            "encoding": "base64",
+            "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+          },
+          "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+            "encoding": "base64",
+            "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+          },
+          "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+            "encoding": "base64",
+            "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+          },
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+            "encoding": "base64",
+            "data": ""
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/a/alternatives-1.21-2.fc38.aarch64.rpm",
+        "checksum": "sha256:d01c3be7e2f5773d0161ea7c01c01b696b979fb658de4bb59474b4a3998b70a1",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/a/audit-libs-3.1-2.fc39.aarch64.rpm",
+        "checksum": "sha256:112df1c64fb363c72ef1ac26957bd84a588ba13daabafaa03a29da307ef1e1ec",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/a/authselect-1.4.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:db7a0a01b05d540e8f7f4bc9e967ceb27647f710beff3a33bceeba56381517f3",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/a/authselect-libs-1.4.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:41a149bfa3edb610eb47716c7e433cade50e898bc71ef0dac39f5390916eb500",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "15.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/b/basesystem-11-15.fc38.noarch.rpm",
+        "checksum": "sha256:16d1843cdac488ad04bdc654dd6b8dfbfeafe33a7728695070481302a7e54345",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.15",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/b/bash-5.2.15-3.fc38.aarch64.rpm",
+        "checksum": "sha256:743c19b00671966ad2f10a08127e52f865e66318e2e538a17afe0de30b5a021d",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/b/bubblewrap-0.7.0-1.fc39.aarch64.rpm",
+        "checksum": "sha256:047b9b3feb3a7c8f4fd26ddd908e6c0a436827b7e73a3fe7af6a0bac9857887c",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "13.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/b/bzip2-libs-1.0.8-13.fc38.aarch64.rpm",
+        "checksum": "sha256:8d071598ec4b502e566d62d160b0f62f2c97a6cd1c9b14a8a238358ae3efc169",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2023.2.60",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm",
+        "checksum": "sha256:3ed298c957602edb7ce91e0d06c4cc876c645d5e9848cd9553b5521ab1dba8a0",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.203.0",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/container-selinux-2.203.0-1.fc39.noarch.rpm",
+        "checksum": "sha256:0cbad3c0b6b1b8c73ac219d5ed3772c89331e46a5fd8e4be3dc065e2021ef904",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "87.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/containers-common-1-87.fc39.noarch.rpm",
+        "checksum": "sha256:6b14738a69996f820a42c8857412d1fa62284932da5874d3d2eb39f0f356714b",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "11.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/coreutils-9.1-11.fc38.aarch64.rpm",
+        "checksum": "sha256:d10f28a9f7871450d5c4b8f365a6204a35c29f4616d1d151147b717ea33c6b32",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "11.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/coreutils-common-9.1-11.fc38.aarch64.rpm",
+        "checksum": "sha256:f48744c52212ec825e84bb98025f2f669202aa8eb34d3cce2402a0bce55d78b7",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "14.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/cpio-2.13-14.fc38.aarch64.rpm",
+        "checksum": "sha256:7e88ebc8a444689e1d8909071e59e6ba7625e700e05160a48dfef197ed315dd2",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/cracklib-2.9.7-31.fc38.aarch64.rpm",
+        "checksum": "sha256:759661a23273cb8a1fbfd9885aa8e596b4787431701cd2cda75ed91d184ec4c0",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/cracklib-dicts-2.9.7-31.fc38.aarch64.rpm",
+        "checksum": "sha256:dcb34a02699a1d5363abfe91b6f485c58fbf11bd4b67ae7c94779972156d8d2b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20230301",
+        "release": "1.gita12f7b2.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/crypto-policies-20230301-1.gita12f7b2.fc39.noarch.rpm",
+        "checksum": "sha256:67b6c981dbc626378729138b7eec77198053d6c4c354a5c638901afa30c5a847",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20230301",
+        "release": "1.gita12f7b2.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/crypto-policies-scripts-20230301-1.gita12f7b2.fc39.noarch.rpm",
+        "checksum": "sha256:73e923d9adbba6384840bac86c7664169fdd74f61a3db9407840f41f91e63d9c",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/cryptsetup-libs-2.6.1-1.fc39.aarch64.rpm",
+        "checksum": "sha256:aefb3f2011381702ef4f32b6c0f7fcdd44b81fea883fea01f514d0219f6f2447",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.88.1",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/curl-7.88.1-1.fc39.aarch64.rpm",
+        "checksum": "sha256:c28bb675110f9884d0250077186cfaad0019cbfe43464d6b82cf31b864bf570d",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "9.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/c/cyrus-sasl-lib-2.1.28-9.fc38.aarch64.rpm",
+        "checksum": "sha256:50bcbb893527129117ecd5f3b7b72ea431d6c129e2dfeed7f1f02a8d65020c05",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/dbus-1.14.6-1.fc38.aarch64.rpm",
+        "checksum": "sha256:4a1609cfe80410fe13237771548eea4631ccbac69f6915e4d21918016f8a8677",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "33",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/dbus-broker-33-1.fc38.aarch64.rpm",
+        "checksum": "sha256:e44b1735f41ec275ccf5c8718c1cc718f2cb7ff7c16d1868fb0521d862a407fb",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm",
+        "checksum": "sha256:42a6fa3db480f36554e51af9ca2c25a523e005ea09dfe3489403254496934e66",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.191",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/device-mapper-1.02.191-2.fc39.aarch64.rpm",
+        "checksum": "sha256:676a082be2f67a4a4c5bd0e6169e07a8bb4373f12bbac806ab1bb24a4b2c52b5",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.191",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/device-mapper-libs-1.02.191-2.fc39.aarch64.rpm",
+        "checksum": "sha256:544c2f28235f316c56969f415db1a7b9928d9f8d22deed5c147a9f7e405b7054",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/diffutils-3.9-3.fc39.aarch64.rpm",
+        "checksum": "sha256:f75e48a0bf1a3f957d356727daf0773868104d98faeca73aa86955e15dcfd01c",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/dosfstools-4.2-6.fc38.aarch64.rpm",
+        "checksum": "sha256:0c11e634fc2571a811eded10a912538838093706011e1785b9cc7b17a940b432",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "059",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/dracut-059-3.fc39.aarch64.rpm",
+        "checksum": "sha256:e7dfdcae92d385722866d220d79fed574af730eab1102fcfa5405f4dddcf6533",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "059",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/dracut-config-generic-059-3.fc39.aarch64.rpm",
+        "checksum": "sha256:9a9bbc5b246511981636eacbe31612d9f7c1573bf6aaae277b1ef45c2982396c",
+        "check_gpg": true
+      },
+      {
+        "name": "duktape",
+        "epoch": 0,
+        "version": "2.7.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/d/duktape-2.7.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:58908e17a3f25173832301e604aaf51fb25c618b1ad1f0ffe64f1f8ae9346a34",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/e2fsprogs-1.46.5-4.fc38.aarch64.rpm",
+        "checksum": "sha256:83319103222ca364d7987d80b6d62d1b7cb957a19e1647793bb7e35584096057",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/e2fsprogs-libs-1.46.5-4.fc38.aarch64.rpm",
+        "checksum": "sha256:8f4d3faf343835b02699666ad813316f7fa769b21e474006b55cbf0cd01e27ef",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "7.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm",
+        "checksum": "sha256:bba199cbc2d5363334072bc40d868c9c0ff301d67dddd14a55f032043c9dc824",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/efibootmgr-18-3.fc38.aarch64.rpm",
+        "checksum": "sha256:c01590f3d237e302c0a9b8dac586469d1b58f37da29b1b815b1b2ae083944470",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "7.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/efivar-libs-38-7.fc38.aarch64.rpm",
+        "checksum": "sha256:2bab8311915e4fdfcc2749558770cfbe63c7a1fad686094d116301c2b42a8109",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/elfutils-debuginfod-client-0.189-1.fc39.aarch64.rpm",
+        "checksum": "sha256:97f90c6b562ed91f0964ef8f5fc74136a19132e6ef86f2b40748928e36c8195b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/elfutils-default-yama-scope-0.189-1.fc39.noarch.rpm",
+        "checksum": "sha256:f33f41efdeb7ed371ca73539df63e0a24e1ba6f1c08eb6b3a13efeee143c22cf",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/elfutils-libelf-0.189-1.fc39.aarch64.rpm",
+        "checksum": "sha256:7c97f56b7531d2779d7c8adacc7fe34ec04077d1b86874afe621ca81fabbdbe2",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/elfutils-libs-0.189-1.fc39.aarch64.rpm",
+        "checksum": "sha256:668e8d6d207ae1d40e11fce1637eae01bec8eb4cee770f29750b197e2b86926a",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/e/expat-2.5.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:7d7d603328d401296327ee05b8fc308cd7a781f71188f6c0e0e4bb3b967624fd",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-gpg-keys-39-0.1.noarch.rpm",
+        "checksum": "sha256:04db736a77296edd4099a9165d68560d52dbf2484d959f668b3b676d68581f97",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.5",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-39-0.5.noarch.rpm",
+        "checksum": "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.5",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-common-39-0.5.noarch.rpm",
+        "checksum": "sha256:69c9711600ede5bd00494ae8dafa400121de28f70cb4784f4546b8810c4b4cd3",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.5",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-identity-basic-39-0.5.noarch.rpm",
+        "checksum": "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-repos-39-0.1.noarch.rpm",
+        "checksum": "sha256:8ecb72298a8b662ee1a17e7fb4e1d279d7fc64b358c9fdf9a568a965022b3f97",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-repos-rawhide-39-0.1.noarch.rpm",
+        "checksum": "sha256:3908078cd7debb2b2e081a7ea30fdf598f702ba7e65db7159836403940ed2421",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/file-5.44-2.fc39.aarch64.rpm",
+        "checksum": "sha256:8284f25f53cfabed300f93598bc16a478b01650066a1b25db8fa2030e9f92b9d",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/file-libs-5.44-2.fc39.aarch64.rpm",
+        "checksum": "sha256:197e34b18cf79c81342485457adb84ae7e111cc0fb0f9391b4c9428208433e84",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/filesystem-3.18-4.fc39.aarch64.rpm",
+        "checksum": "sha256:afe5493369ba96307895e423c10e3c6689a56541c7cc794f5ccd0e79387d8220",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/findutils-4.9.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:9afb2acd6fe8a4d40fba4fee0ad87171b07ac6bd98be1c7b0319312872a67306",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fuse-2.9.9-16.fc38.aarch64.rpm",
+        "checksum": "sha256:3aa089143e2c45970439dc09f3cfc3c4500319a2f5785b6068899cdb02a1f83f",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.14.0",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fuse-common-3.14.0-1.fc39.aarch64.rpm",
+        "checksum": "sha256:e0b4d0383998437ac5af31fd5c88b2f1de632971f2a38b8cc04201fac7bf5450",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fuse-libs-2.9.9-16.fc38.aarch64.rpm",
+        "checksum": "sha256:ebde9d7dd013fdb8e8f3ffa45638f394de1202facbbe81eac6c23c1dec068c85",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fuse-overlayfs-1.10-4.fc39.aarch64.rpm",
+        "checksum": "sha256:761a0f650fbbfb1ace613cdd42ba5f16f4737c93b3bbb23a7792df444027dfa2",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.14.0",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fuse3-3.14.0-1.fc39.aarch64.rpm",
+        "checksum": "sha256:a8462017b0d07c30506328d18f4b8c4ef60e5e53c9f9b2f6e53c1223b765f955",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.14.0",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fuse3-libs-3.14.0-1.fc39.aarch64.rpm",
+        "checksum": "sha256:41cabf9fc1ff8f073ed7b7760cf92bcaeaac1816e0fc1818f771e611dc11bc58",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gawk-5.1.1-5.fc38.aarch64.rpm",
+        "checksum": "sha256:b22812b369fa7c7f63dc2a9847a893073f6344d21990d9df57b12666b9739f75",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gawk-all-langpacks-5.1.1-5.fc38.aarch64.rpm",
+        "checksum": "sha256:25de7b2c0838b1c5c14d73ee0ebd9e2e9fdce428e276f0eaa7c6979791be8490",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gdbm-libs-1.23-3.fc38.aarch64.rpm",
+        "checksum": "sha256:70a8414ed24797eba9fa8cde6224ac222774ce808537abd5bdc8763484d6c146",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gettext-envsubst-0.21.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:cd4ca78530d858c1e084bc647181f589f156179a89ec0d949f0fd5550b8ba9ba",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gettext-libs-0.21.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:0370d617744ed39409d0cf7177faa39f712fc88d8a44c465e624fe91b03120a0",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gettext-runtime-0.21.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:697a1db85006f84026632c9b40fb41b03c5aa7cd41c72f6bb7232002f89d16b4",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.75.4",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/glib2-2.75.4-2.fc39.aarch64.rpm",
+        "checksum": "sha256:1986f592f87e9f4027b726ec89627f707dcdd93af302dd251049915747819957",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/glibc-2.37.9000-3.fc39.aarch64.rpm",
+        "checksum": "sha256:a84a1855158cb046f471d4f5766a2aa564662caa47dcbed418181856fed92c6d",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/glibc-common-2.37.9000-3.fc39.aarch64.rpm",
+        "checksum": "sha256:a4bf51d3c2401fd612d9cbb04c6677b2ac74196af1ba36f4f39ef864ae47ad0b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/glibc-gconv-extra-2.37.9000-3.fc39.aarch64.rpm",
+        "checksum": "sha256:510e948c49041b4481f4e749066ca1d52dae50294c182b92d281e1652c185d16",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/glibc-minimal-langpack-2.37.9000-3.fc39.aarch64.rpm",
+        "checksum": "sha256:f43c1499f87baf84bc6d298497fb8c323258cd9052573ae9ba6880d940bac4e7",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gmp-6.2.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:1fce9ea5c004b04b39bceb83069c2791f4f725639be52f94a0eb438bd1087be3",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gnupg2-2.4.0-3.fc39.aarch64.rpm",
+        "checksum": "sha256:53b418b81b706324137460ab14b73af13c71587b9d5189e5018a242991970915",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gnupg2-smime-2.4.0-3.fc39.aarch64.rpm",
+        "checksum": "sha256:767f4aea7eb5fba311b11f13eb22c71b40c31ccaca8bd07cc4b3b18dffa4d21f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.8.0",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gnutls-3.8.0-2.fc39.aarch64.rpm",
+        "checksum": "sha256:f5489b5688cf6e05405dd49f2096652686d3c83dd0666ce0d8de422100cc4d0d",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.1",
+        "release": "5.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gpgme-1.17.1-5.fc39.aarch64.rpm",
+        "checksum": "sha256:8fb14724ad07464e9da98e15badb7523c299f6188a39bf65e02bbccfde8b44a5",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/grep-3.9-1.fc39.aarch64.rpm",
+        "checksum": "sha256:37bbecfe2755c8fe18722b8ce7a939bbaad2e9d1bf21e4d74b81041ca64df00f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "88.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/grub2-common-2.06-88.fc39.noarch.rpm",
+        "checksum": "sha256:e2101508acd9f16f43fb1781e7242fd5ea1570275ab9f596ec1fdd622ac947d0",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "88.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/grub2-efi-aa64-2.06-88.fc39.aarch64.rpm",
+        "checksum": "sha256:1dc3519e436d1a3551ea1201d786a503797c3d817805b5fc72a47febce816dc3",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "88.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/grub2-tools-2.06-88.fc39.aarch64.rpm",
+        "checksum": "sha256:5ce085a7077df5c5969c018d1c242fa6546bf57353132a786bae06183b892836",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "88.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/grub2-tools-minimal-2.06-88.fc39.aarch64.rpm",
+        "checksum": "sha256:61c40ecfc56c4667221bd6254024268d1295514ec93447976c40dfbe696e9863",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "70.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/grubby-8.40-70.fc39.aarch64.rpm",
+        "checksum": "sha256:91a4beb90b9cd9bfcc46d5262116e682ffe2be99591759a2a0437bfd3c9b394e",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/g/gzip-1.12-3.fc38.aarch64.rpm",
+        "checksum": "sha256:1ff4a903b24533b661ca8d5f40d1fc0087da8de2cfad3a544adeb8037ae7e8e6",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/j/json-c-0.16-4.fc38.aarch64.rpm",
+        "checksum": "sha256:47edf9a5d80e60334b0523f36a86b40b430a55c1afc91232181961152a3c8f25",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/j/json-glib-1.6.6-4.fc38.aarch64.rpm",
+        "checksum": "sha256:7b91df9b6fbeec00604181db29069eda114926e290e0acc3cfc8d7f74118db0c",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/kbd-2.5.1-5.fc39.aarch64.rpm",
+        "checksum": "sha256:7ca4acd8f26f010ebf04411a651df7bf3a5111881d7cbeffbe056367a2347ba6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/kbd-legacy-2.5.1-5.fc39.noarch.rpm",
+        "checksum": "sha256:9858eb4e6a8aca2d0e69a57d3db25f1a561e117e6c6221ccd0b3518f7db7f01e",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/kbd-misc-2.5.1-5.fc39.noarch.rpm",
+        "checksum": "sha256:58f75a8368b74d16380f7eeb1c506c3907ab4d168a91bb092c96da81bd27f59f",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/keyutils-libs-1.6.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:a6810adc621e586b0cefd779767e2a962ed18f4f1267a05fab8a94a1593e12be",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/kmod-30-4.fc38.aarch64.rpm",
+        "checksum": "sha256:51ac501495ce47ed0204bc06ff012476e655a100c9f21d7889dbbf9747404a74",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/kmod-libs-30-4.fc38.aarch64.rpm",
+        "checksum": "sha256:c0c00f1f7adec2ad2ec68b320585aa34c52b911d9565518b25c8633b39a55cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/kpartx-0.9.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:093fda317974455beb2b64f877902ffda898977e506c6ec4c6c18974b8f14ec7",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.20.1",
+        "release": "9.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/k/krb5-libs-1.20.1-9.fc39.aarch64.rpm",
+        "checksum": "sha256:a5d131c1a4b194e5aab7e7925c524562d20b6e7b08a0e24045b0d11634c59c12",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libacl-2.3.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:7adca8bd302126014d8d1721189422747a9a480f2e2d9abbf5b85f3d9c07804f",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "5.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libarchive-3.6.1-5.fc39.aarch64.rpm",
+        "checksum": "sha256:1c49f0eb53cb43c935cc6d155ebd3d6353d17b23e0e8f69f8a984d7dc65f6ba5",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libargon2-20190702-2.fc38.aarch64.rpm",
+        "checksum": "sha256:0061480328390c3954b9e497aa6ab8bc62eb279e6efd050965661fd79a70e3b4",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libassuan-2.5.5-6.fc38.aarch64.rpm",
+        "checksum": "sha256:d164fbd54f9921913cc39b71fc00d2a27b24f796e385e6e6a86502f6357958da",
+        "check_gpg": true
+      },
+      {
+        "name": "libatomic",
+        "epoch": 0,
+        "version": "13.0.1",
+        "release": "0.6.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libatomic-13.0.1-0.6.fc39.aarch64.rpm",
+        "checksum": "sha256:7dfeaaaf4b49fd68b4b17aef47fefcfd6aedb83f7551123182dec1ba30f4eb48",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libattr-2.5.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:e28b42b8fcb1771c9ef3bd78045ffdceb00f4255fa8a08f5aa90399b4f8a1414",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libb2-0.98.1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:9e9cec829b408d471e732cd8a9e54babefded5234a31b2b6e81b8907e9bd9fd8",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libblkid-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:6e6ea4123e4777b1d66c46d919934ba6d3a95cb6cbc6ac797d88f1ac21bb1b06",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "11.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libbrotli-1.0.9-11.fc38.aarch64.rpm",
+        "checksum": "sha256:ea903340bb561eb07e43a9d3659badceb2992696015f1869b42e2c8932158d5c",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libcap-2.48-6.fc38.aarch64.rpm",
+        "checksum": "sha256:a63abb2c9c20877409f8b7a74c7fef52c8ad701219a206e52ba20c9fe03da376",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libcap-ng-0.8.3-5.fc38.aarch64.rpm",
+        "checksum": "sha256:487fb0cea28d207da310d7d8e7e298ed4784e21bc198cf44b4f8ae1303c9abe7",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.10.2",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libcbor-0.10.2-1.fc39.aarch64.rpm",
+        "checksum": "sha256:b799e33ca82fca0be8ffe86202c725912e46ea61d160a957502424a40f095e1f",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libcom_err-1.46.5-4.fc38.aarch64.rpm",
+        "checksum": "sha256:eb8e22f358ffa431a7e4e13e564089af70de3dd009421bb12299227ceb5348be",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.88.1",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libcurl-7.88.1-1.fc39.aarch64.rpm",
+        "checksum": "sha256:7859fa38c737344f1dfa05c31143db413f14704908feec07b3a67a2a487e30a6",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "55.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libdb-5.3.28-55.fc38.aarch64.rpm",
+        "checksum": "sha256:db3f92441621b09e664be6790e6a279c036688093e7a5175927cda394756c214",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libeconf-0.4.0-5.fc38.aarch64.rpm",
+        "checksum": "sha256:9bcccd2b110d8a6a3d07a7aeed82b4416db762a22239346839838445a0a870d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libevent-2.1.12-8.fc38.aarch64.rpm",
+        "checksum": "sha256:c7a71bdfdb966bbc2166e214aca99d324e16e8a0623246ed8664be8be7a56aa0",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libfdisk-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:1235525527c3615d54e069b5df00c6528f6b359196cf8bff2e6703bb46a786a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libffi-3.4.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:fdcd3745c2206fed259467bd49a96344c15a192952bc6f04b070e8b2995085dc",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.13.0",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libfido2-1.13.0-2.fc39.aarch64.rpm",
+        "checksum": "sha256:f3b9a49762bbfa7832b11514eaf441eec3431a174ec257607cbb221d7014cf44",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "13.0.1",
+        "release": "0.6.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libgcc-13.0.1-0.6.fc39.aarch64.rpm",
+        "checksum": "sha256:6d630a00ff5c09a3ccfcb2f40d1317b2b75cb97650840df6cd5b1c436c984747",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "7.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libgcrypt-1.10.1-7.fc38.aarch64.rpm",
+        "checksum": "sha256:79fecda5af50e235d6b4ee9bc20834bf046cb15cb6f8f71ebf3b534759a78649",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "13.0.1",
+        "release": "0.6.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libgomp-13.0.1-0.6.fc39.aarch64.rpm",
+        "checksum": "sha256:1bca2d927fe01ab25b2cc591bdb9f494397d99ec9eb72a93bcc53d1b8173da14",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.46",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libgpg-error-1.46-2.fc38.aarch64.rpm",
+        "checksum": "sha256:de3b9ad8d5651675a2293e93fd88fcb3f6eb0f269f255494898d40fa9c3cdf34",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libidn2-2.3.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:55756638296d53fdc9dd8c6b46c29bac98c890cfd9d558fec3aefa3406b358a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libkcapi-1.4.0-5.fc38.aarch64.rpm",
+        "checksum": "sha256:b676e51dda545d40276b27e5b39adb68a26611ee2f2881efca9a63a99dbc5674",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.aarch64.rpm",
+        "checksum": "sha256:d79bd2d236c80c08037c820c56ecfd85faaa227af10b08ef96540e1fbb5623b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libksba-1.6.3-2.fc38.aarch64.rpm",
+        "checksum": "sha256:19ca5402cac14d896f0422469446a4ad2157909ac383d611918f0436be1aa7b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libmodulemd-2.14.0-5.fc38.aarch64.rpm",
+        "checksum": "sha256:00dec4b42cc8db4401eccc6a71353313a8f1c9e85b8237ae74bcb67a1f4415b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libmount-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:fac4d4b98282f5defc0802b2468bec30e5e6748c93719773b80da15e5567934f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.52.0",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libnghttp2-1.52.0-1.fc39.aarch64.rpm",
+        "checksum": "sha256:eb127da21f77c89e9e892b657018961ed54ffb43e55693482f1aaff06690f521",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libnsl2-2.0.0-5.fc38.aarch64.rpm",
+        "checksum": "sha256:4b9f156faebae07f512e2e22a6d104e86bc9fc86056dcde54ae1eb87ca057eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libpsl-0.21.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:4e266ae94a5854f59791cb040dd6e3ecc89a7c87590122a5161991b351d5408b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.5",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libpwquality-1.4.5-3.fc38.aarch64.rpm",
+        "checksum": "sha256:52b8c81f48a48855c95c65eb166dff0130d80948d3128ad3cd295e643b278d74",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/librepo-1.15.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:8e7220bd2de39708cd2be2788c4c3bd95bf12590260ced37673849b892dec309",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libseccomp-2.5.3-4.fc38.aarch64.rpm",
+        "checksum": "sha256:5bb6e5af81ec4523bda8aa99eff6940eec288d9e45ed354796a1aba58a8f531d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libsecret-0.20.5-3.fc38.aarch64.rpm",
+        "checksum": "sha256:6dd14c7a6678bca18e33694e37d8e26cd6cb165165a4acb04fbeb019d0edf05f",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libselinux-3.5-1.fc39.aarch64.rpm",
+        "checksum": "sha256:0667adcc1838d0193392fbded9d354955b2c591d5526930e30f2b083215975af",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libselinux-utils-3.5-1.fc39.aarch64.rpm",
+        "checksum": "sha256:a78cc23b4f327c88acfe7a57fc24419563efd94e44987ed7b23ffaad3c0cfea7",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libsemanage-3.5-1.fc39.aarch64.rpm",
+        "checksum": "sha256:09dc9676b44df287dfa05d9bc7b14c83b8474fb44c48e10c1e244d23017b5656",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libsepol-3.5-1.fc39.aarch64.rpm",
+        "checksum": "sha256:529bcb4c6d2060c8fce9b52bd8fb4cfbb807df374281a4e0d69e7c905df662e8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libsigsegv-2.14-4.fc38.aarch64.rpm",
+        "checksum": "sha256:6b1a20e0fc39a72fd9e555ee7aa9975276427524508d48250d0bcf1f8f8de0f7",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libsmartcols-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:e067c951e005c0d2c6e8153828eeaec0cc8f50aad60a3af56764eeb79128dec8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libsolv-0.7.22-4.fc38.aarch64.rpm",
+        "checksum": "sha256:02a1eb4105799bbbc62d2a5964a29ab0e2c89d8e07932609af067152e358ec56",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libss-1.46.5-4.fc38.aarch64.rpm",
+        "checksum": "sha256:c5828fe90bb4659e9373383d381c73a0232cb5dc6abb4144ebf0d194c81176c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libssh-0.10.4-4.fc39.aarch64.rpm",
+        "checksum": "sha256:e85faea7d600be67caa99decaa81a248fbfe90a629a38a66bb3a43f2a8050bd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "4.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libssh-config-0.10.4-4.fc39.noarch.rpm",
+        "checksum": "sha256:1bc707f6df0aac3eb69be6e32be2edb32c772c1afb63300577e72fcec472af54",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "13.0.1",
+        "release": "0.6.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libstdc++-13.0.1-0.6.fc39.aarch64.rpm",
+        "checksum": "sha256:24152292f7b94c35e36aa896f1cdf79b67e9804b8f69dcae79d69232233442e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.19.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libtasn1-4.19.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:301dfc48d40ab87f54178c1805bc3ddf40daa666f72a9c986442dd3e3febe657",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libtirpc-1.3.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:24a4231bde0e44e99eaafa9ae7fc65940170e9df0654e81c3a85ae8979ff61b8",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libunistring-1.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:45ad13f2e16525392a44e438a549c2244b0ed6f91f8053c7780bd381a3448c25",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring1.0",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libunistring1.0-1.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:342b090523748dbd93de4d39adc5b059f388893bd086b3c11f1c3dc16770a520",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.26",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libusb1-1.0.26-2.fc38.aarch64.rpm",
+        "checksum": "sha256:a9f260ba16734b6d1be9672e6fe2c7b77f6e868a627d56e0c0664bf32388dfad",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libutempter-1.2.1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:5d2895e8e2c0f843631a268130c1d24dca9c78bc29151ba9052c717bf9cf945c",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libuuid-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:ec754b5d6d177e9a91469c45729b7849c231d06a7dd004f8e5eb0c8cc304fe28",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libverto-0.3.2-5.fc38.aarch64.rpm",
+        "checksum": "sha256:f1bfcaeb6e03a843aa6a06c064737c4a3e48ace9e5353328aea3754eb0d489bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "7.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libxcrypt-4.4.33-7.fc39.aarch64.rpm",
+        "checksum": "sha256:141e746033217535d30b989e20cb565aad275e05e7971067f4a11913d2fc499d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libxkbcommon-1.5.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:86aa1169ef9757e59ca01b1557482b04d08d9436ac08e880c81efda71a26f346",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libxml2-2.10.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:a6842664d722aa02d086ee369f12831e614cf7d3bb022620d201271a26372915",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "9.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libyaml-0.2.5-9.fc38.aarch64.rpm",
+        "checksum": "sha256:4644a24bef92e3c236f2273a2771e6172ad32a6ef23e274aed537285ff934cd5",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.4",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/libzstd-1.5.4-1.fc39.aarch64.rpm",
+        "checksum": "sha256:c6dfece5f9bdcefd5e881bfe85239bf0b662ef45af238827620653519142cc28",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "9.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/lua-libs-5.4.4-9.fc39.aarch64.rpm",
+        "checksum": "sha256:267735e6b9efc4cc058fa926a9e432fb6c44b97b0c6e5037e24ae7bab75fa53a",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/lz4-libs-1.9.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:1885d9d961bd04783d3c34309883c96eb041c0a5b3ce287892765444247cc8d3",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/m/memstrack-0.2.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:5f2f2310459ef50d0bb8504f6744608abd949c46f7d798937bc129ef5153d647",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.15",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/m/mkpasswd-5.5.15-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f0bf5be760140e4d27eccc9ba1c45c1db070ac1b03420e8677000f82e6eeb107",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/m/mokutil-0.6.0-6.fc38.aarch64.rpm",
+        "checksum": "sha256:d63c198d35e144112b2bb3fff5918c56967a1a764478584e79be0967c71c35d2",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/m/mpdecimal-2.5.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:d94deb4d35588d4c8e91242266b2d7b776b94ecc3234bc7b94ef5ff786bfdad1",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/m/mpfr-4.1.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:ba9f5eeb8b85d79e215f70369aaca0c441073ef0a4bc94833842395c0ea8c8f5",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "3.20230114.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/n/ncurses-base-6.4-3.20230114.fc38.noarch.rpm",
+        "checksum": "sha256:f5c2b7e34cd518428e2b57b97d53038a35112bfd7dcf70b99a362edf6df03174",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "3.20230114.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/n/ncurses-libs-6.4-3.20230114.fc38.aarch64.rpm",
+        "checksum": "sha256:f00be46cf33948f4608beb6e3a08cc4aa33bdd4ca53dd66cc1995ac82529967c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/n/nettle-3.8-3.fc38.aarch64.rpm",
+        "checksum": "sha256:d41ee6bf1cf3506dc2e686da05fa297abda41b0aca14c1df121f9e788719ee5c",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "12.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/n/npth-1.6-12.fc38.aarch64.rpm",
+        "checksum": "sha256:70e7c2d53e2d87ceb220bc6d1c06535d4a11ab3c8d1ff964a498d058698aeb36",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.4",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/o/openldap-2.6.4-1.fc39.aarch64.rpm",
+        "checksum": "sha256:24602018d0132dd1b8fa5e703844d8a732d7715b82949784f886128985f61646",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.8",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/o/openssl-libs-3.0.8-1.fc39.aarch64.rpm",
+        "checksum": "sha256:e89e25b52a60c39da1a2bed8d386572c3dfa5f06b7659c5ba52d45745336355d",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/o/openssl-pkcs11-0.4.12-3.fc38.aarch64.rpm",
+        "checksum": "sha256:2a487be4156533f0d60db98bfd3459c2bef15bbf231f9d474d0ebf123d3ddfc0",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/o/os-prober-1.81-3.fc38.aarch64.rpm",
+        "checksum": "sha256:c500caab153179a9c7c4ecb6defe2d925cac2ba56621541db5afc576ed3230a4",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2023.1",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/o/ostree-2023.1-2.fc39.aarch64.rpm",
+        "checksum": "sha256:ed631d2c111797912e1ac855d02ef78296d1853e4d1957f72f19c83afae02079",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2023.1",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/o/ostree-libs-2023.1-2.fc39.aarch64.rpm",
+        "checksum": "sha256:a518527771195f92ff52297a56da79ce282d4a658ec610e159c9a6be97cc2e17",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/p11-kit-0.24.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:5e8458439742e626901956a5c65347e23af571fddca04e2987e1e25320811e31",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/p11-kit-trust-0.24.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:4883bcb01e87f0dd5182e3200b24640424fdd55c3a18e46b4164eb92af904c3c",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "17.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pam-1.5.2-17.fc39.aarch64.rpm",
+        "checksum": "sha256:d9e0f5c2291d5cc4818f014caa6dd5c465d873e4d958d85d9bf7be04a8d9fa91",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "17.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pam-libs-1.5.2-17.fc39.aarch64.rpm",
+        "checksum": "sha256:ea126779940d8cfd1f0f0b8428c1d8ce2ca07a6d21e3db77a00f036f15004f9c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pcre2-10.42-1.fc38.1.aarch64.rpm",
+        "checksum": "sha256:9628ab6436ad123ff03b6d1ba703218604f5f1b9845f8cc835614df30341c678",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm",
+        "checksum": "sha256:4f19a70d3fbf30ac298700d3918d7fb483a387adf3d08b96efaa07d51dd0b156",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pcsc-lite-1.9.9-3.fc38.aarch64.rpm",
+        "checksum": "sha256:b4a95381f9f9aa1228c429aa9cb25502a448632b344f16bb693e5b8993f4d1c4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:89b0edd10bdd990197605b7a938a0e25070524d83ffd986232817ca436874719",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.aarch64.rpm",
+        "checksum": "sha256:fcd6ad8c1b3550477db0783a1b5e59c74ce21909bae128259f4215aac4b03e9b",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pigz-2.7-3.fc38.aarch64.rpm",
+        "checksum": "sha256:d5892ae6b2d9f370615dc668f1b4d4de7fe5067c192939e1f9c5648181198369",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/pinentry-1.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:7787ae522c7e74b912d13598e199c523d7ded171f9bc872f1f2656b393b6db19",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/policycoreutils-3.5-1.fc39.aarch64.rpm",
+        "checksum": "sha256:76fa76c9c989b54d0677e3bb8eb89805083d6c2c4475325fdb57d2db23c45275",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "122",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/polkit-122-4.fc39.aarch64.rpm",
+        "checksum": "sha256:4278312d7fa6c806c42a56c332f68a95cdabc86450ac3c0ebd8f2ff696c8c19c",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "122",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/polkit-libs-122-4.fc39.aarch64.rpm",
+        "checksum": "sha256:b1fb1418b8643edbbede7ae066d929946118a35832e4ee58676e7f65303ee781",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "23.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/polkit-pkla-compat-0.1-23.fc38.aarch64.rpm",
+        "checksum": "sha256:7fb924a539d5f6a8d9656886a2ffcc4850e6674e37d427d424623fbbcb64fc65",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/popt-1.19-2.fc38.aarch64.rpm",
+        "checksum": "sha256:67bfe5c18c4eebe6cb28ade72b9af54d0f377b311da527a6cc7d133bf02a5e99",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "9.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/procps-ng-3.3.17-9.fc38.aarch64.rpm",
+        "checksum": "sha256:27df4c19fd4e7b72e35493f84f0f79ed809e02e9e628615583fc44973ca2d493",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20221208",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/publicsuffix-list-dafsa-20221208-2.fc38.noarch.rpm",
+        "checksum": "sha256:3cf03283e8e07e37763931446a599809c069fe25c20a0eb6dd6386f447673e06",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "23.0.1",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/python-pip-wheel-23.0.1-1.fc39.noarch.rpm",
+        "checksum": "sha256:b0d44fc3728295b16ee16e3eea5981c56115ef494e0e1dbabc04670c3a99aad9",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "65.5.1",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/python-setuptools-wheel-65.5.1-2.fc38.noarch.rpm",
+        "checksum": "sha256:54aa1a0699326aae0137529166df648a393331e99280ca10f77f6fc904caf9e4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.2",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/python-unversioned-command-3.11.2-1.fc39.noarch.rpm",
+        "checksum": "sha256:7d54836133ed06083473cb58977db4422dfb201cb73f18e730d4691eebfa5414",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.2",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/python3-3.11.2-1.fc39.aarch64.rpm",
+        "checksum": "sha256:a8207759999dd01b23b25e81cfa591a9f51c60cffd59c62c095f4bae948d1063",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.2",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/p/python3-libs-3.11.2-1.fc39.aarch64.rpm",
+        "checksum": "sha256:133e62a07a3424a90352289359aeaefa078a1657d12329f97f24c86799230c53",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/q/qrencode-libs-4.1.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:f8b227c1cd6fb8987ef5885853349f2521fa2103c4c8577bbb77893589559a3a",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/readline-8.2-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f198fa50d35112320ae2f81bfe83d4d626160ef3e8dbba16285183a747a96655",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "11.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-4.18.0-11.fc39.aarch64.rpm",
+        "checksum": "sha256:9e932e568356dee94c58e0c59ac0a825d11a89f45e8b82c5dd17b046acf8c9f8",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "11.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-libs-4.18.0-11.fc39.aarch64.rpm",
+        "checksum": "sha256:8005fb24037a3c7c4940bef13fb0b37df42581e567e935c86281a5ea30a01d82",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2023.2",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-ostree-2023.2-1.fc39.aarch64.rpm",
+        "checksum": "sha256:87f3fc51ecc7dbbebcf9c1290d1d959d483cc171552bdff4194ad741e34bc0e4",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2023.2",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-ostree-libs-2023.2-1.fc39.aarch64.rpm",
+        "checksum": "sha256:154d5875948c1aae996881b55ed71d42a51f9c138abc65950657cadff707269d",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "11.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-plugin-selinux-4.18.0-11.fc39.aarch64.rpm",
+        "checksum": "sha256:4c812941dda067452d42b3820ac7b56a1edd0cdcd3df4002f17ecc1c69ba630f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sequoia",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-sequoia-1.3.0-1.fc39.aarch64.rpm",
+        "checksum": "sha256:fb71e84c6261a71b49cc96be5305c71c54598c602c58dc7f709fc5755dba2af7",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "12.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/sed-4.8-12.fc38.aarch64.rpm",
+        "checksum": "sha256:06c58a3605d3cafc7c442d2bb39ed2c944ea988fcdbe9b62dfb0b123f368c7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "38.8",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/selinux-policy-38.8-1.fc39.noarch.rpm",
+        "checksum": "sha256:f894df6361e474e904a667bbe9ab110af509541462932ffaa2cd1ca6b550c726",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "38.8",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/selinux-policy-targeted-38.8-1.fc39.noarch.rpm",
+        "checksum": "sha256:f6d14f22f3b4e8bb3428d2cbef4e75821ec5c132a08816f159d82025be36f774",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.3",
+        "release": "3.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/setup-2.14.3-3.fc39.noarch.rpm",
+        "checksum": "sha256:e10c0ec1a70226866cd13c044cdb398d519fa28ae3f2cf5747b6ce799d3bd0c5",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.13",
+        "release": "6.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/shadow-utils-4.13-6.fc39.aarch64.rpm",
+        "checksum": "sha256:fb3ca377066ec35b4e93c52dd47625dc371d6ebfc5fe1da28b4e6c97186eda67",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/shim-aa64-15.6-2.aarch64.rpm",
+        "checksum": "sha256:3aa9b7d8bf7c0d00e83d52180b24b2660ab3f4d72b454d82ecd0bc5e5aed4263",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.11.1",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/skopeo-1.11.1-2.fc39.aarch64.rpm",
+        "checksum": "sha256:8cd25bf3b1e71ea95424a8a2c9e1b608bc6fc22a0be1b2915824a9f133924731",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.40.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/sqlite-libs-3.40.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:ea43195642f245445df81cb11388ba262834e84643cf4cdf325e15c90014eb82",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "253.1",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/systemd-253.1-4.fc39.aarch64.rpm",
+        "checksum": "sha256:b12f7396d7bc5071ea8551cb8f6c28fb6fbe716ea38a7d5b73fb3d5b30948ab2",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "253.1",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/systemd-libs-253.1-4.fc39.aarch64.rpm",
+        "checksum": "sha256:a743bc050a18d34091325448e5e7f7ea9baee51045d3485ea13f27f7459671e1",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "253.1",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/systemd-networkd-253.1-4.fc39.aarch64.rpm",
+        "checksum": "sha256:b662e452c110095492b561a02bc1b96088e2e25b9cb925239b5f81358a58cacd",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "253.1",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/systemd-pam-253.1-4.fc39.aarch64.rpm",
+        "checksum": "sha256:de66d62ae7c16f6e74a20b0dd8635c7dbe77c7ebc4e6bdc23cc234329c2676ca",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "253.1",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/systemd-resolved-253.1-4.fc39.aarch64.rpm",
+        "checksum": "sha256:2122d4c0d41ac42bd3a7cb365d199bc462203fe443e403ca470784a1e02ac17a",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "253.1",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/s/systemd-udev-253.1-4.fc39.aarch64.rpm",
+        "checksum": "sha256:c0feebfa4ef016fd8645cd1f75291a97a79769957347d4b5c2f13042a11a9670",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.5",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/t/tpm2-tools-5.5-1.fc39.aarch64.rpm",
+        "checksum": "sha256:517b9d47e7b4ec7b8d1856f4525a6a60feed38617fa47767bee1140f812d5214",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "4.0.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/t/tpm2-tss-4.0.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:33132e2cfc1552b6429ddfde328d8e350294cad519a34860c3021b4e4289bccc",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022g",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/t/tzdata-2022g-2.fc38.noarch.rpm",
+        "checksum": "sha256:e9f81f7b77e1011de9e9cf4c68a149aa70f4f33e2bfa394213396115eaf9a2d0",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/u/util-linux-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:60245c3414a8c444103e937dfb1251cd1b18afc5f3c811daff1faa6f4b8875b1",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/u/util-linux-core-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:c15357e1e23afd9e156eeb8955b08a68c0be3ef65089d2aa4beb4aaefca3300e",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "39.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/w/which-2.21-39.fc39.aarch64.rpm",
+        "checksum": "sha256:5349c5841c28e67a4f1ac33c0e83ab7029a2aa16ec323dad176b3543e65006e3",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.15",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/w/whois-nls-5.5.15-3.fc38.noarch.rpm",
+        "checksum": "sha256:05cee3fe2968c1f5e507a7c0908e40ab2337f03df07292d9743578a7069af40b",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm",
+        "checksum": "sha256:c77fd27cb1dc592a2d9ba9238b80aafdf340749d690f15db59e8483609da884c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/x/xz-5.4.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:14dccf84910696379b89995cb513cca8e2f7b7367989b3263045b299286b9234",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/x/xz-libs-5.4.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:278c8a31a736d96b08f1042eb801290c7e3b28d899364d9bb7c300762f2bc313",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/z/zchunk-libs-1.3.0-1.fc39.aarch64.rpm",
+        "checksum": "sha256:06579903320ca98b1290fbf773743cc464df3af43bb64e92c735b455f2b4ff26",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.13",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.aarch64.rpm",
+        "checksum": "sha256:b1f3751a9fdaf0c918bad3ca42a0984bea6d94d382995c3162bf6b391e53e21d",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_39-x86_64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-iot_raw_image_customizations-boot.json
@@ -1,0 +1,5647 @@
+{
+  "compose-request": {
+    "distro": "fedora-39",
+    "arch": "x86_64",
+    "image-type": "iot-raw-image",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-modular-20230310/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "image.raw.xz",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {
+      "customizations": {
+        "user": [
+          {
+            "name": "user2",
+            "description": "description 2",
+            "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+            "home": "/home/home2",
+            "shell": "/bin/sh",
+            "groups": [
+              "group1"
+            ],
+            "uid": 1020,
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "uid": 1060,
+            "gid": 1060
+          }
+        ],
+        "group": [
+          {
+            "name": "group1",
+            "gid": 1030
+          },
+          {
+            "name": "group2",
+            "gid": 1050
+          },
+          {
+            "name": "user3",
+            "gid": 1060
+          }
+        ],
+        "services": {
+          "enabled": [
+            "custom.service"
+          ]
+        },
+        "directories": [
+          {
+            "path": "/etc/systemd/system/custom.service.d"
+          },
+          {
+            "path": "/etc/custom_dir",
+            "user": 1020,
+            "group": 1050,
+            "mode": "0770"
+          }
+        ],
+        "files": [
+          {
+            "path": "/etc/systemd/system/custom.service",
+            "data": "[Unit]\nDescription=Custom service\n\n[Service]\nExecStart=/usr/bin/false\n\n[Install]\nWantedBy=multi-user.target\n"
+          },
+          {
+            "path": "/etc/systemd/system/custom.service.d/override.conf",
+            "data": "[Service]\nExecStart=\nExecStart=/usr/bin/cat /etc/custom_file.txt\n"
+          },
+          {
+            "path": "/etc/custom_file.txt",
+            "user": "root",
+            "group": "root",
+            "mode": "0644",
+            "data": "image builder is the best"
+          },
+          {
+            "path": "/etc/empty_file.txt",
+            "user": 0,
+            "group": 0
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora39",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:ba73a191eecdd07dfdf6c9e9c05ee8a7fc033d00ab22f71c9d765a9f79430932",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ba219030ec4140c0275c00482cbf8a8130e27d6185eea52f715350656a7f853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4a9066b30983c17036794e7873dcd62acb2559ebd298d00bbf27a555bc1e0db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:156c71be29a4227e99d5198272a6fdbd38f25884de10bd3b03722602f383e56d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:16d1843cdac488ad04bdc654dd6b8dfbfeafe33a7728695070481302a7e54345",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aafa892d920ab841a6e6076da3f0bfd4d5783a88927473acb6fd8cdff1686f90",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:228e3e665e38c1e49397b1fe6e1c98aa29b7434e8aa25b39a44b3edc5a362aa9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0214026e8899bf3455f97bed98c287644e52f9350ce977fd0ccab05dbb35b77",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ed298c957602edb7ce91e0d06c4cc876c645d5e9848cd9553b5521ab1dba8a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cbad3c0b6b1b8c73ac219d5ed3772c89331e46a5fd8e4be3dc065e2021ef904",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b14738a69996f820a42c8857412d1fa62284932da5874d3d2eb39f0f356714b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7867d881d29f8c33cb137a99f2c6bbe01456e502291fdb760e7542c8c291b4ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b6f3880d1daa1e26cbc410cb9a297be024967d49aa60a660c4e3bb210c1867b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7da7355b078353592654642e662cd68d9518c104b3d95fe6c24cbca3510a0d5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d792de0f75798996e8cf2851ae04b3a47d3e267bacffbfcfb02a3d9571f9be00",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77e278739167196fcbf7b6a538e954dc7857c3ebe1dad36a3940be0128746d60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67b6c981dbc626378729138b7eec77198053d6c4c354a5c638901afa30c5a847",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73e923d9adbba6384840bac86c7664169fdd74f61a3db9407840f41f91e63d9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80a414135a766a8ca123eb392157e82e837aec38c4d6aec849d62494a1acf28f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2320484133302a774460dca284f0b78a41623a0169e935ca62b3e7c9ac291ce7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:288c3f12e3c1c65e522c82a1583eb57972b595ff4e62c685b904b6e479d67093",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ad0000a318a04be81dc299677f2993b7283c39c5a350a56888c1266194f7602",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:527026089d1cbf7b681d916a37078e552349c7183df0bc51a37276c330391e22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42a6fa3db480f36554e51af9ca2c25a523e005ea09dfe3489403254496934e66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90fefdd11b8d06bfee61cfac21bfbf92325b3b4dae06547395f6f2c7b5deed10",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2f93d70bc111d246a0bf846c86e98b14e625e4e3eba0d95bdb1b6e3d803d3e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99ab50da3c0a25f5bbb92d3b3920abf4a01800c3aeac76e61fef877e760a3b41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e25af815ea18afcfe8cab5f50fec3b2c8e602880e912b37dbc07e81e7a48f69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d7d79d18255d8e8e45c4b9fd666fc9562d9a253b599b9ba4631b6991221479e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6a82c3256e0420169b0dd940d978894321883e4c316fb4e996989adfa89c25c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e919ba41c7e69504041ec33a5118cf696c19408b9bda7d30acacab8e0e8fea83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:291c42304b5977f3c2c611ade53af3d146d8ad5f8c83c1c1f5c6ac92acadf2a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5fa9010ad567df986d484ddcac865ea25a26c818def22df0c4e3688fc346568d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bba199cbc2d5363334072bc40d868c9c0ff301d67dddd14a55f032043c9dc824",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d57c8a275a9db4aaa234a73685d075b74b00930d7881ed7892748b790773764",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ff9a034c4cc68941868d2fab9fb0489fb7d2f7667ce3fc645c296b70ecb408d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbed67f96b39130ef7cc8f0b1a267eed02cf7b7f7c17faa2be7ddc3e4374ac72",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f33f41efdeb7ed371ca73539df63e0a24e1ba6f1c08eb6b3a13efeee143c22cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:450ad2cb89b8e99a9e285a87e5942e1eb04c19da70afd229a9c0a168860b64d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70059465e292dc49a920ef7db57d26e82410aebf6ab8d1264d8e2716c19f6645",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2af61bff099ba092381fc3bcfad33abeb46e0bbd80d39957160ebeeeae6662af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04db736a77296edd4099a9165d68560d52dbf2484d959f668b3b676d68581f97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69c9711600ede5bd00494ae8dafa400121de28f70cb4784f4546b8810c4b4cd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ecb72298a8b662ee1a17e7fb4e1d279d7fc64b358c9fdf9a568a965022b3f97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3908078cd7debb2b2e081a7ea30fdf598f702ba7e65db7159836403940ed2421",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02f807f62c5d65d6e204aaf604413cb960f322d9eae08b38b82de21a537d0d59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9d47d4f8c115837a086789d8da306a435a77f25789ebad06c110da407864f34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38e188b7682c3df92bcebd568812b4f0de6f35d785a7d3e568acc3e6e14c28c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dec19668dc6051323597760b1dcfba516e049d99f4d4faba181ab89bb76dfd26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d949521c5b898a94e9c3e2ffed751671b652687b34016ceca4bef650c68eb3ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0fd0950f4c4766556a58a23aa878c6e43ff2aadb16541361c16330b275532ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f6c383fa225665fc42dc174762cee30f9ae6ffcc247b324cc3cfa67ff75ba44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94a66aeb619bcc64c9f4da716ac356eae4cc48fd746a4efeaeb3be1d47339003",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7db0f713c86eff1668979f122b8cba968dc621a17b6d60dab73470c6aeac478c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:68772d2dd6659cd0eafb405000585bd7589c987274809ed0fe07d28ff85ecb2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:319b782e36d052581555edca137af6095cc1aaac007d9bdc1d963893085587c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b835a3d70d4b826f41d9bd2894fc0575fa609d0431d1ba2934db60eb261135a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:212cb1084c3d5a05d12308d768417dd12678a860ccfc89c2f70dada566e11259",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d7baf4131395fdd190b584309e4656c86a3cae3e39368866be827ffd8a31576",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c5d61f2209be9748c7ca38cfb9714b699d1cf3ed84087cc7af55f45382d6716",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:164b2bec69f169b4ba2e706655d1cb92a1e547c0ecd99cc7ba190e2643600d6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36a64a62d2f251871c1616451befd54d2761448d668de0371e05a59a185c99c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e911b2035148f19a606bdd11bbcca202e673b1e3d8c6dbff989b77b2ff761fd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1573a247a3f3a89273c1bf230cd5a62196c5aa22ddf13d0c44684ff3ad78ca9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f50f77a0ba03e554cced7c779b18e11c099a5abeef74d35f8bdc015c7618b5b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b30c7dc86e31ea87fcdbd58c9ee126c8af9a84bc8a23cf30858af5e8ae8c822",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b940446486f6dfaa2a7651fd9cf7050cae6171d75b7fca865fa8d58400c1a0c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ef881ad8a2f683020cb4d49a4bac6a8947ca5f826266391da945834f95b42ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7aa9604ad09e1985b610278a5412b1393b1928b9beb64baee783d4618ccc90ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42aca1f4d1635dff866d060af6a97707b015f892570077ac92f52cd940522266",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8a381267845f761809f10b8d27db002a1a5c6b2b54bd6720fa0d921439268f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1edd6d0c726af868fe64c6fb8e62b72e55dbad94ae0e3a835548aa1160f57bda",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2101508acd9f16f43fb1781e7242fd5ea1570275ab9f596ec1fdd622ac947d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ded6a789884bf08981d97c15f86e24bcf62d47ab0453404068949087ab63706c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c76b7bb46e9eee4137415778575da7d0b06db811c35afa2a9833d82b25d6bd91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5ea642626ff8f0506e27fa9dc70fcfa89a430f1eb641a03926ef38af4b2158d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30eea609388f8cf3f8418eb7e648262d5053f9171eb627225c89118dda9faa6e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ee988694d3c875dcaa4741453ee07b4dc1da31205abb035065dbc7c8c72c0da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d06140e05f5d7c831331260a898d83e5079a3ead0f4616925dd94da8a33e5ede",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5540bc7f5d2f38cc82aa329a0c2078060a13dd27096238776f7b063cae7ccd70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d55660b07157161b5c6c54182033581497d3704433f9a4701c36e36b8f668616",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9858eb4e6a8aca2d0e69a57d3db25f1a561e117e6c6221ccd0b3518f7db7f01e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58f75a8368b74d16380f7eeb1c506c3907ab4d168a91bb092c96da81bd27f59f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8003e886f65342e06c75edaef2bc54b1f313a9b19ba3d8b573b7b72a9583d87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8411db01396745b0f2a9fd2107e04ed89da22e743dc1f8c2b1c341391be7c819",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:162ef2aebef5ec4dafe56be3f7fbf82c5d1fee147ec4d85e350713258cf45865",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:821b12de1c46ef30a5b177bad1f0bed53097311692845c55dba98e4af15c2033",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96e794f0c3a2d542760e6584f792b76b187699f58e218ea84d1232d1f43ed0fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bd57ae89a0e8c2205bb8a043e605a445e1983834f1fe8d29edccb7ee8ecb0dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4b337632153e008b8fcd39c5cafedb90fb03c6e765ebc610b0effb6e9409721",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a930ab3e11e25093f322f907e1d96cf38d75054b2566611c4414723ac1b5016",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13b6ee1aaadee8fc6ad6713f6fcca12d340d8b662c341ef11eb1bbca9f28b1d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a6b60b523093bc2c3f31a14618c3f168faf5b9088cb422e08c450af62292153",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9dc90426b66ef657dd666b8cff6a8b79d97049940e04fe432c1679407d7190a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f07644af2a3529eac157814f85268a09d8697ceb068ebd564011789d7ca8391d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1437effaa1e9cef61e6d942b5e7e352965d33e44666805fd4107f660d7a825e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e848c54481fef3a2afc80a5c38dfd580ec05d821d65361d48a989128c36e5aaf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a8b121b402d579ba941a7e47513e68ffce46211b252d022ceef6d38706f7328",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7428fe201f901420f8b84fe5271744d97aa06eff52ebe35b6b1671531e54418",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7eee29c05014366ade22f339b3b064bdda71a02d76d833173127255e2bc87c8a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ccdcc7c5e8bdc1eda8407a6644dc5ed8f66b4915ad7e54c462373b4e8b7e5f19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24b6237f18f6e0643e96a882d3711b5e7411256fffc547ee1a4daa7da0a62f9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed115185dd2524d6ad37c4e5a7c26c2ef11461ddd2d52a4e0c73c9b61963f709",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0bb1b0d7fa1b5107c98636cc9046912b848e770eefa43161127392bb86ab4559",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb26853ca1388c3c8488ec6459f0288253f8e31e01c7494c0b3073430efa7ba7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cdee7e7f885d9efe8156bd86e644e2b45f34537870f30c17bbd5113e493b994",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaec98669b65aa4761783244a9bcbae47dedae32889d1b9cac72ad74fb165951",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe2f422d5c7b9940e4b6f5ba8df16a7f1a566469af6190b2e61b81e743bb570b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f13a3ba0f10a4924a4ac460a506e45559421b392ecf5c2ee258661e19ed93941",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49e5cc3613a661ac06ba5c14513f4dd3d752b7a4b308a8ece3bdd81468cf2aa3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3aa69b60ec18c1fc47367041aca9dea0582fa14b31c7bee12538c4106acce87f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e24b40ad581933d9ca22b525c434777d90a46cb4c0b097c497c788e49fd946d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0dbf7d0db94a9cf1745aedb5462d6877d82a99f9010f5037c796ba41f5c737ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96ceddead12aca9f75215a0492c6c0308902a55e1d756267dedc7fa68850aef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7036d00dd6f881adb9e4870edfd5a1240f5b647084ed53be464cf8cc6d40c452",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:858e728f42806ce65520953f756c178764c60e29e1a3fa1ea1e1eb95b14950b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea61e5c61c7df5d65ff43dfa34c3e6fc2420bd1e479d4e15519023c1b832e261",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:893c52ea0bac3758fb0c61c6449a7204fb088193d5ad2f0480ab8ef7af40e59a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e88d40b14861564cbbf640d366076b5b381cc3a30d818930f043dfb3f158e68a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8cb49ad623d30a9fbe923b31b0413732b22f8763ec719efdcb535a356a9d0d6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:893d2125cc10c36b67e5d04544015be0f27d5a99e2ac83ba14904219c5e15d68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f18410a0d1d25049f39315372924c318314254cba55f2d3f24d0c28e31cbbbb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:843187a57219bd86402b570db6ce0b7ef50e9bd3b7dcf57124542356c85e4c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff4d38483cd963b3f43c45738773b2998257e1cd1ed2b9da1ad3770bf6357edb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a861e4c858fb8b7b246c9a5156780ef9188e5058b430a09d5274cf8154e4651b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89ea4d920d4b97d56fc88c4abcc30454059e2a5698aba86633a29346c4d66d88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6cf83800141978f0b6f88a9cf218ddeaf84ad7459f2270f1bbf6da32f18d4cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a119520536c2d78fe4ab09fa36de55321fa5a926aca955640504d6fa7e98790b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f95ec8a9e82166735d2a0dad196caf86d3b03b1d751333664fdc49af04652e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:10295dcfa946c6fb7b52c1b8781da4dc6c59dc8fc0e07bab2f3187fc1f143b9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ac4cd82686478387e18d884e52254370152123a14a6476ece6810b78e0fc9fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ede3d13a4e42ba9fb840d351b3039939e5552f974f5a23981271c6bc4ac7f8a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ee7aaf7efddee4b3dcbad1e7b13f79c4ea58f40d6d0734a29dca359f540930d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bc707f6df0aac3eb69be6e32be2edb32c772c1afb63300577e72fcec472af54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4879018880886651208d90a74357ff33d9230f1cfe05a0c6efc21fcdfe21acba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:755f70836736d33825f0ca0a30966364f9c47f336a9679647806efca38935468",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:633ce6404f6ac32892f2124fa9d8e511ed6d2e3c31d6c9fcb5f9f183416547ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2cf3c52adb539112d160d78ad0eb0536f41a4fc0087ca74043de59267ae397ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a437f855037feb83c8388e0d7799050d178a0e33b72ca2b2845ade7182ad104a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6e85db2da9cc041eef3c34d38d50ec07e0c71a1c1aff8772296572c987076c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f657e5e5c5985e114fd9f957a371d7dd123fa1c38ad8df6a75b1713edd0fa4d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c05ae7b8c8c32ece4656d4aa296c383e9327168c1417232caca03612ff7f043e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a724e47d0afbe9ea8b8750ac8b1db8e1faad7cb77f7dc1907990789f5f5dec71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71a9cbe5c77f55cac9084cbff178924e28b44981a53f82c66c3053521875c39b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27a0bdd0cd20b0e73f2285100a00a81eb162687d159f5952dceb8d298e34ef66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9950c21e3c2932edd669e93be82ae8343cc6ec7b0aa2a9e3656b4b449758658",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9a9659d705cbafd77164f6e9aad0990c4f28822216f59750d3a6835815f688d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae1b79663b5e2810668f0b9350e5d62b64af07cf3e6a85da386b4accd08b699",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3fa33d2f4eb43a83bcf3ddc2775d0a7c272183a1ef6f2d5c0ff9cf95a983d73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:245491bf843da1571cd8b6f16ec3e9569c4b983bef02a28fd53e63a1fac9fa21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a2dd2ddcf1ab7a789633d7a0f5890b0fe12c96ad3c88c7a5f8df547190fdb32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7c0d81cb8f51af66460df06dc8266ca59ba0fe11b9af6649268e3aed51c73b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b263e183ca9f2ad3d1d6525bd466ec30e1dd716318c0efa7ab13fc7a0181ca72",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa3d842fa6c4670b6157050baddb4f2fbb3145ef6249e12ff4d7a75661e552e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c98c47d647f33a5a552c0031d1c7b035a9f54a8a0ba64d220f1b90d4cb990926",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dce785f0955e4bc212f5642fbf76752e8e758fddaf31d423c76064442c382a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5c2b7e34cd518428e2b57b97d53038a35112bfd7dcf70b99a362edf6df03174",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c611cb6193f4bb3971727d46a5f02a196d4d594fbc00ee76d22668e5f9eac477",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ab436b853babb890810427c0906f401a8778570d9c106aae2a93dd689b56395",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdfcd7132d187c79dc0f3752e14f7b4e990a2390c9e62f119e648988403fd977",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:665924d246f41013251f24cc626757abd2a932fb12c58c25d4e8bb005c36605f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bed6e9157e37283845bfd06b1f2e42b3b921e7f7c17786bd48fa535c3da17c15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2f6a4a9a1bdc46e03263959c4a898c29d9873ca2c031a61f365c6842823eef4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f196c1696af163c77062c566618e52a7df7fe6d0f76744596d00d15a86a3ca7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bf2514fbb41e260c1bfb0192ca64f3277ba828c2df6f44ad2877f572e5adf52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f58a005f676fa9c84983fce7348af1f6ee5018edf7bf2c085f5fa39b3b6e7f4f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d099f56457cac6b78d5a7fa1a288449b2fd40940ba79c38f3a8cdf72de08d0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17ccfb5f326ac494420b346b6a19633f6a29666edff3bd2927b24a181c30043d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2759df9eae082382df537953d18a34d81203837669ec30d13d5e6c2ed1345ea3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf1084af759222796497ae1db44733d8572475170e706828af4d4c0c093a3da2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e9d90ae76137486c9584ad0ff007348d83349fe97e29310659b13057dba78b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f19a70d3fbf30ac298700d3918d7fb483a387adf3d08b96efaa07d51dd0b156",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a1a5f81238d9ba5b45b29bfec7a842281f7b623d218b0aa2deb5c6ac7e3bcf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38ff8aa05c220dd39d0c93be24ef211424a04ee3ac3ad9ea67906e38b799bf22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35146cabf07ec78d2390120c9bb9e2f5aa35cb8e0bfff84fb748a198b90ce3ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ac270e3158bcf929b5034d3b8e03d28e877e364b9c1d9c769bf54af783973e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72d5ce188da2f45a3450e472bfde16b72d8d881414298ea3cf321628cf1fe646",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19d52491b049e52228176ecffcedf9a76ddff15bfb2afd8d91aeb76a24b9f277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:419353b49f29e4bd5e5fe58f264db093424c148776c32dcc78a82c8793c8725f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15ae42ad0d83c8e708c06cd6286ca5fcb35f780b032d012c809e96b216a77e60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fafbb148be2f9e1e78095899314044e1ee30a14956b38f295a24f32f3832abfe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00c43379a70e7167e59f71d7da775489dc2f218c768cff68c1edc8e51f35c2c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:139c6a046ae7b9a5693783f75a28b2b99b9411b62e89df3ca634d8b950d7d005",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cf03283e8e07e37763931446a599809c069fe25c20a0eb6dd6386f447673e06",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0d44fc3728295b16ee16e3eea5981c56115ef494e0e1dbabc04670c3a99aad9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54aa1a0699326aae0137529166df648a393331e99280ca10f77f6fc904caf9e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d54836133ed06083473cb58977db4422dfb201cb73f18e730d4691eebfa5414",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ed4609b92a2f2ecebed214447b4f3ba450a5e86e52209af421b45bdedface8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f8b50a8229265341fdefc8472f9d36897e6430439c159d6a3aa87e186f92f6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8d6d9c6f976e196f8eb0a8d04ca1f02821d0dbc904120d0c4bd7d7fc2ef8fdc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a878a4a0448222e0a34864ef4f3c8b674b05ef08a05ea992d9c50b3ecbae10d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8321f09000e84895f3ae6a52963761f2ab2a67fb36753a2d02f587f121e2b3ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:44c3fd81aa5de107c630c8ad571f225e5338450d24df4dcdf2de1b00f619ea20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9210dac0631e049bf2d21111db062b58c668a1cb07584b525da10233870ff5a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55691164bb75a80738db0691ba6493d678f7797953bea35b2df4e60494b059cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dca9b9ef6667bd5fb311bc39129370664d1cfe627be04aa2f78b2c0651a4906b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d77c48d393ffada69140de4d0adb89cec02153c6884d5829d2ed30b422cde82b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13767df6745449f9458b4097fd10cdc5a6f577f53a14cf4d3608052a9cb368a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f894df6361e474e904a667bbe9ab110af509541462932ffaa2cd1ca6b550c726",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f6d14f22f3b4e8bb3428d2cbef4e75821ec5c132a08816f159d82025be36f774",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e10c0ec1a70226866cd13c044cdb398d519fa28ae3f2cf5747b6ce799d3bd0c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8a2cbec7fc78f885cf077f6ee088e64634a48694b94e611ad57f9ee15314731",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:174bda41056c4cac41ef9bf8a7adb06affd92bcb18a258d319b9153bf0f00686",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d82246ac2f3d4f4c5c47739e5176550ca759ac89ee35be920d511ba4d809f4a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e96e91ff1c7b0667539c2d00d1f674a4b97638bfe1b6bc2eb2dfeaa59c127f9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:861df4978f7a58b561d78dadd633e0b642f1fe010f5d9ad7ee1c104a1984b41f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:199b1cd22fe6fb5f3a1d8035dc4f6348486ce9f623618714085fe641221decd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2ef95d47ec9eb73b3054d778c31755c0f487d93d7393f18451e34c9c019ae5b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c159d71832d6b89b2e9ba696464027e54ea91125670bd9d012483b3a7451298",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:499b7d4998f9ee1beaec404e83e5be8ce0b20ac86caa91f849e9f4f2c4161563",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:351b576c1e36e1519502aa1a7e6b3dcec269a18c6bc6230eabb1043f93c6a87b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bb31f92c186b8b042f0e56833f9e3efaeb66dd6c979f869921ff75a249882c0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d624895c7f19e23fb77b7f2ae21a9dcf0698820a3325ae5b1343f6bb612a178e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9f81f7b77e1011de9e9cf4c68a149aa70f4f33e2bfa394213396115eaf9a2d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f601b8e483465177d65aaf099005bc66bda448cedbd860af5cc2577b582fa04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4901b670be1372e70460dfcf943bc9e1442c190f64778c865d5a18dda80b0efc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45b50ec7c49cdaf0d9116037718e11de09c6684633ee8a6123dd1dab0016723e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05cee3fe2968c1f5e507a7c0908e40ab2337f03df07292d9743578a7069af40b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c77fd27cb1dc592a2d9ba9238b80aafdf340749d690f15db59e8483609da884c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c09c17d5100fd441511d8bc79c4dd58f00fd6bac019287bd1507998fc711f22d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80a1d66fcdf2572fb1583b3a2e8a342dc9375aa4205f002aa7d798df7011ffc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:473274e5b2d2b84575bbb14a145efd15aa638ce14b543b66118bb90d55c3dc3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6fc47cd2f53b150153a3865c2fbd6b1c57fcc265fb3602b6f4f3883cf6ec64e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "user2": {
+                  "uid": 1020,
+                  "gid": 1050,
+                  "groups": [
+                    "group1"
+                  ],
+                  "description": "description 2",
+                  "home": "/home/home2",
+                  "shell": "/bin/sh",
+                  "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                },
+                "user3": {
+                  "uid": 1060,
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.groups",
+            "options": {
+              "groups": {
+                "group1": {
+                  "gid": 1030
+                },
+                "group2": {
+                  "gid": 1050
+                },
+                "user3": {
+                  "gid": 1060
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/etc/systemd/system/custom.service.d",
+                  "exist_ok": true
+                },
+                {
+                  "path": "/etc/custom_dir"
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "mode": "0770"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_dir": {
+                  "user": 1020,
+                  "group": 1050
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e"
+                  }
+                ]
+              },
+              "file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2"
+                  }
+                ]
+              },
+              "file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258"
+                  }
+                ]
+              },
+              "file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  }
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://file-246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e/sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e",
+                  "to": "tree:///etc/systemd/system/custom.service",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2/sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2",
+                  "to": "tree:///etc/systemd/system/custom.service.d/override.conf",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258/sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258",
+                  "to": "tree:///etc/custom_file.txt",
+                  "remove_destination": true
+                },
+                {
+                  "from": "input://file-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                  "to": "tree:///etc/empty_file.txt",
+                  "remove_destination": true
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chmod",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "mode": "0644"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.chown",
+            "options": {
+              "items": {
+                "/etc/custom_file.txt": {
+                  "user": "root",
+                  "group": "root"
+                },
+                "/etc/empty_file.txt": {
+                  "user": 0,
+                  "group": 0
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.systemd",
+            "options": {
+              "enabled_services": [
+                "custom.service"
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 5263327,
+                  "start": 3125248,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263327,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 3125248,
+                  "size": 5263327
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "xz",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.xz",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "image.raw.xz"
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:00c43379a70e7167e59f71d7da775489dc2f218c768cff68c1edc8e51f35c2c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/popt-1.19-2.fc38.x86_64.rpm"
+          },
+          "sha256:02f807f62c5d65d6e204aaf604413cb960f322d9eae08b38b82de21a537d0d59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/file-5.44-2.fc39.x86_64.rpm"
+          },
+          "sha256:04db736a77296edd4099a9165d68560d52dbf2484d959f668b3b676d68581f97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-gpg-keys-39-0.1.noarch.rpm"
+          },
+          "sha256:05cee3fe2968c1f5e507a7c0908e40ab2337f03df07292d9743578a7069af40b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/w/whois-nls-5.5.15-3.fc38.noarch.rpm"
+          },
+          "sha256:0ad0000a318a04be81dc299677f2993b7283c39c5a350a56888c1266194f7602": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/dbus-1.14.6-1.fc38.x86_64.rpm"
+          },
+          "sha256:0bb1b0d7fa1b5107c98636cc9046912b848e770eefa43161127392bb86ab4559": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libevent-2.1.12-8.fc38.x86_64.rpm"
+          },
+          "sha256:0cbad3c0b6b1b8c73ac219d5ed3772c89331e46a5fd8e4be3dc065e2021ef904": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/container-selinux-2.203.0-1.fc39.noarch.rpm"
+          },
+          "sha256:0d7baf4131395fdd190b584309e4656c86a3cae3e39368866be827ffd8a31576": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gettext-envsubst-0.21.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:0dbf7d0db94a9cf1745aedb5462d6877d82a99f9010f5037c796ba41f5c737ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libkcapi-1.4.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:0f601b8e483465177d65aaf099005bc66bda448cedbd860af5cc2577b582fa04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/u/util-linux-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:10295dcfa946c6fb7b52c1b8781da4dc6c59dc8fc0e07bab2f3187fc1f143b9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libsmartcols-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:13767df6745449f9458b4097fd10cdc5a6f577f53a14cf4d3608052a9cb368a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/sed-4.8-12.fc38.x86_64.rpm"
+          },
+          "sha256:139c6a046ae7b9a5693783f75a28b2b99b9411b62e89df3ca634d8b950d7d005": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/procps-ng-3.3.17-9.fc38.x86_64.rpm"
+          },
+          "sha256:13b6ee1aaadee8fc6ad6713f6fcca12d340d8b662c341ef11eb1bbca9f28b1d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libassuan-2.5.5-6.fc38.x86_64.rpm"
+          },
+          "sha256:1437effaa1e9cef61e6d942b5e7e352965d33e44666805fd4107f660d7a825e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libbrotli-1.0.9-11.fc38.x86_64.rpm"
+          },
+          "sha256:156c71be29a4227e99d5198272a6fdbd38f25884de10bd3b03722602f383e56d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/a/authselect-libs-1.4.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:1573a247a3f3a89273c1bf230cd5a62196c5aa22ddf13d0c44684ff3ad78ca9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/glibc-common-2.37.9000-3.fc39.x86_64.rpm"
+          },
+          "sha256:15ae42ad0d83c8e708c06cd6286ca5fcb35f780b032d012c809e96b216a77e60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/polkit-libs-122-4.fc39.x86_64.rpm"
+          },
+          "sha256:162ef2aebef5ec4dafe56be3f7fbf82c5d1fee147ec4d85e350713258cf45865": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/kmod-libs-30-4.fc38.x86_64.rpm"
+          },
+          "sha256:164b2bec69f169b4ba2e706655d1cb92a1e547c0ecd99cc7ba190e2643600d6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gettext-runtime-0.21.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:16d1843cdac488ad04bdc654dd6b8dfbfeafe33a7728695070481302a7e54345": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/b/basesystem-11-15.fc38.noarch.rpm"
+          },
+          "sha256:174bda41056c4cac41ef9bf8a7adb06affd92bcb18a258d319b9153bf0f00686": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/shim-x64-15.6-2.x86_64.rpm"
+          },
+          "sha256:17ccfb5f326ac494420b346b6a19633f6a29666edff3bd2927b24a181c30043d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/p11-kit-trust-0.24.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:199b1cd22fe6fb5f3a1d8035dc4f6348486ce9f623618714085fe641221decd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/systemd-libs-253.1-4.fc39.x86_64.rpm"
+          },
+          "sha256:19d52491b049e52228176ecffcedf9a76ddff15bfb2afd8d91aeb76a24b9f277": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/policycoreutils-3.5-1.fc39.x86_64.rpm"
+          },
+          "sha256:1a2dd2ddcf1ab7a789633d7a0f5890b0fe12c96ad3c88c7a5f8df547190fdb32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/lz4-libs-1.9.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:1a878a4a0448222e0a34864ef4f3c8b674b05ef08a05ea992d9c50b3ecbae10d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/readline-8.2-3.fc38.x86_64.rpm"
+          },
+          "sha256:1ab436b853babb890810427c0906f401a8778570d9c106aae2a93dd689b56395": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/n/nettle-3.8-3.fc38.x86_64.rpm"
+          },
+          "sha256:1ac270e3158bcf929b5034d3b8e03d28e877e364b9c1d9c769bf54af783973e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pigz-2.7-3.fc38.x86_64.rpm"
+          },
+          "sha256:1bc707f6df0aac3eb69be6e32be2edb32c772c1afb63300577e72fcec472af54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libssh-config-0.10.4-4.fc39.noarch.rpm"
+          },
+          "sha256:1bf2514fbb41e260c1bfb0192ca64f3277ba828c2df6f44ad2877f572e5adf52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/o/ostree-2023.1-2.fc39.x86_64.rpm"
+          },
+          "sha256:1edd6d0c726af868fe64c6fb8e62b72e55dbad94ae0e3a835548aa1160f57bda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/grep-3.9-1.fc39.x86_64.rpm"
+          },
+          "sha256:1ee7aaf7efddee4b3dcbad1e7b13f79c4ea58f40d6d0734a29dca359f540930d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libssh-0.10.4-4.fc39.x86_64.rpm"
+          },
+          "sha256:1f8b50a8229265341fdefc8472f9d36897e6430439c159d6a3aa87e186f92f6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/python3-libs-3.11.2-1.fc39.x86_64.rpm"
+          },
+          "sha256:212cb1084c3d5a05d12308d768417dd12678a860ccfc89c2f70dada566e11259": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gdbm-libs-1.23-3.fc38.x86_64.rpm"
+          },
+          "sha256:228e3e665e38c1e49397b1fe6e1c98aa29b7434e8aa25b39a44b3edc5a362aa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/b/bubblewrap-0.7.0-1.fc39.x86_64.rpm"
+          },
+          "sha256:2320484133302a774460dca284f0b78a41623a0169e935ca62b3e7c9ac291ce7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/curl-7.88.1-1.fc39.x86_64.rpm"
+          },
+          "sha256:245491bf843da1571cd8b6f16ec3e9569c4b983bef02a28fd53e63a1fac9fa21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/lua-libs-5.4.4-9.fc39.x86_64.rpm"
+          },
+          "sha256:24b6237f18f6e0643e96a882d3711b5e7411256fffc547ee1a4daa7da0a62f9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libdb-5.3.28-55.fc38.x86_64.rpm"
+          },
+          "sha256:25a1a5f81238d9ba5b45b29bfec7a842281f7b623d218b0aa2deb5c6ac7e3bcf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pcsc-lite-1.9.9-3.fc38.x86_64.rpm"
+          },
+          "sha256:2759df9eae082382df537953d18a34d81203837669ec30d13d5e6c2ed1345ea3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pam-1.5.2-17.fc39.x86_64.rpm"
+          },
+          "sha256:27a0bdd0cd20b0e73f2285100a00a81eb162687d159f5952dceb8d298e34ef66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libxcrypt-compat-4.4.33-7.fc39.x86_64.rpm"
+          },
+          "sha256:288c3f12e3c1c65e522c82a1583eb57972b595ff4e62c685b904b6e479d67093": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/cyrus-sasl-lib-2.1.28-9.fc38.x86_64.rpm"
+          },
+          "sha256:291c42304b5977f3c2c611ade53af3d146d8ad5f8c83c1c1f5c6ac92acadf2a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/e2fsprogs-1.46.5-4.fc38.x86_64.rpm"
+          },
+          "sha256:2a6b60b523093bc2c3f31a14618c3f168faf5b9088cb422e08c450af62292153": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libattr-2.5.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:2af61bff099ba092381fc3bcfad33abeb46e0bbd80d39957160ebeeeae6662af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/expat-2.5.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:2ba219030ec4140c0275c00482cbf8a8130e27d6185eea52f715350656a7f853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/a/audit-libs-3.1-2.fc39.x86_64.rpm"
+          },
+          "sha256:2bd57ae89a0e8c2205bb8a043e605a445e1983834f1fe8d29edccb7ee8ecb0dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libacl-2.3.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:2cf3c52adb539112d160d78ad0eb0536f41a4fc0087ca74043de59267ae397ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libunistring-1.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:2ee988694d3c875dcaa4741453ee07b4dc1da31205abb035065dbc7c8c72c0da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gzip-1.12-3.fc38.x86_64.rpm"
+          },
+          "sha256:2f95ec8a9e82166735d2a0dad196caf86d3b03b1d751333664fdc49af04652e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libsigsegv-2.14-4.fc38.x86_64.rpm"
+          },
+          "sha256:30eea609388f8cf3f8418eb7e648262d5053f9171eb627225c89118dda9faa6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/grubby-8.40-70.fc39.x86_64.rpm"
+          },
+          "sha256:319b782e36d052581555edca137af6095cc1aaac007d9bdc1d963893085587c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gawk-5.1.1-5.fc38.x86_64.rpm"
+          },
+          "sha256:35146cabf07ec78d2390120c9bb9e2f5aa35cb8e0bfff84fb748a198b90ce3ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.x86_64.rpm"
+          },
+          "sha256:351b576c1e36e1519502aa1a7e6b3dcec269a18c6bc6230eabb1043f93c6a87b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/systemd-udev-253.1-4.fc39.x86_64.rpm"
+          },
+          "sha256:36a64a62d2f251871c1616451befd54d2761448d668de0371e05a59a185c99c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/glib2-2.75.4-2.fc39.x86_64.rpm"
+          },
+          "sha256:38e188b7682c3df92bcebd568812b4f0de6f35d785a7d3e568acc3e6e14c28c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/filesystem-3.18-4.fc39.x86_64.rpm"
+          },
+          "sha256:38ff8aa05c220dd39d0c93be24ef211424a04ee3ac3ad9ea67906e38b799bf22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.x86_64.rpm"
+          },
+          "sha256:3908078cd7debb2b2e081a7ea30fdf598f702ba7e65db7159836403940ed2421": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-repos-rawhide-39-0.1.noarch.rpm"
+          },
+          "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-39-0.5.noarch.rpm"
+          },
+          "sha256:3aa69b60ec18c1fc47367041aca9dea0582fa14b31c7bee12538c4106acce87f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libgpg-error-1.46-2.fc38.x86_64.rpm"
+          },
+          "sha256:3c5d61f2209be9748c7ca38cfb9714b699d1cf3ed84087cc7af55f45382d6716": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gettext-libs-0.21.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:3cf03283e8e07e37763931446a599809c069fe25c20a0eb6dd6386f447673e06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/publicsuffix-list-dafsa-20221208-2.fc38.noarch.rpm"
+          },
+          "sha256:3d099f56457cac6b78d5a7fa1a288449b2fd40940ba79c38f3a8cdf72de08d0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/p11-kit-0.24.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:3d57c8a275a9db4aaa234a73685d075b74b00930d7881ed7892748b790773764": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/efibootmgr-18-3.fc38.x86_64.rpm"
+          },
+          "sha256:3ed298c957602edb7ce91e0d06c4cc876c645d5e9848cd9553b5521ab1dba8a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm"
+          },
+          "sha256:419353b49f29e4bd5e5fe58f264db093424c148776c32dcc78a82c8793c8725f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/polkit-122-4.fc39.x86_64.rpm"
+          },
+          "sha256:42a6fa3db480f36554e51af9ca2c25a523e005ea09dfe3489403254496934e66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm"
+          },
+          "sha256:42aca1f4d1635dff866d060af6a97707b015f892570077ac92f52cd940522266": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gnutls-3.8.0-2.fc39.x86_64.rpm"
+          },
+          "sha256:44c3fd81aa5de107c630c8ad571f225e5338450d24df4dcdf2de1b00f619ea20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/rpm-libs-4.18.0-11.fc39.x86_64.rpm"
+          },
+          "sha256:450ad2cb89b8e99a9e285a87e5942e1eb04c19da70afd229a9c0a168860b64d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/elfutils-libelf-0.189-1.fc39.x86_64.rpm"
+          },
+          "sha256:45b50ec7c49cdaf0d9116037718e11de09c6684633ee8a6123dd1dab0016723e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/w/which-2.21-39.fc39.x86_64.rpm"
+          },
+          "sha256:473274e5b2d2b84575bbb14a145efd15aa638ce14b543b66118bb90d55c3dc3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/z/zchunk-libs-1.3.0-1.fc39.x86_64.rpm"
+          },
+          "sha256:4879018880886651208d90a74357ff33d9230f1cfe05a0c6efc21fcdfe21acba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libstdc++-13.0.1-0.6.fc39.x86_64.rpm"
+          },
+          "sha256:4901b670be1372e70460dfcf943bc9e1442c190f64778c865d5a18dda80b0efc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/u/util-linux-core-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:499b7d4998f9ee1beaec404e83e5be8ce0b20ac86caa91f849e9f4f2c4161563": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/systemd-resolved-253.1-4.fc39.x86_64.rpm"
+          },
+          "sha256:49e5cc3613a661ac06ba5c14513f4dd3d752b7a4b308a8ece3bdd81468cf2aa3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libgomp-13.0.1-0.6.fc39.x86_64.rpm"
+          },
+          "sha256:4b30c7dc86e31ea87fcdbd58c9ee126c8af9a84bc8a23cf30858af5e8ae8c822": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/glibc-minimal-langpack-2.37.9000-3.fc39.x86_64.rpm"
+          },
+          "sha256:4cdee7e7f885d9efe8156bd86e644e2b45f34537870f30c17bbd5113e493b994": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libffi-3.4.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:4dce785f0955e4bc212f5642fbf76752e8e758fddaf31d423c76064442c382a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/m/mpfr-4.1.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:4ef881ad8a2f683020cb4d49a4bac6a8947ca5f826266391da945834f95b42ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gnupg2-2.4.0-3.fc39.x86_64.rpm"
+          },
+          "sha256:4f19a70d3fbf30ac298700d3918d7fb483a387adf3d08b96efaa07d51dd0b156": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm"
+          },
+          "sha256:527026089d1cbf7b681d916a37078e552349c7183df0bc51a37276c330391e22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/dbus-broker-33-1.fc38.x86_64.rpm"
+          },
+          "sha256:54aa1a0699326aae0137529166df648a393331e99280ca10f77f6fc904caf9e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/python-setuptools-wheel-65.5.1-2.fc38.noarch.rpm"
+          },
+          "sha256:5540bc7f5d2f38cc82aa329a0c2078060a13dd27096238776f7b063cae7ccd70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/j/json-glib-1.6.6-4.fc38.x86_64.rpm"
+          },
+          "sha256:55691164bb75a80738db0691ba6493d678f7797953bea35b2df4e60494b059cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/rpm-ostree-libs-2023.2-1.fc39.x86_64.rpm"
+          },
+          "sha256:58f75a8368b74d16380f7eeb1c506c3907ab4d168a91bb092c96da81bd27f59f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/kbd-misc-2.5.1-5.fc39.noarch.rpm"
+          },
+          "sha256:5a8b121b402d579ba941a7e47513e68ffce46211b252d022ceef6d38706f7328": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libcap-ng-0.8.3-5.fc38.x86_64.rpm"
+          },
+          "sha256:5c159d71832d6b89b2e9ba696464027e54ea91125670bd9d012483b3a7451298": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/systemd-pam-253.1-4.fc39.x86_64.rpm"
+          },
+          "sha256:5d7d79d18255d8e8e45c4b9fd666fc9562d9a253b599b9ba4631b6991221479e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/dracut-059-3.fc39.x86_64.rpm"
+          },
+          "sha256:5fa9010ad567df986d484ddcac865ea25a26c818def22df0c4e3688fc346568d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/e2fsprogs-libs-1.46.5-4.fc38.x86_64.rpm"
+          },
+          "sha256:633ce6404f6ac32892f2124fa9d8e511ed6d2e3c31d6c9fcb5f9f183416547ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libtirpc-1.3.3-1.fc38.x86_64.rpm"
+          },
+          "sha256:665924d246f41013251f24cc626757abd2a932fb12c58c25d4e8bb005c36605f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/o/openldap-2.6.4-1.fc39.x86_64.rpm"
+          },
+          "sha256:67b6c981dbc626378729138b7eec77198053d6c4c354a5c638901afa30c5a847": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/crypto-policies-20230301-1.gita12f7b2.fc39.noarch.rpm"
+          },
+          "sha256:68772d2dd6659cd0eafb405000585bd7589c987274809ed0fe07d28ff85ecb2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fuse3-libs-3.14.0-1.fc39.x86_64.rpm"
+          },
+          "sha256:69c9711600ede5bd00494ae8dafa400121de28f70cb4784f4546b8810c4b4cd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-common-39-0.5.noarch.rpm"
+          },
+          "sha256:6b14738a69996f820a42c8857412d1fa62284932da5874d3d2eb39f0f356714b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/containers-common-1-87.fc39.noarch.rpm"
+          },
+          "sha256:6f50f77a0ba03e554cced7c779b18e11c099a5abeef74d35f8bdc015c7618b5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/glibc-gconv-extra-2.37.9000-3.fc39.x86_64.rpm"
+          },
+          "sha256:6fc47cd2f53b150153a3865c2fbd6b1c57fcc265fb3602b6f4f3883cf6ec64e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm"
+          },
+          "sha256:70059465e292dc49a920ef7db57d26e82410aebf6ab8d1264d8e2716c19f6645": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/elfutils-libs-0.189-1.fc39.x86_64.rpm"
+          },
+          "sha256:7036d00dd6f881adb9e4870edfd5a1240f5b647084ed53be464cf8cc6d40c452": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libksba-1.6.3-2.fc38.x86_64.rpm"
+          },
+          "sha256:71a9cbe5c77f55cac9084cbff178924e28b44981a53f82c66c3053521875c39b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libxcrypt-4.4.33-7.fc39.x86_64.rpm"
+          },
+          "sha256:72d5ce188da2f45a3450e472bfde16b72d8d881414298ea3cf321628cf1fe646": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pinentry-1.2.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:73e923d9adbba6384840bac86c7664169fdd74f61a3db9407840f41f91e63d9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/crypto-policies-scripts-20230301-1.gita12f7b2.fc39.noarch.rpm"
+          },
+          "sha256:755f70836736d33825f0ca0a30966364f9c47f336a9679647806efca38935468": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libtasn1-4.19.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:77e278739167196fcbf7b6a538e954dc7857c3ebe1dad36a3940be0128746d60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/cracklib-dicts-2.9.7-31.fc38.x86_64.rpm"
+          },
+          "sha256:7867d881d29f8c33cb137a99f2c6bbe01456e502291fdb760e7542c8c291b4ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/coreutils-9.1-11.fc38.x86_64.rpm"
+          },
+          "sha256:7aa9604ad09e1985b610278a5412b1393b1928b9beb64baee783d4618ccc90ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gnupg2-smime-2.4.0-3.fc39.x86_64.rpm"
+          },
+          "sha256:7d54836133ed06083473cb58977db4422dfb201cb73f18e730d4691eebfa5414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/python-unversioned-command-3.11.2-1.fc39.noarch.rpm"
+          },
+          "sha256:7da7355b078353592654642e662cd68d9518c104b3d95fe6c24cbca3510a0d5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/cpio-2.13-14.fc38.x86_64.rpm"
+          },
+          "sha256:7db0f713c86eff1668979f122b8cba968dc621a17b6d60dab73470c6aeac478c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fuse3-3.14.0-1.fc39.x86_64.rpm"
+          },
+          "sha256:7eee29c05014366ade22f339b3b064bdda71a02d76d833173127255e2bc87c8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libcom_err-1.46.5-4.fc38.x86_64.rpm"
+          },
+          "sha256:80a1d66fcdf2572fb1583b3a2e8a342dc9375aa4205f002aa7d798df7011ffc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/x/xz-libs-5.4.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:80a414135a766a8ca123eb392157e82e837aec38c4d6aec849d62494a1acf28f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/cryptsetup-libs-2.6.1-1.fc39.x86_64.rpm"
+          },
+          "sha256:821b12de1c46ef30a5b177bad1f0bed53097311692845c55dba98e4af15c2033": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/kpartx-0.9.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:8321f09000e84895f3ae6a52963761f2ab2a67fb36753a2d02f587f121e2b3ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/rpm-4.18.0-11.fc39.x86_64.rpm"
+          },
+          "sha256:8411db01396745b0f2a9fd2107e04ed89da22e743dc1f8c2b1c341391be7c819": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/kmod-30-4.fc38.x86_64.rpm"
+          },
+          "sha256:843187a57219bd86402b570db6ce0b7ef50e9bd3b7dcf57124542356c85e4c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libseccomp-2.5.3-4.fc38.x86_64.rpm"
+          },
+          "sha256:858e728f42806ce65520953f756c178764c60e29e1a3fa1ea1e1eb95b14950b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libmodulemd-2.14.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:861df4978f7a58b561d78dadd633e0b642f1fe010f5d9ad7ee1c104a1984b41f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/systemd-253.1-4.fc39.x86_64.rpm"
+          },
+          "sha256:893c52ea0bac3758fb0c61c6449a7204fb088193d5ad2f0480ab8ef7af40e59a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libnghttp2-1.52.0-1.fc39.x86_64.rpm"
+          },
+          "sha256:893d2125cc10c36b67e5d04544015be0f27d5a99e2ac83ba14904219c5e15d68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libpwquality-1.4.5-3.fc38.x86_64.rpm"
+          },
+          "sha256:89ea4d920d4b97d56fc88c4abcc30454059e2a5698aba86633a29346c4d66d88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libselinux-utils-3.5-1.fc39.x86_64.rpm"
+          },
+          "sha256:8a930ab3e11e25093f322f907e1d96cf38d75054b2566611c4414723ac1b5016": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libargon2-20190702-2.fc38.x86_64.rpm"
+          },
+          "sha256:8ac4cd82686478387e18d884e52254370152123a14a6476ece6810b78e0fc9fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libsolv-0.7.22-4.fc38.x86_64.rpm"
+          },
+          "sha256:8b6f3880d1daa1e26cbc410cb9a297be024967d49aa60a660c4e3bb210c1867b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/coreutils-common-9.1-11.fc38.x86_64.rpm"
+          },
+          "sha256:8cb49ad623d30a9fbe923b31b0413732b22f8763ec719efdcb535a356a9d0d6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libpsl-0.21.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:8e9d90ae76137486c9584ad0ff007348d83349fe97e29310659b13057dba78b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pcre2-10.42-1.fc38.1.x86_64.rpm"
+          },
+          "sha256:8ecb72298a8b662ee1a17e7fb4e1d279d7fc64b358c9fdf9a568a965022b3f97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-repos-39-0.1.noarch.rpm"
+          },
+          "sha256:8ff9a034c4cc68941868d2fab9fb0489fb7d2f7667ce3fc645c296b70ecb408d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/efivar-libs-38-7.fc38.x86_64.rpm"
+          },
+          "sha256:90fefdd11b8d06bfee61cfac21bfbf92325b3b4dae06547395f6f2c7b5deed10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/device-mapper-1.02.191-2.fc39.x86_64.rpm"
+          },
+          "sha256:9210dac0631e049bf2d21111db062b58c668a1cb07584b525da10233870ff5a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/rpm-ostree-2023.2-1.fc39.x86_64.rpm"
+          },
+          "sha256:94a66aeb619bcc64c9f4da716ac356eae4cc48fd746a4efeaeb3be1d47339003": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fuse-overlayfs-1.10-4.fc39.x86_64.rpm"
+          },
+          "sha256:96ceddead12aca9f75215a0492c6c0308902a55e1d756267dedc7fa68850aef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:96e794f0c3a2d542760e6584f792b76b187699f58e218ea84d1232d1f43ed0fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/krb5-libs-1.20.1-9.fc39.x86_64.rpm"
+          },
+          "sha256:9858eb4e6a8aca2d0e69a57d3db25f1a561e117e6c6221ccd0b3518f7db7f01e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/kbd-legacy-2.5.1-5.fc39.noarch.rpm"
+          },
+          "sha256:99ab50da3c0a25f5bbb92d3b3920abf4a01800c3aeac76e61fef877e760a3b41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/diffutils-3.9-3.fc39.x86_64.rpm"
+          },
+          "sha256:9dc90426b66ef657dd666b8cff6a8b79d97049940e04fe432c1679407d7190a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libb2-0.98.1-8.fc38.x86_64.rpm"
+          },
+          "sha256:9e25af815ea18afcfe8cab5f50fec3b2c8e602880e912b37dbc07e81e7a48f69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/dosfstools-4.2-6.fc38.x86_64.rpm"
+          },
+          "sha256:9ed4609b92a2f2ecebed214447b4f3ba450a5e86e52209af421b45bdedface8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/python3-3.11.2-1.fc39.x86_64.rpm"
+          },
+          "sha256:9f196c1696af163c77062c566618e52a7df7fe6d0f76744596d00d15a86a3ca7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/o/os-prober-1.81-3.fc38.x86_64.rpm"
+          },
+          "sha256:9f6c383fa225665fc42dc174762cee30f9ae6ffcc247b324cc3cfa67ff75ba44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fuse-libs-2.9.9-16.fc38.x86_64.rpm"
+          },
+          "sha256:a0fd0950f4c4766556a58a23aa878c6e43ff2aadb16541361c16330b275532ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fuse-common-3.14.0-1.fc39.x86_64.rpm"
+          },
+          "sha256:a119520536c2d78fe4ab09fa36de55321fa5a926aca955640504d6fa7e98790b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libsepol-3.5-1.fc39.x86_64.rpm"
+          },
+          "sha256:a2f93d70bc111d246a0bf846c86e98b14e625e4e3eba0d95bdb1b6e3d803d3e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/device-mapper-libs-1.02.191-2.fc39.x86_64.rpm"
+          },
+          "sha256:a437f855037feb83c8388e0d7799050d178a0e33b72ca2b2845ade7182ad104a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libunistring1.0-1.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:a6cf83800141978f0b6f88a9cf218ddeaf84ad7459f2270f1bbf6da32f18d4cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libsemanage-3.5-1.fc39.x86_64.rpm"
+          },
+          "sha256:a6e85db2da9cc041eef3c34d38d50ec07e0c71a1c1aff8772296572c987076c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libusb1-1.0.26-2.fc38.x86_64.rpm"
+          },
+          "sha256:a724e47d0afbe9ea8b8750ac8b1db8e1faad7cb77f7dc1907990789f5f5dec71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libverto-0.3.2-5.fc38.x86_64.rpm"
+          },
+          "sha256:a8003e886f65342e06c75edaef2bc54b1f313a9b19ba3d8b573b7b72a9583d87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/keyutils-libs-1.6.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:a861e4c858fb8b7b246c9a5156780ef9188e5058b430a09d5274cf8154e4651b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libselinux-3.5-1.fc39.x86_64.rpm"
+          },
+          "sha256:a8a381267845f761809f10b8d27db002a1a5c6b2b54bd6720fa0d921439268f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gpgme-1.17.1-5.fc39.x86_64.rpm"
+          },
+          "sha256:aafa892d920ab841a6e6076da3f0bfd4d5783a88927473acb6fd8cdff1686f90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/b/bash-5.2.15-3.fc38.x86_64.rpm"
+          },
+          "sha256:b0d44fc3728295b16ee16e3eea5981c56115ef494e0e1dbabc04670c3a99aad9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/python-pip-wheel-23.0.1-1.fc39.noarch.rpm"
+          },
+          "sha256:b263e183ca9f2ad3d1d6525bd466ec30e1dd716318c0efa7ab13fc7a0181ca72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/m/mkpasswd-5.5.15-3.fc38.x86_64.rpm"
+          },
+          "sha256:b2ef95d47ec9eb73b3054d778c31755c0f487d93d7393f18451e34c9c019ae5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/systemd-networkd-253.1-4.fc39.x86_64.rpm"
+          },
+          "sha256:b835a3d70d4b826f41d9bd2894fc0575fa609d0431d1ba2934db60eb261135a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gawk-all-langpacks-5.1.1-5.fc38.x86_64.rpm"
+          },
+          "sha256:b8d6d9c6f976e196f8eb0a8d04ca1f02821d0dbc904120d0c4bd7d7fc2ef8fdc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/q/qrencode-libs-4.1.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:b940446486f6dfaa2a7651fd9cf7050cae6171d75b7fca865fa8d58400c1a0c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gmp-6.2.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:b9a9659d705cbafd77164f6e9aad0990c4f28822216f59750d3a6835815f688d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libxml2-2.10.3-3.fc38.x86_64.rpm"
+          },
+          "sha256:ba73a191eecdd07dfdf6c9e9c05ee8a7fc033d00ab22f71c9d765a9f79430932": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/a/alternatives-1.21-2.fc38.x86_64.rpm"
+          },
+          "sha256:bb31f92c186b8b042f0e56833f9e3efaeb66dd6c979f869921ff75a249882c0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/t/tpm2-tools-5.5-1.fc39.x86_64.rpm"
+          },
+          "sha256:bba199cbc2d5363334072bc40d868c9c0ff301d67dddd14a55f032043c9dc824": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm"
+          },
+          "sha256:bbed67f96b39130ef7cc8f0b1a267eed02cf7b7f7c17faa2be7ddc3e4374ac72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/elfutils-debuginfod-client-0.189-1.fc39.x86_64.rpm"
+          },
+          "sha256:bed6e9157e37283845bfd06b1f2e42b3b921e7f7c17786bd48fa535c3da17c15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/o/openssl-libs-3.0.8-1.fc39.x86_64.rpm"
+          },
+          "sha256:c05ae7b8c8c32ece4656d4aa296c383e9327168c1417232caca03612ff7f043e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libuuid-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:c09c17d5100fd441511d8bc79c4dd58f00fd6bac019287bd1507998fc711f22d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/x/xz-5.4.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:c4b337632153e008b8fcd39c5cafedb90fb03c6e765ebc610b0effb6e9409721": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libarchive-3.6.1-5.fc39.x86_64.rpm"
+          },
+          "sha256:c611cb6193f4bb3971727d46a5f02a196d4d594fbc00ee76d22668e5f9eac477": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/n/ncurses-libs-6.4-3.20230114.fc38.x86_64.rpm"
+          },
+          "sha256:c7428fe201f901420f8b84fe5271744d97aa06eff52ebe35b6b1671531e54418": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libcbor-0.10.2-1.fc39.x86_64.rpm"
+          },
+          "sha256:c76b7bb46e9eee4137415778575da7d0b06db811c35afa2a9833d82b25d6bd91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/grub2-tools-2.06-88.fc39.x86_64.rpm"
+          },
+          "sha256:c77fd27cb1dc592a2d9ba9238b80aafdf340749d690f15db59e8483609da884c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm"
+          },
+          "sha256:c8a2cbec7fc78f885cf077f6ee088e64634a48694b94e611ad57f9ee15314731": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/shadow-utils-4.13-6.fc39.x86_64.rpm"
+          },
+          "sha256:c98c47d647f33a5a552c0031d1c7b035a9f54a8a0ba64d220f1b90d4cb990926": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/m/mpdecimal-2.5.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:ccdcc7c5e8bdc1eda8407a6644dc5ed8f66b4915ad7e54c462373b4e8b7e5f19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libcurl-7.88.1-1.fc39.x86_64.rpm"
+          },
+          "sha256:cf1084af759222796497ae1db44733d8572475170e706828af4d4c0c093a3da2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pam-libs-1.5.2-17.fc39.x86_64.rpm"
+          },
+          "sha256:d06140e05f5d7c831331260a898d83e5079a3ead0f4616925dd94da8a33e5ede": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/j/json-c-0.16-4.fc38.x86_64.rpm"
+          },
+          "sha256:d55660b07157161b5c6c54182033581497d3704433f9a4701c36e36b8f668616": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/kbd-2.5.1-5.fc39.x86_64.rpm"
+          },
+          "sha256:d624895c7f19e23fb77b7f2ae21a9dcf0698820a3325ae5b1343f6bb612a178e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/t/tpm2-tss-4.0.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:d6a82c3256e0420169b0dd940d978894321883e4c316fb4e996989adfa89c25c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/dracut-config-generic-059-3.fc39.x86_64.rpm"
+          },
+          "sha256:d77c48d393ffada69140de4d0adb89cec02153c6884d5829d2ed30b422cde82b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/rpm-sequoia-1.3.0-1.fc39.x86_64.rpm"
+          },
+          "sha256:d792de0f75798996e8cf2851ae04b3a47d3e267bacffbfcfb02a3d9571f9be00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/cracklib-2.9.7-31.fc38.x86_64.rpm"
+          },
+          "sha256:d7c0d81cb8f51af66460df06dc8266ca59ba0fe11b9af6649268e3aed51c73b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/m/memstrack-0.2.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:d82246ac2f3d4f4c5c47739e5176550ca759ac89ee35be920d511ba4d809f4a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/skopeo-1.11.1-2.fc39.x86_64.rpm"
+          },
+          "sha256:d949521c5b898a94e9c3e2ffed751671b652687b34016ceca4bef650c68eb3ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fuse-2.9.9-16.fc38.x86_64.rpm"
+          },
+          "sha256:dae1b79663b5e2810668f0b9350e5d62b64af07cf3e6a85da386b4accd08b699": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libyaml-0.2.5-9.fc38.x86_64.rpm"
+          },
+          "sha256:dca9b9ef6667bd5fb311bc39129370664d1cfe627be04aa2f78b2c0651a4906b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/rpm-plugin-selinux-4.18.0-11.fc39.x86_64.rpm"
+          },
+          "sha256:dec19668dc6051323597760b1dcfba516e049d99f4d4faba181ab89bb76dfd26": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/findutils-4.9.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:ded6a789884bf08981d97c15f86e24bcf62d47ab0453404068949087ab63706c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/grub2-efi-x64-2.06-88.fc39.x86_64.rpm"
+          },
+          "sha256:e0214026e8899bf3455f97bed98c287644e52f9350ce977fd0ccab05dbb35b77": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/b/bzip2-libs-1.0.8-13.fc38.x86_64.rpm"
+          },
+          "sha256:e10c0ec1a70226866cd13c044cdb398d519fa28ae3f2cf5747b6ce799d3bd0c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/setup-2.14.3-3.fc39.noarch.rpm"
+          },
+          "sha256:e2101508acd9f16f43fb1781e7242fd5ea1570275ab9f596ec1fdd622ac947d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/grub2-common-2.06-88.fc39.noarch.rpm"
+          },
+          "sha256:e24b40ad581933d9ca22b525c434777d90a46cb4c0b097c497c788e49fd946d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libidn2-2.3.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:e3fa33d2f4eb43a83bcf3ddc2775d0a7c272183a1ef6f2d5c0ff9cf95a983d73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libzstd-1.5.4-1.fc39.x86_64.rpm"
+          },
+          "sha256:e848c54481fef3a2afc80a5c38dfd580ec05d821d65361d48a989128c36e5aaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libcap-2.48-6.fc38.x86_64.rpm"
+          },
+          "sha256:e88d40b14861564cbbf640d366076b5b381cc3a30d818930f043dfb3f158e68a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libnsl2-2.0.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:e911b2035148f19a606bdd11bbcca202e673b1e3d8c6dbff989b77b2ff761fd9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/glibc-2.37.9000-3.fc39.x86_64.rpm"
+          },
+          "sha256:e919ba41c7e69504041ec33a5118cf696c19408b9bda7d30acacab8e0e8fea83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/duktape-2.7.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:e96e91ff1c7b0667539c2d00d1f674a4b97638bfe1b6bc2eb2dfeaa59c127f9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/sqlite-libs-3.40.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:e9d47d4f8c115837a086789d8da306a435a77f25789ebad06c110da407864f34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/file-libs-5.44-2.fc39.x86_64.rpm"
+          },
+          "sha256:e9f81f7b77e1011de9e9cf4c68a149aa70f4f33e2bfa394213396115eaf9a2d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/t/tzdata-2022g-2.fc38.noarch.rpm"
+          },
+          "sha256:ea61e5c61c7df5d65ff43dfa34c3e6fc2420bd1e479d4e15519023c1b832e261": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libmount-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:eaec98669b65aa4761783244a9bcbae47dedae32889d1b9cac72ad74fb165951": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libfido2-1.13.0-2.fc39.x86_64.rpm"
+          },
+          "sha256:eb26853ca1388c3c8488ec6459f0288253f8e31e01c7494c0b3073430efa7ba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libfdisk-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:ed115185dd2524d6ad37c4e5a7c26c2ef11461ddd2d52a4e0c73c9b61963f709": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libeconf-0.4.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:ede3d13a4e42ba9fb840d351b3039939e5552f974f5a23981271c6bc4ac7f8a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libss-1.46.5-4.fc38.x86_64.rpm"
+          },
+          "sha256:f07644af2a3529eac157814f85268a09d8697ceb068ebd564011789d7ca8391d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libblkid-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:f13a3ba0f10a4924a4ac460a506e45559421b392ecf5c2ee258661e19ed93941": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libgcrypt-1.10.1-7.fc38.x86_64.rpm"
+          },
+          "sha256:f18410a0d1d25049f39315372924c318314254cba55f2d3f24d0c28e31cbbbb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/librepo-1.15.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:f2f6a4a9a1bdc46e03263959c4a898c29d9873ca2c031a61f365c6842823eef4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/o/openssl-pkcs11-0.4.12-3.fc38.x86_64.rpm"
+          },
+          "sha256:f33f41efdeb7ed371ca73539df63e0a24e1ba6f1c08eb6b3a13efeee143c22cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/elfutils-default-yama-scope-0.189-1.fc39.noarch.rpm"
+          },
+          "sha256:f4a9066b30983c17036794e7873dcd62acb2559ebd298d00bbf27a555bc1e0db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/a/authselect-1.4.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:f58a005f676fa9c84983fce7348af1f6ee5018edf7bf2c085f5fa39b3b6e7f4f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/o/ostree-libs-2023.1-2.fc39.x86_64.rpm"
+          },
+          "sha256:f5c2b7e34cd518428e2b57b97d53038a35112bfd7dcf70b99a362edf6df03174": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/n/ncurses-base-6.4-3.20230114.fc38.noarch.rpm"
+          },
+          "sha256:f5ea642626ff8f0506e27fa9dc70fcfa89a430f1eb641a03926ef38af4b2158d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/grub2-tools-minimal-2.06-88.fc39.x86_64.rpm"
+          },
+          "sha256:f657e5e5c5985e114fd9f957a371d7dd123fa1c38ad8df6a75b1713edd0fa4d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libutempter-1.2.1-8.fc38.x86_64.rpm"
+          },
+          "sha256:f6d14f22f3b4e8bb3428d2cbef4e75821ec5c132a08816f159d82025be36f774": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/selinux-policy-targeted-38.8-1.fc39.noarch.rpm"
+          },
+          "sha256:f894df6361e474e904a667bbe9ab110af509541462932ffaa2cd1ca6b550c726": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/selinux-policy-38.8-1.fc39.noarch.rpm"
+          },
+          "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-identity-basic-39-0.5.noarch.rpm"
+          },
+          "sha256:f9950c21e3c2932edd669e93be82ae8343cc6ec7b0aa2a9e3656b4b449758658": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libxkbcommon-1.5.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:fa3d842fa6c4670b6157050baddb4f2fbb3145ef6249e12ff4d7a75661e552e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/m/mokutil-0.6.0-6.fc38.x86_64.rpm"
+          },
+          "sha256:fafbb148be2f9e1e78095899314044e1ee30a14956b38f295a24f32f3832abfe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/polkit-pkla-compat-0.1-23.fc38.x86_64.rpm"
+          },
+          "sha256:fdfcd7132d187c79dc0f3752e14f7b4e990a2390c9e62f119e648988403fd977": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/n/npth-1.6-12.fc38.x86_64.rpm"
+          },
+          "sha256:fe2f422d5c7b9940e4b6f5ba8df16a7f1a566469af6190b2e61b81e743bb570b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libgcc-13.0.1-0.6.fc39.x86_64.rpm"
+          },
+          "sha256:ff4d38483cd963b3f43c45738773b2998257e1cd1ed2b9da1ad3770bf6357edb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libsecret-0.20.5-3.fc38.x86_64.rpm"
+          }
+        }
+      },
+      "org.osbuild.inline": {
+        "items": {
+          "sha256:246c90eeaabd45d57f9c52ba19ec83577e1ece72cfb262b674dcd444f8f33a8e": {
+            "encoding": "base64",
+            "data": "W1VuaXRdCkRlc2NyaXB0aW9uPUN1c3RvbSBzZXJ2aWNlCgpbU2VydmljZV0KRXhlY1N0YXJ0PS91c3IvYmluL2ZhbHNlCgpbSW5zdGFsbF0KV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQK"
+          },
+          "sha256:3858d66c9da0509af1f75847bf49134bf8df01bd712b59ce251826744d3bafe2": {
+            "encoding": "base64",
+            "data": "W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NhdCAvZXRjL2N1c3RvbV9maWxlLnR4dAo="
+          },
+          "sha256:a08a06016ca077755a7948a9631271011f1a1c3ecaa0e701e10ec0bec1923258": {
+            "encoding": "base64",
+            "data": "aW1hZ2UgYnVpbGRlciBpcyB0aGUgYmVzdA=="
+          },
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {
+            "encoding": "base64",
+            "data": ""
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/a/alternatives-1.21-2.fc38.x86_64.rpm",
+        "checksum": "sha256:ba73a191eecdd07dfdf6c9e9c05ee8a7fc033d00ab22f71c9d765a9f79430932",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/a/audit-libs-3.1-2.fc39.x86_64.rpm",
+        "checksum": "sha256:2ba219030ec4140c0275c00482cbf8a8130e27d6185eea52f715350656a7f853",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/a/authselect-1.4.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:f4a9066b30983c17036794e7873dcd62acb2559ebd298d00bbf27a555bc1e0db",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/a/authselect-libs-1.4.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:156c71be29a4227e99d5198272a6fdbd38f25884de10bd3b03722602f383e56d",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "15.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/b/basesystem-11-15.fc38.noarch.rpm",
+        "checksum": "sha256:16d1843cdac488ad04bdc654dd6b8dfbfeafe33a7728695070481302a7e54345",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.15",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/b/bash-5.2.15-3.fc38.x86_64.rpm",
+        "checksum": "sha256:aafa892d920ab841a6e6076da3f0bfd4d5783a88927473acb6fd8cdff1686f90",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/b/bubblewrap-0.7.0-1.fc39.x86_64.rpm",
+        "checksum": "sha256:228e3e665e38c1e49397b1fe6e1c98aa29b7434e8aa25b39a44b3edc5a362aa9",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "13.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/b/bzip2-libs-1.0.8-13.fc38.x86_64.rpm",
+        "checksum": "sha256:e0214026e8899bf3455f97bed98c287644e52f9350ce977fd0ccab05dbb35b77",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2023.2.60",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm",
+        "checksum": "sha256:3ed298c957602edb7ce91e0d06c4cc876c645d5e9848cd9553b5521ab1dba8a0",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.203.0",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/container-selinux-2.203.0-1.fc39.noarch.rpm",
+        "checksum": "sha256:0cbad3c0b6b1b8c73ac219d5ed3772c89331e46a5fd8e4be3dc065e2021ef904",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "87.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/containers-common-1-87.fc39.noarch.rpm",
+        "checksum": "sha256:6b14738a69996f820a42c8857412d1fa62284932da5874d3d2eb39f0f356714b",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "11.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/coreutils-9.1-11.fc38.x86_64.rpm",
+        "checksum": "sha256:7867d881d29f8c33cb137a99f2c6bbe01456e502291fdb760e7542c8c291b4ea",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "11.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/coreutils-common-9.1-11.fc38.x86_64.rpm",
+        "checksum": "sha256:8b6f3880d1daa1e26cbc410cb9a297be024967d49aa60a660c4e3bb210c1867b",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "14.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/cpio-2.13-14.fc38.x86_64.rpm",
+        "checksum": "sha256:7da7355b078353592654642e662cd68d9518c104b3d95fe6c24cbca3510a0d5f",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/cracklib-2.9.7-31.fc38.x86_64.rpm",
+        "checksum": "sha256:d792de0f75798996e8cf2851ae04b3a47d3e267bacffbfcfb02a3d9571f9be00",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/cracklib-dicts-2.9.7-31.fc38.x86_64.rpm",
+        "checksum": "sha256:77e278739167196fcbf7b6a538e954dc7857c3ebe1dad36a3940be0128746d60",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20230301",
+        "release": "1.gita12f7b2.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/crypto-policies-20230301-1.gita12f7b2.fc39.noarch.rpm",
+        "checksum": "sha256:67b6c981dbc626378729138b7eec77198053d6c4c354a5c638901afa30c5a847",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20230301",
+        "release": "1.gita12f7b2.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/crypto-policies-scripts-20230301-1.gita12f7b2.fc39.noarch.rpm",
+        "checksum": "sha256:73e923d9adbba6384840bac86c7664169fdd74f61a3db9407840f41f91e63d9c",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/cryptsetup-libs-2.6.1-1.fc39.x86_64.rpm",
+        "checksum": "sha256:80a414135a766a8ca123eb392157e82e837aec38c4d6aec849d62494a1acf28f",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.88.1",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/curl-7.88.1-1.fc39.x86_64.rpm",
+        "checksum": "sha256:2320484133302a774460dca284f0b78a41623a0169e935ca62b3e7c9ac291ce7",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/c/cyrus-sasl-lib-2.1.28-9.fc38.x86_64.rpm",
+        "checksum": "sha256:288c3f12e3c1c65e522c82a1583eb57972b595ff4e62c685b904b6e479d67093",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/dbus-1.14.6-1.fc38.x86_64.rpm",
+        "checksum": "sha256:0ad0000a318a04be81dc299677f2993b7283c39c5a350a56888c1266194f7602",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "33",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/dbus-broker-33-1.fc38.x86_64.rpm",
+        "checksum": "sha256:527026089d1cbf7b681d916a37078e552349c7183df0bc51a37276c330391e22",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm",
+        "checksum": "sha256:42a6fa3db480f36554e51af9ca2c25a523e005ea09dfe3489403254496934e66",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.191",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/device-mapper-1.02.191-2.fc39.x86_64.rpm",
+        "checksum": "sha256:90fefdd11b8d06bfee61cfac21bfbf92325b3b4dae06547395f6f2c7b5deed10",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.191",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/device-mapper-libs-1.02.191-2.fc39.x86_64.rpm",
+        "checksum": "sha256:a2f93d70bc111d246a0bf846c86e98b14e625e4e3eba0d95bdb1b6e3d803d3e2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/diffutils-3.9-3.fc39.x86_64.rpm",
+        "checksum": "sha256:99ab50da3c0a25f5bbb92d3b3920abf4a01800c3aeac76e61fef877e760a3b41",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/dosfstools-4.2-6.fc38.x86_64.rpm",
+        "checksum": "sha256:9e25af815ea18afcfe8cab5f50fec3b2c8e602880e912b37dbc07e81e7a48f69",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "059",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/dracut-059-3.fc39.x86_64.rpm",
+        "checksum": "sha256:5d7d79d18255d8e8e45c4b9fd666fc9562d9a253b599b9ba4631b6991221479e",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "059",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/dracut-config-generic-059-3.fc39.x86_64.rpm",
+        "checksum": "sha256:d6a82c3256e0420169b0dd940d978894321883e4c316fb4e996989adfa89c25c",
+        "check_gpg": true
+      },
+      {
+        "name": "duktape",
+        "epoch": 0,
+        "version": "2.7.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/d/duktape-2.7.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:e919ba41c7e69504041ec33a5118cf696c19408b9bda7d30acacab8e0e8fea83",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/e2fsprogs-1.46.5-4.fc38.x86_64.rpm",
+        "checksum": "sha256:291c42304b5977f3c2c611ade53af3d146d8ad5f8c83c1c1f5c6ac92acadf2a1",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/e2fsprogs-libs-1.46.5-4.fc38.x86_64.rpm",
+        "checksum": "sha256:5fa9010ad567df986d484ddcac865ea25a26c818def22df0c4e3688fc346568d",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "7.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm",
+        "checksum": "sha256:bba199cbc2d5363334072bc40d868c9c0ff301d67dddd14a55f032043c9dc824",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/efibootmgr-18-3.fc38.x86_64.rpm",
+        "checksum": "sha256:3d57c8a275a9db4aaa234a73685d075b74b00930d7881ed7892748b790773764",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "7.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/efivar-libs-38-7.fc38.x86_64.rpm",
+        "checksum": "sha256:8ff9a034c4cc68941868d2fab9fb0489fb7d2f7667ce3fc645c296b70ecb408d",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/elfutils-debuginfod-client-0.189-1.fc39.x86_64.rpm",
+        "checksum": "sha256:bbed67f96b39130ef7cc8f0b1a267eed02cf7b7f7c17faa2be7ddc3e4374ac72",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/elfutils-default-yama-scope-0.189-1.fc39.noarch.rpm",
+        "checksum": "sha256:f33f41efdeb7ed371ca73539df63e0a24e1ba6f1c08eb6b3a13efeee143c22cf",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/elfutils-libelf-0.189-1.fc39.x86_64.rpm",
+        "checksum": "sha256:450ad2cb89b8e99a9e285a87e5942e1eb04c19da70afd229a9c0a168860b64d1",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/elfutils-libs-0.189-1.fc39.x86_64.rpm",
+        "checksum": "sha256:70059465e292dc49a920ef7db57d26e82410aebf6ab8d1264d8e2716c19f6645",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/expat-2.5.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:2af61bff099ba092381fc3bcfad33abeb46e0bbd80d39957160ebeeeae6662af",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-gpg-keys-39-0.1.noarch.rpm",
+        "checksum": "sha256:04db736a77296edd4099a9165d68560d52dbf2484d959f668b3b676d68581f97",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.5",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-39-0.5.noarch.rpm",
+        "checksum": "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.5",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-common-39-0.5.noarch.rpm",
+        "checksum": "sha256:69c9711600ede5bd00494ae8dafa400121de28f70cb4784f4546b8810c4b4cd3",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.5",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-identity-basic-39-0.5.noarch.rpm",
+        "checksum": "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-repos-39-0.1.noarch.rpm",
+        "checksum": "sha256:8ecb72298a8b662ee1a17e7fb4e1d279d7fc64b358c9fdf9a568a965022b3f97",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-repos-rawhide-39-0.1.noarch.rpm",
+        "checksum": "sha256:3908078cd7debb2b2e081a7ea30fdf598f702ba7e65db7159836403940ed2421",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/file-5.44-2.fc39.x86_64.rpm",
+        "checksum": "sha256:02f807f62c5d65d6e204aaf604413cb960f322d9eae08b38b82de21a537d0d59",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/file-libs-5.44-2.fc39.x86_64.rpm",
+        "checksum": "sha256:e9d47d4f8c115837a086789d8da306a435a77f25789ebad06c110da407864f34",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/filesystem-3.18-4.fc39.x86_64.rpm",
+        "checksum": "sha256:38e188b7682c3df92bcebd568812b4f0de6f35d785a7d3e568acc3e6e14c28c7",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/findutils-4.9.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:dec19668dc6051323597760b1dcfba516e049d99f4d4faba181ab89bb76dfd26",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fuse-2.9.9-16.fc38.x86_64.rpm",
+        "checksum": "sha256:d949521c5b898a94e9c3e2ffed751671b652687b34016ceca4bef650c68eb3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.14.0",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fuse-common-3.14.0-1.fc39.x86_64.rpm",
+        "checksum": "sha256:a0fd0950f4c4766556a58a23aa878c6e43ff2aadb16541361c16330b275532ff",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fuse-libs-2.9.9-16.fc38.x86_64.rpm",
+        "checksum": "sha256:9f6c383fa225665fc42dc174762cee30f9ae6ffcc247b324cc3cfa67ff75ba44",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fuse-overlayfs-1.10-4.fc39.x86_64.rpm",
+        "checksum": "sha256:94a66aeb619bcc64c9f4da716ac356eae4cc48fd746a4efeaeb3be1d47339003",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.14.0",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fuse3-3.14.0-1.fc39.x86_64.rpm",
+        "checksum": "sha256:7db0f713c86eff1668979f122b8cba968dc621a17b6d60dab73470c6aeac478c",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.14.0",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fuse3-libs-3.14.0-1.fc39.x86_64.rpm",
+        "checksum": "sha256:68772d2dd6659cd0eafb405000585bd7589c987274809ed0fe07d28ff85ecb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gawk-5.1.1-5.fc38.x86_64.rpm",
+        "checksum": "sha256:319b782e36d052581555edca137af6095cc1aaac007d9bdc1d963893085587c5",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gawk-all-langpacks-5.1.1-5.fc38.x86_64.rpm",
+        "checksum": "sha256:b835a3d70d4b826f41d9bd2894fc0575fa609d0431d1ba2934db60eb261135a5",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gdbm-libs-1.23-3.fc38.x86_64.rpm",
+        "checksum": "sha256:212cb1084c3d5a05d12308d768417dd12678a860ccfc89c2f70dada566e11259",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gettext-envsubst-0.21.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:0d7baf4131395fdd190b584309e4656c86a3cae3e39368866be827ffd8a31576",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gettext-libs-0.21.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:3c5d61f2209be9748c7ca38cfb9714b699d1cf3ed84087cc7af55f45382d6716",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gettext-runtime-0.21.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:164b2bec69f169b4ba2e706655d1cb92a1e547c0ecd99cc7ba190e2643600d6f",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.75.4",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/glib2-2.75.4-2.fc39.x86_64.rpm",
+        "checksum": "sha256:36a64a62d2f251871c1616451befd54d2761448d668de0371e05a59a185c99c3",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/glibc-2.37.9000-3.fc39.x86_64.rpm",
+        "checksum": "sha256:e911b2035148f19a606bdd11bbcca202e673b1e3d8c6dbff989b77b2ff761fd9",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/glibc-common-2.37.9000-3.fc39.x86_64.rpm",
+        "checksum": "sha256:1573a247a3f3a89273c1bf230cd5a62196c5aa22ddf13d0c44684ff3ad78ca9b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/glibc-gconv-extra-2.37.9000-3.fc39.x86_64.rpm",
+        "checksum": "sha256:6f50f77a0ba03e554cced7c779b18e11c099a5abeef74d35f8bdc015c7618b5b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/glibc-minimal-langpack-2.37.9000-3.fc39.x86_64.rpm",
+        "checksum": "sha256:4b30c7dc86e31ea87fcdbd58c9ee126c8af9a84bc8a23cf30858af5e8ae8c822",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gmp-6.2.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:b940446486f6dfaa2a7651fd9cf7050cae6171d75b7fca865fa8d58400c1a0c7",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gnupg2-2.4.0-3.fc39.x86_64.rpm",
+        "checksum": "sha256:4ef881ad8a2f683020cb4d49a4bac6a8947ca5f826266391da945834f95b42ce",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gnupg2-smime-2.4.0-3.fc39.x86_64.rpm",
+        "checksum": "sha256:7aa9604ad09e1985b610278a5412b1393b1928b9beb64baee783d4618ccc90ff",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.8.0",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gnutls-3.8.0-2.fc39.x86_64.rpm",
+        "checksum": "sha256:42aca1f4d1635dff866d060af6a97707b015f892570077ac92f52cd940522266",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.1",
+        "release": "5.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gpgme-1.17.1-5.fc39.x86_64.rpm",
+        "checksum": "sha256:a8a381267845f761809f10b8d27db002a1a5c6b2b54bd6720fa0d921439268f1",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/grep-3.9-1.fc39.x86_64.rpm",
+        "checksum": "sha256:1edd6d0c726af868fe64c6fb8e62b72e55dbad94ae0e3a835548aa1160f57bda",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "88.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/grub2-common-2.06-88.fc39.noarch.rpm",
+        "checksum": "sha256:e2101508acd9f16f43fb1781e7242fd5ea1570275ab9f596ec1fdd622ac947d0",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "88.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/grub2-efi-x64-2.06-88.fc39.x86_64.rpm",
+        "checksum": "sha256:ded6a789884bf08981d97c15f86e24bcf62d47ab0453404068949087ab63706c",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "88.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/grub2-tools-2.06-88.fc39.x86_64.rpm",
+        "checksum": "sha256:c76b7bb46e9eee4137415778575da7d0b06db811c35afa2a9833d82b25d6bd91",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "88.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/grub2-tools-minimal-2.06-88.fc39.x86_64.rpm",
+        "checksum": "sha256:f5ea642626ff8f0506e27fa9dc70fcfa89a430f1eb641a03926ef38af4b2158d",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "70.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/grubby-8.40-70.fc39.x86_64.rpm",
+        "checksum": "sha256:30eea609388f8cf3f8418eb7e648262d5053f9171eb627225c89118dda9faa6e",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/g/gzip-1.12-3.fc38.x86_64.rpm",
+        "checksum": "sha256:2ee988694d3c875dcaa4741453ee07b4dc1da31205abb035065dbc7c8c72c0da",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/j/json-c-0.16-4.fc38.x86_64.rpm",
+        "checksum": "sha256:d06140e05f5d7c831331260a898d83e5079a3ead0f4616925dd94da8a33e5ede",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/j/json-glib-1.6.6-4.fc38.x86_64.rpm",
+        "checksum": "sha256:5540bc7f5d2f38cc82aa329a0c2078060a13dd27096238776f7b063cae7ccd70",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/kbd-2.5.1-5.fc39.x86_64.rpm",
+        "checksum": "sha256:d55660b07157161b5c6c54182033581497d3704433f9a4701c36e36b8f668616",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/kbd-legacy-2.5.1-5.fc39.noarch.rpm",
+        "checksum": "sha256:9858eb4e6a8aca2d0e69a57d3db25f1a561e117e6c6221ccd0b3518f7db7f01e",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/kbd-misc-2.5.1-5.fc39.noarch.rpm",
+        "checksum": "sha256:58f75a8368b74d16380f7eeb1c506c3907ab4d168a91bb092c96da81bd27f59f",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/keyutils-libs-1.6.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:a8003e886f65342e06c75edaef2bc54b1f313a9b19ba3d8b573b7b72a9583d87",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/kmod-30-4.fc38.x86_64.rpm",
+        "checksum": "sha256:8411db01396745b0f2a9fd2107e04ed89da22e743dc1f8c2b1c341391be7c819",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/kmod-libs-30-4.fc38.x86_64.rpm",
+        "checksum": "sha256:162ef2aebef5ec4dafe56be3f7fbf82c5d1fee147ec4d85e350713258cf45865",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/kpartx-0.9.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:821b12de1c46ef30a5b177bad1f0bed53097311692845c55dba98e4af15c2033",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.20.1",
+        "release": "9.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/k/krb5-libs-1.20.1-9.fc39.x86_64.rpm",
+        "checksum": "sha256:96e794f0c3a2d542760e6584f792b76b187699f58e218ea84d1232d1f43ed0fe",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libacl-2.3.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:2bd57ae89a0e8c2205bb8a043e605a445e1983834f1fe8d29edccb7ee8ecb0dd",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "5.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libarchive-3.6.1-5.fc39.x86_64.rpm",
+        "checksum": "sha256:c4b337632153e008b8fcd39c5cafedb90fb03c6e765ebc610b0effb6e9409721",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libargon2-20190702-2.fc38.x86_64.rpm",
+        "checksum": "sha256:8a930ab3e11e25093f322f907e1d96cf38d75054b2566611c4414723ac1b5016",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libassuan-2.5.5-6.fc38.x86_64.rpm",
+        "checksum": "sha256:13b6ee1aaadee8fc6ad6713f6fcca12d340d8b662c341ef11eb1bbca9f28b1d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libattr-2.5.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:2a6b60b523093bc2c3f31a14618c3f168faf5b9088cb422e08c450af62292153",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libb2-0.98.1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:9dc90426b66ef657dd666b8cff6a8b79d97049940e04fe432c1679407d7190a0",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libblkid-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:f07644af2a3529eac157814f85268a09d8697ceb068ebd564011789d7ca8391d",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "11.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libbrotli-1.0.9-11.fc38.x86_64.rpm",
+        "checksum": "sha256:1437effaa1e9cef61e6d942b5e7e352965d33e44666805fd4107f660d7a825e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libcap-2.48-6.fc38.x86_64.rpm",
+        "checksum": "sha256:e848c54481fef3a2afc80a5c38dfd580ec05d821d65361d48a989128c36e5aaf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libcap-ng-0.8.3-5.fc38.x86_64.rpm",
+        "checksum": "sha256:5a8b121b402d579ba941a7e47513e68ffce46211b252d022ceef6d38706f7328",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.10.2",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libcbor-0.10.2-1.fc39.x86_64.rpm",
+        "checksum": "sha256:c7428fe201f901420f8b84fe5271744d97aa06eff52ebe35b6b1671531e54418",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libcom_err-1.46.5-4.fc38.x86_64.rpm",
+        "checksum": "sha256:7eee29c05014366ade22f339b3b064bdda71a02d76d833173127255e2bc87c8a",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.88.1",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libcurl-7.88.1-1.fc39.x86_64.rpm",
+        "checksum": "sha256:ccdcc7c5e8bdc1eda8407a6644dc5ed8f66b4915ad7e54c462373b4e8b7e5f19",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "55.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libdb-5.3.28-55.fc38.x86_64.rpm",
+        "checksum": "sha256:24b6237f18f6e0643e96a882d3711b5e7411256fffc547ee1a4daa7da0a62f9d",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libeconf-0.4.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:ed115185dd2524d6ad37c4e5a7c26c2ef11461ddd2d52a4e0c73c9b61963f709",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libevent-2.1.12-8.fc38.x86_64.rpm",
+        "checksum": "sha256:0bb1b0d7fa1b5107c98636cc9046912b848e770eefa43161127392bb86ab4559",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libfdisk-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:eb26853ca1388c3c8488ec6459f0288253f8e31e01c7494c0b3073430efa7ba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libffi-3.4.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:4cdee7e7f885d9efe8156bd86e644e2b45f34537870f30c17bbd5113e493b994",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.13.0",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libfido2-1.13.0-2.fc39.x86_64.rpm",
+        "checksum": "sha256:eaec98669b65aa4761783244a9bcbae47dedae32889d1b9cac72ad74fb165951",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "13.0.1",
+        "release": "0.6.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libgcc-13.0.1-0.6.fc39.x86_64.rpm",
+        "checksum": "sha256:fe2f422d5c7b9940e4b6f5ba8df16a7f1a566469af6190b2e61b81e743bb570b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "7.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libgcrypt-1.10.1-7.fc38.x86_64.rpm",
+        "checksum": "sha256:f13a3ba0f10a4924a4ac460a506e45559421b392ecf5c2ee258661e19ed93941",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "13.0.1",
+        "release": "0.6.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libgomp-13.0.1-0.6.fc39.x86_64.rpm",
+        "checksum": "sha256:49e5cc3613a661ac06ba5c14513f4dd3d752b7a4b308a8ece3bdd81468cf2aa3",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.46",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libgpg-error-1.46-2.fc38.x86_64.rpm",
+        "checksum": "sha256:3aa69b60ec18c1fc47367041aca9dea0582fa14b31c7bee12538c4106acce87f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libidn2-2.3.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:e24b40ad581933d9ca22b525c434777d90a46cb4c0b097c497c788e49fd946d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libkcapi-1.4.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:0dbf7d0db94a9cf1745aedb5462d6877d82a99f9010f5037c796ba41f5c737ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:96ceddead12aca9f75215a0492c6c0308902a55e1d756267dedc7fa68850aef2",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libksba-1.6.3-2.fc38.x86_64.rpm",
+        "checksum": "sha256:7036d00dd6f881adb9e4870edfd5a1240f5b647084ed53be464cf8cc6d40c452",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libmodulemd-2.14.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:858e728f42806ce65520953f756c178764c60e29e1a3fa1ea1e1eb95b14950b9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libmount-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:ea61e5c61c7df5d65ff43dfa34c3e6fc2420bd1e479d4e15519023c1b832e261",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.52.0",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libnghttp2-1.52.0-1.fc39.x86_64.rpm",
+        "checksum": "sha256:893c52ea0bac3758fb0c61c6449a7204fb088193d5ad2f0480ab8ef7af40e59a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libnsl2-2.0.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:e88d40b14861564cbbf640d366076b5b381cc3a30d818930f043dfb3f158e68a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libpsl-0.21.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:8cb49ad623d30a9fbe923b31b0413732b22f8763ec719efdcb535a356a9d0d6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.5",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libpwquality-1.4.5-3.fc38.x86_64.rpm",
+        "checksum": "sha256:893d2125cc10c36b67e5d04544015be0f27d5a99e2ac83ba14904219c5e15d68",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/librepo-1.15.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:f18410a0d1d25049f39315372924c318314254cba55f2d3f24d0c28e31cbbbb5",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libseccomp-2.5.3-4.fc38.x86_64.rpm",
+        "checksum": "sha256:843187a57219bd86402b570db6ce0b7ef50e9bd3b7dcf57124542356c85e4c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libsecret-0.20.5-3.fc38.x86_64.rpm",
+        "checksum": "sha256:ff4d38483cd963b3f43c45738773b2998257e1cd1ed2b9da1ad3770bf6357edb",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libselinux-3.5-1.fc39.x86_64.rpm",
+        "checksum": "sha256:a861e4c858fb8b7b246c9a5156780ef9188e5058b430a09d5274cf8154e4651b",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libselinux-utils-3.5-1.fc39.x86_64.rpm",
+        "checksum": "sha256:89ea4d920d4b97d56fc88c4abcc30454059e2a5698aba86633a29346c4d66d88",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libsemanage-3.5-1.fc39.x86_64.rpm",
+        "checksum": "sha256:a6cf83800141978f0b6f88a9cf218ddeaf84ad7459f2270f1bbf6da32f18d4cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libsepol-3.5-1.fc39.x86_64.rpm",
+        "checksum": "sha256:a119520536c2d78fe4ab09fa36de55321fa5a926aca955640504d6fa7e98790b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libsigsegv-2.14-4.fc38.x86_64.rpm",
+        "checksum": "sha256:2f95ec8a9e82166735d2a0dad196caf86d3b03b1d751333664fdc49af04652e3",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libsmartcols-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:10295dcfa946c6fb7b52c1b8781da4dc6c59dc8fc0e07bab2f3187fc1f143b9a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libsolv-0.7.22-4.fc38.x86_64.rpm",
+        "checksum": "sha256:8ac4cd82686478387e18d884e52254370152123a14a6476ece6810b78e0fc9fe",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libss-1.46.5-4.fc38.x86_64.rpm",
+        "checksum": "sha256:ede3d13a4e42ba9fb840d351b3039939e5552f974f5a23981271c6bc4ac7f8a4",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libssh-0.10.4-4.fc39.x86_64.rpm",
+        "checksum": "sha256:1ee7aaf7efddee4b3dcbad1e7b13f79c4ea58f40d6d0734a29dca359f540930d",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.4",
+        "release": "4.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libssh-config-0.10.4-4.fc39.noarch.rpm",
+        "checksum": "sha256:1bc707f6df0aac3eb69be6e32be2edb32c772c1afb63300577e72fcec472af54",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "13.0.1",
+        "release": "0.6.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libstdc++-13.0.1-0.6.fc39.x86_64.rpm",
+        "checksum": "sha256:4879018880886651208d90a74357ff33d9230f1cfe05a0c6efc21fcdfe21acba",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.19.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libtasn1-4.19.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:755f70836736d33825f0ca0a30966364f9c47f336a9679647806efca38935468",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libtirpc-1.3.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:633ce6404f6ac32892f2124fa9d8e511ed6d2e3c31d6c9fcb5f9f183416547ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libunistring-1.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:2cf3c52adb539112d160d78ad0eb0536f41a4fc0087ca74043de59267ae397ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring1.0",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libunistring1.0-1.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:a437f855037feb83c8388e0d7799050d178a0e33b72ca2b2845ade7182ad104a",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.26",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libusb1-1.0.26-2.fc38.x86_64.rpm",
+        "checksum": "sha256:a6e85db2da9cc041eef3c34d38d50ec07e0c71a1c1aff8772296572c987076c8",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libutempter-1.2.1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:f657e5e5c5985e114fd9f957a371d7dd123fa1c38ad8df6a75b1713edd0fa4d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libuuid-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:c05ae7b8c8c32ece4656d4aa296c383e9327168c1417232caca03612ff7f043e",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libverto-0.3.2-5.fc38.x86_64.rpm",
+        "checksum": "sha256:a724e47d0afbe9ea8b8750ac8b1db8e1faad7cb77f7dc1907990789f5f5dec71",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "7.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libxcrypt-4.4.33-7.fc39.x86_64.rpm",
+        "checksum": "sha256:71a9cbe5c77f55cac9084cbff178924e28b44981a53f82c66c3053521875c39b",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "7.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libxcrypt-compat-4.4.33-7.fc39.x86_64.rpm",
+        "checksum": "sha256:27a0bdd0cd20b0e73f2285100a00a81eb162687d159f5952dceb8d298e34ef66",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libxkbcommon-1.5.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:f9950c21e3c2932edd669e93be82ae8343cc6ec7b0aa2a9e3656b4b449758658",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libxml2-2.10.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:b9a9659d705cbafd77164f6e9aad0990c4f28822216f59750d3a6835815f688d",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libyaml-0.2.5-9.fc38.x86_64.rpm",
+        "checksum": "sha256:dae1b79663b5e2810668f0b9350e5d62b64af07cf3e6a85da386b4accd08b699",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.4",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/libzstd-1.5.4-1.fc39.x86_64.rpm",
+        "checksum": "sha256:e3fa33d2f4eb43a83bcf3ddc2775d0a7c272183a1ef6f2d5c0ff9cf95a983d73",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "9.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/lua-libs-5.4.4-9.fc39.x86_64.rpm",
+        "checksum": "sha256:245491bf843da1571cd8b6f16ec3e9569c4b983bef02a28fd53e63a1fac9fa21",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/l/lz4-libs-1.9.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:1a2dd2ddcf1ab7a789633d7a0f5890b0fe12c96ad3c88c7a5f8df547190fdb32",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/m/memstrack-0.2.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:d7c0d81cb8f51af66460df06dc8266ca59ba0fe11b9af6649268e3aed51c73b9",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.15",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/m/mkpasswd-5.5.15-3.fc38.x86_64.rpm",
+        "checksum": "sha256:b263e183ca9f2ad3d1d6525bd466ec30e1dd716318c0efa7ab13fc7a0181ca72",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/m/mokutil-0.6.0-6.fc38.x86_64.rpm",
+        "checksum": "sha256:fa3d842fa6c4670b6157050baddb4f2fbb3145ef6249e12ff4d7a75661e552e7",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/m/mpdecimal-2.5.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:c98c47d647f33a5a552c0031d1c7b035a9f54a8a0ba64d220f1b90d4cb990926",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/m/mpfr-4.1.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:4dce785f0955e4bc212f5642fbf76752e8e758fddaf31d423c76064442c382a4",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "3.20230114.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/n/ncurses-base-6.4-3.20230114.fc38.noarch.rpm",
+        "checksum": "sha256:f5c2b7e34cd518428e2b57b97d53038a35112bfd7dcf70b99a362edf6df03174",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "3.20230114.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/n/ncurses-libs-6.4-3.20230114.fc38.x86_64.rpm",
+        "checksum": "sha256:c611cb6193f4bb3971727d46a5f02a196d4d594fbc00ee76d22668e5f9eac477",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/n/nettle-3.8-3.fc38.x86_64.rpm",
+        "checksum": "sha256:1ab436b853babb890810427c0906f401a8778570d9c106aae2a93dd689b56395",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "12.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/n/npth-1.6-12.fc38.x86_64.rpm",
+        "checksum": "sha256:fdfcd7132d187c79dc0f3752e14f7b4e990a2390c9e62f119e648988403fd977",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.4",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/o/openldap-2.6.4-1.fc39.x86_64.rpm",
+        "checksum": "sha256:665924d246f41013251f24cc626757abd2a932fb12c58c25d4e8bb005c36605f",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.8",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/o/openssl-libs-3.0.8-1.fc39.x86_64.rpm",
+        "checksum": "sha256:bed6e9157e37283845bfd06b1f2e42b3b921e7f7c17786bd48fa535c3da17c15",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/o/openssl-pkcs11-0.4.12-3.fc38.x86_64.rpm",
+        "checksum": "sha256:f2f6a4a9a1bdc46e03263959c4a898c29d9873ca2c031a61f365c6842823eef4",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/o/os-prober-1.81-3.fc38.x86_64.rpm",
+        "checksum": "sha256:9f196c1696af163c77062c566618e52a7df7fe6d0f76744596d00d15a86a3ca7",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2023.1",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/o/ostree-2023.1-2.fc39.x86_64.rpm",
+        "checksum": "sha256:1bf2514fbb41e260c1bfb0192ca64f3277ba828c2df6f44ad2877f572e5adf52",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2023.1",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/o/ostree-libs-2023.1-2.fc39.x86_64.rpm",
+        "checksum": "sha256:f58a005f676fa9c84983fce7348af1f6ee5018edf7bf2c085f5fa39b3b6e7f4f",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/p11-kit-0.24.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:3d099f56457cac6b78d5a7fa1a288449b2fd40940ba79c38f3a8cdf72de08d0b",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/p11-kit-trust-0.24.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:17ccfb5f326ac494420b346b6a19633f6a29666edff3bd2927b24a181c30043d",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "17.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pam-1.5.2-17.fc39.x86_64.rpm",
+        "checksum": "sha256:2759df9eae082382df537953d18a34d81203837669ec30d13d5e6c2ed1345ea3",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "17.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pam-libs-1.5.2-17.fc39.x86_64.rpm",
+        "checksum": "sha256:cf1084af759222796497ae1db44733d8572475170e706828af4d4c0c093a3da2",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pcre2-10.42-1.fc38.1.x86_64.rpm",
+        "checksum": "sha256:8e9d90ae76137486c9584ad0ff007348d83349fe97e29310659b13057dba78b4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm",
+        "checksum": "sha256:4f19a70d3fbf30ac298700d3918d7fb483a387adf3d08b96efaa07d51dd0b156",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pcsc-lite-1.9.9-3.fc38.x86_64.rpm",
+        "checksum": "sha256:25a1a5f81238d9ba5b45b29bfec7a842281f7b623d218b0aa2deb5c6ac7e3bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:38ff8aa05c220dd39d0c93be24ef211424a04ee3ac3ad9ea67906e38b799bf22",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.x86_64.rpm",
+        "checksum": "sha256:35146cabf07ec78d2390120c9bb9e2f5aa35cb8e0bfff84fb748a198b90ce3ac",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pigz-2.7-3.fc38.x86_64.rpm",
+        "checksum": "sha256:1ac270e3158bcf929b5034d3b8e03d28e877e364b9c1d9c769bf54af783973e9",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/pinentry-1.2.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:72d5ce188da2f45a3450e472bfde16b72d8d881414298ea3cf321628cf1fe646",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/policycoreutils-3.5-1.fc39.x86_64.rpm",
+        "checksum": "sha256:19d52491b049e52228176ecffcedf9a76ddff15bfb2afd8d91aeb76a24b9f277",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "122",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/polkit-122-4.fc39.x86_64.rpm",
+        "checksum": "sha256:419353b49f29e4bd5e5fe58f264db093424c148776c32dcc78a82c8793c8725f",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "122",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/polkit-libs-122-4.fc39.x86_64.rpm",
+        "checksum": "sha256:15ae42ad0d83c8e708c06cd6286ca5fcb35f780b032d012c809e96b216a77e60",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "23.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/polkit-pkla-compat-0.1-23.fc38.x86_64.rpm",
+        "checksum": "sha256:fafbb148be2f9e1e78095899314044e1ee30a14956b38f295a24f32f3832abfe",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/popt-1.19-2.fc38.x86_64.rpm",
+        "checksum": "sha256:00c43379a70e7167e59f71d7da775489dc2f218c768cff68c1edc8e51f35c2c5",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/procps-ng-3.3.17-9.fc38.x86_64.rpm",
+        "checksum": "sha256:139c6a046ae7b9a5693783f75a28b2b99b9411b62e89df3ca634d8b950d7d005",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20221208",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/publicsuffix-list-dafsa-20221208-2.fc38.noarch.rpm",
+        "checksum": "sha256:3cf03283e8e07e37763931446a599809c069fe25c20a0eb6dd6386f447673e06",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "23.0.1",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/python-pip-wheel-23.0.1-1.fc39.noarch.rpm",
+        "checksum": "sha256:b0d44fc3728295b16ee16e3eea5981c56115ef494e0e1dbabc04670c3a99aad9",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "65.5.1",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/python-setuptools-wheel-65.5.1-2.fc38.noarch.rpm",
+        "checksum": "sha256:54aa1a0699326aae0137529166df648a393331e99280ca10f77f6fc904caf9e4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.2",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/python-unversioned-command-3.11.2-1.fc39.noarch.rpm",
+        "checksum": "sha256:7d54836133ed06083473cb58977db4422dfb201cb73f18e730d4691eebfa5414",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.2",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/python3-3.11.2-1.fc39.x86_64.rpm",
+        "checksum": "sha256:9ed4609b92a2f2ecebed214447b4f3ba450a5e86e52209af421b45bdedface8c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.2",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/p/python3-libs-3.11.2-1.fc39.x86_64.rpm",
+        "checksum": "sha256:1f8b50a8229265341fdefc8472f9d36897e6430439c159d6a3aa87e186f92f6a",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/q/qrencode-libs-4.1.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:b8d6d9c6f976e196f8eb0a8d04ca1f02821d0dbc904120d0c4bd7d7fc2ef8fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/readline-8.2-3.fc38.x86_64.rpm",
+        "checksum": "sha256:1a878a4a0448222e0a34864ef4f3c8b674b05ef08a05ea992d9c50b3ecbae10d",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "11.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/rpm-4.18.0-11.fc39.x86_64.rpm",
+        "checksum": "sha256:8321f09000e84895f3ae6a52963761f2ab2a67fb36753a2d02f587f121e2b3ed",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "11.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/rpm-libs-4.18.0-11.fc39.x86_64.rpm",
+        "checksum": "sha256:44c3fd81aa5de107c630c8ad571f225e5338450d24df4dcdf2de1b00f619ea20",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2023.2",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/rpm-ostree-2023.2-1.fc39.x86_64.rpm",
+        "checksum": "sha256:9210dac0631e049bf2d21111db062b58c668a1cb07584b525da10233870ff5a7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2023.2",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/rpm-ostree-libs-2023.2-1.fc39.x86_64.rpm",
+        "checksum": "sha256:55691164bb75a80738db0691ba6493d678f7797953bea35b2df4e60494b059cc",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "11.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/rpm-plugin-selinux-4.18.0-11.fc39.x86_64.rpm",
+        "checksum": "sha256:dca9b9ef6667bd5fb311bc39129370664d1cfe627be04aa2f78b2c0651a4906b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sequoia",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/r/rpm-sequoia-1.3.0-1.fc39.x86_64.rpm",
+        "checksum": "sha256:d77c48d393ffada69140de4d0adb89cec02153c6884d5829d2ed30b422cde82b",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "12.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/sed-4.8-12.fc38.x86_64.rpm",
+        "checksum": "sha256:13767df6745449f9458b4097fd10cdc5a6f577f53a14cf4d3608052a9cb368a3",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "38.8",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/selinux-policy-38.8-1.fc39.noarch.rpm",
+        "checksum": "sha256:f894df6361e474e904a667bbe9ab110af509541462932ffaa2cd1ca6b550c726",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "38.8",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/selinux-policy-targeted-38.8-1.fc39.noarch.rpm",
+        "checksum": "sha256:f6d14f22f3b4e8bb3428d2cbef4e75821ec5c132a08816f159d82025be36f774",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.3",
+        "release": "3.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/setup-2.14.3-3.fc39.noarch.rpm",
+        "checksum": "sha256:e10c0ec1a70226866cd13c044cdb398d519fa28ae3f2cf5747b6ce799d3bd0c5",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.13",
+        "release": "6.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/shadow-utils-4.13-6.fc39.x86_64.rpm",
+        "checksum": "sha256:c8a2cbec7fc78f885cf077f6ee088e64634a48694b94e611ad57f9ee15314731",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/shim-x64-15.6-2.x86_64.rpm",
+        "checksum": "sha256:174bda41056c4cac41ef9bf8a7adb06affd92bcb18a258d319b9153bf0f00686",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.11.1",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/skopeo-1.11.1-2.fc39.x86_64.rpm",
+        "checksum": "sha256:d82246ac2f3d4f4c5c47739e5176550ca759ac89ee35be920d511ba4d809f4a4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.40.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/sqlite-libs-3.40.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:e96e91ff1c7b0667539c2d00d1f674a4b97638bfe1b6bc2eb2dfeaa59c127f9f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "253.1",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/systemd-253.1-4.fc39.x86_64.rpm",
+        "checksum": "sha256:861df4978f7a58b561d78dadd633e0b642f1fe010f5d9ad7ee1c104a1984b41f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "253.1",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/systemd-libs-253.1-4.fc39.x86_64.rpm",
+        "checksum": "sha256:199b1cd22fe6fb5f3a1d8035dc4f6348486ce9f623618714085fe641221decd7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "253.1",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/systemd-networkd-253.1-4.fc39.x86_64.rpm",
+        "checksum": "sha256:b2ef95d47ec9eb73b3054d778c31755c0f487d93d7393f18451e34c9c019ae5b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "253.1",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/systemd-pam-253.1-4.fc39.x86_64.rpm",
+        "checksum": "sha256:5c159d71832d6b89b2e9ba696464027e54ea91125670bd9d012483b3a7451298",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "253.1",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/systemd-resolved-253.1-4.fc39.x86_64.rpm",
+        "checksum": "sha256:499b7d4998f9ee1beaec404e83e5be8ce0b20ac86caa91f849e9f4f2c4161563",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "253.1",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/systemd-udev-253.1-4.fc39.x86_64.rpm",
+        "checksum": "sha256:351b576c1e36e1519502aa1a7e6b3dcec269a18c6bc6230eabb1043f93c6a87b",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.5",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/t/tpm2-tools-5.5-1.fc39.x86_64.rpm",
+        "checksum": "sha256:bb31f92c186b8b042f0e56833f9e3efaeb66dd6c979f869921ff75a249882c0d",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "4.0.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/t/tpm2-tss-4.0.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:d624895c7f19e23fb77b7f2ae21a9dcf0698820a3325ae5b1343f6bb612a178e",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022g",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/t/tzdata-2022g-2.fc38.noarch.rpm",
+        "checksum": "sha256:e9f81f7b77e1011de9e9cf4c68a149aa70f4f33e2bfa394213396115eaf9a2d0",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/u/util-linux-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:0f601b8e483465177d65aaf099005bc66bda448cedbd860af5cc2577b582fa04",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/u/util-linux-core-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:4901b670be1372e70460dfcf943bc9e1442c190f64778c865d5a18dda80b0efc",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "39.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/w/which-2.21-39.fc39.x86_64.rpm",
+        "checksum": "sha256:45b50ec7c49cdaf0d9116037718e11de09c6684633ee8a6123dd1dab0016723e",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.15",
+        "release": "3.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/w/whois-nls-5.5.15-3.fc38.noarch.rpm",
+        "checksum": "sha256:05cee3fe2968c1f5e507a7c0908e40ab2337f03df07292d9743578a7069af40b",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm",
+        "checksum": "sha256:c77fd27cb1dc592a2d9ba9238b80aafdf340749d690f15db59e8483609da884c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/x/xz-5.4.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:c09c17d5100fd441511d8bc79c4dd58f00fd6bac019287bd1507998fc711f22d",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/x/xz-libs-5.4.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:80a1d66fcdf2572fb1583b3a2e8a342dc9375aa4205f002aa7d798df7011ffc5",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/z/zchunk-libs-1.3.0-1.fc39.x86_64.rpm",
+        "checksum": "sha256:473274e5b2d2b84575bbb14a145efd15aa638ce14b543b66118bb90d55c3dc3c",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.13",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
+        "checksum": "sha256:6fc47cd2f53b150153a3865c2fbd6b1c57fcc265fb3602b6f4f3883cf6ec64e2",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -537,6 +537,96 @@
     },
     "overrides": {}
   },
+  "iot-raw-image-customizations": {
+    "compose-request": {
+      "distro": "",
+      "arch": "",
+      "image-type": "iot-raw-image",
+      "repositories": [],
+      "filename": "image.raw.xz",
+      "ostree": {
+        "ref": "test/fedora/iot",
+        "url": "http://fedora.example.com/repo"
+      },
+      "blueprint": {
+        "customizations": {
+          "user": [
+            {
+              "name": "user2",
+              "description": "description 2",
+              "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+              "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+              "home": "/home/home2",
+              "shell": "/bin/sh",
+              "groups": [
+                "group1"
+              ],
+              "uid": 1020,
+              "gid": 1050
+            },
+            {
+              "name": "user3",
+              "uid": 1060,
+              "gid": 1060
+            }
+          ],
+          "group": [
+            {
+              "name": "group1",
+              "gid": 1030
+            },
+            {
+              "name": "group2",
+              "gid": 1050
+            },
+            {
+              "name": "user3",
+              "gid": 1060
+            }
+          ],
+          "services": {
+            "enabled": [
+              "custom.service"
+            ]
+          },
+          "directories": [
+            {
+              "path": "/etc/systemd/system/custom.service.d"
+            },
+            {
+              "path": "/etc/custom_dir",
+              "mode": "0770",
+              "user": 1020,
+              "group": 1050
+            }
+          ],
+          "files": [
+            {
+              "path": "/etc/systemd/system/custom.service",
+              "data": "[Unit]\nDescription=Custom service\n\n[Service]\nExecStart=/usr/bin/false\n\n[Install]\nWantedBy=multi-user.target\n"
+            },
+            {
+              "path": "/etc/systemd/system/custom.service.d/override.conf",
+              "data": "[Service]\nExecStart=\nExecStart=/usr/bin/cat /etc/custom_file.txt\n"
+            },
+            {
+              "path": "/etc/custom_file.txt",
+              "data": "image builder is the best",
+              "mode": "0644",
+              "user": "root",
+              "group": "root"
+            },
+            {
+              "path": "/etc/empty_file.txt",
+              "user": 0,
+              "group": 0
+            }
+          ]
+        }
+      }
+    },
+    "overrides": {}
+  },
   "openstack": {
     "boot": {
       "type": "openstack"


### PR DESCRIPTION
This is a follow-up for https://github.com/osbuild/osbuild-composer/pull/3281 adding support for the new customizations to ostree-deploy pipeline and exposing it for the Fedora `iot-raw-image`.

These customizations could be technically used also by RHEL edge image types, but the BP customization values are not passed through to the pipeline in the RHEL distro image type implementation.

Notable changes:

- Allow Files and Directories customization for Fedora `iot-raw-image` image type.
- Allow Services customization for iot-raw-image image type, to allow using the existing test case from `check_ostree.yaml`
- Restrict allowed customization for the iot/edge-raw-image, because some of them are currently just silently ignored.

Resolves [COMPOSER-1912](https://issues.redhat.com/browse/COMPOSER-1912)

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
  - added image test manifests for Fedora `iot-raw-image` with all the supported customizations
  - extended the `ostree-raw-image.sh` test case to test the customization on Fedora
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/ **(will update once this PR is merged)** 

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
