### PR TITLE
manifest/os: fix SUPPRESSED_ERROR issue reported by Coverity

### DIFF
--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -544,8 +544,8 @@ func (p *OS) serialize() osbuild.Pipeline {
 					Nick:    p.OSNick,
 				}
 
-				rescueVer, _ := rpmmd.GetVerStrFromPackageSpecList(p.packageSpecs, "dracut-config-rescue")
-				hasRescue := rescueVer != ""
+				_, err := rpmmd.GetVerStrFromPackageSpecList(p.packageSpecs, "dracut-config-rescue")
+				hasRescue := err == nil
 				bootloader = osbuild.NewGrub2LegacyStage(
 					osbuild.NewGrub2LegacyStageOptions(
 						p.Grub2Config,


### PR DESCRIPTION
Fix the following error reported by Coverity:
```
Defect type: SUPPRESSED_ERROR
1. osbuild-composer-75/_build/src/github.com/osbuild/osbuild-composer/internal/manifest/os.go:546: suppressed_error: The error returned by the function "GetVerStrFromPackageSpecList(p.packageSpecs, "dracut-config-rescue")" is not explicitly checked.
2. osbuild-composer-75/_build/src/github.com/osbuild/osbuild-composer/internal/manifest/os.go:546: remediation: Explicitly check the return error.
   544|   				}
   545|
   546|-> 				rescueVer, _ := rpmmd.GetVerStrFromPackageSpecList(p.packageSpecs, "dracut-config-rescue")
   547|   				hasRescue := rescueVer != ""
   548|   				bootloader = osbuild.NewGrub2LegacyStage(
```

Change the code to check if the called function returned an error or not. If not error is returned, then the function returns a package version string.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
