### PR TITLE
ignition: enable systemd firstboot condition through kargs

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-36": {
     "dependencies": {
       "osbuild": {
-        "commit": "200c2b0129877c5b0c61a0c31fd3f663e1d39952"
+        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
       }
     },
     "repos": [
@@ -79,7 +79,7 @@
   "fedora-37": {
     "dependencies": {
       "osbuild": {
-        "commit": "200c2b0129877c5b0c61a0c31fd3f663e1d39952"
+        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
       }
     },
     "repos": [
@@ -156,28 +156,28 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "200c2b0129877c5b0c61a0c31fd3f663e1d39952"
+        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
       }
     }
   },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {
-        "commit": "200c2b0129877c5b0c61a0c31fd3f663e1d39952"
+        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
       }
     }
   },
   "rhel-8.7": {
     "dependencies": {
       "osbuild": {
-        "commit": "200c2b0129877c5b0c61a0c31fd3f663e1d39952"
+        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
       }
     }
   },
   "rhel-8.8": {
     "dependencies": {
       "osbuild": {
-        "commit": "200c2b0129877c5b0c61a0c31fd3f663e1d39952"
+        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
       }
     },
     "repos": [
@@ -223,21 +223,21 @@
   "rhel-9.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "200c2b0129877c5b0c61a0c31fd3f663e1d39952"
+        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
       }
     }
   },
   "rhel-9.1": {
     "dependencies": {
       "osbuild": {
-        "commit": "200c2b0129877c5b0c61a0c31fd3f663e1d39952"
+        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
       }
     }
   },
   "rhel-9.2": {
     "dependencies": {
       "osbuild": {
-        "commit": "200c2b0129877c5b0c61a0c31fd3f663e1d39952"
+        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
       }
     },
     "repos": [
@@ -283,21 +283,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "200c2b0129877c5b0c61a0c31fd3f663e1d39952"
+        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "200c2b0129877c5b0c61a0c31fd3f663e1d39952"
+        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "200c2b0129877c5b0c61a0c31fd3f663e1d39952"
+        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
       }
     },
     "repos": [
@@ -343,7 +343,7 @@
   "centos-stream-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "200c2b0129877c5b0c61a0c31fd3f663e1d39952"
+        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
       }
     },
     "repos": [

--- a/internal/osbuild/ignition_stage.go
+++ b/internal/osbuild/ignition_stage.go
@@ -6,6 +6,7 @@ import (
 )
 
 type IgnitionStageOptions struct {
+	Network []string `json:"network,omitempty"`
 }
 
 func (IgnitionStageOptions) isStageOptions() {}

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -295,10 +295,10 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 80
-Requires:   osbuild-ostree >= 80
-Requires:   osbuild-lvm2 >= 80
-Requires:   osbuild-luks2 >= 80
+Requires:   osbuild >= 81
+Requires:   osbuild-ostree >= 81
+Requires:   osbuild-lvm2 >= 81
+Requires:   osbuild-luks2 >= 81
 Requires:   %{name}-dnf-json = %{version}-%{release}
 
 %description worker

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -71,6 +71,29 @@
       when: ignition == "true" and ((ansible_facts['distribution'] == 'RedHat' and ansible_facts['distribution_version'] is version('9.2', '>=')) or
             (ansible_facts['distribution'] == 'CentOS' and (ansible_facts['distribution_version'] == '9')))
 
+    - name: check systemd service correctly started on firstboot
+      block:
+
+        - name: check hello.service logs
+          command: journalctl -b -0 -u hello.service
+          register: result_hello_service_log
+
+        - assert:
+            that:
+              - "'Hello, World!' in result_hello_service_log.stdout"
+            fail_msg: "hello.service doesn't have the correct log"
+            success_msg: "hello.service started and working"
+
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: ignition == "true" and ((ansible_facts['distribution'] == 'RedHat' and ansible_facts['distribution_version'] is version('9.2', '>=')) or
+            (ansible_facts['distribution'] == 'CentOS' and (ansible_facts['distribution_version'] == '9')))
+
     - name: wait for FDO onboarding
       block:
         - wait_for:

--- a/test/data/manifests/centos_9-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_raw_image-boot.json
@@ -2263,7 +2263,12 @@
           },
           {
             "type": "org.osbuild.ignition",
-            "options": {}
+            "options": {
+              "network": [
+                "systemd.firstboot=off",
+                "systemd.condition-first-boot=true"
+              ]
+            }
           },
           {
             "type": "org.osbuild.users",

--- a/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
@@ -2647,7 +2647,12 @@
           },
           {
             "type": "org.osbuild.ignition",
-            "options": {}
+            "options": {
+              "network": [
+                "systemd.firstboot=off",
+                "systemd.condition-first-boot=true"
+              ]
+            }
           },
           {
             "type": "org.osbuild.users",

--- a/test/data/manifests/centos_9-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_raw_image-boot.json
@@ -2390,7 +2390,12 @@
           },
           {
             "type": "org.osbuild.ignition",
-            "options": {}
+            "options": {
+              "network": [
+                "systemd.firstboot=off",
+                "systemd.condition-first-boot=true"
+              ]
+            }
           },
           {
             "type": "org.osbuild.users",

--- a/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
@@ -2702,7 +2702,12 @@
           },
           {
             "type": "org.osbuild.ignition",
-            "options": {}
+            "options": {
+              "network": [
+                "systemd.firstboot=off",
+                "systemd.condition-first-boot=true"
+              ]
+            }
           },
           {
             "type": "org.osbuild.users",

--- a/test/data/manifests/rhel_92-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_raw_image-boot.json
@@ -2271,7 +2271,12 @@
           },
           {
             "type": "org.osbuild.ignition",
-            "options": {}
+            "options": {
+              "network": [
+                "systemd.firstboot=off",
+                "systemd.condition-first-boot=true"
+              ]
+            }
           },
           {
             "type": "org.osbuild.users",

--- a/test/data/manifests/rhel_92-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_simplified_installer-boot.json
@@ -2655,7 +2655,12 @@
           },
           {
             "type": "org.osbuild.ignition",
-            "options": {}
+            "options": {
+              "network": [
+                "systemd.firstboot=off",
+                "systemd.condition-first-boot=true"
+              ]
+            }
           },
           {
             "type": "org.osbuild.users",

--- a/test/data/manifests/rhel_92-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_raw_image-boot.json
@@ -2391,7 +2391,12 @@
           },
           {
             "type": "org.osbuild.ignition",
-            "options": {}
+            "options": {
+              "network": [
+                "systemd.firstboot=off",
+                "systemd.condition-first-boot=true"
+              ]
+            }
           },
           {
             "type": "org.osbuild.users",

--- a/test/data/manifests/rhel_92-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_simplified_installer-boot.json
@@ -2703,7 +2703,12 @@
           },
           {
             "type": "org.osbuild.ignition",
-            "options": {}
+            "options": {
+              "network": [
+                "systemd.firstboot=off",
+                "systemd.condition-first-boot=true"
+              ]
+            }
           },
           {
             "type": "org.osbuild.users",


### PR DESCRIPTION
This is a workaround to make the systemd believe it's firstboot when ignition runs on real firstboot.
Right now, since we ship /etc/machine-id, systemd thinks it's not firstboot and ignition depends on it to run on the real firstboot to enable services from presets. Since this only applies to artifacts with ignition and changing machineid-compat at commit creation time may have undesiderable effect, we're doing it here as a stopgap. We may revisit this in the future.

Requires https://github.com/osbuild/osbuild/pull/1249


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
