### PR TITLE
tools/appsre-ansible: don't subscribe machines used for rpmbuild

### DIFF
--- a/templates/packer/ansible/roles/common/tasks/packages.yml
+++ b/templates/packer/ansible/roles/common/tasks/packages.yml
@@ -24,18 +24,6 @@
   # if osbuild_commit is not defined, osbuild from distribution repositories is installed
   when: osbuild_commit is defined
 
-# Upgrading authselect without --allowerasing currently fails on RHEL 9.1 with RHUI repos
-# https://issues.redhat.com/browse/RHUIOPS-84
-# TODO: remove this once the issue is fixed
-- name: Upgrade authselect package
-  dnf:
-    name: authselect
-    state: latest
-    allowerasing: yes
-  register: result
-  retries: 5
-  until: result is success
-
 - name: Upgrade all packages
   package:
     name: "*"

--- a/tools/appsre-ansible/rpmbuild.yml
+++ b/tools/appsre-ansible/rpmbuild.yml
@@ -20,11 +20,6 @@
       name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
       disable_gpg_check: yes
 
-  - name: Subscribe
-    community.general.redhat_subscription:
-      activationkey: "{{ RH_ACTIVATION_KEY }}"
-      org_id: "{{ RH_ORG_ID }}"
-
   # Upgrading authselect without --allowerasing currently fails on RHEL 9.1 with RHUI repos
   # https://issues.redhat.com/browse/RHUIOPS-84
   # TODO: remove this once the issue is fixed

--- a/tools/appsre-ansible/rpmbuild.yml
+++ b/tools/appsre-ansible/rpmbuild.yml
@@ -20,18 +20,6 @@
       name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
       disable_gpg_check: yes
 
-  # Upgrading authselect without --allowerasing currently fails on RHEL 9.1 with RHUI repos
-  # https://issues.redhat.com/browse/RHUIOPS-84
-  # TODO: remove this once the issue is fixed
-  - name: Upgrade authselect package
-    dnf:
-      name: authselect
-      state: latest
-      allowerasing: yes
-    register: result
-    retries: 5
-    until: result is success
-
   - name: Upgrade all packages
     package:
       name: "*"

--- a/tools/appsre-build-worker-packer.sh
+++ b/tools/appsre-build-worker-packer.sh
@@ -26,9 +26,6 @@ if [ "$ON_JENKINS" = false ]; then
     # see https://bugzilla.redhat.com/show_bug.cgi?id=2143282
     # TODO: Remove me when the bug is fixed or we switch to 9.1
     sudo dnf remove -y python-unversioned-command
-    # TODO: Remove once authselect-compat-1.2.5-2.el9_1.x86_64 is in el9 RHUI repos
-    # https://issues.redhat.com/browse/RHUIOPS-84
-    sudo dnf upgrade -y --allowerasing authselect
     sudo dnf upgrade -y
 
     sudo dnf install -y podman jq


### PR DESCRIPTION
We actually use rhui/cloud access images for rpmbuild as well. And the sync issue between cdn and rhui repos can cause issues when rpms are build against older packages.
