### PR TITLE
Add worker dockerfile for devel purposes

### DIFF
--- a/distribution/Dockerfile-worker-devel
+++ b/distribution/Dockerfile-worker-devel
@@ -1,0 +1,35 @@
+FROM fedora:37 AS builder
+ENV GOBIN=/opt/app-root/src/go/bin
+# extra packages are needed
+# to compile osbuild
+RUN dnf install -y golang \
+  krb5-devel \
+  gpgme-devel \
+  libassuan-devel
+WORKDIR /osbuild-composer
+COPY . /osbuild-composer
+ENV GOFLAGS=-mod=vendor
+RUN go install ./cmd/osbuild-worker
+
+FROM fedora:37 AS osbuild-builder
+RUN dnf install -y git rpm-build make python3 'dnf-command(builddep)'\
+ && dnf builddep -y osbuild
+COPY ./osbuild /osbuild
+WORKDIR /osbuild
+RUN make rpm
+
+FROM fedora
+RUN dnf update -y && dnf upgrade -y
+COPY --from=osbuild-builder /osbuild/rpmbuild/RPMS/* /opt
+RUN dnf localinstall -y /opt/*.rpm\
+ && dnf install -y libxcrypt-compat qemu-img osbuild-ostree
+RUN mkdir -p "/usr/libexec/osbuild-composer"
+RUN mkdir -p "/etc/osbuild-composer/"
+RUN mkdir -p "/run/osbuild-composer/"
+RUN mkdir -p "/var/cache/osbuild-worker/"
+RUN mkdir -p "/var/lib/osbuild-composer/"
+RUN mkdir -p "/var/cache/osbuild-composer/output"
+COPY --from=builder /opt/app-root/src/go/bin/osbuild-worker /usr/libexec/osbuild-composer/
+COPY ./dnf-json /usr/libexec/osbuild-composer/
+
+ENTRYPOINT ["/usr/libexec/osbuild-composer/osbuild-worker"]


### PR DESCRIPTION
The original worker dockerfile was installing osbuild from fedora repositories rather than from local checkout which interferes with docker-compose setup


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
