### PR TITLE
worker: allow configuring number of upload threads for Azure

### DIFF
--- a/cmd/osbuild-worker/config_test.go
+++ b/cmd/osbuild-worker/config_test.go
@@ -43,6 +43,7 @@ credentials = "/etc/osbuild-worker/gcp-creds"
 
 [azure]
 credentials = "/etc/osbuild-worker/azure-creds"
+upload_threads = 8
 
 [aws]
 credentials = "/etc/osbuild-worker/aws-creds"
@@ -88,7 +89,8 @@ offline_token = "/etc/osbuild-worker/offline_token"
 					Credentials: "/etc/osbuild-worker/gcp-creds",
 				},
 				Azure: &azureConfig{
-					Credentials: "/etc/osbuild-worker/azure-creds",
+					Credentials:   "/etc/osbuild-worker/azure-creds",
+					UploadThreads: 8,
 				},
 				AWS: &awsConfig{
 					Credentials: "/etc/osbuild-worker/aws-creds",
@@ -141,6 +143,17 @@ offline_token = "/etc/osbuild-worker/offline_token"
 		_, err := parseConfig(configFile)
 		require.Error(t, err)
 	})
+
+	t.Run("wrong Azure config", func(t *testing.T) {
+		configFile := prepareConfig(t, `
+[azure]
+credentials = "/etc/osbuild-worker/azure-creds"
+upload_threads = -5
+`)
+		_, err := parseConfig(configFile)
+		require.Error(t, err)
+	})
+
 }
 
 func prepareConfig(t *testing.T, config string) string {

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -341,12 +341,13 @@ func main() {
 	// Load Azure credentials early. If the credentials file is malformed,
 	// we can report the issue early instead of waiting for the first osbuild
 	// job with the org.osbuild.azure.image target.
-	var azureCredentials *azure.Credentials
+	var azureConfig AzureConfiguration
 	if config.Azure != nil {
-		azureCredentials, err = azure.ParseAzureCredentialsFile(config.Azure.Credentials)
+		azureConfig.Creds, err = azure.ParseAzureCredentialsFile(config.Azure.Credentials)
 		if err != nil {
 			logrus.Fatalf("cannot load azure credentials: %v", err)
 		}
+		azureConfig.UploadThreads = config.Azure.UploadThreads
 	}
 
 	// If the credentials are not provided in the configuration, then the
@@ -437,7 +438,7 @@ func main() {
 			Output:      output,
 			KojiServers: kojiServers,
 			GCPConfig:   gcpConfig,
-			AzureCreds:  azureCredentials,
+			AzureConfig: azureConfig,
 			AWSCreds:    awsCredentials,
 			AWSBucket:   awsBucket,
 			S3Config: S3Configuration{


### PR DESCRIPTION
The default number of threads (16) is OK for general use case. However, we are being asked by RH IT to lower the number of threads when uploading the image to Azure using proxy server.

Make the number of threads configurable in the worker configuration and default to the currently used value if it is not provided.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
  - [ ] unit test for invalid value.
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
