### PR TITLE
test/vmware: boot VMs with EFI and use SCSI as a disk controller

### DIFF
--- a/test/cases/api/common/vsphere.sh
+++ b/test/cases/api/common/vsphere.sh
@@ -152,9 +152,9 @@ function verifyInVSphere() {
         -folder="${GOVMOMI_FOLDER}" \
         -net="${GOVMOMI_NETWORK}" \
         -net.adapter=vmxnet3 \
-        -m=4096 -c=2 -g=rhel8_64Guest -on=true -firmware=bios \
+        -m=4096 -c=2 -g=rhel8_64Guest -on=true -firmware=efi \
         -disk="${VSPHERE_VM_NAME}/${VSPHERE_IMAGE_NAME}" \
-        -disk.controller=ide \
+        -disk.controller=scsi \
         -on=false \
         "${VSPHERE_VM_NAME}"
 

--- a/test/cases/vmware.sh
+++ b/test/cases/vmware.sh
@@ -182,9 +182,9 @@ $GOVC_CMD vm.create -u "${GOVMOMI_USERNAME}":"${GOVMOMI_PASSWORD}"@"${GOVMOMI_UR
     -folder="${GOVMOMI_FOLDER}" \
     -net="${GOVMOMI_NETWORK}" \
     -net.adapter=vmxnet3 \
-    -m=4096 -c=2 -g=rhel8_64Guest -on=true -firmware=bios \
+    -m=4096 -c=2 -g=rhel8_64Guest -on=true -firmware=efi \
     -disk="${IMAGE_KEY}"/"${IMAGE_KEY}".vmdk \
-    --disk.controller=ide \
+    --disk.controller=scsi \
     "${IMAGE_KEY}"
 
 # tagging vm as testing object


### PR DESCRIPTION
Since we use streamOptimized images everywhere, we no longer need to use IDE and boot with bios. Let's test a more realistic scenario.

