### PR TITLE
Save manifest lists when pulling containers

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-36": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     },
     "repos": [
@@ -79,7 +79,7 @@
   "fedora-37": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     },
     "repos": [
@@ -199,28 +199,28 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "rhel-8.7": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "rhel-8.8": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     },
     "repos": [
@@ -266,21 +266,21 @@
   "rhel-9.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "rhel-9.1": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "rhel-9.2": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     },
     "repos": [
@@ -326,21 +326,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     },
     "repos": [
@@ -386,7 +386,7 @@
   "centos-stream-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     },
     "repos": [

--- a/cmd/osbuild-worker/jobimpl-container-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-container-resolve.go
@@ -42,11 +42,12 @@ func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
 	} else {
 		for i, spec := range specs {
 			result.Specs[i] = worker.ContainerSpec{
-				Source:    spec.Source,
-				Name:      spec.LocalName,
-				TLSVerify: spec.TLSVerify,
-				ImageID:   spec.ImageID,
-				Digest:    spec.Digest,
+				Source:     spec.Source,
+				Name:       spec.LocalName,
+				TLSVerify:  spec.TLSVerify,
+				ImageID:    spec.ImageID,
+				Digest:     spec.Digest,
+				ListDigest: spec.ListDigest,
 			}
 		}
 	}

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -434,6 +434,7 @@ func generateManifest(ctx context.Context, workers *worker.Server, depsolveJobID
 			containerSpecs[i].LocalName = s.Name
 			containerSpecs[i].TLSVerify = s.TLSVerify
 			containerSpecs[i].ImageID = s.ImageID
+			containerSpecs[i].ListDigest = s.ListDigest
 		}
 	}
 

--- a/internal/container/client.go
+++ b/internal/container/client.go
@@ -480,8 +480,7 @@ func (cl *Client) Resolve(ctx context.Context, name string) (Spec, error) {
 		return Spec{}, err
 	}
 
-	spec := NewSpec(cl.Target, ids.Manifest, ids.Config)
-	spec.TLSVerify = cl.GetTLSVerify()
+	spec := NewSpec(cl.Target, ids.Manifest, ids.Config, cl.GetTLSVerify(), "")
 
 	return spec, nil
 }

--- a/internal/container/client_test.go
+++ b/internal/container/client_test.go
@@ -18,7 +18,7 @@ func TestClientResolve(t *testing.T) {
 	defer registry.Close()
 
 	repo := registry.AddRepo("library/osbuild")
-	repo.AddImage(
+	listDigest := repo.AddImage(
 		[]Blob{NewDataBlobFromBase64(rootLayer)},
 		[]string{"amd64", "ppc64le"},
 		"cool container",
@@ -39,11 +39,12 @@ func TestClientResolve(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, container.Spec{
-		Source:    ref,
-		Digest:    "sha256:f29b6cd42a94a574583439addcd6694e6224f0e4b32044c9e3aee4c4856c2a50",
-		ImageID:   "sha256:c2ecf25cf190e76b12b07436ad5140d4ba53d8a136d498705e57a006837a720f",
-		TLSVerify: client.GetTLSVerify(),
-		LocalName: ref,
+		Source:     ref,
+		Digest:     "sha256:f29b6cd42a94a574583439addcd6694e6224f0e4b32044c9e3aee4c4856c2a50",
+		ImageID:    "sha256:c2ecf25cf190e76b12b07436ad5140d4ba53d8a136d498705e57a006837a720f",
+		TLSVerify:  client.GetTLSVerify(),
+		LocalName:  ref,
+		ListDigest: listDigest,
 	}, spec)
 
 	client.SetArchitectureChoice("ppc64le")
@@ -51,11 +52,12 @@ func TestClientResolve(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, container.Spec{
-		Source:    ref,
-		Digest:    "sha256:d49eebefb6c7ce5505594bef652bd4adc36f413861bd44209d9b9486310b1264",
-		ImageID:   "sha256:d2ab8fea7f08a22f03b30c13c6ea443121f25e87202a7496e93736efa6fe345a",
-		TLSVerify: client.GetTLSVerify(),
-		LocalName: ref,
+		Source:     ref,
+		Digest:     "sha256:d49eebefb6c7ce5505594bef652bd4adc36f413861bd44209d9b9486310b1264",
+		ImageID:    "sha256:d2ab8fea7f08a22f03b30c13c6ea443121f25e87202a7496e93736efa6fe345a",
+		TLSVerify:  client.GetTLSVerify(),
+		LocalName:  ref,
+		ListDigest: listDigest,
 	}, spec)
 
 	// don't have that architecture

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -348,6 +348,7 @@ func (reg *Registry) Resolve(target, arch string) (container.Spec, error) {
 	}
 
 	lst, ok := repo.images[checksum]
+	listDigest := checksum
 
 	if ok {
 		checksum = ""
@@ -370,11 +371,12 @@ func (reg *Registry) Resolve(target, arch string) (container.Spec, error) {
 	}
 
 	return container.Spec{
-		Source:    ref.String(),
-		Digest:    checksum,
-		ImageID:   mf.ConfigDescriptor.Digest.String(),
-		LocalName: ref.String(),
-		TLSVerify: common.ToPtr(false),
+		Source:     ref.String(),
+		Digest:     checksum,
+		ImageID:    mf.ConfigDescriptor.Digest.String(),
+		LocalName:  ref.String(),
+		TLSVerify:  common.ToPtr(false),
+		ListDigest: listDigest,
 	}, nil
 }
 

--- a/internal/container/spec.go
+++ b/internal/container/spec.go
@@ -22,13 +22,14 @@ type Spec struct {
 // NewSpec creates a new Spec from the essential information.
 // It also converts is the transition point from container
 // specific types (digest.Digest) to generic types (string).
-func NewSpec(source reference.Named, digest, imageID digest.Digest) Spec {
+func NewSpec(source reference.Named, digest, imageID digest.Digest, tlsVerify *bool, listDigest string) Spec {
 	name := source.Name()
 	return Spec{
-		Source:  name,
-		Digest:  digest.String(),
-		ImageID: imageID.String(),
-
-		LocalName: name,
+		Source:     name,
+		Digest:     digest.String(),
+		TLSVerify:  tlsVerify,
+		ImageID:    imageID.String(),
+		LocalName:  name,
+		ListDigest: listDigest,
 	}
 }

--- a/internal/container/spec.go
+++ b/internal/container/spec.go
@@ -11,11 +11,12 @@ import (
 // at the Source via Digest and ImageID. The latter one
 // should remain the same in the target image as well.
 type Spec struct {
-	Source    string // does not include the manifest digest
-	Digest    string // digest of the manifest at the Source
-	TLSVerify *bool  // controls TLS verification
-	ImageID   string // container image identifier
-	LocalName string // name to use inside the image
+	Source     string // does not include the manifest digest
+	Digest     string // digest of the manifest at the Source
+	TLSVerify  *bool  // controls TLS verification
+	ImageID    string // container image identifier
+	LocalName  string // name to use inside the image
+	ListDigest string // digest of the list manifest at the Source (optional)
 }
 
 // NewSpec creates a new Spec from the essential information.

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -352,7 +352,8 @@ func (p *OS) serialize() osbuild.Pipeline {
 			pipeline.AddStage(osbuild.NewContainersStorageConfStage(containerStoreOpts))
 		}
 
-		skopeo := osbuild.NewSkopeoStage(storagePath, images, nil)
+		manifests := osbuild.NewFilesInputForManifestLists(p.Containers)
+		skopeo := osbuild.NewSkopeoStage(storagePath, images, manifests)
 		pipeline.AddStage(skopeo)
 	}
 

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -352,7 +352,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 			pipeline.AddStage(osbuild.NewContainersStorageConfStage(containerStoreOpts))
 		}
 
-		skopeo := osbuild.NewSkopeoStage(images, storagePath)
+		skopeo := osbuild.NewSkopeoStage(storagePath, images)
 		pipeline.AddStage(skopeo)
 	}
 

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -352,7 +352,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 			pipeline.AddStage(osbuild.NewContainersStorageConfStage(containerStoreOpts))
 		}
 
-		skopeo := osbuild.NewSkopeoStage(storagePath, images)
+		skopeo := osbuild.NewSkopeoStage(storagePath, images, nil)
 		pipeline.AddStage(skopeo)
 	}
 

--- a/internal/osbuild/containers_input.go
+++ b/internal/osbuild/containers_input.go
@@ -9,7 +9,7 @@ type ContainersInputReferences interface {
 }
 
 type ContainersInputSourceRef struct {
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 }
 
 type ContainersInputSourceMap map[string]ContainersInputSourceRef

--- a/internal/osbuild/files_input.go
+++ b/internal/osbuild/files_input.go
@@ -3,6 +3,8 @@ package osbuild
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/osbuild/osbuild-composer/internal/container"
 )
 
 // SPECIFIC INPUT STRUCTURE
@@ -275,4 +277,20 @@ func NewFilesInputSourceObjectRef(entries map[string]FilesInputRefMetadata) File
 		refs[fmt.Sprintf("sha256:%s", sha256Sum)] = FilesInputSourceOptions{Metadata: metadata}
 	}
 	return &refs
+}
+
+// NewFilesInputForManifestLists creates a FilesInput for container manifest
+// lists. If there are no list digests in the container specs, it returns nil.
+func NewFilesInputForManifestLists(containers []container.Spec) *FilesInput {
+	refs := make([]string, 0, len(containers))
+	for _, c := range containers {
+		if c.ListDigest != "" {
+			refs = append(refs, c.ListDigest)
+		}
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	filesRef := FilesInputSourcePlainRef(refs)
+	return NewFilesInput(&filesRef)
 }

--- a/internal/osbuild/skopeo_index_source.go
+++ b/internal/osbuild/skopeo_index_source.go
@@ -1,0 +1,57 @@
+package osbuild
+
+import (
+	"fmt"
+)
+
+type SkopeoIndexSource struct {
+	Items map[string]SkopeoIndexSourceItem `json:"items"`
+}
+
+func (SkopeoIndexSource) isSource() {}
+
+type SkopeoIndexSourceImage struct {
+	Name      string `json:"name"`
+	TLSVerify *bool  `json:"tls-verify,omitempty"`
+}
+
+type SkopeoIndexSourceItem struct {
+	Image SkopeoIndexSourceImage `json:"image"`
+}
+
+func (item SkopeoIndexSourceItem) validate() error {
+
+	if item.Image.Name == "" {
+		return fmt.Errorf("source item has empty name")
+	}
+
+	return nil
+}
+
+// NewSkopeoIndexSource creates a new and empty SkopeoIndexSource
+func NewSkopeoIndexSource() *SkopeoIndexSource {
+	return &SkopeoIndexSource{
+		Items: make(map[string]SkopeoIndexSourceItem),
+	}
+}
+
+// AddItem adds a source item to the source; will panic
+// if any of the supplied options are invalid or missing
+func (source *SkopeoIndexSource) AddItem(name, image string, tlsVerify *bool) {
+	item := SkopeoIndexSourceItem{
+		Image: SkopeoIndexSourceImage{
+			Name:      name,
+			TLSVerify: tlsVerify,
+		},
+	}
+
+	if err := item.validate(); err != nil {
+		panic(err)
+	}
+
+	if !skopeoDigestPattern.MatchString(image) {
+		panic("item has invalid image id")
+	}
+
+	source.Items[image] = item
+}

--- a/internal/osbuild/skopeo_stage.go
+++ b/internal/osbuild/skopeo_stage.go
@@ -12,10 +12,18 @@ type SkopeoStageOptions struct {
 
 func (o SkopeoStageOptions) isStageOptions() {}
 
-func NewSkopeoStage(path string, images ContainersInput) *Stage {
+type SkopeoStageInputs struct {
+	Images        ContainersInput `json:"images"`
+	ManifestLists *FilesInput     `json:"manifest-lists,omitempty"`
+}
 
-	inputs := ContainersInputs{
-		"images": images,
+func (SkopeoStageInputs) isStageInputs() {}
+
+func NewSkopeoStage(path string, images ContainersInput, manifests *FilesInput) *Stage {
+
+	inputs := SkopeoStageInputs{
+		Images:        images,
+		ManifestLists: manifests,
 	}
 
 	return &Stage{

--- a/internal/osbuild/skopeo_stage.go
+++ b/internal/osbuild/skopeo_stage.go
@@ -12,7 +12,7 @@ type SkopeoStageOptions struct {
 
 func (o SkopeoStageOptions) isStageOptions() {}
 
-func NewSkopeoStage(images ContainersInput, path string) *Stage {
+func NewSkopeoStage(path string, images ContainersInput) *Stage {
 
 	inputs := ContainersInputs{
 		"images": images,

--- a/internal/osbuild/source.go
+++ b/internal/osbuild/source.go
@@ -102,12 +102,21 @@ func GenSources(packages []rpmmd.PackageSpec, ostreeCommits []ostree.CommitSpec,
 	}
 
 	skopeo := NewSkopeoSource()
+	skopeoIndex := NewSkopeoIndexSource()
 	for _, c := range containers {
 		skopeo.AddItem(c.Source, c.Digest, c.ImageID, c.TLSVerify)
+
+		// if we have a list digest, add a skopeo-index source as well
+		if c.ListDigest != "" {
+			skopeoIndex.AddItem(c.Source, c.ListDigest, c.TLSVerify)
+		}
 	}
 
 	if len(skopeo.Items) > 0 {
 		sources["org.osbuild.skopeo"] = skopeo
+	}
+	if len(skopeoIndex.Items) > 0 {
+		sources["org.osbuild.skopeo-index"] = skopeoIndex
 	}
 
 	return sources

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -2306,6 +2306,7 @@ func (api *API) resolveContainersForImageType(bp blueprint.Blueprint, imageType 
 		specs[i].LocalName = s.Name
 		specs[i].TLSVerify = s.TLSVerify
 		specs[i].ImageID = s.ImageID
+		specs[i].ListDigest = s.ListDigest
 	}
 
 	return specs, nil

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -253,8 +253,9 @@ type ContainerSpec struct {
 	Name      string `json:"name"`
 	TLSVerify *bool  `json:"tls-verify,omitempty"`
 
-	ImageID string `json:"image_id"`
-	Digest  string `json:"digest"`
+	ImageID    string `json:"image_id"`
+	Digest     string `json:"digest"`
+	ListDigest string `json:"list-digest,omitempty"`
 }
 
 type ContainerResolveJob struct {

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -296,10 +296,10 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 81
-Requires:   osbuild-ostree >= 81
-Requires:   osbuild-lvm2 >= 81
-Requires:   osbuild-luks2 >= 81
+Requires:   osbuild >= 83
+Requires:   osbuild-ostree >= 83
+Requires:   osbuild-lvm2 >= 83
+Requires:   osbuild-luks2 >= 83
 Requires:   %{name}-dnf-json = %{version}-%{release}
 
 %description worker

--- a/test/data/manifests/centos_8-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4887,10 +4890,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6164,10 +6177,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -12156,7 +12184,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/centos_8-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5049,8 +5052,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6373,6 +6386,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -12561,7 +12589,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4527,10 +4530,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -5785,10 +5798,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11329,6 +11357,14 @@
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
       "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
       "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
@@ -11327,7 +11327,8 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
@@ -11827,7 +11827,8 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4737,8 +4740,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6039,6 +6052,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11829,6 +11857,14 @@
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
       "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
       "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_36-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_commit_with_container-boot.json
@@ -36,6 +36,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5393,10 +5396,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6819,10 +6832,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -13421,7 +13449,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_36-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_commit_with_container-boot.json
@@ -36,6 +36,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5515,8 +5518,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6979,6 +6992,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -13727,7 +13755,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_37-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5463,10 +5466,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6910,10 +6923,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -13622,7 +13650,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_37-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5585,8 +5588,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -7070,6 +7083,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -13928,7 +13956,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_38-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5295,10 +5298,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6745,10 +6758,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -13247,7 +13275,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_38-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5585,8 +5588,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -7136,6 +7149,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -13994,7 +14022,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_39-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-iot_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5527,10 +5530,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -7058,10 +7071,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -13850,7 +13878,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_39-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-iot_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5609,8 +5612,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -7166,6 +7179,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -14054,7 +14082,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1903,10 +1906,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3191,10 +3204,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8595,7 +8623,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1975,8 +1978,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3310,6 +3323,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8890,7 +8918,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_84-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1864,10 +1867,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3159,10 +3172,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8446,7 +8474,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_84-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1936,8 +1939,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3278,6 +3291,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8741,7 +8769,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_85-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1885,10 +1888,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3148,10 +3161,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8498,7 +8526,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_85-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1957,8 +1960,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3267,6 +3280,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8793,7 +8821,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1897,10 +1900,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3182,10 +3195,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8568,7 +8596,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1969,8 +1972,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3301,6 +3314,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8863,7 +8891,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1903,10 +1906,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3191,10 +3204,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8595,7 +8623,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1975,8 +1978,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3310,6 +3323,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8890,7 +8918,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1903,10 +1906,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3191,10 +3204,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8595,7 +8623,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1975,8 +1978,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3310,6 +3323,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8890,7 +8918,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_9-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4575,10 +4578,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -5836,10 +5849,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11438,7 +11466,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_9-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_commit_with_container-boot.json
@@ -31,6 +31,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4788,8 +4791,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6093,6 +6106,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11941,7 +11969,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1777,10 +1780,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3032,10 +3045,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8058,7 +8086,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1867,8 +1870,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3169,6 +3182,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8425,7 +8453,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4575,10 +4578,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -5836,10 +5849,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11438,7 +11466,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
@@ -13442,7 +13442,8 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
@@ -14937,7 +14937,8 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
@@ -15430,7 +15430,8 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
@@ -31,6 +31,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4788,8 +4791,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6093,6 +6106,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11941,7 +11969,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
@@ -14273,7 +14273,8 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4543,10 +4546,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -5812,10 +5825,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11374,7 +11402,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
@@ -31,6 +31,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4756,8 +4759,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6069,6 +6082,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11877,7 +11905,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -137,6 +137,9 @@
         "containers": [
           {
             "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+          },
+          {
+            "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
           }
         ]
       }
@@ -310,6 +313,9 @@
         "containers": [
           {
             "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+          },
+          {
+            "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
           }
         ]
       }


### PR DESCRIPTION
This PR adds support for the features added in https://github.com/osbuild/osbuild/pull/1252.

1. New osbuild source: `org.osbuld.skopeo-index`, which downloads the manifest list for a container using `skopeo copy --multi-arch=index-only ...`
2. New files input `org.osbulid.files` on the skopeo stage.
3. When the container name specified in the blueprint points to a manifest-list, composer will:
    - Store the list digest on the appropriate container spec while resolving the image ID.
    - Add the source to download the list digest.
    - Add the digest of the manifest list to the skopeo source so that it is merged with the container when embedding into the image.

With these changes, users can now refer to a container with the same digest they used in the blueprint.  Manifest-lists are also downloaded when a container is specified using a tag.

Created a test container and pushed it to the osbuild-composer registry on gitlab (see https://github.com/osbuild/osbuild/pull/1252#issuecomment-1485484680).  I've added the container to the ostree-commit manifests for testing and also to the container-embedding test script.

Temporarily pinned the osbuild commit from the PR to get CI running until it's merged.

_Requires https://github.com/osbuild/osbuild/pull/1252_

Related: COMPOSER-1898