### PR TITLE
tests/ostree: Change centos-8 BOOT_LOCATION to a working boot.iso

### DIFF
--- a/test/cases/ostree-rebase-bios.sh
+++ b/test/cases/ostree-rebase-bios.sh
@@ -112,7 +112,7 @@ case "${ID}-${VERSION_ID}" in
     "centos-8")
         OSTREE_REF="centos/8/${ARCH}/edge"
         OS_VARIANT="centos8"
-        BOOT_LOCATION="http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/"
+        BOOT_LOCATION="https://composes.centos.org/latest-CentOS-Stream-8/compose/BaseOS/x86_64/os/"
         PARENT_REF="centos/8/${ARCH}/edge"
         KERNEL_RT_PKG="kernel-rt-core"
         ;;
@@ -361,7 +361,7 @@ echo -e 'admin\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 STOPHERE
 
 # Get the boot.iso from BOOT_LOCATION
-curl -O "$BOOT_LOCATION"/images/boot.iso
+curl -O "$BOOT_LOCATION"images/boot.iso
 sudo mv boot.iso /var/lib/libvirt/images
 LOCAL_BOOT_LOCATION="/var/lib/libvirt/images/boot.iso"
 

--- a/test/cases/ostree-rebase-uefi.sh
+++ b/test/cases/ostree-rebase-uefi.sh
@@ -112,7 +112,7 @@ case "${ID}-${VERSION_ID}" in
     "centos-8")
         OSTREE_REF="centos/8/${ARCH}/edge"
         OS_VARIANT="centos8"
-        BOOT_LOCATION="http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/"
+        BOOT_LOCATION="https://composes.centos.org/latest-CentOS-Stream-8/compose/BaseOS/x86_64/os/"
         PARENT_REF="centos/8/${ARCH}/edge"
         KERNEL_RT_PKG="kernel-rt-core"
         ;;
@@ -363,7 +363,7 @@ LIBVIRT_IMAGE_PATH=/var/lib/libvirt/images/${IMAGE_KEY}-uefi.qcow2
 sudo qemu-img create -f qcow2 "${LIBVIRT_IMAGE_PATH}" 20G
 
 # Get the boot.iso from BOOT_LOCATION
-curl -O "$BOOT_LOCATION"/images/boot.iso
+curl -O "$BOOT_LOCATION"images/boot.iso
 sudo mv boot.iso /var/lib/libvirt/images
 LOCAL_BOOT_LOCATION="/var/lib/libvirt/images/boot.iso"
 

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -107,7 +107,7 @@ case "${ID}-${VERSION_ID}" in
         OSTREE_REF="centos/8/${ARCH}/edge"
         OS_VARIANT="centos8"
         USER_IN_COMMIT="true"
-        BOOT_LOCATION="http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/"
+        BOOT_LOCATION="https://composes.centos.org/latest-CentOS-Stream-8/compose/BaseOS/x86_64/os/"
         EMBEDED_CONTAINER="true"
         FIREWALL_FEATURE="false"
         DIRS_FILES_CUSTOMIZATION="true"
@@ -490,7 +490,7 @@ if [[ "${USER_IN_COMMIT}" == "true" ]]; then
 fi
 
 # Get the boot.iso from BOOT_LOCATION
-curl -O "$BOOT_LOCATION"/images/boot.iso
+curl -O "$BOOT_LOCATION"images/boot.iso
 sudo mv boot.iso /var/lib/libvirt/images
 LOCAL_BOOT_LOCATION="/var/lib/libvirt/images/boot.iso"
 


### PR DESCRIPTION
The latest boot.iso stopped working. Changing to an older version to unblock CI. RHBZ#2180024 opened with this issue.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
