### PR TITLE
Manifest: always set kernel options in grub2 stage

### DIFF
--- a/internal/manifest/commit_deployment.go
+++ b/internal/manifest/commit_deployment.go
@@ -238,6 +238,7 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 	}
 
 	grubOptions := osbuild.NewGrub2StageOptionsUnified(p.PartitionTable,
+		strings.Join(kernelOpts, " "),
 		"",
 		p.platform.GetUEFIVendor() != "",
 		p.platform.GetBIOSPlatform(),
@@ -249,7 +250,6 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 		Timeout:        1,
 		TerminalOutput: []string{"console"},
 	}
-	grubOptions.KernelOptions = strings.Join(kernelOpts, ",")
 	bootloader := osbuild.NewGRUB2Stage(grubOptions)
 	bootloader.MountOSTree(p.osName, p.commit.Ref, 0)
 	pipeline.AddStage(bootloader)

--- a/internal/osbuild/grub2_stage.go
+++ b/internal/osbuild/grub2_stage.go
@@ -101,6 +101,7 @@ func NewGrub2StageOptions(pt *disk.PartitionTable,
 }
 
 func NewGrub2StageOptionsUnified(pt *disk.PartitionTable,
+	kernelOptions string,
 	kernelVer string,
 	uefi bool,
 	legacy string,
@@ -112,9 +113,16 @@ func NewGrub2StageOptionsUnified(pt *disk.PartitionTable,
 		panic("root filesystem must be defined for grub2 stage, this is a programming error")
 	}
 
+	// NB: We need to set the kernel options regardless of whether we are
+	// writing the command line to grubenv or not. This is because the kernel
+	// options are also written to /etc/default/grub under the GRUB_CMDLINE_LINUX
+	// variable. This is used by the 10_linux script executed by grub2-mkconfig
+	// to override the kernel options in /etc/kernel/cmdline if the file has
+	// older timestamp than /etc/default/grub.
 	stageOptions := GRUB2StageOptions{
 		RootFilesystemUUID: uuid.MustParse(rootFs.GetFSSpec().UUID),
 		Legacy:             legacy,
+		KernelOptions:      kernelOptions,
 		WriteCmdLine:       common.ToPtr(false),
 	}
 

--- a/test/data/manifests/centos_8-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_raw_image-boot.json
@@ -2259,7 +2259,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "centos",
                 "install": true,

--- a/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
@@ -2611,7 +2611,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "centos",
                 "install": true,

--- a/test/data/manifests/centos_8-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_raw_image-boot.json
@@ -2371,7 +2371,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "centos",

--- a/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
@@ -2659,7 +2659,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "centos",
                 "install": true,

--- a/test/data/manifests/centos_9-aarch64-ami-boot.json
+++ b/test/data/manifests/centos_9-aarch64-ami-boot.json
@@ -4421,6 +4421,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0",
               "uefi": {
                 "vendor": "centos",
                 "unified": true

--- a/test/data/manifests/centos_9-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_raw_image-boot.json
@@ -2336,7 +2336,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw,coreos.no_persist_ip,ignition.platform.id=metal,$ignition_firstboot",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4 rw coreos.no_persist_ip ignition.platform.id=metal $ignition_firstboot",
               "uefi": {
                 "vendor": "centos",
                 "install": true,

--- a/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
@@ -2720,7 +2720,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw,coreos.no_persist_ip,ignition.platform.id=metal,$ignition_firstboot",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4 rw coreos.no_persist_ip ignition.platform.id=metal $ignition_firstboot",
               "uefi": {
                 "vendor": "centos",
                 "install": true,

--- a/test/data/manifests/centos_9-aarch64-openstack-boot.json
+++ b/test/data/manifests/centos_9-aarch64-openstack-boot.json
@@ -4446,6 +4446,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "uefi": {
                 "vendor": "centos",
                 "unified": true

--- a/test/data/manifests/centos_9-aarch64-qcow2-boot.json
+++ b/test/data/manifests/centos_9-aarch64-qcow2-boot.json
@@ -4510,6 +4510,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "uefi": {
                 "vendor": "centos",
                 "unified": true

--- a/test/data/manifests/centos_9-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-aarch64-qcow2_customize-boot.json
@@ -4867,6 +4867,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "uefi": {
                 "vendor": "centos",
                 "unified": true

--- a/test/data/manifests/centos_9-aarch64-vhd-boot.json
+++ b/test/data/manifests/centos_9-aarch64-vhd-boot.json
@@ -6059,6 +6059,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "uefi": {
                 "vendor": "centos",
                 "unified": true

--- a/test/data/manifests/centos_9-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/centos_9-ppc64le-qcow2-boot.json
@@ -5151,6 +5151,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "powerpc-ieee1275",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-200.el9.ppc64le",
               "write_cmdline": false,

--- a/test/data/manifests/centos_9-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-ppc64le-qcow2_customize-boot.json
@@ -5492,6 +5492,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "legacy": "powerpc-ieee1275",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-200.el9.ppc64le",
               "write_cmdline": false,

--- a/test/data/manifests/centos_9-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_9-x86_64-ami-boot.json
@@ -4401,6 +4401,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-214.el9.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/centos_9-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_raw_image-boot.json
@@ -2463,7 +2463,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw,coreos.no_persist_ip,ignition.platform.id=metal,$ignition_firstboot",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4 rw coreos.no_persist_ip ignition.platform.id=metal $ignition_firstboot",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "centos",

--- a/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
@@ -2775,7 +2775,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw,coreos.no_persist_ip,ignition.platform.id=metal,$ignition_firstboot",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4 rw coreos.no_persist_ip ignition.platform.id=metal $ignition_firstboot",
               "uefi": {
                 "vendor": "centos",
                 "install": true,

--- a/test/data/manifests/centos_9-x86_64-gce-boot.json
+++ b/test/data/manifests/centos_9-x86_64-gce-boot.json
@@ -4637,6 +4637,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "centos",

--- a/test/data/manifests/centos_9-x86_64-oci-boot.json
+++ b/test/data/manifests/centos_9-x86_64-oci-boot.json
@@ -4777,6 +4777,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "centos",

--- a/test/data/manifests/centos_9-x86_64-openstack-boot.json
+++ b/test/data/manifests/centos_9-x86_64-openstack-boot.json
@@ -4830,6 +4830,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "centos",

--- a/test/data/manifests/centos_9-x86_64-qcow2-boot.json
+++ b/test/data/manifests/centos_9-x86_64-qcow2-boot.json
@@ -4798,6 +4798,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "centos",

--- a/test/data/manifests/centos_9-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-x86_64-qcow2_customize-boot.json
@@ -5235,6 +5235,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "centos",

--- a/test/data/manifests/centos_9-x86_64-vhd-boot.json
+++ b/test/data/manifests/centos_9-x86_64-vhd-boot.json
@@ -6387,6 +6387,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "centos",

--- a/test/data/manifests/centos_9-x86_64-vmdk-boot.json
+++ b/test/data/manifests/centos_9-x86_64-vmdk-boot.json
@@ -4830,6 +4830,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "centos",

--- a/test/data/manifests/fedora_36-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-ami-boot.json
@@ -4860,6 +4860,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_36-aarch64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_raw_image-boot.json
@@ -2219,7 +2219,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4,rw",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
               "uefi": {
                 "vendor": "fedora",
                 "install": true,

--- a/test/data/manifests/fedora_36-aarch64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-minimal_raw-boot.json
@@ -4500,6 +4500,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_36-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-oci-boot.json
@@ -4844,6 +4844,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_36-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-openstack-boot.json
@@ -5089,6 +5089,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_36-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-qcow2-boot.json
@@ -4865,6 +4865,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_36-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-qcow2_customize-boot.json
@@ -5328,6 +5328,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0 debug",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_36-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-ami-boot.json
@@ -4900,6 +4900,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.18.9-200.fc36.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/fedora_36-x86_64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_raw_image-boot.json
@@ -2242,7 +2242,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4,rw",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
               "uefi": {
                 "vendor": "fedora",
                 "install": true,

--- a/test/data/manifests/fedora_36-x86_64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-minimal_raw-boot.json
@@ -4540,6 +4540,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_36-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-oci-boot.json
@@ -4988,6 +4988,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_36-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-openstack-boot.json
@@ -5169,6 +5169,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_36-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-qcow2-boot.json
@@ -5009,6 +5009,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_36-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-qcow2_customize-boot.json
@@ -5472,6 +5472,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0 debug",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_36-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-vhd-boot.json
@@ -4809,6 +4809,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_36-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-vmdk-boot.json
@@ -5113,6 +5113,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_37-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-ami-boot.json
@@ -4850,6 +4850,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_37-aarch64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_raw_image-boot.json
@@ -2235,7 +2235,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4,rw",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
               "uefi": {
                 "vendor": "fedora",
                 "install": true,

--- a/test/data/manifests/fedora_37-aarch64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-minimal_raw-boot.json
@@ -4546,6 +4546,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_37-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-oci-boot.json
@@ -4842,6 +4842,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_37-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-openstack-boot.json
@@ -5079,6 +5079,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_37-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-qcow2-boot.json
@@ -4863,6 +4863,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_37-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-qcow2_customize-boot.json
@@ -5326,6 +5326,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0 debug",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_37-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-ami-boot.json
@@ -4890,6 +4890,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.19.15-301.fc37.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/fedora_37-x86_64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_raw_image-boot.json
@@ -2258,7 +2258,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4,rw",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
               "uefi": {
                 "vendor": "fedora",
                 "install": true,

--- a/test/data/manifests/fedora_37-x86_64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-minimal_raw-boot.json
@@ -4586,6 +4586,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_37-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-oci-boot.json
@@ -4954,6 +4954,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_37-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-openstack-boot.json
@@ -5159,6 +5159,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_37-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-qcow2-boot.json
@@ -4975,6 +4975,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_37-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-qcow2_customize-boot.json
@@ -5438,6 +5438,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0 debug",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_37-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-vhd-boot.json
@@ -4855,6 +4855,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_37-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-vmdk-boot.json
@@ -5079,6 +5079,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_38-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-ami-boot.json
@@ -4858,6 +4858,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_38-aarch64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_raw_image-boot.json
@@ -2050,7 +2050,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4,rw",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
               "uefi": {
                 "vendor": "fedora",
                 "install": true,

--- a/test/data/manifests/fedora_38-aarch64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-minimal_raw-boot.json
@@ -4554,6 +4554,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_38-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-oci-boot.json
@@ -4850,6 +4850,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_38-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-openstack-boot.json
@@ -5087,6 +5087,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_38-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-qcow2-boot.json
@@ -4871,6 +4871,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_38-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-qcow2_customize-boot.json
@@ -5334,6 +5334,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0 debug",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_38-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-ami-boot.json
@@ -4922,6 +4922,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-6.2.0-63.fc38.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/fedora_38-x86_64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_raw_image-boot.json
@@ -2073,7 +2073,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4,rw",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
               "uefi": {
                 "vendor": "fedora",
                 "install": true,

--- a/test/data/manifests/fedora_38-x86_64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-minimal_raw-boot.json
@@ -4618,6 +4618,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_38-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-oci-boot.json
@@ -5074,6 +5074,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_38-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-openstack-boot.json
@@ -5207,6 +5207,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_38-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-qcow2-boot.json
@@ -5095,6 +5095,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_38-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-qcow2_customize-boot.json
@@ -5558,6 +5558,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0 debug",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_38-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-vhd-boot.json
@@ -4895,6 +4895,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_38-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-vmdk-boot.json
@@ -5199,6 +5199,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_39-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-ami-boot.json
@@ -4946,6 +4946,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_39-aarch64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-iot_raw_image-boot.json
@@ -2066,7 +2066,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4,rw",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
               "uefi": {
                 "vendor": "fedora",
                 "install": true,

--- a/test/data/manifests/fedora_39-aarch64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-minimal_raw-boot.json
@@ -4634,6 +4634,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_39-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-oci-boot.json
@@ -5026,6 +5026,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_39-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-openstack-boot.json
@@ -5191,6 +5191,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_39-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-qcow2-boot.json
@@ -5047,6 +5047,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_39-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-qcow2_customize-boot.json
@@ -5510,6 +5510,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0 debug",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_39-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-ami-boot.json
@@ -4954,6 +4954,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-6.3.0-0.rc1.20230308git63355b9884b3.17.fc39.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/fedora_39-x86_64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-iot_raw_image-boot.json
@@ -2081,7 +2081,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4,rw",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
               "uefi": {
                 "vendor": "fedora",
                 "install": true,

--- a/test/data/manifests/fedora_39-x86_64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-minimal_raw-boot.json
@@ -4642,6 +4642,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "uefi": {
                 "vendor": "fedora",
                 "unified": true

--- a/test/data/manifests/fedora_39-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-oci-boot.json
@@ -5106,6 +5106,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_39-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-openstack-boot.json
@@ -5239,6 +5239,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_39-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-qcow2-boot.json
@@ -5127,6 +5127,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_39-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-qcow2_customize-boot.json
@@ -5590,6 +5590,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0 debug",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_39-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-vhd-boot.json
@@ -4919,6 +4919,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_39-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-vmdk-boot.json
@@ -5231,6 +5231,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/rhel_8-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_raw_image-boot.json
@@ -1014,7 +1014,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_simplified_installer-boot.json
@@ -1151,7 +1151,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_8-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_raw_image-boot.json
@@ -1056,7 +1056,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_simplified_installer-boot.json
@@ -1169,7 +1169,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_86-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_raw_image-boot.json
@@ -1014,7 +1014,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
@@ -1154,7 +1154,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_86-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_raw_image-boot.json
@@ -1056,7 +1056,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
@@ -1172,7 +1172,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_87-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_raw_image-boot.json
@@ -1014,7 +1014,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_87-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_simplified_installer-boot.json
@@ -1151,7 +1151,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_87-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_raw_image-boot.json
@@ -1056,7 +1056,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_87-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_simplified_installer-boot.json
@@ -1169,7 +1169,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_88-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_raw_image-boot.json
@@ -1014,7 +1014,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_88-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_simplified_installer-boot.json
@@ -1151,7 +1151,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_88-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_raw_image-boot.json
@@ -1056,7 +1056,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_88-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_simplified_installer-boot.json
@@ -1169,7 +1169,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_9-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-ami-boot.json
@@ -4583,6 +4583,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_9-aarch64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-azure_rhui-boot.json
@@ -6337,6 +6337,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_9-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-ec2-boot.json
@@ -4616,6 +4616,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_9-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_raw_image-boot.json
@@ -2388,7 +2388,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_9-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_simplified_installer-boot.json
@@ -2772,7 +2772,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_9-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-openstack-boot.json
@@ -4558,6 +4558,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_9-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-qcow2-boot.json
@@ -4699,6 +4699,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_9-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-qcow2_customize-boot.json
@@ -5056,6 +5056,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_9-aarch64-vhd-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-vhd-boot.json
@@ -6256,6 +6256,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_9-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_9-ppc64le-qcow2-boot.json
@@ -5316,6 +5316,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "powerpc-ieee1275",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.ppc64le",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_9-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_9-ppc64le-qcow2_customize-boot.json
@@ -5657,6 +5657,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "legacy": "powerpc-ieee1275",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.ppc64le",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_9-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-ami-boot.json
@@ -4547,6 +4547,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_9-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-azure_rhui-boot.json
@@ -6617,6 +6617,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_9-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-ec2-boot.json
@@ -4582,6 +4582,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_9-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-ec2_ha-boot.json
@@ -6026,6 +6026,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_9-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-ec2_sap-boot.json
@@ -8581,6 +8581,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 processor.max_cstate=1 intel_idle.max_cstate=1",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_9-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_raw_image-boot.json
@@ -2508,7 +2508,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_9-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_simplified_installer-boot.json
@@ -2820,7 +2820,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_9-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-gce-boot.json
@@ -4807,6 +4807,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_9-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-gce_rhui-boot.json
@@ -4813,6 +4813,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_9-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-oci-boot.json
@@ -4934,6 +4934,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_9-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-openstack-boot.json
@@ -4918,6 +4918,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_9-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-qcow2-boot.json
@@ -4955,6 +4955,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_9-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-qcow2_customize-boot.json
@@ -5392,6 +5392,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_9-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-vhd-boot.json
@@ -6552,6 +6552,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_9-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-vmdk-boot.json
@@ -4918,6 +4918,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_90-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ami-boot.json
@@ -1888,6 +1888,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_90-aarch64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-azure_rhui-boot.json
@@ -2575,6 +2575,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_90-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ec2-boot.json
@@ -1907,6 +1907,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_90-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_raw_image-boot.json
@@ -993,7 +993,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
@@ -1142,7 +1142,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_90-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-openstack-boot.json
@@ -1808,6 +1808,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
@@ -1857,6 +1857,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
@@ -2086,6 +2086,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_90-aarch64-vhd-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-vhd-boot.json
@@ -2529,6 +2529,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
@@ -2087,6 +2087,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "powerpc-ieee1275",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-55.el9.ppc64le",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
@@ -2310,6 +2310,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "legacy": "powerpc-ieee1275",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-55.el9.ppc64le",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -1891,6 +1891,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-55.el9.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
@@ -2683,6 +2683,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_90-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2-boot.json
@@ -1912,6 +1912,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-55.el9.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
@@ -2484,6 +2484,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-55.el9.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -3404,6 +3404,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 processor.max_cstate=1 intel_idle.max_cstate=1",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-55.el9.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_90-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_raw_image-boot.json
@@ -1041,7 +1041,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
@@ -1163,7 +1163,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_90-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-gce-boot.json
@@ -1977,6 +1977,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_90-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-gce_rhui-boot.json
@@ -1983,6 +1983,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_90-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-oci-boot.json
@@ -1938,6 +1938,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_90-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-openstack-boot.json
@@ -1952,6 +1952,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
@@ -1959,6 +1959,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
@@ -2218,6 +2218,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_90-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-vhd-boot.json
@@ -2643,6 +2643,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_90-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-vmdk-boot.json
@@ -1952,6 +1952,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_91-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-ami-boot.json
@@ -4583,6 +4583,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_91-aarch64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-azure_rhui-boot.json
@@ -6337,6 +6337,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_91-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-ec2-boot.json
@@ -4616,6 +4616,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_91-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_raw_image-boot.json
@@ -2388,7 +2388,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_91-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_simplified_installer-boot.json
@@ -2772,7 +2772,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_91-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-openstack-boot.json
@@ -4558,6 +4558,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_91-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-qcow2-boot.json
@@ -4699,6 +4699,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
@@ -5329,6 +5329,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_91-aarch64-vhd-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-vhd-boot.json
@@ -6256,6 +6256,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_91-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_91-ppc64le-qcow2-boot.json
@@ -5316,6 +5316,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "powerpc-ieee1275",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.ppc64le",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
@@ -5930,6 +5930,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "legacy": "powerpc-ieee1275",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.ppc64le",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_91-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ami-boot.json
@@ -4547,6 +4547,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
@@ -6617,6 +6617,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_91-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2-boot.json
@@ -4582,6 +4582,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
@@ -6026,6 +6026,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
@@ -8581,6 +8581,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 processor.max_cstate=1 intel_idle.max_cstate=1",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_91-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_raw_image-boot.json
@@ -2508,7 +2508,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_91-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_simplified_installer-boot.json
@@ -2820,7 +2820,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_91-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-gce-boot.json
@@ -4807,6 +4807,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_91-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-gce_rhui-boot.json
@@ -4813,6 +4813,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_91-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-oci-boot.json
@@ -4934,6 +4934,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_91-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-openstack-boot.json
@@ -4918,6 +4918,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_91-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-qcow2-boot.json
@@ -4955,6 +4955,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
@@ -5665,6 +5665,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_91-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-vhd-boot.json
@@ -6552,6 +6552,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_91-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-vmdk-boot.json
@@ -4918,6 +4918,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_92-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-ami-boot.json
@@ -4559,6 +4559,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_92-aarch64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-azure_rhui-boot.json
@@ -6305,6 +6305,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_92-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-ec2-boot.json
@@ -4592,6 +4592,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_92-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_raw_image-boot.json
@@ -2344,7 +2344,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw,coreos.no_persist_ip,ignition.platform.id=metal,$ignition_firstboot",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4 rw coreos.no_persist_ip ignition.platform.id=metal $ignition_firstboot",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_92-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_simplified_installer-boot.json
@@ -2728,7 +2728,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw,coreos.no_persist_ip,ignition.platform.id=metal,$ignition_firstboot",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4 rw coreos.no_persist_ip ignition.platform.id=metal $ignition_firstboot",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_92-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-openstack-boot.json
@@ -4534,6 +4534,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_92-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-qcow2-boot.json
@@ -4667,6 +4667,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_92-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-qcow2_customize-boot.json
@@ -5032,6 +5032,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_92-aarch64-vhd-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-vhd-boot.json
@@ -6224,6 +6224,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "uefi": {
                 "vendor": "redhat",
                 "unified": true

--- a/test/data/manifests/rhel_92-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_92-ppc64le-qcow2-boot.json
@@ -5316,6 +5316,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "powerpc-ieee1275",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-177.el9.ppc64le",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_92-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-ppc64le-qcow2_customize-boot.json
@@ -5665,6 +5665,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "legacy": "powerpc-ieee1275",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-177.el9.ppc64le",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_92-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ami-boot.json
@@ -4539,6 +4539,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-226.el9.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_92-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-azure_rhui-boot.json
@@ -6609,6 +6609,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_92-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ec2-boot.json
@@ -4574,6 +4574,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-226.el9.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_92-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ec2_ha-boot.json
@@ -6018,6 +6018,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-226.el9.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_92-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ec2_sap-boot.json
@@ -8525,6 +8525,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 processor.max_cstate=1 intel_idle.max_cstate=1",
               "legacy": "i386-pc",
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-226.el9.x86_64",
               "write_cmdline": false,

--- a/test/data/manifests/rhel_92-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_raw_image-boot.json
@@ -2464,7 +2464,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw,coreos.no_persist_ip,ignition.platform.id=metal,$ignition_firstboot",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4 rw coreos.no_persist_ip ignition.platform.id=metal $ignition_firstboot",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_92-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_simplified_installer-boot.json
@@ -2776,7 +2776,7 @@
             "options": {
               "root_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75,modprobe.blacklist=vc4,rw,coreos.no_persist_ip,ignition.platform.id=metal,$ignition_firstboot",
+              "kernel_opts": "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 modprobe.blacklist=vc4 rw coreos.no_persist_ip ignition.platform.id=metal $ignition_firstboot",
               "uefi": {
                 "vendor": "redhat",
                 "install": true,

--- a/test/data/manifests/rhel_92-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-gce-boot.json
@@ -4847,6 +4847,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_92-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-gce_rhui-boot.json
@@ -4853,6 +4853,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_92-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-oci-boot.json
@@ -4926,6 +4926,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_92-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-openstack-boot.json
@@ -4910,6 +4910,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_92-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-qcow2-boot.json
@@ -4947,6 +4947,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_92-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-qcow2_customize-boot.json
@@ -5392,6 +5392,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_92-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-vhd-boot.json
@@ -6544,6 +6544,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",

--- a/test/data/manifests/rhel_92-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-vmdk-boot.json
@@ -4910,6 +4910,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "ro net.ifnames=0",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "redhat",


### PR DESCRIPTION
It turned out that when we stopped setting the kernel options in grubenv file, we also stopped setting them in /etc/default/grub under `GRUB_CMDLINE_LINUX`. This file is used by grub2-mkconfig when generating grub configuration.

10_linux script executed by grub2-mkconfig recently started to overwrite the /etc/kernel/cmdline, if its timestamp is older than the timestamp of /etc/default/grub [1]. As a result, all kernel options were wiped out from /etc/kernel/cmdline.

Make sure that we always set the `KernelOptions` in the grub2 stage options, even if the `WriteCmdLine` is set to `false`.

In addition, unify the way we concatenate kernel options set in the grub2 stage options. Some pipeline implementations were previously using space, other were using comma. Space is now used everywhere.

Regenerate all affected image manifests.

[1] https://src.fedoraproject.org/rpms/grub2/c/fc76aed5333f56dd05400521a35b944a5df52ebc


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
