### PR TITLE
packit: build RPMs also for EPEL 9 and RHEL

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -43,6 +43,11 @@ jobs:
     - centos-stream-9-x86_64
     - epel-8-aarch64
     - epel-8-x86_64
+    - epel-9-aarch64
+    - epel-9-x86_64
+    - rhel-8-x86_64
+    - rhel-9-aarch64
+    - rhel-9-x86_64
     - fedora-all-aarch64
     - fedora-all-s390x
     - fedora-all-ppc64le
@@ -60,6 +65,11 @@ jobs:
     - centos-stream-9-x86_64
     - epel-8-aarch64
     - epel-8-x86_64
+    - epel-9-aarch64
+    - epel-9-x86_64
+    - rhel-8-x86_64
+    - rhel-9-aarch64
+    - rhel-9-x86_64
     - fedora-all-aarch64
     - fedora-all-s390x
     - fedora-all-ppc64le


### PR DESCRIPTION
We got request for these, so let's enable them. I wonder if we should remove epel and leave only rhel in, since we don't technically need epel for anything.