### PR TITLE
packit: Add EPEL9 to copr builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -43,6 +43,8 @@ jobs:
     - centos-stream-9-x86_64
     - epel-8-aarch64
     - epel-8-x86_64
+    - epel-9-aarch64
+    - epel-9-x86_64
     - fedora-all-aarch64
     - fedora-all-s390x
     - fedora-all-ppc64le
@@ -60,6 +62,8 @@ jobs:
     - centos-stream-9-x86_64
     - epel-8-aarch64
     - epel-8-x86_64
+    - epel-9-aarch64
+    - epel-9-x86_64
     - fedora-all-aarch64
     - fedora-all-s390x
     - fedora-all-ppc64le


### PR DESCRIPTION
Enable EPEL9 as target for COPR builds for PRs and on `main` to remain consistent with osbuild (see https://github.com/osbuild/osbuild/blob/main/.packit.yaml#L31).