### PR TITLE
internal/cloudapi: Double manifest job timeout

### DIFF
--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -325,7 +325,7 @@ func (s *Server) enqueueKojiCompose(taskID uint64, server, name, version, releas
 }
 
 func generateManifest(ctx context.Context, workers *worker.Server, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID uuid.UUID, imageType distro.ImageType, repos []rpmmd.RepoConfig, options distro.ImageOptions, seed int64, b *blueprint.Customizations) {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*10)
 	defer cancel()
 
 	// wait until job is in a pending state


### PR DESCRIPTION
Brew often reaches these timeouts.

