### PR TITLE
minimal-raw: zstd compress the raw image

### DIFF
--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -329,8 +329,8 @@ var (
 
 	minimalrawImgType = imageType{
 		name:     "minimal-raw",
-		filename: "raw.img",
-		mimeType: "application/disk",
+		filename: "raw.img.zstd",
+		mimeType: "application/zstd",
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: minimalrpmPackageSet,
 		},
@@ -338,10 +338,10 @@ var (
 		kernelOptions:       defaultKernelOptions,
 		bootable:            true,
 		defaultSize:         2 * common.GibiByte,
-		image:               liveImage,
+		image:               minimalRawImage,
 		buildPipelines:      []string{"build"},
-		payloadPipelines:    []string{"os", "image"},
-		exports:             []string{"image"},
+		payloadPipelines:    []string{"os", "image", "zstd"},
+		exports:             []string{"zstd"},
 		basePartitionTables: defaultBasePartitionTables,
 	}
 )

--- a/internal/distro/fedora/distro_test.go
+++ b/internal/distro/fedora/distro_test.go
@@ -173,8 +173,8 @@ func TestFilenameFromType(t *testing.T) {
 			name: "minimal-raw",
 			args: args{"minimal-raw"},
 			want: wantResult{
-				filename: "raw.img",
-				mimeType: "application/disk",
+				filename: "raw.img.zstd",
+				mimeType: "application/zstd",
 			},
 		},
 	}

--- a/internal/distro/fedora/images.go
+++ b/internal/distro/fedora/images.go
@@ -168,6 +168,32 @@ func osCustomizations(
 
 // IMAGES
 
+func minimalRawImage(workload workload.Workload,
+	t *imageType,
+	customizations *blueprint.Customizations,
+	options distro.ImageOptions,
+	packageSets map[string]rpmmd.PackageSet,
+	containers []container.Spec,
+	rng *rand.Rand) (image.ImageKind, error) {
+
+	img := image.NewLiveImage()
+	img.Compression = "zstd"
+	img.Platform = t.platform
+	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, customizations)
+	img.Environment = t.environment
+	img.Workload = workload
+	// TODO: move generation into LiveImage
+	pt, err := t.getPartitionTable(customizations.GetFilesystems(), options, rng)
+	if err != nil {
+		return nil, err
+	}
+	img.PartitionTable = pt
+
+	img.Filename = t.Filename()
+
+	return img, nil
+}
+
 func liveImage(workload workload.Workload,
 	t *imageType,
 	customizations *blueprint.Customizations,

--- a/internal/image/live.go
+++ b/internal/image/live.go
@@ -114,6 +114,10 @@ func (img *LiveImage) InstantiateManifest(m *manifest.Manifest,
 		xzPipeline := manifest.NewXZ(m, buildPipeline, artifactPipeline)
 		xzPipeline.Filename = img.Filename
 		artifact = xzPipeline.Export()
+	case "zstd":
+		zstdPipeline := manifest.NewZstd(m, buildPipeline, artifactPipeline)
+		zstdPipeline.Filename = img.Filename
+		artifact = zstdPipeline.Export()
 	case "":
 		// do nothing
 	default:

--- a/internal/manifest/zstd.go
+++ b/internal/manifest/zstd.go
@@ -1,0 +1,50 @@
+package manifest
+
+import (
+	"github.com/osbuild/osbuild-composer/internal/artifact"
+	"github.com/osbuild/osbuild-composer/internal/osbuild"
+)
+
+// The zstd pipeline compresses a raw image file using zstd.
+type Zstd struct {
+	Base
+	Filename string
+
+	imgPipeline Pipeline
+}
+
+// NewZstd creates a new zstd pipeline. imgPipeline is the pipeline producing the
+// raw image that will be zstd compressed.
+func NewZstd(m *Manifest,
+	buildPipeline *Build,
+	imgPipeline Pipeline) *Zstd {
+	p := &Zstd{
+		Base:        NewBase(m, "zstd", buildPipeline),
+		Filename:    "image.zstd",
+		imgPipeline: imgPipeline,
+	}
+	buildPipeline.addDependent(p)
+	m.addPipeline(p)
+	return p
+}
+
+func (p *Zstd) serialize() osbuild.Pipeline {
+	pipeline := p.Base.serialize()
+
+	pipeline.AddStage(osbuild.NewZstdStage(
+		osbuild.NewZstdStageOptions(p.Filename),
+		osbuild.NewZstdStageInputs(osbuild.NewFilesInputPipelineObjectRef(p.imgPipeline.Name(), p.imgPipeline.Export().Filename(), nil)),
+	))
+
+	return pipeline
+}
+
+func (p *Zstd) getBuildPackages() []string {
+	return []string{"zstd"}
+}
+
+func (p *Zstd) Export() *artifact.Artifact {
+	p.Base.export = true
+	mimeType := "application/zstd"
+	return artifact.New(p.Name(), p.Filename, &mimeType)
+}

--- a/internal/osbuild/zstd_stage.go
+++ b/internal/osbuild/zstd_stage.go
@@ -1,0 +1,40 @@
+package osbuild
+
+type ZstdStageOptions struct {
+	// Filename for xz archive
+	Filename string `json:"filename"`
+}
+
+func (ZstdStageOptions) isStageOptions() {}
+
+func NewZstdStageOptions(filename string) *ZstdStageOptions {
+	return &ZstdStageOptions{
+		Filename: filename,
+	}
+}
+
+type ZstdStageInputs struct {
+	File *FilesInput `json:"file"`
+}
+
+func (*ZstdStageInputs) isStageInputs() {}
+
+func NewZstdStageInputs(references FilesInputRef) *ZstdStageInputs {
+	return &ZstdStageInputs{
+		File: NewFilesInput(references),
+	}
+}
+
+// Compresses a file into a zstd archive.
+func NewZstdStage(options *ZstdStageOptions, inputs *ZstdStageInputs) *Stage {
+	var stageInputs Inputs
+	if inputs != nil {
+		stageInputs = inputs
+	}
+
+	return &Stage{
+		Type:    "org.osbuild.zstd",
+		Options: options,
+		Inputs:  stageInputs,
+	}
+}

--- a/internal/osbuild/zstd_stage_test.go
+++ b/internal/osbuild/zstd_stage_test.go
@@ -1,0 +1,47 @@
+package osbuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewZstdStageOptions(t *testing.T) {
+	filename := "image.raw.zstd"
+
+	expectedOptions := &ZstdStageOptions{
+		Filename: filename,
+	}
+
+	actualOptions := NewZstdStageOptions(filename)
+	assert.Equal(t, expectedOptions, actualOptions)
+}
+
+func TestNewZstdStage(t *testing.T) {
+	inputFilename := "image.raw"
+	filename := "image.raw.zstd"
+	pipeline := "os"
+
+	expectedStage := &Stage{
+		Type:    "org.osbuild.zstd",
+		Options: NewZstdStageOptions(filename),
+		Inputs:  NewZstdStageInputs(NewFilesInputPipelineObjectRef(pipeline, inputFilename, nil)),
+	}
+
+	actualStage := NewZstdStage(NewZstdStageOptions(filename),
+		NewZstdStageInputs(NewFilesInputPipelineObjectRef(pipeline, inputFilename, nil)))
+	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestNewZstdStageNoInputs(t *testing.T) {
+	filename := "image.raw.zstd"
+
+	expectedStage := &Stage{
+		Type:    "org.osbuild.zstd",
+		Options: &ZstdStageOptions{Filename: filename},
+		Inputs:  nil,
+	}
+
+	actualStage := NewZstdStage(&ZstdStageOptions{Filename: filename}, nil)
+	assert.Equal(t, expectedStage, actualStage)
+}

--- a/test/cases/minimal-raw.sh
+++ b/test/cases/minimal-raw.sh
@@ -57,6 +57,7 @@ TEST_UUID=$(uuidgen)
 IMAGE_KEY="minimal-raw-${TEST_UUID}"
 UEFI_GUEST_ADDRESS=192.168.100.51
 MINIMAL_RAW_TYPE=minimal-raw
+MINIMAL_RAW_FILENAME_COMPRESSED=raw.img.zstd
 MINIMAL_RAW_FILENAME=raw.img
 BOOT_ARGS="uefi"
 
@@ -243,10 +244,12 @@ build_image minimal-raw "${MINIMAL_RAW_TYPE}"
 # Download the image
 greenprint "📥 Downloading the minimal-raw image"
 sudo composer-cli compose image "${COMPOSE_ID}" > /dev/null
+MINIMAL_RAW_FILENAME_COMPRESSED="${COMPOSE_ID}-${MINIMAL_RAW_FILENAME_COMPRESSED}"
 MINIMAL_RAW_FILENAME="${COMPOSE_ID}-${MINIMAL_RAW_FILENAME}"
 
 greenprint "Extracting and converting the raw image to a qcow2 file"
 LIBVIRT_IMAGE_PATH_UEFI=/var/lib/libvirt/images/"${IMAGE_KEY}-uefi.qcow2"
+sudo unzstd "$MINIMAL_RAW_FILENAME_COMPRESSED"
 sudo qemu-img convert -f raw "$MINIMAL_RAW_FILENAME" -O qcow2 "$LIBVIRT_IMAGE_PATH_UEFI"
 # Remove raw file
 sudo rm -f "$MINIMAL_RAW_FILENAME"

--- a/test/data/manifests/fedora_36-aarch64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-minimal_raw-boot.json
@@ -1423,6 +1423,14 @@
                         "rpm.check_gpg": true
                       }
                     }
+                  },
+                  {
+                    "id": "sha256:cf25a2821d434c3d094f9e5d1b9e3fa9f609ed4f59daca188749a3e762b22f73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
                   }
                 ]
               }
@@ -4527,7 +4535,7 @@
           {
             "type": "org.osbuild.truncate",
             "options": {
-              "filename": "raw.img",
+              "filename": "disk.img",
               "size": "3957325824"
             }
           },
@@ -4561,7 +4569,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "lock": true
                 }
               }
@@ -4576,7 +4584,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 2048,
                   "size": 409600,
                   "lock": true
@@ -4594,7 +4602,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 411648,
                   "size": 1024000,
                   "lock": true
@@ -4612,7 +4620,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1435648,
                   "size": 6293471,
                   "lock": true
@@ -4643,7 +4651,7 @@
               "boot": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 411648,
                   "size": 1024000
                 }
@@ -4651,7 +4659,7 @@
               "boot.efi": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 2048,
                   "size": 409600
                 }
@@ -4659,7 +4667,7 @@
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1435648,
                   "size": 6293471
                 }
@@ -4685,6 +4693,29 @@
                 "target": "/boot/efi"
               }
             ]
+          }
+        ]
+      },
+      {
+        "name": "zstd",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.zstd",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "raw.img.zstd"
+            }
           }
         ]
       }
@@ -5579,6 +5610,9 @@
           },
           "sha256:ce799cfef53276047634cf1418c6463c2bd06ffce8d3b41272cd9f3e16d2d242": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.aarch64.rpm"
+          },
+          "sha256:cf25a2821d434c3d094f9e5d1b9e3fa9f609ed4f59daca188749a3e762b22f73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zstd-1.5.2-2.fc36.aarch64.rpm"
           },
           "sha256:cf7fd9b6579cafbaf0a8eb7f2b920b811a9eb140100e1c3757ed8e3d8981fcf0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libdnf-0.67.0-2.fc36.aarch64.rpm"
@@ -7529,6 +7563,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
         "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      },
+      {
+        "name": "zstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zstd-1.5.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:cf25a2821d434c3d094f9e5d1b9e3fa9f609ed4f59daca188749a3e762b22f73",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_36-x86_64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-minimal_raw-boot.json
@@ -1431,6 +1431,14 @@
                         "rpm.check_gpg": true
                       }
                     }
+                  },
+                  {
+                    "id": "sha256:bcdee9cd3a3f67dcd283e1f43a7e611baa6ee5b0ce2dbd3e888849adb73d8f5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
                   }
                 ]
               }
@@ -4567,7 +4575,7 @@
           {
             "type": "org.osbuild.truncate",
             "options": {
-              "filename": "raw.img",
+              "filename": "disk.img",
               "size": "3958374400"
             }
           },
@@ -4608,7 +4616,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "lock": true
                 }
               }
@@ -4623,7 +4631,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 4096,
                   "size": 409600,
                   "lock": true
@@ -4641,7 +4649,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 413696,
                   "size": 1024000,
                   "lock": true
@@ -4659,7 +4667,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1437696,
                   "size": 6293471,
                   "lock": true
@@ -4690,7 +4698,7 @@
               "boot": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 413696,
                   "size": 1024000
                 }
@@ -4698,7 +4706,7 @@
               "boot.efi": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 4096,
                   "size": 409600
                 }
@@ -4706,7 +4714,7 @@
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1437696,
                   "size": 6293471
                 }
@@ -4732,6 +4740,29 @@
                 "target": "/boot/efi"
               }
             ]
+          }
+        ]
+      },
+      {
+        "name": "zstd",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.zstd",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "raw.img.zstd"
+            }
           }
         ]
       }
@@ -5554,6 +5585,9 @@
           },
           "sha256:bc3339d24b5e60cb8967a671cd9dd357955f46c3825ccf1e4a3b542dcc4ae19a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.x86_64.rpm"
+          },
+          "sha256:bcdee9cd3a3f67dcd283e1f43a7e611baa6ee5b0ce2dbd3e888849adb73d8f5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zstd-1.5.2-2.fc36.x86_64.rpm"
           },
           "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm"
@@ -7598,6 +7632,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
         "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      },
+      {
+        "name": "zstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zstd-1.5.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:bcdee9cd3a3f67dcd283e1f43a7e611baa6ee5b0ce2dbd3e888849adb73d8f5d",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_37-aarch64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-minimal_raw-boot.json
@@ -1425,6 +1425,14 @@
                         "rpm.check_gpg": true
                       }
                     }
+                  },
+                  {
+                    "id": "sha256:caee7bc8aca2754aaf592c37b6e77757575a6b2d47d4ffe6c39755c6b728d900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
                   }
                 ]
               }
@@ -4573,7 +4581,7 @@
           {
             "type": "org.osbuild.truncate",
             "options": {
-              "filename": "raw.img",
+              "filename": "disk.img",
               "size": "3957325824"
             }
           },
@@ -4607,7 +4615,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "lock": true
                 }
               }
@@ -4622,7 +4630,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 2048,
                   "size": 409600,
                   "lock": true
@@ -4640,7 +4648,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 411648,
                   "size": 1024000,
                   "lock": true
@@ -4658,7 +4666,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1435648,
                   "size": 6293471,
                   "lock": true
@@ -4689,7 +4697,7 @@
               "boot": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 411648,
                   "size": 1024000
                 }
@@ -4697,7 +4705,7 @@
               "boot.efi": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 2048,
                   "size": 409600
                 }
@@ -4705,7 +4713,7 @@
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1435648,
                   "size": 6293471
                 }
@@ -4731,6 +4739,29 @@
                 "target": "/boot/efi"
               }
             ]
+          }
+        ]
+      },
+      {
+        "name": "zstd",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.zstd",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "raw.img.zstd"
+            }
           }
         ]
       }
@@ -5619,6 +5650,9 @@
           },
           "sha256:c8650dafee9357adb6e6f878e5c3eb32aeb72ccce5bf68056920e77c7abc8da9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/t/tpm2-tools-5.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:caee7bc8aca2754aaf592c37b6e77757575a6b2d47d4ffe6c39755c6b728d900": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zstd-1.5.2-3.fc37.aarch64.rpm"
           },
           "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm"
@@ -7613,6 +7647,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.aarch64.rpm",
         "checksum": "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875",
+        "check_gpg": true
+      },
+      {
+        "name": "zstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zstd-1.5.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:caee7bc8aca2754aaf592c37b6e77757575a6b2d47d4ffe6c39755c6b728d900",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_37-x86_64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-minimal_raw-boot.json
@@ -1433,6 +1433,14 @@
                         "rpm.check_gpg": true
                       }
                     }
+                  },
+                  {
+                    "id": "sha256:8afdf1a4ba131d3c08f841fc262364383621de2646b8cf9563804ec9f50d0534",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
                   }
                 ]
               }
@@ -4613,7 +4621,7 @@
           {
             "type": "org.osbuild.truncate",
             "options": {
-              "filename": "raw.img",
+              "filename": "disk.img",
               "size": "3958374400"
             }
           },
@@ -4654,7 +4662,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "lock": true
                 }
               }
@@ -4669,7 +4677,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 4096,
                   "size": 409600,
                   "lock": true
@@ -4687,7 +4695,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 413696,
                   "size": 1024000,
                   "lock": true
@@ -4705,7 +4713,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1437696,
                   "size": 6293471,
                   "lock": true
@@ -4736,7 +4744,7 @@
               "boot": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 413696,
                   "size": 1024000
                 }
@@ -4744,7 +4752,7 @@
               "boot.efi": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 4096,
                   "size": 409600
                 }
@@ -4752,7 +4760,7 @@
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1437696,
                   "size": 6293471
                 }
@@ -4778,6 +4786,29 @@
                 "target": "/boot/efi"
               }
             ]
+          }
+        ]
+      },
+      {
+        "name": "zstd",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.zstd",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "raw.img.zstd"
+            }
           }
         ]
       }
@@ -5378,6 +5409,9 @@
           },
           "sha256:8adebc901848979df7c1c96c51055426c0ac7212b536a5cf82bd650dbbb322cd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/i/initscripts-service-10.17-1.fc37.noarch.rpm"
+          },
+          "sha256:8afdf1a4ba131d3c08f841fc262364383621de2646b8cf9563804ec9f50d0534": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zstd-1.5.2-3.fc37.x86_64.rpm"
           },
           "sha256:8b3b3f611f93e849b5c03219fb2a28b63ac4215ebe28a8219da5e5be15e5ed52": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/n/nvidia-gpu-firmware-20220913-140.fc37.noarch.rpm"
@@ -7682,6 +7716,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.x86_64.rpm",
         "checksum": "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70",
+        "check_gpg": true
+      },
+      {
+        "name": "zstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zstd-1.5.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:8afdf1a4ba131d3c08f841fc262364383621de2646b8cf9563804ec9f50d0534",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_38-aarch64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-minimal_raw-boot.json
@@ -1425,6 +1425,14 @@
                         "rpm.check_gpg": true
                       }
                     }
+                  },
+                  {
+                    "id": "sha256:1a635ca67c05e411d859b5bd4b59efa84308deafd15fdd6f4044f5af977918da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
                   }
                 ]
               }
@@ -4581,7 +4589,7 @@
           {
             "type": "org.osbuild.truncate",
             "options": {
-              "filename": "raw.img",
+              "filename": "disk.img",
               "size": "3957325824"
             }
           },
@@ -4615,7 +4623,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "lock": true
                 }
               }
@@ -4630,7 +4638,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 2048,
                   "size": 409600,
                   "lock": true
@@ -4648,7 +4656,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 411648,
                   "size": 1024000,
                   "lock": true
@@ -4666,7 +4674,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1435648,
                   "size": 6293471,
                   "lock": true
@@ -4697,7 +4705,7 @@
               "boot": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 411648,
                   "size": 1024000
                 }
@@ -4705,7 +4713,7 @@
               "boot.efi": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 2048,
                   "size": 409600
                 }
@@ -4713,7 +4721,7 @@
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1435648,
                   "size": 6293471
                 }
@@ -4739,6 +4747,29 @@
                 "target": "/boot/efi"
               }
             ]
+          }
+        ]
+      },
+      {
+        "name": "zstd",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.zstd",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "raw.img.zstd"
+            }
           }
         ]
       }
@@ -4877,6 +4908,9 @@
           },
           "sha256:1a4d8cc770e436919ebad73a32168e2cd4da3cad8781d3cce6c9d654a5d3fe59": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/c/curl-7.85.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:1a635ca67c05e411d859b5bd4b59efa84308deafd15fdd6f4044f5af977918da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zstd-1.5.2-3.fc37.aarch64.rpm"
           },
           "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm"
@@ -7624,6 +7658,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zlib-1.2.12-5.fc38.aarch64.rpm",
         "checksum": "sha256:fa38c933e194c67185d9982e700bd67f65b9c8fbe23f0146a3a96987516eb668",
+        "check_gpg": true
+      },
+      {
+        "name": "zstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zstd-1.5.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1a635ca67c05e411d859b5bd4b59efa84308deafd15fdd6f4044f5af977918da",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_38-x86_64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-minimal_raw-boot.json
@@ -1441,6 +1441,14 @@
                         "rpm.check_gpg": true
                       }
                     }
+                  },
+                  {
+                    "id": "sha256:167ba501b5837843a0691e683ad6bac11824ac15bfbfd47b4c4cb1045d2f311d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
                   }
                 ]
               }
@@ -4645,7 +4653,7 @@
           {
             "type": "org.osbuild.truncate",
             "options": {
-              "filename": "raw.img",
+              "filename": "disk.img",
               "size": "3958374400"
             }
           },
@@ -4686,7 +4694,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "lock": true
                 }
               }
@@ -4701,7 +4709,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 4096,
                   "size": 409600,
                   "lock": true
@@ -4719,7 +4727,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 413696,
                   "size": 1024000,
                   "lock": true
@@ -4737,7 +4745,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1437696,
                   "size": 6293471,
                   "lock": true
@@ -4768,7 +4776,7 @@
               "boot": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 413696,
                   "size": 1024000
                 }
@@ -4776,7 +4784,7 @@
               "boot.efi": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 4096,
                   "size": 409600
                 }
@@ -4784,7 +4792,7 @@
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1437696,
                   "size": 6293471
                 }
@@ -4810,6 +4818,29 @@
                 "target": "/boot/efi"
               }
             ]
+          }
+        ]
+      },
+      {
+        "name": "zstd",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.zstd",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "raw.img.zstd"
+            }
           }
         ]
       }
@@ -4897,6 +4928,9 @@
           },
           "sha256:166e842798813a72e4d075dcd9b6e814d7ad3fc8d1b5860281cffe7a68784b25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/g/gzip-1.12-3.fc38.x86_64.rpm"
+          },
+          "sha256:167ba501b5837843a0691e683ad6bac11824ac15bfbfd47b4c4cb1045d2f311d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/z/zstd-1.5.4-1.fc38.x86_64.rpm"
           },
           "sha256:1812689be8bbc4ef39718dbb8ef862105225348310052ddaf0b1cb0f0a1bf296": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/d/dbus-1.14.6-1.fc38.x86_64.rpm"
@@ -7733,6 +7767,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
         "checksum": "sha256:c26d4d161f8eddd7cb794075e383d0f4d3a77aa88e453a2db51e53346981f04c",
+        "check_gpg": true
+      },
+      {
+        "name": "zstd",
+        "epoch": 0,
+        "version": "1.5.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/z/zstd-1.5.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:167ba501b5837843a0691e683ad6bac11824ac15bfbfd47b4c4cb1045d2f311d",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_39-aarch64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-minimal_raw-boot.json
@@ -1441,6 +1441,14 @@
                         "rpm.check_gpg": true
                       }
                     }
+                  },
+                  {
+                    "id": "sha256:18221395156f20da18e9c6a0e7b7f3dc762f28eda6170a6506ec041a8046db04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
                   }
                 ]
               }
@@ -4661,7 +4669,7 @@
           {
             "type": "org.osbuild.truncate",
             "options": {
-              "filename": "raw.img",
+              "filename": "disk.img",
               "size": "3957325824"
             }
           },
@@ -4695,7 +4703,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "lock": true
                 }
               }
@@ -4710,7 +4718,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 2048,
                   "size": 409600,
                   "lock": true
@@ -4728,7 +4736,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 411648,
                   "size": 1024000,
                   "lock": true
@@ -4746,7 +4754,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1435648,
                   "size": 6293471,
                   "lock": true
@@ -4777,7 +4785,7 @@
               "boot": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 411648,
                   "size": 1024000
                 }
@@ -4785,7 +4793,7 @@
               "boot.efi": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 2048,
                   "size": 409600
                 }
@@ -4793,7 +4801,7 @@
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1435648,
                   "size": 6293471
                 }
@@ -4819,6 +4827,29 @@
                 "target": "/boot/efi"
               }
             ]
+          }
+        ]
+      },
+      {
+        "name": "zstd",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.zstd",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "raw.img.zstd"
+            }
           }
         ]
       }
@@ -4924,6 +4955,9 @@
           },
           "sha256:16d1843cdac488ad04bdc654dd6b8dfbfeafe33a7728695070481302a7e54345": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/b/basesystem-11-15.fc38.noarch.rpm"
+          },
+          "sha256:18221395156f20da18e9c6a0e7b7f3dc762f28eda6170a6506ec041a8046db04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/z/zstd-1.5.4-1.fc39.aarch64.rpm"
           },
           "sha256:1885d9d961bd04783d3c34309883c96eb041c0a5b3ce287892765444247cc8d3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/l/lz4-libs-1.9.4-2.fc38.aarch64.rpm"
@@ -7748,6 +7782,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.aarch64.rpm",
         "checksum": "sha256:b1f3751a9fdaf0c918bad3ca42a0984bea6d94d382995c3162bf6b391e53e21d",
+        "check_gpg": true
+      },
+      {
+        "name": "zstd",
+        "epoch": 0,
+        "version": "1.5.4",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/z/zstd-1.5.4-1.fc39.aarch64.rpm",
+        "checksum": "sha256:18221395156f20da18e9c6a0e7b7f3dc762f28eda6170a6506ec041a8046db04",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_39-x86_64-minimal_raw-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-minimal_raw-boot.json
@@ -1449,6 +1449,14 @@
                         "rpm.check_gpg": true
                       }
                     }
+                  },
+                  {
+                    "id": "sha256:5e884d5017d7799f3f158b1c045dc6428036a1ccc3bc6719bb970b8397b0c8a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
                   }
                 ]
               }
@@ -4669,7 +4677,7 @@
           {
             "type": "org.osbuild.truncate",
             "options": {
-              "filename": "raw.img",
+              "filename": "disk.img",
               "size": "3958374400"
             }
           },
@@ -4710,7 +4718,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "lock": true
                 }
               }
@@ -4725,7 +4733,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 4096,
                   "size": 409600,
                   "lock": true
@@ -4743,7 +4751,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 413696,
                   "size": 1024000,
                   "lock": true
@@ -4761,7 +4769,7 @@
               "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1437696,
                   "size": 6293471,
                   "lock": true
@@ -4792,7 +4800,7 @@
               "boot": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 413696,
                   "size": 1024000
                 }
@@ -4800,7 +4808,7 @@
               "boot.efi": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 4096,
                   "size": 409600
                 }
@@ -4808,7 +4816,7 @@
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
-                  "filename": "raw.img",
+                  "filename": "disk.img",
                   "start": 1437696,
                   "size": 6293471
                 }
@@ -4834,6 +4842,29 @@
                 "target": "/boot/efi"
               }
             ]
+          }
+        ]
+      },
+      {
+        "name": "zstd",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.zstd",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "raw.img.zstd"
+            }
           }
         ]
       }
@@ -5290,6 +5321,9 @@
           },
           "sha256:5d859d54837e9e2b4aa1b5d10fd4077260328ef028a1a17dab368609ddad5cef": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/v/volume_key-libs-0.3.12-18.fc38.x86_64.rpm"
+          },
+          "sha256:5e884d5017d7799f3f158b1c045dc6428036a1ccc3bc6719bb970b8397b0c8a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/z/zstd-1.5.4-1.fc39.x86_64.rpm"
           },
           "sha256:5fa9010ad567df986d484ddcac865ea25a26c818def22df0c4e3688fc346568d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/e/e2fsprogs-libs-1.46.5-4.fc38.x86_64.rpm"
@@ -7773,6 +7807,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
         "checksum": "sha256:6fc47cd2f53b150153a3865c2fbd6b1c57fcc265fb3602b6f4f3883cf6ec64e2",
+        "check_gpg": true
+      },
+      {
+        "name": "zstd",
+        "epoch": 0,
+        "version": "1.5.4",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/z/zstd-1.5.4-1.fc39.x86_64.rpm",
+        "checksum": "sha256:5e884d5017d7799f3f158b1c045dc6428036a1ccc3bc6719bb970b8397b0c8a9",
         "check_gpg": true
       }
     ],


### PR DESCRIPTION
Transferring 3.6+ GB over slow networks is just a no go. This brings down the image size to something around 700MB which is sane.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
