### PR TITLE
COMPOSER-1943: Fix failure in cross-distro.sh

### DIFF
--- a/test/cases/cross-distro.sh
+++ b/test/cases/cross-distro.sh
@@ -115,7 +115,14 @@ if [ "$ALL_EXPECTED_DISTROS" != "$INSTALLED_DISTROS" ];then
     echo "Some distros are missing!"
     echo "Missing distros:"
     diff <(echo "${ALL_EXPECTED_DISTROS}") <(echo "${INSTALLED_DISTROS}") | grep "<" | sed 's/^<\ //g'
-    exit 1
+
+    # the check above compares repositories/*.json files from git checkout
+    # vs the files installed from an RPM package in order to find files which are
+    # not included in the RPM. Don't fail when running on nightly CI pipeline b/c
+    # very often the repository will be newer than the downstream RPM.
+    if [[ "${CI_PIPELINE_SOURCE:-}" != "schedule" ]]; then
+        exit 1
+    fi
 fi
 
 # Push a blueprint with unsupported distro to see if composer fails gracefuly

--- a/test/cases/cross-distro.sh
+++ b/test/cases/cross-distro.sh
@@ -108,7 +108,12 @@ fi
 # Filter out beta and centos-stream, see GH issue #2257
 ALL_DISTROS=$(find "$REPO_PATH" -name '*.json' -printf '%P\n' | awk -F "." '{ print $1 }')
 ALL_EXPECTED_DISTROS=$(echo "$ALL_DISTROS" | grep -E "$PATTERN" | grep -Ev 'beta|stream' | sort)
-ALL_REMAINDERS=$(echo "$ALL_DISTROS" | grep -v "$RECOGNIZED_DISTROS")
+# Warning: filter out the remaining distros by matching whole words to avoid matching
+# the value rhel-93 by the pattern rhel-9!
+# If we're running on a RHEL 9.2 osbuild-composer doesn't know anything about 9.3
+# images so the value rhel-9.3 should be treated as unrecognized and error out as
+# expected in the test snippet further below
+ALL_REMAINDERS=$(echo "$ALL_DISTROS" | grep -vw "$RECOGNIZED_DISTROS")
 
 # Check for any missing distros based on the expected host pattern
 if [ "$ALL_EXPECTED_DISTROS" != "$INSTALLED_DISTROS" ];then


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
