### PR TITLE
COMPOSER-1936: Enable regression-insecure-repo test for nightly CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -306,12 +306,11 @@ regression-old-worker-new-composer:
     SCRIPT: regression-old-worker-new-composer.sh
 
 regression-insecure-repo:
-  parallel:
-    matrix:
-      - RUNNER:
-          - aws/rhel-9.1-ga-x86_64
-        INTERNAL_NETWORK: ["true"]
   extends: .regression
+  rules:
+    # WHITELIST
+    - if: $RUNNER =~ "/^.*(rhel-*).*$/" && $CI_PIPELINE_SOURCE != "schedule"
+    - !reference [.nightly_rules_all, rules]
   variables:
     SCRIPT: regression-insecure-repo.sh
 

--- a/test/cases/regression-insecure-repo.sh
+++ b/test/cases/regression-insecure-repo.sh
@@ -107,6 +107,7 @@ blueprint="${composedir}/blueprint.toml"
 dummysource="${composedir}/dummy.toml"
 composestart="${composedir}/compose-start.json"
 composeinfo="${composedir}/compose-info.json"
+modulesinfo="${composedir}/modules-info.json"
 
 # Write a source (repo) config to add to composer
 cat <<EOF > "${dummysource}"
@@ -137,7 +138,8 @@ sudo composer-cli blueprints push "${blueprint}"
 sudo composer-cli blueprints depsolve dummy
 
 # confirm dummy is fetched from the custom repo
-dummysourceurl="$(sudo composer-cli modules info --json dummy | jq -r '.body.modules[0].dependencies[0].remote_location')"
+sudo composer-cli modules info --json dummy | tee "${modulesinfo}"
+dummysourceurl=$(get_build_info '.modules[0].dependencies[0].remote_location' "${modulesinfo}")
 expectedurl="${websrvurl}/dummy-1.0.0-0.noarch.rpm"
 if [[ "${dummysourceurl}" != "${expectedurl}" ]]; then
     echo "Unexpected package URL: ${dummysourceurl}"


### PR DESCRIPTION
Related: RHBZ#2177699


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
