### PR TITLE
Test/fix cs9 edge-simplified-installer test failure

### DIFF
--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -663,6 +663,22 @@ for _ in $(seq 0 30); do
     sleep 10
 done
 
+# Workaround to fix edge-simplified-installer test failure (ansible runs before fdouser is created)
+# Bug link: https://github.com/osbuild/osbuild-composer/pull/3378#issuecomment-1502633131
+if [[ "${ANSIBLE_USER}" == "fdouser" ]]; then
+    greenprint "🕹 Check if user 'fdouser' exist in edge vm"
+    for _ in $(seq 0 30); do
+        FDOUSER_EXIST=$(ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@$PUB_KEY_GUEST_ADDRESS "grep fdouser /etc/passwd")
+        if [[ ${FDOUSER_EXIST} =~ "fdouser" ]]; then
+            echo "fdouser has been created"
+            break
+        else
+            echo "fdouser has not been created yet"
+            sleep 10
+        fi
+    done
+fi
+
 # Check image installation result
 check_result
 


### PR DESCRIPTION
Test script ostree-simplified-installer.sh failed on cs9, in these two prs.

1. https://github.com/osbuild/osbuild-composer/pull/3378#issuecomment-1502633131
2. https://github.com/osbuild/osbuild-composer/pull/3379

I reproduced this failure in my local environment (it's not 100% reproducible), and found the root cause:
sometimes, when run ansible tasks with fdouser(which is created during fdo onboarding), fdouser is not created yet, caused ansible task failed. In fact, this user is created about two minutes later.

This PR added a step to verify if fdouser exist before run ansible tasks with fdouser.