### PR TITLE
use full source as image local name

### DIFF
--- a/internal/container/client_test.go
+++ b/internal/container/client_test.go
@@ -43,7 +43,7 @@ func TestClientResolve(t *testing.T) {
 		Digest:     "sha256:f29b6cd42a94a574583439addcd6694e6224f0e4b32044c9e3aee4c4856c2a50",
 		ImageID:    "sha256:c2ecf25cf190e76b12b07436ad5140d4ba53d8a136d498705e57a006837a720f",
 		TLSVerify:  client.GetTLSVerify(),
-		LocalName:  ref,
+		LocalName:  ref + ":latest",
 		ListDigest: listDigest,
 	}, spec)
 
@@ -56,7 +56,7 @@ func TestClientResolve(t *testing.T) {
 		Digest:     "sha256:d49eebefb6c7ce5505594bef652bd4adc36f413861bd44209d9b9486310b1264",
 		ImageID:    "sha256:d2ab8fea7f08a22f03b30c13c6ea443121f25e87202a7496e93736efa6fe345a",
 		TLSVerify:  client.GetTLSVerify(),
-		LocalName:  ref,
+		LocalName:  ref + ":latest",
 		ListDigest: listDigest,
 	}, spec)
 

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -332,8 +332,8 @@ func (reg *Registry) Resolve(target, arch string) (container.Spec, error) {
 		return container.Spec{}, fmt.Errorf("unknown domain")
 	}
 
-	ref = reference.TrimNamed(ref)
-	path := reference.Path(ref)
+	tref := reference.TrimNamed(ref)
+	path := reference.Path(tref)
 
 	repo, ok := reg.repos[path]
 	if !ok {
@@ -371,7 +371,7 @@ func (reg *Registry) Resolve(target, arch string) (container.Spec, error) {
 	}
 
 	return container.Spec{
-		Source:     ref.String(),
+		Source:     tref.String(),
 		Digest:     checksum,
 		ImageID:    mf.ConfigDescriptor.Digest.String(),
 		LocalName:  ref.String(),

--- a/internal/container/spec.go
+++ b/internal/container/spec.go
@@ -29,7 +29,7 @@ func NewSpec(source reference.Named, digest, imageID digest.Digest, tlsVerify *b
 		Digest:     digest.String(),
 		TLSVerify:  tlsVerify,
 		ImageID:    imageID.String(),
-		LocalName:  name,
+		LocalName:  source.String(),
 		ListDigest: listDigest,
 	}
 }


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
