### PR TITLE
RHELSQ-4656: Conditional skip for container embedding test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -800,6 +800,7 @@ ContainerEmbedding:
   extends: .terraform
   rules:
     - !reference [.upstream_rules_all, rules]
+    - !reference [.nightly_rules_all, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/container-embedding.sh
@@ -809,6 +810,10 @@ ContainerEmbedding:
         RUNNER:
         - aws/centos-stream-8-x86_64
         - aws/centos-stream-9-x86_64
+        - aws/rhel-8.8-nightly-x86_64
+        - aws/rhel-8.8-nightly-aarch64
+        - aws/rhel-9.2-nightly-x86_64
+        - aws/rhel-9.2-nightly-aarch64
 
 finish:
   stage: finish

--- a/test/cases/container-embedding.sh
+++ b/test/cases/container-embedding.sh
@@ -141,6 +141,11 @@ else
   exit 1
 fi
 
+if ! nvrGreaterOrEqual "osbuild" "83"; then
+    echo "INFO: osbuild version is older. Exiting test here"
+    exit 0
+fi
+
 # Check that the local name was set in the names array
 FEDORA_NAME_EXISTS=$(jq -e --arg name "${FEDORA_LOCAL_NAME}" 'any(."container-images"[].Names[] | select(. != null and . == $name); .)' <<< "${INFO}")
 


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
