### PR TITLE
packer: pin the version of the amazon plugin to 1.2.2

### DIFF
--- a/templates/packer/config.pkr.hcl
+++ b/templates/packer/config.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     amazon = {
-      version = ">= 1.1.1"
+      version = "= 1.2.2"
       source = "github.com/hashicorp/amazon"
     }
   }


### PR DESCRIPTION
Version 1.2.3 made changes to how the plugin handles auto-selection of a subnet when it's not specified, see

https://github.com/hashicorp/packer-plugin-amazon/commit/f1ec287c7710e5b6284d6a637ecf092b9e248886

Sadly, the new algorithm selects us-east-1e for us that doesn't support the machine types we use (c6*.large) which causes the build to fail. I reported it here:
https://github.com/hashicorp/packer-plugin-amazon/issues/368

One workaround might be to pin a working subnet, but that's apparently also broken in 1.2.3, see
https://github.com/hashicorp/packer-plugin-amazon/issues/367

Therefore, I decided to pin the plugin to 1.2.2 for now, and see what's the recommended approach from terraform guys.