### PR TITLE
Adjust packer build to work with the amazon plugin 1.2.3

### DIFF
--- a/templates/packer/config.pkr.hcl
+++ b/templates/packer/config.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     amazon = {
-      version = "= 1.2.2"
+      version = ">= 1.2.3"
       source = "github.com/hashicorp/amazon"
     }
   }

--- a/templates/packer/worker.pkr.hcl
+++ b/templates/packer/worker.pkr.hcl
@@ -18,7 +18,6 @@ source "amazon-ebs" "image_builder" {
   ami_users = "${var.image_users}"
 
   # Network configuration for the instance building our image.
-  associate_public_ip_address = true
   ssh_interface = "public_ip"
 
   skip_create_ami=var.skip_create_ami


### PR DESCRIPTION
It turns out that we might have been using the plugin improperly: `associate_public_ip_address` isn't needed if we use the default VPC (which we do). If this option isn't set, we shouldn't hit the new subnet selection algorithm introduced in https://github.com/hashicorp/packer-plugin-amazon/commit/f1ec287c7710e5b6284d6a637ecf092b9e248886 and rely on the AWS's default one, that doesn't ever select a subnet not supporting the instance type we want.

See [packer's docs](https://developer.hashicorp.com/packer/plugins/builders/amazon/ebs#run-configuration) and [this comment](https://github.com/hashicorp/packer-plugin-amazon/issues/368#issuecomment-1516975441).