### PR TITLE
Backport PR#3336 and PR#3398 to `rhel-9.2.0`

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-36": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     },
     "repos": [
@@ -79,7 +79,7 @@
   "fedora-37": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     },
     "repos": [
@@ -156,28 +156,28 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "rhel-8.7": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "rhel-8.8": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     },
     "repos": [
@@ -223,21 +223,21 @@
   "rhel-9.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "rhel-9.1": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "rhel-9.2": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     },
     "repos": [
@@ -283,21 +283,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     },
     "repos": [
@@ -343,7 +343,7 @@
   "centos-stream-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "345b2a599788e0ce3090025c06a7480e7497a94d"
+        "commit": "76a80bd8c590dba4480305efcb067145db3bf347"
       }
     },
     "repos": [

--- a/cmd/osbuild-worker/jobimpl-container-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-container-resolve.go
@@ -42,11 +42,12 @@ func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
 	} else {
 		for i, spec := range specs {
 			result.Specs[i] = worker.ContainerSpec{
-				Source:    spec.Source,
-				Name:      spec.LocalName,
-				TLSVerify: spec.TLSVerify,
-				ImageID:   spec.ImageID,
-				Digest:    spec.Digest,
+				Source:     spec.Source,
+				Name:       spec.LocalName,
+				TLSVerify:  spec.TLSVerify,
+				ImageID:    spec.ImageID,
+				Digest:     spec.Digest,
+				ListDigest: spec.ListDigest,
 			}
 		}
 	}

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -434,6 +434,7 @@ func generateManifest(ctx context.Context, workers *worker.Server, depsolveJobID
 			containerSpecs[i].LocalName = s.Name
 			containerSpecs[i].TLSVerify = s.TLSVerify
 			containerSpecs[i].ImageID = s.ImageID
+			containerSpecs[i].ListDigest = s.ListDigest
 		}
 	}
 

--- a/internal/container/client.go
+++ b/internal/container/client.go
@@ -480,8 +480,7 @@ func (cl *Client) Resolve(ctx context.Context, name string) (Spec, error) {
 		return Spec{}, err
 	}
 
-	spec := NewSpec(cl.Target, ids.Manifest, ids.Config)
-	spec.TLSVerify = cl.GetTLSVerify()
+	spec := NewSpec(cl.Target, ids.Manifest, ids.Config, cl.GetTLSVerify(), "")
 
 	return spec, nil
 }

--- a/internal/container/client.go
+++ b/internal/container/client.go
@@ -500,7 +500,7 @@ func (cl *Client) Resolve(ctx context.Context, name string) (Spec, error) {
 		return Spec{}, err
 	}
 
-	spec := NewSpec(cl.Target, ids.Manifest, ids.Config, cl.GetTLSVerify(), ids.ListManifest.String())
+	spec := NewSpec(cl.Target, ids.Manifest, ids.Config, cl.GetTLSVerify(), ids.ListManifest.String(), name)
 
 	return spec, nil
 }

--- a/internal/container/client_test.go
+++ b/internal/container/client_test.go
@@ -44,7 +44,7 @@ func TestClientResolve(t *testing.T) {
 		Digest:     "sha256:f29b6cd42a94a574583439addcd6694e6224f0e4b32044c9e3aee4c4856c2a50",
 		ImageID:    "sha256:c2ecf25cf190e76b12b07436ad5140d4ba53d8a136d498705e57a006837a720f",
 		TLSVerify:  client.GetTLSVerify(),
-		LocalName:  ref,
+		LocalName:  client.Target.String(),
 		ListDigest: listDigest,
 	}, spec)
 
@@ -57,7 +57,7 @@ func TestClientResolve(t *testing.T) {
 		Digest:     "sha256:d49eebefb6c7ce5505594bef652bd4adc36f413861bd44209d9b9486310b1264",
 		ImageID:    "sha256:d2ab8fea7f08a22f03b30c13c6ea443121f25e87202a7496e93736efa6fe345a",
 		TLSVerify:  client.GetTLSVerify(),
-		LocalName:  ref,
+		LocalName:  client.Target.String(),
 		ListDigest: listDigest,
 	}, spec)
 

--- a/internal/container/client_test.go
+++ b/internal/container/client_test.go
@@ -19,7 +19,7 @@ func TestClientResolve(t *testing.T) {
 	defer registry.Close()
 
 	repo := registry.AddRepo("library/osbuild")
-	repo.AddImage(
+	listDigest := repo.AddImage(
 		[]Blob{NewDataBlobFromBase64(rootLayer)},
 		[]string{"amd64", "ppc64le"},
 		"cool container",
@@ -40,11 +40,12 @@ func TestClientResolve(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, container.Spec{
-		Source:    ref,
-		Digest:    "sha256:f29b6cd42a94a574583439addcd6694e6224f0e4b32044c9e3aee4c4856c2a50",
-		ImageID:   "sha256:c2ecf25cf190e76b12b07436ad5140d4ba53d8a136d498705e57a006837a720f",
-		TLSVerify: client.GetTLSVerify(),
-		LocalName: ref,
+		Source:     ref,
+		Digest:     "sha256:f29b6cd42a94a574583439addcd6694e6224f0e4b32044c9e3aee4c4856c2a50",
+		ImageID:    "sha256:c2ecf25cf190e76b12b07436ad5140d4ba53d8a136d498705e57a006837a720f",
+		TLSVerify:  client.GetTLSVerify(),
+		LocalName:  ref,
+		ListDigest: listDigest,
 	}, spec)
 
 	client.SetArchitectureChoice("ppc64le")
@@ -52,11 +53,12 @@ func TestClientResolve(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, container.Spec{
-		Source:    ref,
-		Digest:    "sha256:d49eebefb6c7ce5505594bef652bd4adc36f413861bd44209d9b9486310b1264",
-		ImageID:   "sha256:d2ab8fea7f08a22f03b30c13c6ea443121f25e87202a7496e93736efa6fe345a",
-		TLSVerify: client.GetTLSVerify(),
-		LocalName: ref,
+		Source:     ref,
+		Digest:     "sha256:d49eebefb6c7ce5505594bef652bd4adc36f413861bd44209d9b9486310b1264",
+		ImageID:    "sha256:d2ab8fea7f08a22f03b30c13c6ea443121f25e87202a7496e93736efa6fe345a",
+		TLSVerify:  client.GetTLSVerify(),
+		LocalName:  ref,
+		ListDigest: listDigest,
 	}, spec)
 
 	// don't have that architecture

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -348,6 +348,7 @@ func (reg *Registry) Resolve(target, arch string) (container.Spec, error) {
 	}
 
 	lst, ok := repo.images[checksum]
+	listDigest := checksum
 
 	if ok {
 		checksum = ""
@@ -370,11 +371,12 @@ func (reg *Registry) Resolve(target, arch string) (container.Spec, error) {
 	}
 
 	return container.Spec{
-		Source:    ref.String(),
-		Digest:    checksum,
-		ImageID:   mf.ConfigDescriptor.Digest.String(),
-		LocalName: ref.String(),
-		TLSVerify: common.ToPtr(false),
+		Source:     ref.String(),
+		Digest:     checksum,
+		ImageID:    mf.ConfigDescriptor.Digest.String(),
+		LocalName:  ref.String(),
+		TLSVerify:  common.ToPtr(false),
+		ListDigest: listDigest,
 	}, nil
 }
 

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -374,7 +374,7 @@ func (reg *Registry) Resolve(target, arch string) (container.Spec, error) {
 		Source:     ref.String(),
 		Digest:     checksum,
 		ImageID:    mf.ConfigDescriptor.Digest.String(),
-		LocalName:  ref.String(),
+		LocalName:  target,
 		TLSVerify:  common.ToPtr(false),
 		ListDigest: listDigest,
 	}, nil

--- a/internal/container/spec.go
+++ b/internal/container/spec.go
@@ -22,13 +22,14 @@ type Spec struct {
 // NewSpec creates a new Spec from the essential information.
 // It also converts is the transition point from container
 // specific types (digest.Digest) to generic types (string).
-func NewSpec(source reference.Named, digest, imageID digest.Digest) Spec {
+func NewSpec(source reference.Named, digest, imageID digest.Digest, tlsVerify *bool, listDigest string) Spec {
 	name := source.Name()
 	return Spec{
-		Source:  name,
-		Digest:  digest.String(),
-		ImageID: imageID.String(),
-
-		LocalName: name,
+		Source:     name,
+		Digest:     digest.String(),
+		TLSVerify:  tlsVerify,
+		ImageID:    imageID.String(),
+		LocalName:  name,
+		ListDigest: listDigest,
 	}
 }

--- a/internal/container/spec.go
+++ b/internal/container/spec.go
@@ -22,14 +22,16 @@ type Spec struct {
 // NewSpec creates a new Spec from the essential information.
 // It also converts is the transition point from container
 // specific types (digest.Digest) to generic types (string).
-func NewSpec(source reference.Named, digest, imageID digest.Digest, tlsVerify *bool, listDigest string) Spec {
-	name := source.Name()
+func NewSpec(source reference.Named, digest, imageID digest.Digest, tlsVerify *bool, listDigest string, localName string) Spec {
+	if localName == "" {
+		localName = source.String()
+	}
 	return Spec{
-		Source:     name,
+		Source:     source.Name(),
 		Digest:     digest.String(),
 		TLSVerify:  tlsVerify,
 		ImageID:    imageID.String(),
-		LocalName:  name,
+		LocalName:  localName,
 		ListDigest: listDigest,
 	}
 }

--- a/internal/container/spec.go
+++ b/internal/container/spec.go
@@ -11,11 +11,12 @@ import (
 // at the Source via Digest and ImageID. The latter one
 // should remain the same in the target image as well.
 type Spec struct {
-	Source    string // does not include the manifest digest
-	Digest    string // digest of the manifest at the Source
-	TLSVerify *bool  // controls TLS verification
-	ImageID   string // container image identifier
-	LocalName string // name to use inside the image
+	Source     string // does not include the manifest digest
+	Digest     string // digest of the manifest at the Source
+	TLSVerify  *bool  // controls TLS verification
+	ImageID    string // container image identifier
+	LocalName  string // name to use inside the image
+	ListDigest string // digest of the list manifest at the Source (optional)
 }
 
 // NewSpec creates a new Spec from the essential information.

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -348,7 +348,8 @@ func (p *OS) serialize() osbuild.Pipeline {
 			pipeline.AddStage(osbuild.NewContainersStorageConfStage(containerStoreOpts))
 		}
 
-		skopeo := osbuild.NewSkopeoStage(storagePath, images, nil)
+		manifests := osbuild.NewFilesInputForManifestLists(p.Containers)
+		skopeo := osbuild.NewSkopeoStage(storagePath, images, manifests)
 		pipeline.AddStage(skopeo)
 	}
 

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -348,7 +348,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 			pipeline.AddStage(osbuild.NewContainersStorageConfStage(containerStoreOpts))
 		}
 
-		skopeo := osbuild.NewSkopeoStage(images, storagePath)
+		skopeo := osbuild.NewSkopeoStage(storagePath, images)
 		pipeline.AddStage(skopeo)
 	}
 

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -348,7 +348,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 			pipeline.AddStage(osbuild.NewContainersStorageConfStage(containerStoreOpts))
 		}
 
-		skopeo := osbuild.NewSkopeoStage(storagePath, images)
+		skopeo := osbuild.NewSkopeoStage(storagePath, images, nil)
 		pipeline.AddStage(skopeo)
 	}
 

--- a/internal/osbuild/containers_input.go
+++ b/internal/osbuild/containers_input.go
@@ -9,7 +9,7 @@ type ContainersInputReferences interface {
 }
 
 type ContainersInputSourceRef struct {
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 }
 
 type ContainersInputSourceMap map[string]ContainersInputSourceRef

--- a/internal/osbuild/files_input.go
+++ b/internal/osbuild/files_input.go
@@ -3,6 +3,8 @@ package osbuild
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/osbuild/osbuild-composer/internal/container"
 )
 
 // SPECIFIC INPUT STRUCTURE
@@ -275,4 +277,20 @@ func NewFilesInputSourceObjectRef(entries map[string]FilesInputRefMetadata) File
 		refs[fmt.Sprintf("sha256:%s", sha256Sum)] = FilesInputSourceOptions{Metadata: metadata}
 	}
 	return &refs
+}
+
+// NewFilesInputForManifestLists creates a FilesInput for container manifest
+// lists. If there are no list digests in the container specs, it returns nil.
+func NewFilesInputForManifestLists(containers []container.Spec) *FilesInput {
+	refs := make([]string, 0, len(containers))
+	for _, c := range containers {
+		if c.ListDigest != "" {
+			refs = append(refs, c.ListDigest)
+		}
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	filesRef := FilesInputSourcePlainRef(refs)
+	return NewFilesInput(&filesRef)
 }

--- a/internal/osbuild/skopeo_index_source.go
+++ b/internal/osbuild/skopeo_index_source.go
@@ -1,0 +1,57 @@
+package osbuild
+
+import (
+	"fmt"
+)
+
+type SkopeoIndexSource struct {
+	Items map[string]SkopeoIndexSourceItem `json:"items"`
+}
+
+func (SkopeoIndexSource) isSource() {}
+
+type SkopeoIndexSourceImage struct {
+	Name      string `json:"name"`
+	TLSVerify *bool  `json:"tls-verify,omitempty"`
+}
+
+type SkopeoIndexSourceItem struct {
+	Image SkopeoIndexSourceImage `json:"image"`
+}
+
+func (item SkopeoIndexSourceItem) validate() error {
+
+	if item.Image.Name == "" {
+		return fmt.Errorf("source item has empty name")
+	}
+
+	return nil
+}
+
+// NewSkopeoIndexSource creates a new and empty SkopeoIndexSource
+func NewSkopeoIndexSource() *SkopeoIndexSource {
+	return &SkopeoIndexSource{
+		Items: make(map[string]SkopeoIndexSourceItem),
+	}
+}
+
+// AddItem adds a source item to the source; will panic
+// if any of the supplied options are invalid or missing
+func (source *SkopeoIndexSource) AddItem(name, image string, tlsVerify *bool) {
+	item := SkopeoIndexSourceItem{
+		Image: SkopeoIndexSourceImage{
+			Name:      name,
+			TLSVerify: tlsVerify,
+		},
+	}
+
+	if err := item.validate(); err != nil {
+		panic(err)
+	}
+
+	if !skopeoDigestPattern.MatchString(image) {
+		panic("item has invalid image id")
+	}
+
+	source.Items[image] = item
+}

--- a/internal/osbuild/skopeo_stage.go
+++ b/internal/osbuild/skopeo_stage.go
@@ -12,10 +12,18 @@ type SkopeoStageOptions struct {
 
 func (o SkopeoStageOptions) isStageOptions() {}
 
-func NewSkopeoStage(path string, images ContainersInput) *Stage {
+type SkopeoStageInputs struct {
+	Images        ContainersInput `json:"images"`
+	ManifestLists *FilesInput     `json:"manifest-lists,omitempty"`
+}
 
-	inputs := ContainersInputs{
-		"images": images,
+func (SkopeoStageInputs) isStageInputs() {}
+
+func NewSkopeoStage(path string, images ContainersInput, manifests *FilesInput) *Stage {
+
+	inputs := SkopeoStageInputs{
+		Images:        images,
+		ManifestLists: manifests,
 	}
 
 	return &Stage{

--- a/internal/osbuild/skopeo_stage.go
+++ b/internal/osbuild/skopeo_stage.go
@@ -12,7 +12,7 @@ type SkopeoStageOptions struct {
 
 func (o SkopeoStageOptions) isStageOptions() {}
 
-func NewSkopeoStage(images ContainersInput, path string) *Stage {
+func NewSkopeoStage(path string, images ContainersInput) *Stage {
 
 	inputs := ContainersInputs{
 		"images": images,

--- a/internal/osbuild/source.go
+++ b/internal/osbuild/source.go
@@ -102,12 +102,21 @@ func GenSources(packages []rpmmd.PackageSpec, ostreeCommits []ostree.CommitSpec,
 	}
 
 	skopeo := NewSkopeoSource()
+	skopeoIndex := NewSkopeoIndexSource()
 	for _, c := range containers {
 		skopeo.AddItem(c.Source, c.Digest, c.ImageID, c.TLSVerify)
+
+		// if we have a list digest, add a skopeo-index source as well
+		if c.ListDigest != "" {
+			skopeoIndex.AddItem(c.Source, c.ListDigest, c.TLSVerify)
+		}
 	}
 
 	if len(skopeo.Items) > 0 {
 		sources["org.osbuild.skopeo"] = skopeo
+	}
+	if len(skopeoIndex.Items) > 0 {
+		sources["org.osbuild.skopeo-index"] = skopeoIndex
 	}
 
 	return sources

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -2303,6 +2303,7 @@ func (api *API) resolveContainersForImageType(bp blueprint.Blueprint, imageType 
 		specs[i].LocalName = s.Name
 		specs[i].TLSVerify = s.TLSVerify
 		specs[i].ImageID = s.ImageID
+		specs[i].ListDigest = s.ListDigest
 	}
 
 	return specs, nil

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -241,8 +241,9 @@ type ContainerSpec struct {
 	Name      string `json:"name"`
 	TLSVerify *bool  `json:"tls-verify,omitempty"`
 
-	ImageID string `json:"image_id"`
-	Digest  string `json:"digest"`
+	ImageID    string `json:"image_id"`
+	Digest     string `json:"digest"`
+	ListDigest string `json:"list-digest,omitempty"`
 }
 
 type ContainerResolveJob struct {

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -295,10 +295,10 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 81
-Requires:   osbuild-ostree >= 81
-Requires:   osbuild-lvm2 >= 81
-Requires:   osbuild-luks2 >= 81
+Requires:   osbuild >= 83
+Requires:   osbuild-ostree >= 83
+Requires:   osbuild-lvm2 >= 83
+Requires:   osbuild-luks2 >= 83
 Requires:   %{name}-dnf-json = %{version}-%{release}
 
 %description worker

--- a/templates/packer/config.pkr.hcl
+++ b/templates/packer/config.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     amazon = {
-      version = ">= 1.1.1"
+      version = "= 1.2.2"
       source = "github.com/hashicorp/amazon"
     }
   }

--- a/test/data/manifests/centos_8-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4887,10 +4890,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6164,10 +6177,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -12156,7 +12184,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/centos_8-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_commit_with_container-boot.json
@@ -24,7 +24,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -4891,10 +4892,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -12184,7 +12185,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -12192,7 +12193,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/centos_8-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5049,8 +5052,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6373,6 +6386,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -12561,7 +12589,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/centos_8-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit_with_container-boot.json
@@ -24,7 +24,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -5051,10 +5052,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   }
                 }
               },
@@ -12589,7 +12590,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -12597,7 +12598,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
@@ -24,7 +24,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -4531,10 +4532,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -11355,7 +11356,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -11363,7 +11364,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4527,10 +4530,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -5785,10 +5798,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11329,6 +11357,14 @@
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
       "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
       "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
@@ -11327,7 +11327,8 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
@@ -11827,7 +11827,8 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
@@ -30,7 +30,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -4739,10 +4740,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   }
                 }
               },
@@ -11855,7 +11856,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -11863,7 +11864,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4737,8 +4740,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6039,6 +6052,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11829,6 +11857,14 @@
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
       "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
       "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_36-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_commit_with_container-boot.json
@@ -36,6 +36,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5393,10 +5396,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6819,10 +6832,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -13421,7 +13449,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_36-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_commit_with_container-boot.json
@@ -38,7 +38,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "manifest-list-test:v1"
         }
       ]
     }
@@ -5397,10 +5398,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -13449,7 +13450,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -13457,7 +13458,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/fedora_36-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_commit_with_container-boot.json
@@ -38,7 +38,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "manifest-list-test:v1"
         }
       ]
     }
@@ -5517,10 +5518,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "manifest-list-test:v1"
                   }
                 }
               },
@@ -13755,7 +13756,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -13763,7 +13764,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/fedora_36-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_commit_with_container-boot.json
@@ -36,6 +36,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5515,8 +5518,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6979,6 +6992,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -13727,7 +13755,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_37-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5463,10 +5466,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6910,10 +6923,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -13622,7 +13650,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_37-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_commit_with_container-boot.json
@@ -24,7 +24,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "manifest-list-test:v1"
         }
       ]
     }
@@ -5467,10 +5468,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -13650,7 +13651,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -13658,7 +13659,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/fedora_37-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5585,8 +5588,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -7070,6 +7083,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -13928,7 +13956,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_37-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_commit_with_container-boot.json
@@ -24,7 +24,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "manifest-list-test:v1"
         }
       ]
     }
@@ -5587,10 +5588,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "manifest-list-test:v1"
                   }
                 }
               },
@@ -13956,7 +13957,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -13964,7 +13965,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/fedora_38-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_commit_with_container-boot.json
@@ -24,7 +24,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "manifest-list-test:v1"
         }
       ]
     }
@@ -5299,10 +5300,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -13271,20 +13272,20 @@
   },
   "containers": [
     {
-      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
-      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
-      "TLSVerify": null,
-      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
-      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
-    },
-    {
       "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "manifest-list-test:v1",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_38-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5295,10 +5298,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6745,10 +6758,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -13243,11 +13271,20 @@
   },
   "containers": [
     {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+    },
+    {
       "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/fedora_38-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_commit_with_container-boot.json
@@ -24,7 +24,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "manifest-list-test:v1"
         }
       ]
     }
@@ -5403,10 +5404,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "manifest-list-test:v1"
                   }
                 }
               },
@@ -13542,7 +13543,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -13550,7 +13551,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/fedora_38-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -5401,8 +5404,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6886,6 +6899,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -13514,7 +13542,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
@@ -22,7 +22,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1907,10 +1908,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -8623,7 +8624,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8631,7 +8632,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1903,10 +1906,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3191,10 +3204,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8595,7 +8623,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
@@ -30,7 +30,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1977,10 +1978,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   }
                 }
               },
@@ -8918,7 +8919,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8926,7 +8927,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1975,8 +1978,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3310,6 +3323,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8890,7 +8918,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_84-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1864,10 +1867,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3159,10 +3172,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8446,7 +8474,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_84-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_commit_with_container-boot.json
@@ -22,7 +22,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1868,10 +1869,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -8474,7 +8475,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8482,7 +8483,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_84-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_commit_with_container-boot.json
@@ -30,7 +30,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1938,10 +1939,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   }
                 }
               },
@@ -8769,7 +8770,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8777,7 +8778,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_84-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1936,8 +1939,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3278,6 +3291,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8741,7 +8769,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_85-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1885,10 +1888,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3148,10 +3161,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8498,7 +8526,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_85-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_commit_with_container-boot.json
@@ -22,7 +22,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1889,10 +1890,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -8526,7 +8527,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8534,7 +8535,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_85-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1957,8 +1960,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3267,6 +3280,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8793,7 +8821,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_85-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit_with_container-boot.json
@@ -30,7 +30,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1959,10 +1960,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   }
                 }
               },
@@ -8821,7 +8822,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8829,7 +8830,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
@@ -22,7 +22,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1901,10 +1902,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -8596,7 +8597,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8604,7 +8605,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1897,10 +1900,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3182,10 +3195,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8568,7 +8596,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
@@ -30,7 +30,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1971,10 +1972,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   }
                 }
               },
@@ -8891,7 +8892,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8899,7 +8900,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1969,8 +1972,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3301,6 +3314,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8863,7 +8891,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
@@ -22,7 +22,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1907,10 +1908,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -8623,7 +8624,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8631,7 +8632,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1903,10 +1906,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3191,10 +3204,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8595,7 +8623,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
@@ -30,7 +30,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1977,10 +1978,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   }
                 }
               },
@@ -8918,7 +8919,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8926,7 +8927,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1975,8 +1978,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3310,6 +3323,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8890,7 +8918,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
@@ -22,7 +22,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1907,10 +1908,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -8623,7 +8624,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8631,7 +8632,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1903,10 +1906,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3191,10 +3204,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8595,7 +8623,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
@@ -30,7 +30,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1977,10 +1978,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   }
                 }
               },
@@ -8918,7 +8919,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8926,7 +8927,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1975,8 +1978,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3310,6 +3323,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8890,7 +8918,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_9-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4575,10 +4578,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -5836,10 +5849,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11438,7 +11466,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_9-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_commit_with_container-boot.json
@@ -24,7 +24,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -4579,10 +4580,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -11466,7 +11467,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -11474,7 +11475,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_9-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_commit_with_container-boot.json
@@ -33,7 +33,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -4790,10 +4791,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   }
                 }
               },
@@ -11969,7 +11970,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -11977,7 +11978,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_9-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_commit_with_container-boot.json
@@ -31,6 +31,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4788,8 +4791,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6093,6 +6106,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11941,7 +11969,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
@@ -20,6 +20,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1777,10 +1780,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3032,10 +3045,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8058,7 +8086,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
@@ -22,7 +22,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1781,10 +1782,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -8086,7 +8087,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8094,7 +8095,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
@@ -30,7 +30,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -1869,10 +1870,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   }
                 }
               },
@@ -8453,7 +8454,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -8461,7 +8462,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
@@ -28,6 +28,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -1867,8 +1870,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -3169,6 +3182,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -8425,7 +8453,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4575,10 +4578,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -5836,10 +5849,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11438,7 +11466,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
@@ -24,7 +24,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -4579,10 +4580,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -11466,7 +11467,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -11474,7 +11475,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
@@ -5186,7 +5186,7 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               }
@@ -13442,7 +13442,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     }
   ],

--- a/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
@@ -13442,7 +13442,8 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
@@ -5794,7 +5794,7 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               }
@@ -14937,7 +14937,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     }
   ],

--- a/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
@@ -14937,7 +14937,8 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
@@ -6018,7 +6018,7 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               }
@@ -15430,7 +15430,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     }
   ],

--- a/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
@@ -15430,7 +15430,8 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
@@ -33,7 +33,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -4790,10 +4791,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   }
                 }
               },
@@ -11969,7 +11970,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -11977,7 +11978,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
@@ -31,6 +31,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4788,8 +4791,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6093,6 +6106,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11941,7 +11969,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
@@ -14273,7 +14273,8 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
@@ -5522,7 +5522,7 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               }
@@ -14273,7 +14273,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     }
   ],

--- a/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
@@ -22,6 +22,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4543,10 +4546,20 @@
                 "type": "org.osbuild.containers",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                  },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -5812,10 +5825,25 @@
       },
       "org.osbuild.skopeo": {
         "items": {
+          "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb"
+            }
+          },
           "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11374,7 +11402,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
+      "TLSVerify": null,
+      "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
@@ -24,7 +24,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -4547,10 +4548,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   },
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   }
                 }
               },
@@ -11402,7 +11403,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -11410,7 +11411,7 @@
       "Digest": "sha256:1a19a94647b1379fed8c23eb7553327cb604ba546eb93f9f6c1e6d11911c8beb",
       "TLSVerify": null,
       "ImageID": "sha256:62d2a7b3bf9e0b4f3aba22553d6971227b5a39f7f408d46347b1ee74eb97cb20",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
@@ -31,6 +31,9 @@
       "containers": [
         {
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+        },
+        {
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
         }
       ]
     }
@@ -4756,8 +4759,18 @@
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
                     "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                  },
+                  "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
                   }
                 }
+              },
+              "manifest-lists": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
+                ]
               }
             },
             "options": {
@@ -6069,6 +6082,21 @@
             "image": {
               "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
               "digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b"
+            }
+          },
+          "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+              "digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e"
+            }
+          }
+        }
+      },
+      "org.osbuild.skopeo-index": {
+        "items": {
+          "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc": {
+            "image": {
+              "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
             }
           }
         }
@@ -11877,7 +11905,16 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "ListDigest": ""
+    },
+    {
+      "Source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
+      "TLSVerify": null,
+      "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],
   "no-image-info": true

--- a/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
@@ -33,7 +33,8 @@
           "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
         },
         {
-          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+          "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+          "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
         }
       ]
     }
@@ -4758,10 +4759,10 @@
                 "origin": "org.osbuild.source",
                 "references": {
                   "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest"
                   },
                   "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99": {
-                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+                    "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
                   }
                 }
               },
@@ -11905,7 +11906,7 @@
       "Digest": "sha256:4d76a7480ce1861c95975945633dc9d03807ffb45c64b664ef22e673798d414b",
       "TLSVerify": null,
       "ImageID": "sha256:d4ee87dab8193afad523b1042b9d3f5ec887555a704e5aaec2876798ebb585a6",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal:latest",
       "ListDigest": ""
     },
     {
@@ -11913,7 +11914,7 @@
       "Digest": "sha256:601c98c8148720ec5c29b8e854a1d5d88faddbc443eca12920d76cf993d7290e",
       "TLSVerify": null,
       "ImageID": "sha256:dbb63178dc9157068107961f11397df3fb62c02fa64f697d571bf84aad71cb99",
-      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+      "LocalName": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1",
       "ListDigest": "sha256:58150862447d05feeb263ddb7257bf11d2ce2a697362ac117de2184d10f028fc"
     }
   ],

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -125,7 +125,8 @@
             "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
           },
           {
-            "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+            "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+            "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test:v1"
           }
         ]
       }
@@ -301,7 +302,8 @@
             "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
           },
           {
-            "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
+            "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test",
+            "name": "manifest-list-test:v1"
           }
         ]
       }

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -123,6 +123,9 @@
         "containers": [
           {
             "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+          },
+          {
+            "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
           }
         ]
       }
@@ -296,6 +299,9 @@
         "containers": [
           {
             "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/fedora-minimal"
+          },
+          {
+            "source": "registry.gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/manifest-list-test"
           }
         ]
       }


### PR DESCRIPTION
Backport https://github.com/osbuild/osbuild-composer/pull/3336 and https://github.com/osbuild/osbuild-composer/pull/3398 to `rhel-9.2.0`.