### PR TITLE
internal/manifest: remove redundant insights-client call

### DIFF
--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -499,9 +499,6 @@ func (p *OS) serialize() osbuild.Pipeline {
 		if p.Subscription.Rhc {
 			// Use rhc for registration instead of subscription manager
 			commands = []string{fmt.Sprintf("/usr/bin/rhc connect -o=%s -a=%s --server %s", p.Subscription.Organization, p.Subscription.ActivationKey, p.Subscription.ServerUrl)}
-
-			// Always enable Insights when using rhc
-			commands = append(commands, "/usr/bin/insights-client --register")
 		} else {
 			commands = []string{fmt.Sprintf("/usr/sbin/subscription-manager register --org=%s --activationkey=%s --serverurl %s --baseurl %s", p.Subscription.Organization, p.Subscription.ActivationKey, p.Subscription.ServerUrl, p.Subscription.BaseUrl)}
 

--- a/internal/manifest/os_test.go
+++ b/internal/manifest/os_test.go
@@ -110,7 +110,6 @@ func TestRhcInsightsCommands(t *testing.T) {
 	pipeline := os.serialize()
 	CheckFirstBootStageOptions(t, pipeline.Stages, []string{
 		"/usr/bin/rhc connect -o=2040324 -a=my-secret-key --server subscription.rhsm.redhat.com",
-		"/usr/bin/insights-client --register",
 	})
 }
 


### PR DESCRIPTION
RHC automatically connects to insights already.

---
Done with 1 rhc connect call:
![image](https://user-images.githubusercontent.com/11140201/234841082-c9071559-df57-4156-b96a-8604f8385972.png)

---

marking as draft, as it does seem like it's doing *something*, I asked some other people for help.
![image](https://user-images.githubusercontent.com/11140201/234842862-cc2b568c-14e3-4a17-ad52-95c533e5f26f.png)

---

edit2: clarified the above with the insights devs, rhc already does this. So it's not needed.