### PR TITLE
internal/cloudapi: new prometheus listener

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -108,6 +108,14 @@ func main() {
 		composer.InitLocalWorker(l[0])
 	}
 
+	if l, exists := listeners["osbuild-composer-prometheus.socket"]; exists {
+		if len(l) != 1 {
+			logrus.Warn("The osbuild-composer-prometheus.socket unit is misconfigured. It should contain only one socket.")
+		}
+
+		composer.InitMetricsAPI(l[0])
+	}
+
 	if l, exists := listeners["osbuild-composer-api.socket"]; exists {
 		if len(l) != 1 {
 			logrus.Fatal("The osbuild-composer-api.socket unit is misconfigured. It should contain only one socket.")

--- a/distribution/osbuild-composer-api.socket
+++ b/distribution/osbuild-composer-api.socket
@@ -1,5 +1,6 @@
 [Unit]
 Description=OSBuild Composer API socket
+Requires=osbuild-composer-prometheus.socket
 
 [Socket]
 Service=osbuild-composer.service

--- a/distribution/osbuild-composer-prometheus.socket
+++ b/distribution/osbuild-composer-prometheus.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=OSBuild Composer prometheus socket
+
+[Socket]
+Service=osbuild-composer.service
+ListenStream=8008
+
+[Install]
+WantedBy=sockets.target

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -262,13 +262,13 @@ cd $PWD/_build/src/%{goipath}
 %endif
 
 %post
-%systemd_post osbuild-composer.service osbuild-composer.socket osbuild-composer-api.socket osbuild-remote-worker.socket
+%systemd_post osbuild-composer.service osbuild-composer.socket osbuild-composer-api.socket osbuild-composer-prometheus.socket osbuild-remote-worker.socket
 
 %preun
-%systemd_preun osbuild-composer.service osbuild-composer.socket osbuild-composer-api.socket osbuild-remote-worker.socket
+%systemd_preun osbuild-composer.service osbuild-composer.socket osbuild-composer-api.socket osbuild-composer-prometheus.socket osbuild-remote-worker.socket
 
 %postun
-%systemd_postun_with_restart osbuild-composer.service osbuild-composer.socket osbuild-composer-api.socket osbuild-remote-worker.socket
+%systemd_postun_with_restart osbuild-composer.service osbuild-composer.socket osbuild-composer-api.socket osbuild-composer-prometheus.socket osbuild-remote-worker.socket
 
 %files
 %license LICENSE
@@ -277,6 +277,7 @@ cd $PWD/_build/src/%{goipath}
 %{_unitdir}/osbuild-composer.service
 %{_unitdir}/osbuild-composer.socket
 %{_unitdir}/osbuild-composer-api.socket
+%{_unitdir}/osbuild-composer-prometheus.socket
 %{_unitdir}/osbuild-local-worker.socket
 %{_unitdir}/osbuild-remote-worker.socket
 %{_sysusersdir}/osbuild-composer.conf

--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -109,6 +109,9 @@ objects:
           - name: composer-api
             protocol: TCP
             containerPort: ${{COMPOSER_API_PORT}}
+          - name: prometheus
+            protocol: TCP
+            containerPort: ${{PROMETHEUS_PORT}}
           - name: worker-api
             protocol: TCP
             containerPort: ${{WORKER_API_PORT}}
@@ -217,6 +220,10 @@ objects:
         protocol: TCP
         port: 80
         targetPort: ${{COMPOSER_API_PORT}}
+      - name: prometheus
+        protocol: TCP
+        port: 8008
+        targetPort: ${{PROMETHEUS_PORT}}
     selector:
       app: composer
 
@@ -455,6 +462,9 @@ parameters:
     name: COMPOSER_API_PORT
     required: true
     value: "8080"
+  - description: prometheus port
+    name: PROMETHEUS_PORT
+    value: "8008"
   - description: worker-api port
     name: WORKER_API_PORT
     required: true


### PR DESCRIPTION
Listening on another port, while keeping the existing endpoint


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
