### PR TITLE
HMS-1419: worker/server: optimized JobResult fetching

### DIFF
--- a/internal/cloudapi/v2/errors.go
+++ b/internal/cloudapi/v2/errors.go
@@ -68,6 +68,7 @@ const (
 	ErrorGettingOSBuildJobStatus                  ServiceErrorCode = 1017
 	ErrorGettingAWSEC2JobStatus                   ServiceErrorCode = 1018
 	ErrorGettingJobType                           ServiceErrorCode = 1019
+	ErrorGettingExecutingAsyncDBCall              ServiceErrorCode = 1020
 
 	// Errors contained within this file
 	ErrorUnspecified          ServiceErrorCode = 10000

--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -1143,7 +1143,7 @@ func (h *apiHandlers) getComposeMetadataImpl(ctx echo.Context, id string) error 
 		// no osbuild output recorded for job, error
 		return HTTPError(ErrorMalformedOSBuildJobResult)
 	}
-	hasOSBuildLogs, err := h.server.workers.TestResultFieldExists(jobId, "osbuild_output.log")
+	hasOSBuildLogs, err := h.server.workers.TestResultFieldNotEmpty(jobId, "osbuild_output.log")
 	if err != nil {
 		logrus.Error(err)
 		return HTTPErrorWithInternal(ErrorGettingExecutingAsyncDBCall, err)

--- a/internal/jobqueue/jobqueuetest/jobqueuetest.go
+++ b/internal/jobqueue/jobqueuetest/jobqueuetest.go
@@ -745,6 +745,10 @@ func testQueryJSonField(t *testing.T, q jobqueue.JobQueue) {
 		},
 		nil))
 
+	//
+	// Tests related to querying fields
+	//
+
 	// Test accessing one field is working
 	var res TestStructure
 	err := q.QueryResultFields(id, []string{"name", "expansion"}, &res)
@@ -764,6 +768,12 @@ func testQueryJSonField(t *testing.T, q jobqueue.JobQueue) {
 	// test requesting empty subtype returns nil
 	require.Nil(t, res.EmptySubType)
 	err = q.QueryResultFields(id, []string{"empty_sub_type"}, &res)
+	require.Nil(t, err)
+	require.Nil(t, res.EmptySubType)
+
+	// test that accessing a sub field to an empty subtype does not instantiate the subtype
+	require.Nil(t, res.EmptySubType)
+	err = q.QueryResultFields(id, []string{"empty_sub_type.something"}, &res)
 	require.Nil(t, err)
 	require.Nil(t, res.EmptySubType)
 
@@ -804,6 +814,10 @@ func testQueryJSonField(t *testing.T, q jobqueue.JobQueue) {
 	err = q.QueryResultFields(id, []string{"sub_type_ptr_ptr.something"}, &res6)
 	require.Nil(t, err)
 	require.Equal(t, "nothing_ptr", (*res6.SubTypePtrPtr).Something)
+
+	//
+	// Tests related to testing existence of a field
+	//
 
 	// Check JSON queries errors out on sanitization
 	val, err := q.TestResultFieldExists(id, "'name")

--- a/internal/jsondb/db.go
+++ b/internal/jsondb/db.go
@@ -18,6 +18,7 @@ package jsondb
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -33,6 +34,25 @@ type JSONDatabase struct {
 // have a file mode of `perm`.
 func New(dir string, perm os.FileMode) *JSONDatabase {
 	return &JSONDatabase{dir, perm}
+}
+
+// Reads the value at `name`. `document` must be a type that is deserializable
+// from the JSON document `name`, or nil to not deserialize at all. Returns
+// false if a document with `name` does not exist.
+func (db *JSONDatabase) ReadRaw(name string, raw *json.RawMessage) error {
+	f, err := os.Open(path.Join(db.dir, name+".json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("error accessing db file %s: %v", name, err)
+	}
+	defer f.Close()
+	*raw, err = ioutil.ReadAll(f)
+	if err != nil {
+		return fmt.Errorf("error accessing db file %s: %v", name, err)
+	}
+	return nil
 }
 
 // Reads the value at `name`. `document` must be a type that is deserializable

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -202,7 +202,7 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 	switch jobType {
 	case JobTypeOSBuild:
 		var osbuildJR OSBuildJobResult
-		jobInfo, err = s.OSBuildJobInfo(id, &osbuildJR)
+		jobInfo, err = s.AsyncOSBuildJobInfo(id, &osbuildJR)
 		if err != nil {
 			return nil, err
 		}
@@ -769,7 +769,7 @@ func (s *Server) RequeueOrFinishJob(token uuid.UUID, maxRetries uint64, result j
 	switch jobType {
 	case JobTypeOSBuild:
 		var osbuildJR OSBuildJobResult
-		jobInfo, err = s.OSBuildJobInfo(jobId, &osbuildJR)
+		jobInfo, err = s.AsyncOSBuildJobInfo(jobId, &osbuildJR)
 		if err != nil {
 			return err
 		}

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -370,8 +370,8 @@ func (s *Server) QueryResultFields(id uuid.UUID, paths []string, result any) err
 	return s.jobs.QueryResultFields(id, paths, result)
 }
 
-func (s *Server) TestResultFieldExists(id uuid.UUID, path string) (bool, error) {
-	return s.jobs.TestResultFieldExists(id, path)
+func (s *Server) TestResultFieldNotEmpty(id uuid.UUID, path string) (bool, error) {
+	return s.jobs.TestResultFieldNotEmpty(id, path)
 }
 
 func (s *Server) KojiInitJobInfo(id uuid.UUID, result *KojiInitJobResult) (*JobInfo, error) {

--- a/pkg/jobqueue/dbjobqueue/dbjobqueue.go
+++ b/pkg/jobqueue/dbjobqueue/dbjobqueue.go
@@ -804,8 +804,10 @@ func (q *DBJobQueue) QueryResultFields(id uuid.UUID, paths []string, response an
 	// Unpack each answer into their corresponding recipient, only if there is an answer to unpack.
 	for i, ianswer := range answers {
 		var answer *json.RawMessage = ianswer.(*json.RawMessage)
-		if len(*answer) > 0 {
-			logrus.Infof("unpack %s for path %s", *answer, paths[i])
+		// literal string "null" is a valid result for a json Field, however, we shall treat it as a nil answer. See the
+		// following comment on instantiation to understand the details.
+		isNullAnswer := len(*answer) == 4 && string(*answer) == "null"
+		if len(*answer) > 0 && !isNullAnswer {
 			// if recipient is a pointer to something, the something in question will get allocated by the
 			// FindRecipientByTagPath function. So only call this when there is an actual result to unpack, otherwise
 			// the content will be set to non nil (and that is a problem).

--- a/pkg/jobqueue/jobqueue.go
+++ b/pkg/jobqueue/jobqueue.go
@@ -16,6 +16,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -68,6 +72,50 @@ type JobQueue interface {
 	//
 	// Lastly, the IDs of the jobs dependencies are returned.
 	JobStatus(id uuid.UUID) (jobType string, channel string, result json.RawMessage, queued, started, finished time.Time, canceled bool, deps []uuid.UUID, dependents []uuid.UUID, err error)
+	// Does the same as JobStatus but without fetching the result blob
+	// To be used instead of JobStatus if possible
+	JobStatusWoResult(id uuid.UUID) (jobType string, channel string, queued, started, finished time.Time, canceled bool, deps []uuid.UUID, dependents []uuid.UUID, err error)
+
+	// Query multiple fields under the result column at once and stores them in to the response object.
+	// paths: a list of dot separated fields composing a searchable path in the result column
+	//        each names in the path must correspond to a subsequent json key.
+	// response: an object that has for characteristic to contains public fields associated with json tags matching the paths
+	//
+	// for example:
+	// type Object struct {
+	//     Name string `json:"name"`
+	// }
+	// type ResponseStruct struct {
+	//     Name  string `json:"name"`
+	//     Obj1  Object `json:"obj"`
+	//     Obj2 *Object `json:"obj2"`
+	// }
+	// var response ResponseStruct
+	// err = QueryResultFields(id, []string{"name", "obj.name", "obj2.name"), &response)
+	//
+	// After calling the QueryResultFields, response will contain its Name , Obj1 and Obj2 fields field up.
+	// Obj2 will be instantiated on the fly.
+	//
+	// Pointer instantiation only works for one level of indirection, for pointers on pointers the user needs to provide
+	// a valid chain to dereference.
+	//
+	// For instance:
+	// type Object struct {
+	//     Name string `json:"name"`
+	// }
+	// type ResponseStruct struct {
+	//     Obj **Object `json:"obj"`
+	// }
+	// obj := &Object{}
+	// var response ResponseStruct
+	// response.Obj = &obj
+	// err = QueryResultFields(id, []string{"name", "obj.name", "obj2.name"), &response)
+	QueryResultFields(id uuid.UUID, paths []string, response any) error
+
+	// Check for presence of a specific path and is content in a JSON field.
+	// path -> a dot separated path within the result, for example osbuild_output.error
+	// Returns a boolean set to True if the requested path contains data
+	TestResultFieldExists(id uuid.UUID, path string) (bool, error)
 
 	// Job returns all the parameters that define a job (everything provided during Enqueue).
 	Job(id uuid.UUID) (jobType string, args json.RawMessage, dependencies []uuid.UUID, channel string, err error)
@@ -80,6 +128,106 @@ type JobQueue interface {
 
 	// Reset the last heartbeat time to time.Now()
 	RefreshHeartbeat(token uuid.UUID)
+}
+
+func getFieldByTag(tag string, rt reflect.Type, val reflect.Value) (interface{}, error) {
+	// Only struct can be explored, error out if the recipient is not one.
+	if rt.Kind() != reflect.Struct {
+		return nil, errors.New("Recipient isn't a struct")
+	}
+	// Iterate through the fields to find out the one that has a json tag matching the requested name.
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		// ignore the arguments of the json tag
+		v := strings.Split(f.Tag.Get("json"), ",")[0]
+		if v == tag {
+			// obtain the field from the recipient's instance and generate a pointer to it.
+			v := val.FieldByName(f.Name)
+			// In the special case where the field is a pointer, check that underlying data structure is instantiated
+			// and if not create a New instance of it.
+			if v.Kind() == reflect.Pointer {
+				if v.IsNil() {
+					v.Set(reflect.New(f.Type.Elem()))
+				}
+			}
+			// Then return a pointer to the underlying field, or the field directly if it is impossible to have a
+			// pointer to it.
+			if v.CanAddr() {
+				return v.Addr().Interface(), nil
+			} else {
+				return v.Interface(), nil
+			}
+		}
+		// if the field is anonymous, it means embedding of another structure fields. The code needs to explore this
+		// structure to find out the correct Tag. Jump into this structure, but keep the parent value as reference to
+		// extract the field names.
+		if f.Anonymous {
+			return getFieldByTag(tag, f.Type, val)
+		}
+	}
+	// Nothing was found, return a missing error
+	return nil, errors.New("tag not found in struct")
+}
+
+// returns the struct field having the json tag within the recipient.
+// recipient must be a struct, or a pointer to a struct.
+//
+// If the field pointed by the tag is a pointer to something that is not instantiated, the method will instantiate the
+// pointed content for you before returning the pointer.
+//
+// With a caveat that double pointers aren't automatically supported, if you do need to use pointers on pointers, make
+// sur the final data structure that'll receive information is not nil. If that's what you want.
+func GetFieldByTag(tag string, recipient interface{}) (interface{}, error) {
+	val := reflect.ValueOf(recipient)
+	// Dereference the recipient if it's a pointer, dereferencing can happen many times in a row, for pointer on
+	// pointers, or pointers on struct fields.
+	for val.Kind() == reflect.Ptr {
+		deref := val.Elem()
+		if deref.Kind() == 0 {
+			return nil, fmt.Errorf("Recipient '%s' is nil, please initialize it", tag)
+		} else {
+			val = deref
+		}
+	}
+	return getFieldByTag(tag, val.Type(), val)
+}
+
+// Returns the right hand field of the path by going through each path element from the recipient.
+// path is a dot separated list of fields from the root structure: for example
+// path <- "a.b.c"
+//
+//	recipient <- {
+//	  a:{
+//	     b:{
+//	         c:"bar"
+//	     }
+//	  }
+//	}
+//
+// will return a pointer to c.
+func FindRecipientByTagPath(recipient interface{}, path string) (field interface{}, err error) {
+	field = recipient
+	for _, tag := range strings.Split(path, ".") {
+		field, err = GetFieldByTag(tag, field)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return field, nil
+}
+
+func FieldSanitazation(path string) error {
+	// Check that path element contains only alphanumeric characters (dash and underscore are permitted too)
+	rgx, err := regexp.Compile(`^[\w\d\-_]+$`)
+	if err != nil {
+		return err
+	}
+	for _, str := range strings.Split(path, ".") {
+		if !rgx.MatchString(str) {
+			return errors.New("path element doesn't match validation regex")
+		}
+	}
+	return nil
 }
 
 // SimpleLogger provides a structured logging methods for the jobqueue library.

--- a/pkg/jobqueue/jobqueue.go
+++ b/pkg/jobqueue/jobqueue.go
@@ -115,7 +115,7 @@ type JobQueue interface {
 	// Check for presence of a specific path and is content in a JSON field.
 	// path -> a dot separated path within the result, for example osbuild_output.error
 	// Returns a boolean set to True if the requested path contains data
-	TestResultFieldExists(id uuid.UUID, path string) (bool, error)
+	TestResultFieldNotEmpty(id uuid.UUID, path string) (bool, error)
 
 	// Job returns all the parameters that define a job (everything provided during Enqueue).
 	Job(id uuid.UUID) (jobType string, args json.RawMessage, dependencies []uuid.UUID, channel string, err error)


### PR DESCRIPTION
TLDR:  This pull request is a first step at fixing the bandwidth consumption issue between composer and the `dbjobqueue`.

**The reason why we are doing this:**
* it has been observed huge consumption spikes in bandwidth on the production platform.
* we are afraid of scalability issues on the long run if more people are using the web service

**What's going on:**

It turns out that in many places in the code base, when `composer` wants to access a job state, it will request from the DB the `JobResult`, which is a JSON blob that can be quite heavy. For the order of magnitude, one `OSBBuild` `JobResult` can weight around `90K` for a `fedora36` build.

**The constraints around this work:**

* The reason why we had to transit a result blob is because its content is not API, and is not aimed to be API. The rework needs to preserve that property. The changes can't lock us in a corner API-wise and retro-compatibility-wise. Meaning that changes to the way we request data from postgres must be minimal and not dependent of the `JobResult` content.
* The only way we can really  decrease bandwidth usage is to stop transiting the result blob when we don't really need it in its entirety.

**The way the change is orchestrated:**

* [ ] rewrite description

**Testing:**

* [x] Added new tests in the `internal/jobqueue/jobqueuetest/jobqueuetest.go`.

**Alternative solutions:**

Caching was also another option. But it turns out quite often a user will only request once a full blob, caching can't really help us here.
