### PR TITLE
osbuild: `opts` can't be empty in isolinux

### DIFF
--- a/internal/osbuild/isolinux_stage.go
+++ b/internal/osbuild/isolinux_stage.go
@@ -15,7 +15,7 @@ type ISOLinuxProduct struct {
 type ISOLinuxKernel struct {
 	Dir string `json:"dir"`
 
-	Opts []string `json:"opts,omitempty"`
+	Opts []string `json:"opts"`
 }
 
 func NewISOLinuxStage(options *ISOLinuxStageOptions, inputPipeline string) *Stage {


### PR DESCRIPTION
If `opts` is empty osbuild stage fails:

```
Traceback (most recent call last):
  File "/run/osbuild/bin/org.osbuild.isolinux", line 243, in <module>
    ret = main(args["tree"], args["inputs"], args["options"])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/run/osbuild/bin/org.osbuild.isolinux", line 227, in main
    "cmdline": " ".join(kopts)
               ^^^^^^^^^^^^^^^
TypeError: can only join an iterable
```

Fix on the other side is here: https://github.com/osbuild/osbuild/pull/1309