### PR TITLE
iot: add fedora-release-iot to iot-installer

### DIFF
--- a/internal/distro/fedora/package_sets.go
+++ b/internal/distro/fedora/package_sets.go
@@ -465,7 +465,24 @@ func anacondaPackageSet(t *imageType) rpmmd.PackageSet {
 }
 
 func iotInstallerPackageSet(t *imageType) rpmmd.PackageSet {
-	return anacondaPackageSet(t)
+	// include anaconda packages
+	ps := anacondaPackageSet(t)
+
+	releasever := t.Arch().Distro().Releasever()
+	version, err := strconv.Atoi(releasever)
+	if err != nil {
+		panic("cannot convert releasever to int: " + err.Error())
+	}
+
+	if version >= 38 {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"fedora-release-iot",
+			},
+		})
+	}
+
+	return ps
 }
 
 func imageInstallerPackageSet(t *imageType) rpmmd.PackageSet {

--- a/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
@@ -3529,14 +3529,6 @@
                     }
                   },
                   {
-                    "id": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137",
                     "options": {
                       "metadata": {
@@ -3545,7 +3537,15 @@
                     }
                   },
                   {
-                    "id": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+                    "id": "sha256:576b8999f1988ba2bab3b79550235751cb3106641203b14b25283e084aa34db7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b20b6b28cde122e999e538f01e6987abcc9bfda7a11679eba36265d6d30c2a1",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -10741,6 +10741,9 @@
           "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-common-2.06-60.fc38.noarch.rpm"
           },
+          "sha256:0b20b6b28cde122e999e538f01e6987abcc9bfda7a11679eba36265d6d30c2a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-iot-38-0.4.noarch.rpm"
+          },
           "sha256:0b64aaaa464cf6acff630d21ef963e97f4b0456bbb68d9a650a0f682f585a43d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/osinfo-db-tools-1.10.0-5.fc38.aarch64.rpm"
           },
@@ -11634,6 +11637,9 @@
           },
           "sha256:576353a8452a5283209f9e63fbb70a3743369580156ddb57f726b00c460b58d1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/plymouth-22.02.122-3.fc38.aarch64.rpm"
+          },
+          "sha256:576b8999f1988ba2bab3b79550235751cb3106641203b14b25283e084aa34db7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-identity-iot-38-0.4.noarch.rpm"
           },
           "sha256:57b06c376ce401fe317e9d29527da6095d0d1fbafe5c245f07edb22a235c1630": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/perl-parent-0.238-489.fc37.noarch.rpm"
@@ -15024,16 +15030,6 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release",
-        "epoch": 0,
-        "version": "38",
-        "release": "0.4",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-38-0.4.noarch.rpm",
-        "checksum": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
-        "check_gpg": true
-      },
-      {
         "name": "fedora-release-common",
         "epoch": 0,
         "version": "38",
@@ -15044,13 +15040,23 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release-identity-basic",
+        "name": "fedora-release-identity-iot",
         "epoch": 0,
         "version": "38",
         "release": "0.4",
         "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-identity-basic-38-0.4.noarch.rpm",
-        "checksum": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-identity-iot-38-0.4.noarch.rpm",
+        "checksum": "sha256:576b8999f1988ba2bab3b79550235751cb3106641203b14b25283e084aa34db7",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-iot",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-iot-38-0.4.noarch.rpm",
+        "checksum": "sha256:0b20b6b28cde122e999e538f01e6987abcc9bfda7a11679eba36265d6d30c2a1",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
@@ -3558,14 +3558,6 @@
                     }
                   },
                   {
-                    "id": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0edda99d278d29aca5d1cad69e05d0f3affa66706dbb995bcd4f9e6d2337b137",
                     "options": {
                       "metadata": {
@@ -3574,7 +3566,15 @@
                     }
                   },
                   {
-                    "id": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+                    "id": "sha256:576b8999f1988ba2bab3b79550235751cb3106641203b14b25283e084aa34db7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b20b6b28cde122e999e538f01e6987abcc9bfda7a11679eba36265d6d30c2a1",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -10792,6 +10792,9 @@
           "sha256:0ad44f4c0cf5cff31c9f9b01a27128c671a46867a02a994ba0fd6a63642836ce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/g/grub2-common-2.06-60.fc38.noarch.rpm"
           },
+          "sha256:0b20b6b28cde122e999e538f01e6987abcc9bfda7a11679eba36265d6d30c2a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-iot-38-0.4.noarch.rpm"
+          },
           "sha256:0b64aaaa464cf6acff630d21ef963e97f4b0456bbb68d9a650a0f682f585a43d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/o/osinfo-db-tools-1.10.0-5.fc38.aarch64.rpm"
           },
@@ -11685,6 +11688,9 @@
           },
           "sha256:576353a8452a5283209f9e63fbb70a3743369580156ddb57f726b00c460b58d1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/plymouth-22.02.122-3.fc38.aarch64.rpm"
+          },
+          "sha256:576b8999f1988ba2bab3b79550235751cb3106641203b14b25283e084aa34db7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-identity-iot-38-0.4.noarch.rpm"
           },
           "sha256:57b06c376ce401fe317e9d29527da6095d0d1fbafe5c245f07edb22a235c1630": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/p/perl-parent-0.238-489.fc37.noarch.rpm"
@@ -15075,16 +15081,6 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release",
-        "epoch": 0,
-        "version": "38",
-        "release": "0.4",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-38-0.4.noarch.rpm",
-        "checksum": "sha256:35d685e07b85e29e39ce209112d289d4be338bb4cd94d86cf50c5384fa9fdaeb",
-        "check_gpg": true
-      },
-      {
         "name": "fedora-release-common",
         "epoch": 0,
         "version": "38",
@@ -15095,13 +15091,23 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release-identity-basic",
+        "name": "fedora-release-identity-iot",
         "epoch": 0,
         "version": "38",
         "release": "0.4",
         "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-identity-basic-38-0.4.noarch.rpm",
-        "checksum": "sha256:97fd209ef862b93a03e680e6d9825bc2a899bd08ea545a3c8baa5559c0003eff",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-identity-iot-38-0.4.noarch.rpm",
+        "checksum": "sha256:576b8999f1988ba2bab3b79550235751cb3106641203b14b25283e084aa34db7",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-iot",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/f/fedora-release-iot-38-0.4.noarch.rpm",
+        "checksum": "sha256:0b20b6b28cde122e999e538f01e6987abcc9bfda7a11679eba36265d6d30c2a1",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_38-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_installer-boot.json
@@ -3665,14 +3665,6 @@
                     }
                   },
                   {
-                    "id": "sha256:f828322655ab1b93de1972d8af71689ef239a160f13931e447b0ebcbb764cef9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5e088cea3244085f9d19d2f1bcb171b9f0c3a4ffc2ff0c81932081fbb225e564",
                     "options": {
                       "metadata": {
@@ -3681,7 +3673,15 @@
                     }
                   },
                   {
-                    "id": "sha256:a5b52d9e252e7b653d54a2aee5ae1b9d45034ccd3d8f30e6af9b86952029c535",
+                    "id": "sha256:3dc194d2ff41c46b05fdafd98d13dd31abc8ad3c1cb09ee901b26beb442e9bd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28ffccda4db02cccb3148ccf6cac8aa4288311de4c6a596c1c1e4559b372e235",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -11407,6 +11407,9 @@
           "sha256:2871bb34038a71a4b766bddafd82135a2dc42ac0ee7b158b2378c1cd445f9d03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/skopeo-1.11.1-1.fc38.x86_64.rpm"
           },
+          "sha256:28ffccda4db02cccb3148ccf6cac8aa4288311de4c6a596c1c1e4559b372e235": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-iot-38-0.26.noarch.rpm"
+          },
           "sha256:292791eb37bc312e845e777b2e0e3173e2d951c2bfbbda125bc619dced7f40bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libverto-0.3.2-5.fc38.x86_64.rpm"
           },
@@ -11613,6 +11616,9 @@
           },
           "sha256:3d80716eea29c2b3a50021355977a462872cfff0620f77655f3ad1484aafc2c7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/m/mobile-broadband-provider-info-20221107-2.fc38.noarch.rpm"
+          },
+          "sha256:3dc194d2ff41c46b05fdafd98d13dd31abc8ad3c1cb09ee901b26beb442e9bd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-identity-iot-38-0.26.noarch.rpm"
           },
           "sha256:3dffeb49f059f02f6dee914742b595e5335889d2e6a29a235cbf08771746a2aa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libjxl-0.7.0-6.fc38.x86_64.rpm"
@@ -15339,16 +15345,6 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release",
-        "epoch": 0,
-        "version": "38",
-        "release": "0.26",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-38-0.26.noarch.rpm",
-        "checksum": "sha256:f828322655ab1b93de1972d8af71689ef239a160f13931e447b0ebcbb764cef9",
-        "check_gpg": true
-      },
-      {
         "name": "fedora-release-common",
         "epoch": 0,
         "version": "38",
@@ -15359,13 +15355,23 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release-identity-basic",
+        "name": "fedora-release-identity-iot",
         "epoch": 0,
         "version": "38",
         "release": "0.26",
         "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-identity-basic-38-0.26.noarch.rpm",
-        "checksum": "sha256:a5b52d9e252e7b653d54a2aee5ae1b9d45034ccd3d8f30e6af9b86952029c535",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-identity-iot-38-0.26.noarch.rpm",
+        "checksum": "sha256:3dc194d2ff41c46b05fdafd98d13dd31abc8ad3c1cb09ee901b26beb442e9bd2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-iot",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.26",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-iot-38-0.26.noarch.rpm",
+        "checksum": "sha256:28ffccda4db02cccb3148ccf6cac8aa4288311de4c6a596c1c1e4559b372e235",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_38-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_installer_with_users-boot.json
@@ -3694,14 +3694,6 @@
                     }
                   },
                   {
-                    "id": "sha256:f828322655ab1b93de1972d8af71689ef239a160f13931e447b0ebcbb764cef9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5e088cea3244085f9d19d2f1bcb171b9f0c3a4ffc2ff0c81932081fbb225e564",
                     "options": {
                       "metadata": {
@@ -3710,7 +3702,15 @@
                     }
                   },
                   {
-                    "id": "sha256:a5b52d9e252e7b653d54a2aee5ae1b9d45034ccd3d8f30e6af9b86952029c535",
+                    "id": "sha256:3dc194d2ff41c46b05fdafd98d13dd31abc8ad3c1cb09ee901b26beb442e9bd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28ffccda4db02cccb3148ccf6cac8aa4288311de4c6a596c1c1e4559b372e235",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -11458,6 +11458,9 @@
           "sha256:2871bb34038a71a4b766bddafd82135a2dc42ac0ee7b158b2378c1cd445f9d03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/s/skopeo-1.11.1-1.fc38.x86_64.rpm"
           },
+          "sha256:28ffccda4db02cccb3148ccf6cac8aa4288311de4c6a596c1c1e4559b372e235": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-iot-38-0.26.noarch.rpm"
+          },
           "sha256:292791eb37bc312e845e777b2e0e3173e2d951c2bfbbda125bc619dced7f40bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libverto-0.3.2-5.fc38.x86_64.rpm"
           },
@@ -11664,6 +11667,9 @@
           },
           "sha256:3d80716eea29c2b3a50021355977a462872cfff0620f77655f3ad1484aafc2c7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/m/mobile-broadband-provider-info-20221107-2.fc38.noarch.rpm"
+          },
+          "sha256:3dc194d2ff41c46b05fdafd98d13dd31abc8ad3c1cb09ee901b26beb442e9bd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-identity-iot-38-0.26.noarch.rpm"
           },
           "sha256:3dffeb49f059f02f6dee914742b595e5335889d2e6a29a235cbf08771746a2aa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/l/libjxl-0.7.0-6.fc38.x86_64.rpm"
@@ -15390,16 +15396,6 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release",
-        "epoch": 0,
-        "version": "38",
-        "release": "0.26",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-38-0.26.noarch.rpm",
-        "checksum": "sha256:f828322655ab1b93de1972d8af71689ef239a160f13931e447b0ebcbb764cef9",
-        "check_gpg": true
-      },
-      {
         "name": "fedora-release-common",
         "epoch": 0,
         "version": "38",
@@ -15410,13 +15406,23 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release-identity-basic",
+        "name": "fedora-release-identity-iot",
         "epoch": 0,
         "version": "38",
         "release": "0.26",
         "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-identity-basic-38-0.26.noarch.rpm",
-        "checksum": "sha256:a5b52d9e252e7b653d54a2aee5ae1b9d45034ccd3d8f30e6af9b86952029c535",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-identity-iot-38-0.26.noarch.rpm",
+        "checksum": "sha256:3dc194d2ff41c46b05fdafd98d13dd31abc8ad3c1cb09ee901b26beb442e9bd2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-iot",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.26",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/f/fedora-release-iot-38-0.26.noarch.rpm",
+        "checksum": "sha256:28ffccda4db02cccb3148ccf6cac8aa4288311de4c6a596c1c1e4559b372e235",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_39-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-iot_installer-boot.json
@@ -3641,14 +3641,6 @@
                     }
                   },
                   {
-                    "id": "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:69c9711600ede5bd00494ae8dafa400121de28f70cb4784f4546b8810c4b4cd3",
                     "options": {
                       "metadata": {
@@ -3657,7 +3649,15 @@
                     }
                   },
                   {
-                    "id": "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9",
+                    "id": "sha256:bcc701240d25fdb17b5c708c72649c39478e4cb0115b372fb35099649f6fd534",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5aef6e4dae9d577d738581220b795bbafab736af9acb5a56671e4c70b44929ae",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -11897,6 +11897,9 @@
           "sha256:5ae3dc691d01fcd7c60e347245b56d3f9514084b15fea7488e148f45c089788c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/a/adwaita-icon-theme-44~beta-1.fc39.noarch.rpm"
           },
+          "sha256:5aef6e4dae9d577d738581220b795bbafab736af9acb5a56671e4c70b44929ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-iot-39-0.5.noarch.rpm"
+          },
           "sha256:5b1f57c47625311c3d4f567855bb4dbbd98f1a4f7a8a1db35e2d1ef718b250ad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/i/ima-evm-utils-1.4-7.fc38.aarch64.rpm"
           },
@@ -13048,6 +13051,9 @@
           },
           "sha256:bcb81ea1b3d0bc319414db4e722d9401d82ed79088d8776645bb542576d3eb8d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-11.fc39.aarch64.rpm"
+          },
+          "sha256:bcc701240d25fdb17b5c708c72649c39478e4cb0115b372fb35099649f6fd534": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-identity-iot-39-0.5.noarch.rpm"
           },
           "sha256:bd195cb002136d5688b161f66842d2dfc78fb989724dc8bd147f0acc57ef4888": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/b/btrfs-progs-6.2.1-1.fc39.aarch64.rpm"
@@ -15209,16 +15215,6 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release",
-        "epoch": 0,
-        "version": "39",
-        "release": "0.5",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-39-0.5.noarch.rpm",
-        "checksum": "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8",
-        "check_gpg": true
-      },
-      {
         "name": "fedora-release-common",
         "epoch": 0,
         "version": "39",
@@ -15229,13 +15225,23 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release-identity-basic",
+        "name": "fedora-release-identity-iot",
         "epoch": 0,
         "version": "39",
         "release": "0.5",
         "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-identity-basic-39-0.5.noarch.rpm",
-        "checksum": "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-identity-iot-39-0.5.noarch.rpm",
+        "checksum": "sha256:bcc701240d25fdb17b5c708c72649c39478e4cb0115b372fb35099649f6fd534",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-iot",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.5",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-iot-39-0.5.noarch.rpm",
+        "checksum": "sha256:5aef6e4dae9d577d738581220b795bbafab736af9acb5a56671e4c70b44929ae",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_39-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-iot_installer_with_users-boot.json
@@ -3670,14 +3670,6 @@
                     }
                   },
                   {
-                    "id": "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:69c9711600ede5bd00494ae8dafa400121de28f70cb4784f4546b8810c4b4cd3",
                     "options": {
                       "metadata": {
@@ -3686,7 +3678,15 @@
                     }
                   },
                   {
-                    "id": "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9",
+                    "id": "sha256:bcc701240d25fdb17b5c708c72649c39478e4cb0115b372fb35099649f6fd534",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5aef6e4dae9d577d738581220b795bbafab736af9acb5a56671e4c70b44929ae",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -11948,6 +11948,9 @@
           "sha256:5ae3dc691d01fcd7c60e347245b56d3f9514084b15fea7488e148f45c089788c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/a/adwaita-icon-theme-44~beta-1.fc39.noarch.rpm"
           },
+          "sha256:5aef6e4dae9d577d738581220b795bbafab736af9acb5a56671e4c70b44929ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-iot-39-0.5.noarch.rpm"
+          },
           "sha256:5b1f57c47625311c3d4f567855bb4dbbd98f1a4f7a8a1db35e2d1ef718b250ad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/i/ima-evm-utils-1.4-7.fc38.aarch64.rpm"
           },
@@ -13099,6 +13102,9 @@
           },
           "sha256:bcb81ea1b3d0bc319414db4e722d9401d82ed79088d8776645bb542576d3eb8d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-11.fc39.aarch64.rpm"
+          },
+          "sha256:bcc701240d25fdb17b5c708c72649c39478e4cb0115b372fb35099649f6fd534": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-identity-iot-39-0.5.noarch.rpm"
           },
           "sha256:bd195cb002136d5688b161f66842d2dfc78fb989724dc8bd147f0acc57ef4888": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/b/btrfs-progs-6.2.1-1.fc39.aarch64.rpm"
@@ -15260,16 +15266,6 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release",
-        "epoch": 0,
-        "version": "39",
-        "release": "0.5",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-39-0.5.noarch.rpm",
-        "checksum": "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8",
-        "check_gpg": true
-      },
-      {
         "name": "fedora-release-common",
         "epoch": 0,
         "version": "39",
@@ -15280,13 +15276,23 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release-identity-basic",
+        "name": "fedora-release-identity-iot",
         "epoch": 0,
         "version": "39",
         "release": "0.5",
         "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-identity-basic-39-0.5.noarch.rpm",
-        "checksum": "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-identity-iot-39-0.5.noarch.rpm",
+        "checksum": "sha256:bcc701240d25fdb17b5c708c72649c39478e4cb0115b372fb35099649f6fd534",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-iot",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.5",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/f/fedora-release-iot-39-0.5.noarch.rpm",
+        "checksum": "sha256:5aef6e4dae9d577d738581220b795bbafab736af9acb5a56671e4c70b44929ae",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_39-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-iot_installer-boot.json
@@ -3689,14 +3689,6 @@
                     }
                   },
                   {
-                    "id": "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:69c9711600ede5bd00494ae8dafa400121de28f70cb4784f4546b8810c4b4cd3",
                     "options": {
                       "metadata": {
@@ -3705,7 +3697,15 @@
                     }
                   },
                   {
-                    "id": "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9",
+                    "id": "sha256:bcc701240d25fdb17b5c708c72649c39478e4cb0115b372fb35099649f6fd534",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5aef6e4dae9d577d738581220b795bbafab736af9acb5a56671e4c70b44929ae",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -12040,6 +12040,9 @@
           "sha256:5ae3dc691d01fcd7c60e347245b56d3f9514084b15fea7488e148f45c089788c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/a/adwaita-icon-theme-44~beta-1.fc39.noarch.rpm"
           },
+          "sha256:5aef6e4dae9d577d738581220b795bbafab736af9acb5a56671e4c70b44929ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-iot-39-0.5.noarch.rpm"
+          },
           "sha256:5b42ede89748ca8c068a8b42db59fcbd141465dbff59a21e89cc18bcf779b631": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/x/xdg-desktop-portal-1.16.0-2.fc38.x86_64.rpm"
           },
@@ -13233,6 +13236,9 @@
           },
           "sha256:bcb4bfe9248bb1846904094b02ec3018c71dea9fe734fb0ee4412c9691e61cc0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/sratom-0.6.10-3.fc38.x86_64.rpm"
+          },
+          "sha256:bcc701240d25fdb17b5c708c72649c39478e4cb0115b372fb35099649f6fd534": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-identity-iot-39-0.5.noarch.rpm"
           },
           "sha256:bd3bf7ee718955ae8f8408f46be6ea3294cc02254f53843f19ef7071b5c796a5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/i/iwl105-firmware-18.168.6.1-147.fc39.noarch.rpm"
@@ -15488,16 +15494,6 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release",
-        "epoch": 0,
-        "version": "39",
-        "release": "0.5",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-39-0.5.noarch.rpm",
-        "checksum": "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8",
-        "check_gpg": true
-      },
-      {
         "name": "fedora-release-common",
         "epoch": 0,
         "version": "39",
@@ -15508,13 +15504,23 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release-identity-basic",
+        "name": "fedora-release-identity-iot",
         "epoch": 0,
         "version": "39",
         "release": "0.5",
         "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-identity-basic-39-0.5.noarch.rpm",
-        "checksum": "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-identity-iot-39-0.5.noarch.rpm",
+        "checksum": "sha256:bcc701240d25fdb17b5c708c72649c39478e4cb0115b372fb35099649f6fd534",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-iot",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.5",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-iot-39-0.5.noarch.rpm",
+        "checksum": "sha256:5aef6e4dae9d577d738581220b795bbafab736af9acb5a56671e4c70b44929ae",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_39-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-iot_installer_with_users-boot.json
@@ -3718,14 +3718,6 @@
                     }
                   },
                   {
-                    "id": "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:69c9711600ede5bd00494ae8dafa400121de28f70cb4784f4546b8810c4b4cd3",
                     "options": {
                       "metadata": {
@@ -3734,7 +3726,15 @@
                     }
                   },
                   {
-                    "id": "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9",
+                    "id": "sha256:bcc701240d25fdb17b5c708c72649c39478e4cb0115b372fb35099649f6fd534",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5aef6e4dae9d577d738581220b795bbafab736af9acb5a56671e4c70b44929ae",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -12091,6 +12091,9 @@
           "sha256:5ae3dc691d01fcd7c60e347245b56d3f9514084b15fea7488e148f45c089788c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/a/adwaita-icon-theme-44~beta-1.fc39.noarch.rpm"
           },
+          "sha256:5aef6e4dae9d577d738581220b795bbafab736af9acb5a56671e4c70b44929ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-iot-39-0.5.noarch.rpm"
+          },
           "sha256:5b42ede89748ca8c068a8b42db59fcbd141465dbff59a21e89cc18bcf779b631": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/x/xdg-desktop-portal-1.16.0-2.fc38.x86_64.rpm"
           },
@@ -13284,6 +13287,9 @@
           },
           "sha256:bcb4bfe9248bb1846904094b02ec3018c71dea9fe734fb0ee4412c9691e61cc0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/s/sratom-0.6.10-3.fc38.x86_64.rpm"
+          },
+          "sha256:bcc701240d25fdb17b5c708c72649c39478e4cb0115b372fb35099649f6fd534": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-identity-iot-39-0.5.noarch.rpm"
           },
           "sha256:bd3bf7ee718955ae8f8408f46be6ea3294cc02254f53843f19ef7071b5c796a5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/i/iwl105-firmware-18.168.6.1-147.fc39.noarch.rpm"
@@ -15539,16 +15545,6 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release",
-        "epoch": 0,
-        "version": "39",
-        "release": "0.5",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-39-0.5.noarch.rpm",
-        "checksum": "sha256:3a68f83cda5ee690d8d2a8cf49390ab7d66daadedc47d6d2d5c9756486b36ed8",
-        "check_gpg": true
-      },
-      {
         "name": "fedora-release-common",
         "epoch": 0,
         "version": "39",
@@ -15559,13 +15555,23 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release-identity-basic",
+        "name": "fedora-release-identity-iot",
         "epoch": 0,
         "version": "39",
         "release": "0.5",
         "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-identity-basic-39-0.5.noarch.rpm",
-        "checksum": "sha256:f97838c40ba35b8b7e35dd9adbdaa3085826e46dc65a60aa5a4245108da8c9d9",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-identity-iot-39-0.5.noarch.rpm",
+        "checksum": "sha256:bcc701240d25fdb17b5c708c72649c39478e4cb0115b372fb35099649f6fd534",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-iot",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.5",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/f/fedora-release-iot-39-0.5.noarch.rpm",
+        "checksum": "sha256:5aef6e4dae9d577d738581220b795bbafab736af9acb5a56671e4c70b44929ae",
         "check_gpg": true
       },
       {


### PR DESCRIPTION
This adds 'fedora-release-iot' to the 'iotInstallerPackageSet' and fixes the default filesystem used for Fedora IoT Anaconda installations changing it from btrfs to LVM/ext4. 

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
