### PR TITLE
Dockerfile*: update to ubi9 and chown the files when copying

### DIFF
--- a/distribution/Dockerfile-fauxauth
+++ b/distribution/Dockerfile-fauxauth
@@ -1,10 +1,10 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
 COPY . .
 ENV GOFLAGS=-mod=vendor
 RUN go install ./cmd/osbuild-mock-openid-provider/
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-RUN microdnf install python3
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN microdnf install -y python3
 RUN mkdir -p "/usr/libexec/osbuild-composer"
 RUN mkdir -p "/etc/osbuild-composer/"
 

--- a/distribution/Dockerfile-fauxauth
+++ b/distribution/Dockerfile-fauxauth
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
-COPY . .
+# ubi9/go-toolset defaults to uid 1001. Let's copy the files with this UID as well.
+# Otherwise, VCS stamping will fail because git >= 2.35.2 refuses to work in
+# a repository owned by a different user.
+COPY --chown=1001 . .
 ENV GOFLAGS=-mod=vendor
 RUN go install ./cmd/osbuild-mock-openid-provider/
 

--- a/distribution/Dockerfile-ubi
+++ b/distribution/Dockerfile-ubi
@@ -5,7 +5,10 @@ USER 0
 # uses `libgpgme` so we need to install it and its build dependencies
 RUN dnf install -y gpgme-devel libassuan-devel
 USER 1001
-COPY . .
+# ubi9/go-toolset defaults to uid 1001. Let's copy the files with this UID as well.
+# Otherwise, VCS stamping will fail because git >= 2.35.2 refuses to work in
+# a repository owned by a different user.
+COPY --chown=1001 . .
 ENV GOFLAGS=-mod=vendor
 RUN go install ./cmd/osbuild-composer/
 

--- a/distribution/Dockerfile-ubi
+++ b/distribution/Dockerfile-ubi
@@ -1,5 +1,5 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
-# We need to be root to install packages, but ubi8/go-toolset defaults to uid 1001
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
+# We need to be root to install packages, but ubi9/go-toolset defaults to uid 1001
 USER 0
 # The go package `proglottis/gpgme` a dependency of `containers/image/v5` package
 # uses `libgpgme` so we need to install it and its build dependencies
@@ -9,11 +9,11 @@ COPY . .
 ENV GOFLAGS=-mod=vendor
 RUN go install ./cmd/osbuild-composer/
 
-FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder2
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder2
 RUN go install github.com/jackc/tern@latest
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-RUN microdnf install python3 python3-dnf
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN microdnf install -y python3 python3-dnf
 RUN mkdir -p "/usr/libexec/osbuild-composer"
 RUN mkdir -p "/etc/osbuild-composer/"
 RUN mkdir -p "/run/osbuild-composer/"

--- a/distribution/Dockerfile-ubi-maintenance
+++ b/distribution/Dockerfile-ubi-maintenance
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
-COPY . .
+# ubi9/go-toolset defaults to uid 1001. Let's copy the files with this UID as well.
+# Otherwise, VCS stamping will fail because git >= 2.35.2 refuses to work in
+# a repository owned by a different user.
+COPY --chown=1001 . .
 ENV GOFLAGS=-mod=vendor
 RUN go install ./cmd/osbuild-service-maintenance/
 

--- a/distribution/Dockerfile-ubi-maintenance
+++ b/distribution/Dockerfile-ubi-maintenance
@@ -1,9 +1,9 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
 COPY . .
 ENV GOFLAGS=-mod=vendor
 RUN go install ./cmd/osbuild-service-maintenance/
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 RUN mkdir -p "/usr/libexec/osbuild-composer"
 RUN mkdir -p "/etc/osbuild-composer/"
 COPY --from=builder /opt/app-root/src/go/bin/osbuild-service-maintenance /usr/libexec/osbuild-composer/osbuild-service-maintenance


### PR DESCRIPTION
There's no reason not to update to UBI 9.

However, the latest version of UBI 9 needs also one extra patch:

When `go install` is called, go tries to get the git commit hash and embed it
into the built binary. Internally, go just calls the git executable.

The newer go-toolset seems to be based on RHEL 9.2 that ships a newer version
of git (2.39.1). This version contains the safe directory patch that
disallows git from operating on repositories owned by different users.

Thus, we need to chown the files when copying.

See
https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory