### PR TITLE
wip: implement btrfs for Fedora

### DIFF
--- a/internal/disk/btrfs.go
+++ b/internal/disk/btrfs.go
@@ -75,6 +75,10 @@ func (b *Btrfs) GenUUID(rng *rand.Rand) {
 	if b.UUID == "" {
 		b.UUID = uuid.Must(newRandomUUIDFromReader(rng)).String()
 	}
+
+	for i := range b.Subvolumes {
+		b.Subvolumes[i].UUID = b.UUID
+	}
 }
 
 type BtrfsSubvolume struct {

--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -213,6 +213,10 @@ var (
 			Locale: common.ToPtr("en_US.UTF-8"),
 			EnabledServices: []string{
 				"sshd",
+				"cloud-init.service",
+				"cloud-config.service",
+				"cloud-final.service",
+				"cloud-init-local.service",
 			},
 			DefaultTarget: common.ToPtr("multi-user.target"),
 			DisabledServices: []string{
@@ -227,7 +231,7 @@ var (
 		buildPipelines:      []string{"build"},
 		payloadPipelines:    []string{"os", "image", "vpc"},
 		exports:             []string{"vpc"},
-		basePartitionTables: defaultBasePartitionTables,
+		basePartitionTables: btrfsBasePartitionTables,
 		environment:         &environment.Azure{},
 	}
 

--- a/internal/distro/fedora/package_sets.go
+++ b/internal/distro/fedora/package_sets.go
@@ -66,6 +66,7 @@ func vhdCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"libxcrypt-compat",
 			"initscripts",
 			"glibc-all-langpacks",
+			"cloud-init",
 		},
 		Exclude: []string{
 			"dracut-config-rescue",

--- a/internal/distro/fedora/partition_tables.go
+++ b/internal/distro/fedora/partition_tables.go
@@ -199,3 +199,114 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 }
+
+var btrfsBasePartitionTables = distro.BasePartitionTableMap{
+	distro.X86_64ArchName: disk.PartitionTable{
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []disk.Partition{
+			{
+				Size:     1 * common.MebiByte, // 1MB
+				Bootable: true,
+				Type:     disk.BIOSBootPartitionGUID,
+				UUID:     disk.BIOSBootPartitionUUID,
+			},
+			{
+				Size: 200 * common.MebiByte, // 200 MB
+				Type: disk.EFISystemPartitionGUID,
+				UUID: disk.EFISystemPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         disk.EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 500 * common.MebiByte, // 500 MB
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.FilesystemDataUUID,
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					Mountpoint:   "/boot",
+					Label:        "boot",
+					FSTabOptions: "defaults",
+					FSTabFreq:    1,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 2 * common.GibiByte, // 2GiB
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.RootPartitionUUID,
+				Payload: &disk.Btrfs{
+					Label:      "root",
+					Mountpoint: "/",
+					Subvolumes: []disk.BtrfsSubvolume{
+						{
+							Name:       "root",
+							Size:       42,
+							Mountpoint: "/",
+							MntOps:     "compress=zstd:1",
+						},
+						{
+							Name:       "home",
+							Size:       69,
+							Mountpoint: "/home",
+							MntOps:     "compress=zstd:1",
+						},
+					},
+				},
+			},
+		},
+	},
+	distro.Aarch64ArchName: disk.PartitionTable{
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []disk.Partition{
+			{
+				Size: 200 * common.MebiByte, // 200 MB
+				Type: disk.EFISystemPartitionGUID,
+				UUID: disk.EFISystemPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         disk.EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 500 * common.MebiByte, // 500 MB
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.FilesystemDataUUID,
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					Mountpoint:   "/boot",
+					Label:        "boot",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+			{
+				Size: 2 * common.GibiByte, // 2GiB
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.RootPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+		},
+	},
+}

--- a/internal/osbuild/btrfs_mount.go
+++ b/internal/osbuild/btrfs_mount.go
@@ -1,10 +1,21 @@
 package osbuild
 
-func NewBtrfsMount(name, source, target string) *Mount {
+type btrfsMountOptions struct {
+	Subvol   string `json:"subvol,omitempty"`
+	Compress string `json:"compress,omitempty"`
+}
+
+func (b btrfsMountOptions) isMountOptions() {}
+
+func NewBtrfsMount(name, source, target, subvol, compress string) *Mount {
 	return &Mount{
 		Type:   "org.osbuild.btrfs",
 		Name:   name,
 		Source: source,
 		Target: target,
+		Options: btrfsMountOptions{
+			Subvol:   subvol,
+			Compress: compress,
+		},
 	}
 }

--- a/internal/osbuild/btrfs_subvol_stage.go
+++ b/internal/osbuild/btrfs_subvol_stage.go
@@ -1,0 +1,76 @@
+package osbuild
+
+import (
+	"github.com/osbuild/osbuild-composer/internal/disk"
+)
+
+// Stage to copy items from inputs to mount points or the tree. Multiple items
+// can be copied. The source and destination is a URL.
+
+type BtrfsSubVolOptions struct {
+	Subvolumes []BtrfsSubVol `json:"subvolumes"`
+}
+
+type BtrfsSubVol struct {
+	Name string `json:"name"`
+}
+
+func (BtrfsSubVolOptions) isStageOptions() {}
+
+func NewBtrfsSubVol(options *BtrfsSubVolOptions, devices *Devices, mounts *Mounts) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.btrfs.subvol",
+		Options: options,
+		Devices: *devices,
+		Mounts:  *mounts,
+	}
+}
+
+func GenBtrfsSubVolStage(filename string, pt *disk.PartitionTable) *Stage {
+	var subvolumes []BtrfsSubVol
+
+	genStage := func(mnt disk.Mountable, path []disk.Entity) error {
+		if mnt.GetFSType() != "btrfs" {
+			return nil
+		}
+
+		btrfs := mnt.(*disk.BtrfsSubvolume)
+		subvolumes = append(subvolumes, BtrfsSubVol{Name: "/" + btrfs.Name})
+
+		return nil
+	}
+
+	_ = pt.ForEachMountable(genStage)
+
+	if len(subvolumes) == 0 {
+		return nil
+	}
+
+	devices, mounts := genBtrfsMountDevices(filename, pt)
+
+	return NewBtrfsSubVol(&BtrfsSubVolOptions{subvolumes}, devices, mounts)
+}
+
+func genBtrfsMountDevices(filename string, pt *disk.PartitionTable) (*Devices, *Mounts) {
+	devices := make(map[string]Device, len(pt.Partitions))
+	mounts := make([]Mount, 0, len(pt.Partitions))
+	genMounts := func(ent disk.Entity, path []disk.Entity) error {
+		if _, isBtrfs := ent.(*disk.Btrfs); !isBtrfs {
+			return nil
+		}
+
+		stageDevices, name := getDevices(path, filename, false)
+
+		mounts = append(mounts, *NewBtrfsMount(name, name, "/", "", ""))
+
+		// update devices map with new elements from stageDevices
+		for devName := range stageDevices {
+			devices[devName] = stageDevices[devName]
+		}
+		return nil
+	}
+
+	_ = pt.ForEachEntity(genMounts)
+
+	return (*Devices)(&devices), (*Mounts)(&mounts)
+}

--- a/internal/osbuild/copy_stage.go
+++ b/internal/osbuild/copy_stage.go
@@ -78,7 +78,7 @@ func GenCopyFSTreeOptions(inputName, inputPipeline, filename string, pt *disk.Pa
 		case "ext4":
 			mount = NewExt4Mount(name, name, mountpoint)
 		case "btrfs":
-			mount = NewBtrfsMount(name, name, mountpoint)
+			mount = NewBtrfsMount(mnt.(*disk.BtrfsSubvolume).Name, name, mountpoint, mnt.(*disk.BtrfsSubvolume).Name, "")
 		default:
 			panic("unknown fs type " + t)
 		}

--- a/internal/osbuild/device.go
+++ b/internal/osbuild/device.go
@@ -160,6 +160,8 @@ func deviceName(p disk.Entity) string {
 		return payload.Name + "vg"
 	case *disk.LVMLogicalVolume:
 		return payload.Name
+	case *disk.Btrfs:
+		return "btrfs-" + payload.UUID[:4]
 	}
 	panic(fmt.Sprintf("unsupported device type in deviceName: '%T'", p))
 }


### PR DESCRIPTION
A quick and dirty draft for btrfs support in composer. Currently, only Fedora Azure image is hooked up. Needs https://github.com/osbuild/osbuild/pull/1312

Missing pieces:
- osbuild itself doesn't mount the subvolumes with compression enabled
- `-m dup` isn't enabled in `mkfs.btrfs`