### PR TITLE
internal/manifest: execute rhc's post install script

### DIFF
--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -501,6 +501,8 @@ func (p *OS) serialize() osbuild.Pipeline {
 			commands = []string{fmt.Sprintf("/usr/bin/rhc connect -o=%s -a=%s --server %s", p.Subscription.Organization, p.Subscription.ActivationKey, p.Subscription.ServerUrl)}
 			// insights-client creates the .gnupg directory during boot process, and is labeled incorrectly
 			commands = append(commands, "restorecon -R /root/.gnupg")
+			// execute the rhc post install script as the selinuxenabled check doesn't work in the buildroot container
+			commands = append(commands, "/usr/sbin/semanage permissive --add rhcd_t")
 		} else {
 			commands = []string{fmt.Sprintf("/usr/sbin/subscription-manager register --org=%s --activationkey=%s --serverurl %s --baseurl %s", p.Subscription.Organization, p.Subscription.ActivationKey, p.Subscription.ServerUrl, p.Subscription.BaseUrl)}
 

--- a/internal/manifest/os_test.go
+++ b/internal/manifest/os_test.go
@@ -112,6 +112,7 @@ func TestRhcInsightsCommands(t *testing.T) {
 	CheckFirstBootStageOptions(t, pipeline.Stages, []string{
 		"/usr/bin/rhc connect -o=2040324 -a=my-secret-key --server subscription.rhsm.redhat.com",
 		"restorecon -R /root/.gnupg",
+		"/usr/sbin/semanage permissive --add rhcd_t",
 	})
 }
 


### PR DESCRIPTION
The post install script customises the selinux policy, but is gated on `selinuxenabled`, which will fail inside the buildroot container.

As a result it's never executed.
