### PR TITLE
Revert the hybrid boot mode changes on RHEL (RHUI) EC2 images prior to 8.9 / 9.3

### DIFF
--- a/internal/distro/rhel8/ami.go
+++ b/internal/distro/rhel8/ami.go
@@ -30,6 +30,12 @@ func amiImgTypeX86_64(rd distribution) imageType {
 }
 
 func ec2ImgTypeX86_64(rd distribution) imageType {
+	basePartitionTables := ec2BasePartitionTables
+	// use legacy partition tables for RHEL 8.8 and older
+	if common.VersionLessThan(rd.osVersion, "8.9") {
+		basePartitionTables = ec2LegacyBasePartitionTables
+	}
+
 	it := imageType{
 		name:        "ec2",
 		filename:    "image.raw.xz",
@@ -46,12 +52,18 @@ func ec2ImgTypeX86_64(rd distribution) imageType {
 		buildPipelines:      []string{"build"},
 		payloadPipelines:    []string{"os", "image", "xz"},
 		exports:             []string{"xz"},
-		basePartitionTables: ec2BasePartitionTables,
+		basePartitionTables: basePartitionTables,
 	}
 	return it
 }
 
 func ec2HaImgTypeX86_64(rd distribution) imageType {
+	basePartitionTables := ec2BasePartitionTables
+	// use legacy partition tables for RHEL 8.8 and older
+	if common.VersionLessThan(rd.osVersion, "8.9") {
+		basePartitionTables = ec2LegacyBasePartitionTables
+	}
+
 	it := imageType{
 		name:        "ec2-ha",
 		filename:    "image.raw.xz",
@@ -68,7 +80,7 @@ func ec2HaImgTypeX86_64(rd distribution) imageType {
 		buildPipelines:      []string{"build"},
 		payloadPipelines:    []string{"os", "image", "xz"},
 		exports:             []string{"xz"},
-		basePartitionTables: ec2BasePartitionTables,
+		basePartitionTables: basePartitionTables,
 	}
 	return it
 }
@@ -95,6 +107,12 @@ func amiImgTypeAarch64(rd distribution) imageType {
 }
 
 func ec2ImgTypeAarch64(rd distribution) imageType {
+	basePartitionTables := ec2BasePartitionTables
+	// use legacy partition tables for RHEL 8.8 and older
+	if common.VersionLessThan(rd.osVersion, "8.9") {
+		basePartitionTables = ec2LegacyBasePartitionTables
+	}
+
 	it := imageType{
 		name:        "ec2",
 		filename:    "image.raw.xz",
@@ -111,12 +129,18 @@ func ec2ImgTypeAarch64(rd distribution) imageType {
 		buildPipelines:      []string{"build"},
 		payloadPipelines:    []string{"os", "image", "xz"},
 		exports:             []string{"xz"},
-		basePartitionTables: ec2BasePartitionTables,
+		basePartitionTables: basePartitionTables,
 	}
 	return it
 }
 
 func ec2SapImgTypeX86_64(rd distribution) imageType {
+	basePartitionTables := ec2BasePartitionTables
+	// use legacy partition tables for RHEL 8.8 and older
+	if common.VersionLessThan(rd.osVersion, "8.9") {
+		basePartitionTables = ec2LegacyBasePartitionTables
+	}
+
 	it := imageType{
 		name:        "ec2-sap",
 		filename:    "image.raw.xz",
@@ -133,7 +157,7 @@ func ec2SapImgTypeX86_64(rd distribution) imageType {
 		buildPipelines:      []string{"build"},
 		payloadPipelines:    []string{"os", "image", "xz"},
 		exports:             []string{"xz"},
-		basePartitionTables: ec2BasePartitionTables,
+		basePartitionTables: basePartitionTables,
 	}
 	return it
 }

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -443,6 +443,16 @@ func newDistro(name string, minor int) *distribution {
 		// add azure to RHEL distro only
 		x86_64.addImageTypes(azureX64Platform, azureRhuiImgType(), azureByosImgType(), azureSapRhuiImgType(rd))
 
+		// keep the RHEL EC2 x86_64 images before 8.9 BIOS-only for backward compatibility
+		if common.VersionLessThan(rd.osVersion, "8.9") {
+			ec2X86Platform = &platform.X86{
+				BIOS: true,
+				BasePlatform: platform.BasePlatform{
+					ImageFormat: platform.FORMAT_RAW,
+				},
+			}
+		}
+
 		// add ec2 image types to RHEL distro only
 		x86_64.addImageTypes(ec2X86Platform, ec2ImgTypeX86_64(rd), ec2HaImgTypeX86_64(rd))
 		aarch64.addImageTypes(rawAarch64Platform, ec2ImgTypeAarch64(rd))

--- a/internal/distro/rhel8/partition_tables.go
+++ b/internal/distro/rhel8/partition_tables.go
@@ -218,6 +218,80 @@ var ec2BasePartitionTables = distro.BasePartitionTableMap{
 	},
 }
 
+// ec2LegacyBasePartitionTables is the partition table layout for RHEL EC2
+// images prior to 8.9. It is used for backwards compatibility.
+var ec2LegacyBasePartitionTables = distro.BasePartitionTableMap{
+	distro.X86_64ArchName: disk.PartitionTable{
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []disk.Partition{
+			{
+				Size:     1 * common.MebiByte,
+				Bootable: true,
+				Type:     disk.BIOSBootPartitionGUID,
+				UUID:     disk.BIOSBootPartitionUUID,
+			},
+			{
+				Size: 2 * common.GibiByte, // 2 GiB
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.RootPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "xfs",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+		},
+	},
+	distro.Aarch64ArchName: disk.PartitionTable{
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []disk.Partition{
+			{
+				Size: 200 * common.MebiByte,
+				Type: disk.EFISystemPartitionGUID,
+				UUID: disk.EFISystemPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         disk.EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 512 * common.MebiByte,
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.FilesystemDataUUID,
+				Payload: &disk.Filesystem{
+					Type:         "xfs",
+					Mountpoint:   "/boot",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+			{
+				Size: 2 * common.GibiByte, // 2 GiB
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.RootPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "xfs",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+		},
+	},
+}
+
 var edgeBasePartitionTables = distro.BasePartitionTableMap{
 	distro.X86_64ArchName: disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",

--- a/internal/distro/rhel9/distro.go
+++ b/internal/distro/rhel9/distro.go
@@ -416,6 +416,16 @@ func newDistro(name string, minor int) *distribution {
 		x86_64.addImageTypes(azureX64Platform, azureRhuiImgType, azureByosImgType)
 		aarch64.addImageTypes(azureAarch64Platform, azureRhuiImgType, azureByosImgType)
 
+		// keep the RHEL EC2 x86_64 images before 9.3 BIOS-only for backward compatibility
+		if common.VersionLessThan(rd.osVersion, "9.3") {
+			ec2X86Platform = &platform.X86{
+				BIOS: true,
+				BasePlatform: platform.BasePlatform{
+					ImageFormat: platform.FORMAT_RAW,
+				},
+			}
+		}
+
 		// add ec2 image types to RHEL distro only
 		x86_64.addImageTypes(ec2X86Platform, mkEc2ImgTypeX86_64(rd.osVersion, rd.isRHEL()), mkEc2HaImgTypeX86_64(rd.osVersion, rd.isRHEL()), mkEC2SapImgTypeX86_64(rd.osVersion, rd.isRHEL()))
 

--- a/test/data/manifests/rhel_8-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ec2-boot.json
@@ -2119,14 +2119,14 @@
                   "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
                 },
                 {
-                  "size": 1024000,
+                  "size": 1048576,
                   "start": 411648,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "CB07C243-BC44-4717-853E-28852021225B"
                 },
                 {
-                  "size": 19535839,
-                  "start": 1435648,
+                  "size": 19511263,
+                  "start": 1460224,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2162,8 +2162,7 @@
           {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
-              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
             },
             "devices": {
               "device": {
@@ -2171,7 +2170,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 411648,
-                  "size": 1024000,
+                  "size": 1048576,
                   "lock": true
                 }
               }
@@ -2188,8 +2187,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1435648,
-                  "size": 19535839,
+                  "start": 1460224,
+                  "size": 19511263,
                   "lock": true
                 }
               }
@@ -2220,7 +2219,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 411648,
-                  "size": 1024000
+                  "size": 1048576
                 }
               },
               "boot.efi": {
@@ -2235,8 +2234,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1435648,
-                  "size": 19535839
+                  "start": 1460224,
+                  "size": 19511263
                 }
               }
             },

--- a/test/data/manifests/rhel_8-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ec2-boot.json
@@ -121,9 +121,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -646,9 +643,6 @@
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
                   },
                   {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-                  },
-                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -757,9 +751,6 @@
                     "id": "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -779,15 +770,6 @@
                   },
                   {
                     "id": "sha256:8e0e23d6a9399d9016d721467181d9abd3e888894149767b631889f1aeddf755"
-                  },
-                  {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
                   },
                   {
                     "id": "sha256:45c47f5146e39f50ca18d1561821607bc582c5fd4de0bf05bc06a5e0eb33df34"
@@ -824,9 +806,6 @@
                   },
                   {
                     "id": "sha256:be62c3c22fe4351a434d5b971061e512db199d763205dd8aaf4c6faa35a9be42"
-                  },
-                  {
-                    "id": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
                   },
                   {
                     "id": "sha256:59b3cff57ffbea4c4c011e6a81341a1203c18b91569fff019c93b756331300f8"
@@ -887,9 +866,6 @@
                   },
                   {
                     "id": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-                  },
-                  {
-                    "id": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
                   },
                   {
                     "id": "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d"
@@ -1069,9 +1045,6 @@
                     "id": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:7145b8d179b6c72e61de2b822551b343209adb63b76023fe26e7162d4ff6c107"
                   },
                   {
@@ -1082,12 +1055,6 @@
                   },
                   {
                     "id": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-                  },
-                  {
-                    "id": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-                  },
-                  {
-                    "id": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
                   },
                   {
                     "id": "sha256:4a62975251933dcaff77fdbd7704e8a12bea0ecb6eaaae5ea5e552bedd6788ec"
@@ -1189,9 +1156,6 @@
                     "id": "sha256:d15c8594702ab51f8aa792a6c0ebae49ddefc8740289397b2cd8cb6e4a711187"
                   },
                   {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-                  },
-                  {
                     "id": "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8"
                   },
                   {
@@ -1267,9 +1231,6 @@
                     "id": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf"
                   },
                   {
@@ -1303,16 +1264,10 @@
                     "id": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
                   },
                   {
-                    "id": "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de"
-                  },
-                  {
                     "id": "sha256:ca6208d771fbbfc703217b0f4314d214a866da86b105f222753a6efeb12d6f69"
                   },
                   {
                     "id": "sha256:d3e15db6aaa6d8ba4587408d87863b2f94092024bbb94893faa95c5d259a97d4"
-                  },
-                  {
-                    "id": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -1633,9 +1588,6 @@
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
                   },
                   {
-                    "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
-                  },
-                  {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
                   },
                   {
@@ -1762,36 +1714,6 @@
                     "id": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
                   },
                   {
-                    "id": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-                  },
-                  {
-                    "id": "sha256:91303cb921c3727203c4a25c12524356a2afb2e3fd594bdd12301a7b5edabaa3"
-                  },
-                  {
-                    "id": "sha256:cbca89c39db7fd80dc71deefdcfb15262e2aed69117e66a15632ac581c82b8b6"
-                  },
-                  {
-                    "id": "sha256:95a340a62ae433f5a5cb30e8929b9b4167d2d204bef99beea487ad65e451c2b9"
-                  },
-                  {
-                    "id": "sha256:8ed24bf92f4a389d82399a2dfcdcd2b8812b354d32e50807ddf557b978532756"
-                  },
-                  {
-                    "id": "sha256:5bea1ad0a4491ab6ae8607f741388c983dc471747176a3e82302e94addba6d44"
-                  },
-                  {
-                    "id": "sha256:74789339d67c8fd8545def02ae4a0f5dbbb9c0ee71aee54ee166b633563fe85d"
-                  },
-                  {
-                    "id": "sha256:859c0fe81e8a3e297664c62d725d3224ec6f35bf5078a2993484b35328c16fdd"
-                  },
-                  {
-                    "id": "sha256:fe6788ebe68e3bc8d6e9784c569c3bc5916e5c445a88fb0247ee1243018cfc8c"
-                  },
-                  {
-                    "id": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-                  },
-                  {
                     "id": "sha256:d16252dcb91c3e581ecb29234180fb99ac3199a052a89d0e23603cb6054bee16"
                   },
                   {
@@ -1801,28 +1723,7 @@
                     "id": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
                   },
                   {
-                    "id": "sha256:68e0dfe4bc893170e61539b648f41ef10aa8174a884de6ff91dcb87abc7d03ce"
-                  },
-                  {
                     "id": "sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072"
-                  },
-                  {
-                    "id": "sha256:82cd233003b87e6b810070eead73ec44073050aabccec9a619309074a1868fe9"
-                  },
-                  {
-                    "id": "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a"
-                  },
-                  {
-                    "id": "sha256:319d3d51dfc09875cdbb61518410fe2963887228089d4a9de8f673acc7a2ff82"
-                  },
-                  {
-                    "id": "sha256:4bcbfd3229e3fd2d6e1adfe46bc233872c4184838de40b2e61a9ba84fcb81512"
-                  },
-                  {
-                    "id": "sha256:507c1a196520e4263a0581e70b669c352097d6bdc7a5409ae748ee3942e71f5c"
-                  },
-                  {
-                    "id": "sha256:94d5c3946873b079aa5af985e31501981fef1cb3065024e9f41f70c40fc9b975"
                   },
                   {
                     "id": "sha256:4f542ac06b9101e66033210648ba4bcc86c23f508a194d3a6ccba2966e4ade73"
@@ -1876,13 +1777,7 @@
                     "id": "sha256:37ca74f003d06ada0528d353bdc0df49193a058cece3c51173dc8b9c80f410e5"
                   },
                   {
-                    "id": "sha256:c72fcb71cb08b0e21e56c9b3238cac42bfa90fa43b2e5bfb218e4b22b957f12f"
-                  },
-                  {
                     "id": "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3"
-                  },
-                  {
-                    "id": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
                   },
                   {
                     "id": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
@@ -1903,9 +1798,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -2073,23 +1966,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -2097,13 +1977,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-425.3.1.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -2168,20 +2044,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2198,44 +2062,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -2243,8 +2072,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -2270,28 +2099,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -2301,18 +2114,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -2330,8 +2131,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -2490,9 +2291,6 @@
           "sha256:1d47e465939bba5bcf9c37be2516e60d6c9449ccee70a54a6133df989ac8b1f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libksba-1.3.5-7.el8.x86_64.rpm"
           },
-          "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.x86_64.rpm"
-          },
           "sha256:1dc1dbd0aa4dad715b3242468d4841f2f35bf6aa60d8e1928ee692784b12da1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsecret-0.18.6-1.el8.x86_64.rpm"
           },
@@ -2541,9 +2339,6 @@
           "sha256:2733570f8ea94551f3381538f9c8642c88532c800b384c07b4db02f6b8896c3f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libattr-2.4.48-3.el8.x86_64.rpm"
           },
-          "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fwupd-1.7.8-1.el8.x86_64.rpm"
-          },
           "sha256:283285b4c414c5d0614849e64971730af9d0037e62e535adb538166051e52e1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libdhash-0.5.0-40.el8.x86_64.rpm"
           },
@@ -2580,23 +2375,11 @@
           "sha256:2ff643bfe17476a8dfa94ea900ddf9d89ed0e5f56839f18209f8304a0e31bb2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dmidecode-3.3-4.el8.x86_64.rpm"
           },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
-          "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
-          },
           "sha256:30c6dbc7d2dd8024a16fe2d00b01fa71f4a1ea9d4af5519dc092695d4fa735cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libss-1.45.6-5.el8.x86_64.rpm"
           },
           "sha256:30e0334ada8f6453cd8c2335ac40417f636cdae7d7dc744b6d2bff78785013de": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-all-langpacks-2.28-211.el8.x86_64.rpm"
-          },
-          "sha256:319d3d51dfc09875cdbb61518410fe2963887228089d4a9de8f673acc7a2ff82": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-softokn-3.79.0-10.el8_6.x86_64.rpm"
           },
           "sha256:3267605bdad55274cd02ce3e656edb83048c740fa709452b3fe6ed98f5f5bbbe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/rpm-4.14.3-24.el8_6.x86_64.rpm"
@@ -2670,9 +2453,6 @@
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
           },
-          "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
-          },
           "sha256:3d6a5eeb0da36ce36cd6ddc5e3c2d2bc36cd5962d1450077c5c5754b8f5ac02c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glib2-2.56.4-159.el8.x86_64.rpm"
           },
@@ -2705,9 +2485,6 @@
           },
           "sha256:4658cf807723123b513587887bf226d0b3daf69049c13951c5f88f6196acbb7d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsss_sudo-2.7.3-4.el8.x86_64.rpm"
-          },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efivar-libs-37-4.el8.x86_64.rpm"
           },
           "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-pc-2.02-142.el8.x86_64.rpm"
@@ -2751,9 +2528,6 @@
           "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/man-db-2.7.6.1-18.el8.x86_64.rpm"
           },
-          "sha256:4bcbfd3229e3fd2d6e1adfe46bc233872c4184838de40b2e61a9ba84fcb81512": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-softokn-freebl-3.79.0-10.el8_6.x86_64.rpm"
-          },
           "sha256:4bdac8b052ea5031f85f17e8f8499d491cc2ea8d5110467c5a0e4ec7b7763c2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/authselect-compat-1.2.5-1.el8.x86_64.rpm"
           },
@@ -2786,9 +2560,6 @@
           },
           "sha256:50603f9a5c2a643252949c922d656c83194047469116a33c3c265871bfd0a531": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dnf-data-4.7.0-11.el8.noarch.rpm"
-          },
-          "sha256:507c1a196520e4263a0581e70b669c352097d6bdc7a5409ae748ee3942e71f5c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-sysinit-3.79.0-10.el8_6.x86_64.rpm"
           },
           "sha256:51eb082082e78afa70dd64591219c026d11cf7a6adf3771a36624c80be34dc3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/nettle-3.4.1-7.el8.x86_64.rpm"
@@ -2844,9 +2615,6 @@
           "sha256:5baf694f0ba6606307a449ca22cc62e85d38cd8ae870fac133e3f5df3d710dfc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-pc-modules-2.02-142.el8.noarch.rpm"
           },
-          "sha256:5bea1ad0a4491ab6ae8607f741388c983dc471747176a3e82302e94addba6d44": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-mdraid-2.24-11.el8.x86_64.rpm"
-          },
           "sha256:5d9c5b3341e9b10091a5bc66c08455ce7d9c62911fac6b759b847a46749a1adf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm"
           },
@@ -2880,9 +2648,6 @@
           "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsolv-0.7.20-3.el8.x86_64.rpm"
           },
-          "sha256:68e0dfe4bc893170e61539b648f41ef10aa8174a884de6ff91dcb87abc7d03ce": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libudisks2-2.9.0-9.el8.x86_64.rpm"
-          },
           "sha256:6950a3136327480137b0c3ed7555bd36d107ebb39b687354d2d34c5542e19d2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dbus-1.12.8-23.el8.x86_64.rpm"
           },
@@ -2900,9 +2665,6 @@
           },
           "sha256:6d7a41fb238610416349a53d024cc505ab7f3f6e9953cc2244abb663ec404dad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/ncurses-6.1-9.20180224.el8.x86_64.rpm"
-          },
-          "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm"
           },
           "sha256:6dcdb3c2afc64822ed6945bf9607cd0406197bd9764718beef51f5332edd7c05": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-gconv-extra-2.28-211.el8.x86_64.rpm"
@@ -2925,9 +2687,6 @@
           "sha256:709fb09876846df58d761b2ddb973bbf2b870d995452648ef929a2cdf3ea8216": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libarchive-3.3.3-4.el8.x86_64.rpm"
           },
-          "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgudev-232-4.el8.x86_64.rpm"
-          },
           "sha256:7145b8d179b6c72e61de2b822551b343209adb63b76023fe26e7162d4ff6c107": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcc-8.5.0-15.el8.x86_64.rpm"
           },
@@ -2939,9 +2698,6 @@
           },
           "sha256:73c29baa2cd94f1ae6a1d1333818969a281b16dd4262f413ad284c5333719a4d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/groff-base-1.22.3-18.el8.x86_64.rpm"
-          },
-          "sha256:74789339d67c8fd8545def02ae4a0f5dbbb9c0ee71aee54ee166b633563fe85d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-part-2.24-11.el8.x86_64.rpm"
           },
           "sha256:74cdb3a60d777eb0de980bfc902005757fc16ef0af7db01c1ade1cc56c3852c9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/elfutils-libs-0.187-4.el8.x86_64.rpm"
@@ -3009,17 +2765,11 @@
           "sha256:821923c32f6cd4c764ea7e97bee3335993d405694aa81b923cf1ef46c9e03cf9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/rhc-0.2.1-9.el8.x86_64.rpm"
           },
-          "sha256:82cd233003b87e6b810070eead73ec44073050aabccec9a619309074a1868fe9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nspr-4.34.0-3.el8_6.x86_64.rpm"
-          },
           "sha256:830940ac1860e506f78be51323f21144a40e6244eff2331c1648da06baee9ea6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dhcp-libs-4.3.6-48.el8.x86_64.rpm"
           },
           "sha256:84c4a7d89325e5d405712dff6db06ef55996a09faf7490c1693d032171730777": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/procps-ng-3.3.15-9.el8.x86_64.rpm"
-          },
-          "sha256:859c0fe81e8a3e297664c62d725d3224ec6f35bf5078a2993484b35328c16fdd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-swap-2.24-11.el8.x86_64.rpm"
           },
           "sha256:862e75a1cf6aa5be750a530c8ce8b999d0b2efe9737e20f37f9f9153a82e56fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libassuan-2.5.1-3.el8.x86_64.rpm"
@@ -3039,9 +2789,6 @@
           "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-audit-3.0.7-4.el8.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8a631d059089724f11aed2114ddaf7511c9771f415f638ed5b3a135bb90f2a31": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/coreutils-8.30-13.el8.x86_64.rpm"
           },
@@ -3053,9 +2800,6 @@
           },
           "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8d371e753071edc796d2eadb8278980290511be6279fdf46649c81b859497d6a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/prefixdevname-0.1.0-6.el8.x86_64.rpm"
@@ -3072,9 +2816,6 @@
           "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/snappy-1.1.8-3.el8.x86_64.rpm"
           },
-          "sha256:8ed24bf92f4a389d82399a2dfcdcd2b8812b354d32e50807ddf557b978532756": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-loop-2.24-11.el8.x86_64.rpm"
-          },
           "sha256:8efc0d874bbba80e64c99732956704826ce93ddd1476809c43b4d0b240f1e401": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/authselect-1.2.5-1.el8.x86_64.rpm"
           },
@@ -3086,9 +2827,6 @@
           },
           "sha256:912ff00d4f533a0fc8342910586ecc83f566e43f53e150c5cb7c1a6274dd1ba7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/tzdata-2022d-1.el8.noarch.rpm"
-          },
-          "sha256:91303cb921c3727203c4a25c12524356a2afb2e3fd594bdd12301a7b5edabaa3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-2.24-11.el8.x86_64.rpm"
           },
           "sha256:9137a707b7793567b38e7d8dba78fcf3f70c39320e68a9ee0b745b3a77f182ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/teamd-1.31-2.el8.x86_64.rpm"
@@ -3113,12 +2851,6 @@
           },
           "sha256:9461fa7a5e74bfd8d9e9961af9d3003d9d2b496830c2fd6b0641ae8b8bc8e178": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libacl-2.2.53-1.el8.x86_64.rpm"
-          },
-          "sha256:94d5c3946873b079aa5af985e31501981fef1cb3065024e9f41f70c40fc9b975": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-util-3.79.0-10.el8_6.x86_64.rpm"
-          },
-          "sha256:95a340a62ae433f5a5cb30e8929b9b4167d2d204bef99beea487ad65e451c2b9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-fs-2.24-11.el8.x86_64.rpm"
           },
           "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/unbound-libs-1.16.2-2.el8.x86_64.rpm"
@@ -3234,15 +2966,6 @@
           "sha256:ae6dd4ea3852d1ce30a0988bde8d35e91a8b0709615e3ac64c65a5e24e68fefa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/device-mapper-libs-1.02.181-6.el8.x86_64.rpm"
           },
-          "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
-          },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
-          "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-3.79.0-10.el8_6.x86_64.rpm"
-          },
           "sha256:afb86bb3de3f8b6f8ea6be0318f95d6938749ccf91e0cabe5d95c0f197d5de1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/hardlink-1.3-6.el8.x86_64.rpm"
           },
@@ -3278,9 +3001,6 @@
           },
           "sha256:b4babe48d93eccce4f0249ba34d592bfc306c3b14b40df7a5cc9eaec2eaae20f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/numactl-libs-2.0.12-13.el8.x86_64.rpm"
-          },
-          "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
           },
           "sha256:b76a180508132aaceb8dcebc5de9cec87d3459a39e4749f9af342d242c410dab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/oddjob-mkhomedir-0.34.7-2.el8.x86_64.rpm"
@@ -3351,9 +3071,6 @@
           "sha256:c637ccd812d6458885af67910db0e6698917abd8c397a34ebaf7b66052914433": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-langpack-en-2.28-211.el8.x86_64.rpm"
           },
-          "sha256:c72fcb71cb08b0e21e56c9b3238cac42bfa90fa43b2e5bfb218e4b22b957f12f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/udisks2-2.9.0-9.el8.x86_64.rpm"
-          },
           "sha256:c759f74a96a42a539568a16805461352f84c7e1766f41faccb519ac14a8825d3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/pam-1.3.1-22.el8.x86_64.rpm"
           },
@@ -3371,9 +3088,6 @@
           },
           "sha256:cb849487fb29d658b714045a4afe4886324e4add7d47a7296ae0ee89e3477014": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libini_config-1.3.1-40.el8.x86_64.rpm"
-          },
-          "sha256:cbca89c39db7fd80dc71deefdcfb15262e2aed69117e66a15632ac581c82b8b6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-crypto-2.24-11.el8.x86_64.rpm"
           },
           "sha256:cccb98acc0ead0737b2f7406c48a2039165276a129de1c7c840e412078437f1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libbasicobjects-0.1.1-40.el8.x86_64.rpm"
@@ -3456,17 +3170,11 @@
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/timedatex-0.5-3.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d570af0578f5b2c6225f1f2354404f65bccf91c3974e98dcbc0c7b55a61b9b46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grep-3.1-6.el8.x86_64.rpm"
           },
           "sha256:d67580b9b2af79f599f77c35c694714d2d39d2ea01c28e8aaca1312e6ab25184": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libselinux-2.9-6.el8.x86_64.rpm"
-          },
-          "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm"
           },
           "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
@@ -3503,9 +3211,6 @@
           },
           "sha256:e29131b502b6a199003ed61e27eb3e5cb3d46f4b4a3f8ca1034945a406dcfe80": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsemanage-2.9-9.el8.x86_64.rpm"
-          },
-          "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mdadm-4.2-5.el8.x86_64.rpm"
           },
           "sha256:e4f799b634299835dc1a8e79adcfb223d13b369bd033cbdb14170f845c9464ad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/ethtool-5.13-2.el8.x86_64.rpm"
@@ -3630,9 +3335,6 @@
           "sha256:fc46ac94289cd660db8452aa7093c446b0f087cda089b3c3aeeb988286d80ee2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/systemd-239-68.el8.x86_64.rpm"
           },
-          "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
-          },
           "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
@@ -3644,9 +3346,6 @@
           },
           "sha256:fe1a3e821eab7aafd11152c5d5b9f6cf57de36d8ef3b517e0e2f2315b062742c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm"
-          },
-          "sha256:fe6788ebe68e3bc8d6e9784c569c3bc5916e5c445a88fb0247ee1243018cfc8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-utils-2.24-11.el8.x86_64.rpm"
           },
           "sha256:fec32d37b2f34c891a64a8c5e2faf3d08de25d144289b6f2b7f5fafdd5eec4d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/parted-3.2-39.el8.x86_64.rpm"
@@ -3899,15 +3598,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -5379,15 +5069,6 @@
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-      },
-      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -5712,15 +5393,6 @@
         "checksum": "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711"
       },
       {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "049",
@@ -5782,33 +5454,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/e2fsprogs-libs-1.45.6-5.el8.x86_64.rpm",
         "checksum": "sha256:8e0e23d6a9399d9016d721467181d9abd3e888894149767b631889f1aeddf755"
-      },
-      {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
       },
       {
         "name": "elfutils-debuginfod-client",
@@ -5917,15 +5562,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse-libs-2.9.7-16.el8.x86_64.rpm",
         "checksum": "sha256:be62c3c22fe4351a434d5b971061e512db199d763205dd8aaf4c6faa35a9be42"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.8",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fwupd-1.7.8-1.el8.x86_64.rpm",
-        "checksum": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
       },
       {
         "name": "gawk",
@@ -6106,15 +5742,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-common-2.02-142.el8.noarch.rpm",
         "checksum": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "142.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm",
-        "checksum": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
       },
       {
         "name": "grub2-pc",
@@ -6648,15 +6275,6 @@
         "checksum": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -6691,24 +6309,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgpg-error-1.31-1.el8.x86_64.rpm",
         "checksum": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-      },
-      {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "232",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgudev-232-4.el8.x86_64.rpm",
-        "checksum": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
       },
       {
         "name": "libidn2",
@@ -7008,15 +6608,6 @@
         "checksum": "sha256:d15c8594702ab51f8aa792a6c0ebae49ddefc8740289397b2cd8cb6e4a711187"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -7242,15 +6833,6 @@
         "checksum": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libyaml",
         "epoch": 0,
         "version": "0.1.7",
@@ -7350,15 +6932,6 @@
         "checksum": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mdadm-4.2-5.el8.x86_64.rpm",
-        "checksum": "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de"
-      },
-      {
         "name": "memstrack",
         "epoch": 0,
         "version": "0.2.4",
@@ -7375,15 +6948,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/microcode_ctl-20220809-1.el8.x86_64.rpm",
         "checksum": "sha256:d3e15db6aaa6d8ba4587408d87863b2f94092024bbb94893faa95c5d259a97d4"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "12.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm",
-        "checksum": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
       },
       {
         "name": "mozjs60",
@@ -8340,15 +7904,6 @@
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
-        "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -8727,96 +8282,6 @@
         "checksum": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "14.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.x86_64.rpm",
-        "checksum": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:91303cb921c3727203c4a25c12524356a2afb2e3fd594bdd12301a7b5edabaa3"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-crypto-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:cbca89c39db7fd80dc71deefdcfb15262e2aed69117e66a15632ac581c82b8b6"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-fs-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:95a340a62ae433f5a5cb30e8929b9b4167d2d204bef99beea487ad65e451c2b9"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-loop-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:8ed24bf92f4a389d82399a2dfcdcd2b8812b354d32e50807ddf557b978532756"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-mdraid-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:5bea1ad0a4491ab6ae8607f741388c983dc471747176a3e82302e94addba6d44"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-part-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:74789339d67c8fd8545def02ae4a0f5dbbb9c0ee71aee54ee166b633563fe85d"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-swap-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:859c0fe81e8a3e297664c62d725d3224ec6f35bf5078a2993484b35328c16fdd"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-utils-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:fe6788ebe68e3bc8d6e9784c569c3bc5916e5c445a88fb0247ee1243018cfc8c"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libbytesize-1.4-3.el8.x86_64.rpm",
-        "checksum": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.10",
@@ -8844,15 +8309,6 @@
         "checksum": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
       },
       {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "9.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libudisks2-2.9.0-9.el8.x86_64.rpm",
-        "checksum": "sha256:68e0dfe4bc893170e61539b648f41ef10aa8174a884de6ff91dcb87abc7d03ce"
-      },
-      {
         "name": "libxkbcommon",
         "epoch": 0,
         "version": "0.9.1",
@@ -8860,60 +8316,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libxkbcommon-0.9.1-1.el8.x86_64.rpm",
         "checksum": "sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072"
-      },
-      {
-        "name": "nspr",
-        "epoch": 0,
-        "version": "4.34.0",
-        "release": "3.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nspr-4.34.0-3.el8_6.x86_64.rpm",
-        "checksum": "sha256:82cd233003b87e6b810070eead73ec44073050aabccec9a619309074a1868fe9"
-      },
-      {
-        "name": "nss",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a"
-      },
-      {
-        "name": "nss-softokn",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-softokn-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:319d3d51dfc09875cdbb61518410fe2963887228089d4a9de8f673acc7a2ff82"
-      },
-      {
-        "name": "nss-softokn-freebl",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-softokn-freebl-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:4bcbfd3229e3fd2d6e1adfe46bc233872c4184838de40b2e61a9ba84fcb81512"
-      },
-      {
-        "name": "nss-sysinit",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-sysinit-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:507c1a196520e4263a0581e70b669c352097d6bdc7a5409ae748ee3942e71f5c"
-      },
-      {
-        "name": "nss-util",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-util-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:94d5c3946873b079aa5af985e31501981fef1cb3065024e9f41f70c40fc9b975"
       },
       {
         "name": "oddjob",
@@ -9069,15 +8471,6 @@
         "checksum": "sha256:37ca74f003d06ada0528d353bdc0df49193a058cece3c51173dc8b9c80f410e5"
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "9.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/udisks2-2.9.0-9.el8.x86_64.rpm",
-        "checksum": "sha256:c72fcb71cb08b0e21e56c9b3238cac42bfa90fa43b2e5bfb218e4b22b957f12f"
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.16.2",
@@ -9085,15 +8478,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/unbound-libs-1.16.2-2.el8.x86_64.rpm",
         "checksum": "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.11",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm",
-        "checksum": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
       },
       {
         "name": "xkeyboard-config",

--- a/test/data/manifests/rhel_8-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ec2_ha-boot.json
@@ -130,9 +130,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -659,9 +656,6 @@
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
                   },
                   {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-                  },
-                  {
                     "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
                   },
                   {
@@ -791,9 +785,6 @@
                     "id": "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -813,15 +804,6 @@
                   },
                   {
                     "id": "sha256:8e0e23d6a9399d9016d721467181d9abd3e888894149767b631889f1aeddf755"
-                  },
-                  {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
                   },
                   {
                     "id": "sha256:45c47f5146e39f50ca18d1561821607bc582c5fd4de0bf05bc06a5e0eb33df34"
@@ -861,9 +843,6 @@
                   },
                   {
                     "id": "sha256:be62c3c22fe4351a434d5b971061e512db199d763205dd8aaf4c6faa35a9be42"
-                  },
-                  {
-                    "id": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
                   },
                   {
                     "id": "sha256:59b3cff57ffbea4c4c011e6a81341a1203c18b91569fff019c93b756331300f8"
@@ -924,9 +903,6 @@
                   },
                   {
                     "id": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-                  },
-                  {
-                    "id": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
                   },
                   {
                     "id": "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d"
@@ -1121,9 +1097,6 @@
                     "id": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:7145b8d179b6c72e61de2b822551b343209adb63b76023fe26e7162d4ff6c107"
                   },
                   {
@@ -1134,12 +1107,6 @@
                   },
                   {
                     "id": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-                  },
-                  {
-                    "id": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-                  },
-                  {
-                    "id": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
                   },
                   {
                     "id": "sha256:fe37f767487e0806535a06cda4e302555c27166b6320657ae945d5217b8c36aa"
@@ -1247,9 +1214,6 @@
                     "id": "sha256:d15c8594702ab51f8aa792a6c0ebae49ddefc8740289397b2cd8cb6e4a711187"
                   },
                   {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-                  },
-                  {
                     "id": "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8"
                   },
                   {
@@ -1328,9 +1292,6 @@
                     "id": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15"
                   },
                   {
@@ -1373,16 +1334,10 @@
                     "id": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
                   },
                   {
-                    "id": "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de"
-                  },
-                  {
                     "id": "sha256:ca6208d771fbbfc703217b0f4314d214a866da86b105f222753a6efeb12d6f69"
                   },
                   {
                     "id": "sha256:d3e15db6aaa6d8ba4587408d87863b2f94092024bbb94893faa95c5d259a97d4"
-                  },
-                  {
-                    "id": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -1838,9 +1793,6 @@
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
                   },
                   {
-                    "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
-                  },
-                  {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
                   },
                   {
@@ -2096,36 +2048,6 @@
                     "id": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
                   },
                   {
-                    "id": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-                  },
-                  {
-                    "id": "sha256:91303cb921c3727203c4a25c12524356a2afb2e3fd594bdd12301a7b5edabaa3"
-                  },
-                  {
-                    "id": "sha256:cbca89c39db7fd80dc71deefdcfb15262e2aed69117e66a15632ac581c82b8b6"
-                  },
-                  {
-                    "id": "sha256:95a340a62ae433f5a5cb30e8929b9b4167d2d204bef99beea487ad65e451c2b9"
-                  },
-                  {
-                    "id": "sha256:8ed24bf92f4a389d82399a2dfcdcd2b8812b354d32e50807ddf557b978532756"
-                  },
-                  {
-                    "id": "sha256:5bea1ad0a4491ab6ae8607f741388c983dc471747176a3e82302e94addba6d44"
-                  },
-                  {
-                    "id": "sha256:74789339d67c8fd8545def02ae4a0f5dbbb9c0ee71aee54ee166b633563fe85d"
-                  },
-                  {
-                    "id": "sha256:859c0fe81e8a3e297664c62d725d3224ec6f35bf5078a2993484b35328c16fdd"
-                  },
-                  {
-                    "id": "sha256:fe6788ebe68e3bc8d6e9784c569c3bc5916e5c445a88fb0247ee1243018cfc8c"
-                  },
-                  {
-                    "id": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-                  },
-                  {
                     "id": "sha256:d16252dcb91c3e581ecb29234180fb99ac3199a052a89d0e23603cb6054bee16"
                   },
                   {
@@ -2136,9 +2058,6 @@
                   },
                   {
                     "id": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
-                  },
-                  {
-                    "id": "sha256:68e0dfe4bc893170e61539b648f41ef10aa8174a884de6ff91dcb87abc7d03ce"
                   },
                   {
                     "id": "sha256:34001e2596b82803f289adefe1a263b61917e8a67ff8e45d9ff5fc1ca150eb57"
@@ -2330,13 +2249,7 @@
                     "id": "sha256:bafc9ec3dd737b0dbdf179b9d9b4c8a9b5c1a92423eae1e4eb3047522107695e"
                   },
                   {
-                    "id": "sha256:c72fcb71cb08b0e21e56c9b3238cac42bfa90fa43b2e5bfb218e4b22b957f12f"
-                  },
-                  {
                     "id": "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3"
-                  },
-                  {
-                    "id": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
                   },
                   {
                     "id": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
@@ -2418,9 +2331,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -2588,23 +2499,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -2612,13 +2510,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-425.3.1.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -2683,20 +2577,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2713,44 +2595,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -2758,8 +2605,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -2785,28 +2632,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -2816,18 +2647,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -2845,8 +2664,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -3065,9 +2884,6 @@
           "sha256:1d47e465939bba5bcf9c37be2516e60d6c9449ccee70a54a6133df989ac8b1f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libksba-1.3.5-7.el8.x86_64.rpm"
           },
-          "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.x86_64.rpm"
-          },
           "sha256:1dc1dbd0aa4dad715b3242468d4841f2f35bf6aa60d8e1928ee692784b12da1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsecret-0.18.6-1.el8.x86_64.rpm"
           },
@@ -3134,9 +2950,6 @@
           "sha256:2733570f8ea94551f3381538f9c8642c88532c800b384c07b4db02f6b8896c3f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libattr-2.4.48-3.el8.x86_64.rpm"
           },
-          "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fwupd-1.7.8-1.el8.x86_64.rpm"
-          },
           "sha256:27efba5e62430987380ca7f2e4185e1d27c517a6f8d22958dd3fd0bc2591d3fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/rubygem-io-console-0.4.6-110.module+el8.6.0+15956+aa803fc1.x86_64.rpm"
           },
@@ -3196,15 +3009,6 @@
           },
           "sha256:2ff643bfe17476a8dfa94ea900ddf9d89ed0e5f56839f18209f8304a0e31bb2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dmidecode-3.3-4.el8.x86_64.rpm"
-          },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
-          "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
           "sha256:30c6dbc7d2dd8024a16fe2d00b01fa71f4a1ea9d4af5519dc092695d4fa735cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libss-1.45.6-5.el8.x86_64.rpm"
@@ -3296,9 +3100,6 @@
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
           },
-          "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
-          },
           "sha256:3d6a5eeb0da36ce36cd6ddc5e3c2d2bc36cd5962d1450077c5c5754b8f5ac02c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glib2-2.56.4-159.el8.x86_64.rpm"
           },
@@ -3358,9 +3159,6 @@
           },
           "sha256:46ed1904100326d5ded33a027840de37cf90d3dffe8d1fa88a8f01654539a322": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/fence-agents-hpblade-4.2.1-103.el8.noarch.rpm"
-          },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efivar-libs-37-4.el8.x86_64.rpm"
           },
           "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-pc-2.02-142.el8.x86_64.rpm"
@@ -3536,9 +3334,6 @@
           "sha256:5baf694f0ba6606307a449ca22cc62e85d38cd8ae870fac133e3f5df3d710dfc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-pc-modules-2.02-142.el8.noarch.rpm"
           },
-          "sha256:5bea1ad0a4491ab6ae8607f741388c983dc471747176a3e82302e94addba6d44": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-mdraid-2.24-11.el8.x86_64.rpm"
-          },
           "sha256:5d9c5b3341e9b10091a5bc66c08455ce7d9c62911fac6b759b847a46749a1adf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm"
           },
@@ -3578,9 +3373,6 @@
           "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsolv-0.7.20-3.el8.x86_64.rpm"
           },
-          "sha256:68e0dfe4bc893170e61539b648f41ef10aa8174a884de6ff91dcb87abc7d03ce": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libudisks2-2.9.0-9.el8.x86_64.rpm"
-          },
           "sha256:6950a3136327480137b0c3ed7555bd36d107ebb39b687354d2d34c5542e19d2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dbus-1.12.8-23.el8.x86_64.rpm"
           },
@@ -3605,9 +3397,6 @@
           "sha256:6d7a41fb238610416349a53d024cc505ab7f3f6e9953cc2244abb663ec404dad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/ncurses-6.1-9.20180224.el8.x86_64.rpm"
           },
-          "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm"
-          },
           "sha256:6dcdb3c2afc64822ed6945bf9607cd0406197bd9764718beef51f5332edd7c05": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-gconv-extra-2.28-211.el8.x86_64.rpm"
           },
@@ -3628,9 +3417,6 @@
           },
           "sha256:709fb09876846df58d761b2ddb973bbf2b870d995452648ef929a2cdf3ea8216": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libarchive-3.3.3-4.el8.x86_64.rpm"
-          },
-          "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgudev-232-4.el8.x86_64.rpm"
           },
           "sha256:7145b8d179b6c72e61de2b822551b343209adb63b76023fe26e7162d4ff6c107": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcc-8.5.0-15.el8.x86_64.rpm"
@@ -3655,9 +3441,6 @@
           },
           "sha256:746243a941d8d8299e220e75bed360debcb7f27df661a5f7637deb21cdd67976": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-n8.7-20221015/Packages/libknet1-crypto-nss-plugin-1.24-2.el8.x86_64.rpm"
-          },
-          "sha256:74789339d67c8fd8545def02ae4a0f5dbbb9c0ee71aee54ee166b633563fe85d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-part-2.24-11.el8.x86_64.rpm"
           },
           "sha256:74c60aed4f76cf297ec7fc218763d5b8b87c03280ed94d216f1a71100441ed3f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-n8.7-20221015/Packages/libknet1-compress-lz4-plugin-1.24-2.el8.x86_64.rpm"
@@ -3770,9 +3553,6 @@
           "sha256:84c4a7d89325e5d405712dff6db06ef55996a09faf7490c1693d032171730777": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/procps-ng-3.3.15-9.el8.x86_64.rpm"
           },
-          "sha256:859c0fe81e8a3e297664c62d725d3224ec6f35bf5078a2993484b35328c16fdd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-swap-2.24-11.el8.x86_64.rpm"
-          },
           "sha256:862e75a1cf6aa5be750a530c8ce8b999d0b2efe9737e20f37f9f9153a82e56fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libassuan-2.5.1-3.el8.x86_64.rpm"
           },
@@ -3794,9 +3574,6 @@
           "sha256:891b4ffa90ef5369b7a846fabe4ce87e0d7e604fa31a43104b93c7f5654bbb7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libwbclient-4.16.4-2.el8.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8a631d059089724f11aed2114ddaf7511c9771f415f638ed5b3a135bb90f2a31": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/coreutils-8.30-13.el8.x86_64.rpm"
           },
@@ -3808,9 +3585,6 @@
           },
           "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8d371e753071edc796d2eadb8278980290511be6279fdf46649c81b859497d6a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/prefixdevname-0.1.0-6.el8.x86_64.rpm"
@@ -3827,9 +3601,6 @@
           "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/snappy-1.1.8-3.el8.x86_64.rpm"
           },
-          "sha256:8ed24bf92f4a389d82399a2dfcdcd2b8812b354d32e50807ddf557b978532756": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-loop-2.24-11.el8.x86_64.rpm"
-          },
           "sha256:8efc0d874bbba80e64c99732956704826ce93ddd1476809c43b4d0b240f1e401": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/authselect-1.2.5-1.el8.x86_64.rpm"
           },
@@ -3844,9 +3615,6 @@
           },
           "sha256:912ff00d4f533a0fc8342910586ecc83f566e43f53e150c5cb7c1a6274dd1ba7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/tzdata-2022d-1.el8.noarch.rpm"
-          },
-          "sha256:91303cb921c3727203c4a25c12524356a2afb2e3fd594bdd12301a7b5edabaa3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-2.24-11.el8.x86_64.rpm"
           },
           "sha256:9137a707b7793567b38e7d8dba78fcf3f70c39320e68a9ee0b745b3a77f182ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/teamd-1.31-2.el8.x86_64.rpm"
@@ -3877,9 +3645,6 @@
           },
           "sha256:94d5c3946873b079aa5af985e31501981fef1cb3065024e9f41f70c40fc9b975": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-util-3.79.0-10.el8_6.x86_64.rpm"
-          },
-          "sha256:95a340a62ae433f5a5cb30e8929b9b4167d2d204bef99beea487ad65e451c2b9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-fs-2.24-11.el8.x86_64.rpm"
           },
           "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/unbound-libs-1.16.2-2.el8.x86_64.rpm"
@@ -4049,12 +3814,6 @@
           "sha256:ae6dd4ea3852d1ce30a0988bde8d35e91a8b0709615e3ac64c65a5e24e68fefa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/device-mapper-libs-1.02.181-6.el8.x86_64.rpm"
           },
-          "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
-          },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
           "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-3.79.0-10.el8_6.x86_64.rpm"
           },
@@ -4108,9 +3867,6 @@
           },
           "sha256:b516896f3b3a83a1a5c9d0d6e84b025ecdb8d3676cbb195751b44224ad720078": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-n8.7-20221015/Packages/pacemaker-cli-2.1.4-5.el8.x86_64.rpm"
-          },
-          "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
           },
           "sha256:b5ceaedb078fd24f7b1c8c739c2492ba3c187ac139ee751578b6bae1564c8ca5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/device-mapper-multipath-0.8.4-28.el8.x86_64.rpm"
@@ -4217,9 +3973,6 @@
           "sha256:c65f150b84982102e17a772d66b2db460f74caaa4f56086322efc31ad7121fa7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/device-mapper-event-1.02.181-6.el8.x86_64.rpm"
           },
-          "sha256:c72fcb71cb08b0e21e56c9b3238cac42bfa90fa43b2e5bfb218e4b22b957f12f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/udisks2-2.9.0-9.el8.x86_64.rpm"
-          },
           "sha256:c759f74a96a42a539568a16805461352f84c7e1766f41faccb519ac14a8825d3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/pam-1.3.1-22.el8.x86_64.rpm"
           },
@@ -4255,9 +4008,6 @@
           },
           "sha256:cbc9960daa473a381ebac94367a9f4acb633e603fba4683010c4a040ef7f9f57": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/fence-agents-heuristics-ping-4.2.1-103.el8.noarch.rpm"
-          },
-          "sha256:cbca89c39db7fd80dc71deefdcfb15262e2aed69117e66a15632ac581c82b8b6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-crypto-2.24-11.el8.x86_64.rpm"
           },
           "sha256:cccb98acc0ead0737b2f7406c48a2039165276a129de1c7c840e412078437f1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libbasicobjects-0.1.1-40.el8.x86_64.rpm"
@@ -4358,17 +4108,11 @@
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/timedatex-0.5-3.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d570af0578f5b2c6225f1f2354404f65bccf91c3974e98dcbc0c7b55a61b9b46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grep-3.1-6.el8.x86_64.rpm"
           },
           "sha256:d67580b9b2af79f599f77c35c694714d2d39d2ea01c28e8aaca1312e6ab25184": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libselinux-2.9-6.el8.x86_64.rpm"
-          },
-          "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm"
           },
           "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
@@ -4444,9 +4188,6 @@
           },
           "sha256:e33a380e981f44fb1e1987142e4a41bf3dbeb452490f2030876d221640c52e14": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/samba-client-libs-4.16.4-2.el8.x86_64.rpm"
-          },
-          "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mdadm-4.2-5.el8.x86_64.rpm"
           },
           "sha256:e4f799b634299835dc1a8e79adcfb223d13b369bd033cbdb14170f845c9464ad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/ethtool-5.13-2.el8.x86_64.rpm"
@@ -4631,9 +4372,6 @@
           "sha256:fc46ac94289cd660db8452aa7093c446b0f087cda089b3c3aeeb988286d80ee2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/systemd-239-68.el8.x86_64.rpm"
           },
-          "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
-          },
           "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
@@ -4648,9 +4386,6 @@
           },
           "sha256:fe37f767487e0806535a06cda4e302555c27166b6320657ae945d5217b8c36aa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libicu-60.3-2.el8_1.x86_64.rpm"
-          },
-          "sha256:fe6788ebe68e3bc8d6e9784c569c3bc5916e5c445a88fb0247ee1243018cfc8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-utils-2.24-11.el8.x86_64.rpm"
           },
           "sha256:fe7cfd8d7281295cbc16dd06dcb79f80c1d18679b4eafe8bb22f61bffec2ca25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/fence-agents-ipmilan-4.2.1-103.el8.noarch.rpm"
@@ -4909,15 +4644,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -6398,15 +6124,6 @@
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-      },
-      {
         "name": "bzip2",
         "epoch": 0,
         "version": "1.0.6",
@@ -6794,15 +6511,6 @@
         "checksum": "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711"
       },
       {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "049",
@@ -6864,33 +6572,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/e2fsprogs-libs-1.45.6-5.el8.x86_64.rpm",
         "checksum": "sha256:8e0e23d6a9399d9016d721467181d9abd3e888894149767b631889f1aeddf755"
-      },
-      {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
       },
       {
         "name": "elfutils-debuginfod-client",
@@ -7008,15 +6689,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse-libs-2.9.7-16.el8.x86_64.rpm",
         "checksum": "sha256:be62c3c22fe4351a434d5b971061e512db199d763205dd8aaf4c6faa35a9be42"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.8",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fwupd-1.7.8-1.el8.x86_64.rpm",
-        "checksum": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
       },
       {
         "name": "gawk",
@@ -7197,15 +6869,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-common-2.02-142.el8.noarch.rpm",
         "checksum": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "142.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm",
-        "checksum": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
       },
       {
         "name": "grub2-pc",
@@ -7784,15 +7447,6 @@
         "checksum": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -7827,24 +7481,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgpg-error-1.31-1.el8.x86_64.rpm",
         "checksum": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-      },
-      {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "232",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgudev-232-4.el8.x86_64.rpm",
-        "checksum": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
       },
       {
         "name": "libicu",
@@ -8162,15 +7798,6 @@
         "checksum": "sha256:d15c8594702ab51f8aa792a6c0ebae49ddefc8740289397b2cd8cb6e4a711187"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -8405,15 +8032,6 @@
         "checksum": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libxslt",
         "epoch": 0,
         "version": "1.1.32",
@@ -8540,15 +8158,6 @@
         "checksum": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mdadm-4.2-5.el8.x86_64.rpm",
-        "checksum": "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de"
-      },
-      {
         "name": "memstrack",
         "epoch": 0,
         "version": "0.2.4",
@@ -8565,15 +8174,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/microcode_ctl-20220809-1.el8.x86_64.rpm",
         "checksum": "sha256:d3e15db6aaa6d8ba4587408d87863b2f94092024bbb94893faa95c5d259a97d4"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "12.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm",
-        "checksum": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
       },
       {
         "name": "mozjs60",
@@ -9935,15 +9535,6 @@
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
-        "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -10709,96 +10300,6 @@
         "checksum": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "14.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.x86_64.rpm",
-        "checksum": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:91303cb921c3727203c4a25c12524356a2afb2e3fd594bdd12301a7b5edabaa3"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-crypto-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:cbca89c39db7fd80dc71deefdcfb15262e2aed69117e66a15632ac581c82b8b6"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-fs-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:95a340a62ae433f5a5cb30e8929b9b4167d2d204bef99beea487ad65e451c2b9"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-loop-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:8ed24bf92f4a389d82399a2dfcdcd2b8812b354d32e50807ddf557b978532756"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-mdraid-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:5bea1ad0a4491ab6ae8607f741388c983dc471747176a3e82302e94addba6d44"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-part-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:74789339d67c8fd8545def02ae4a0f5dbbb9c0ee71aee54ee166b633563fe85d"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-swap-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:859c0fe81e8a3e297664c62d725d3224ec6f35bf5078a2993484b35328c16fdd"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-utils-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:fe6788ebe68e3bc8d6e9784c569c3bc5916e5c445a88fb0247ee1243018cfc8c"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libbytesize-1.4-3.el8.x86_64.rpm",
-        "checksum": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.10",
@@ -10833,15 +10334,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libmaxminddb-1.2.0-10.el8.x86_64.rpm",
         "checksum": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
-      },
-      {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "9.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libudisks2-2.9.0-9.el8.x86_64.rpm",
-        "checksum": "sha256:68e0dfe4bc893170e61539b648f41ef10aa8174a884de6ff91dcb87abc7d03ce"
       },
       {
         "name": "libverto-libev",
@@ -11411,15 +10903,6 @@
         "checksum": "sha256:bafc9ec3dd737b0dbdf179b9d9b4c8a9b5c1a92423eae1e4eb3047522107695e"
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "9.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/udisks2-2.9.0-9.el8.x86_64.rpm",
-        "checksum": "sha256:c72fcb71cb08b0e21e56c9b3238cac42bfa90fa43b2e5bfb218e4b22b957f12f"
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.16.2",
@@ -11427,15 +10910,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/unbound-libs-1.16.2-2.el8.x86_64.rpm",
         "checksum": "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.11",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm",
-        "checksum": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
       },
       {
         "name": "xkeyboard-config",

--- a/test/data/manifests/rhel_8-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ec2_sap-boot.json
@@ -155,9 +155,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -726,9 +723,6 @@
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
                   },
                   {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-                  },
-                  {
                     "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
                   },
                   {
@@ -915,15 +909,6 @@
                     "id": "sha256:d5689e2894c59a375f985b5228b32e78d10b4ceeec9fd7c79f2000480494d368"
                   },
                   {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
-                  },
-                  {
                     "id": "sha256:45c47f5146e39f50ca18d1561821607bc582c5fd4de0bf05bc06a5e0eb33df34"
                   },
                   {
@@ -979,9 +964,6 @@
                   },
                   {
                     "id": "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987"
-                  },
-                  {
-                    "id": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
                   },
                   {
                     "id": "sha256:59b3cff57ffbea4c4c011e6a81341a1203c18b91569fff019c93b756331300f8"
@@ -1048,9 +1030,6 @@
                   },
                   {
                     "id": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-                  },
-                  {
-                    "id": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
                   },
                   {
                     "id": "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d"
@@ -1290,9 +1269,6 @@
                     "id": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:7145b8d179b6c72e61de2b822551b343209adb63b76023fe26e7162d4ff6c107"
                   },
                   {
@@ -1449,9 +1425,6 @@
                     "id": "sha256:cfa953b5825141026d5e6cd951f5aca15a88e8998e297e07d537e4aae8da5b21"
                   },
                   {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-                  },
-                  {
                     "id": "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8"
                   },
                   {
@@ -1542,9 +1515,6 @@
                     "id": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15"
                   },
                   {
@@ -1615,9 +1585,6 @@
                   },
                   {
                     "id": "sha256:48e1edacae05696360d0dd0706b2d3debb617ae15e9f7ce47e528839231a6c25"
-                  },
-                  {
-                    "id": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -2104,9 +2071,6 @@
                   },
                   {
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
-                  },
-                  {
-                    "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
                   },
                   {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
@@ -3082,9 +3046,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -3369,23 +3331,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -3393,13 +3342,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto processor.max_cstate=1 intel_idle.max_cstate=1",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-425.3.1.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -3464,20 +3409,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -3494,44 +3427,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -3539,8 +3437,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -3566,28 +3464,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -3597,18 +3479,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -3626,8 +3496,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -3993,9 +3863,6 @@
           "sha256:273c756dce0c543a12e1a6c3ccf745235397430ab9258bb13cb34d3a79e215e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python39-libs-3.9.13-1.module+el8.7.0+15656+ffd4a257.x86_64.rpm"
           },
-          "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fwupd-1.7.8-1.el8.x86_64.rpm"
-          },
           "sha256:27d04a9a33eb9300a55a8ec7623c02da13d19185278e367b60422c8fe70279e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sssd-common-pac-2.7.3-4.el8.x86_64.rpm"
           },
@@ -4086,17 +3953,11 @@
           "sha256:2ff643bfe17476a8dfa94ea900ddf9d89ed0e5f56839f18209f8304a0e31bb2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dmidecode-3.3-4.el8.x86_64.rpm"
           },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
           "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
           "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
           "sha256:30c6dbc7d2dd8024a16fe2d00b01fa71f4a1ea9d4af5519dc092695d4fa735cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libss-1.45.6-5.el8.x86_64.rpm"
@@ -4295,9 +4156,6 @@
           },
           "sha256:471930ec9d0e115809eaae8aa5c888bc07104c600ff49b55ab746701691c7c0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iptables-libs-1.8.4-23.el8.x86_64.rpm"
-          },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efivar-libs-37-4.el8.x86_64.rpm"
           },
           "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-pc-2.02-142.el8.x86_64.rpm"
@@ -4638,9 +4496,6 @@
           "sha256:6d7a41fb238610416349a53d024cc505ab7f3f6e9953cc2244abb663ec404dad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/ncurses-6.1-9.20180224.el8.x86_64.rpm"
           },
-          "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm"
-          },
           "sha256:6dcdb3c2afc64822ed6945bf9607cd0406197bd9764718beef51f5332edd7c05": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-gconv-extra-2.28-211.el8.x86_64.rpm"
           },
@@ -4914,9 +4769,6 @@
           "sha256:8942bd9f52f391bf7832aa81ebc8ea66f420ed5b4d35310666997567f0ea9351": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/pinfo-0.6.10-18.el8.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8a3d3e06022e15746a023ace227a8ab3737b468b651cd20f01b5959afa4de75c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/cockpit-podman-53-1.module+el8.7.0+16772+33343656.noarch.rpm"
           },
@@ -4937,9 +4789,6 @@
           },
           "sha256:8c81bb15456e441250d2ed53b223bf85c21a9b25b6a36ab09953cc831f9e7109": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/tcsh-6.20.00-15.el8.x86_64.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8ca5dd4feea941aba58c6d6e981883bca79704dba06583f880c0bf5e0cf4efcf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/desktop-file-utils-0.23-8.el8.x86_64.rpm"
@@ -5295,9 +5144,6 @@
           "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
           },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
           "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-3.79.0-10.el8_6.x86_64.rpm"
           },
@@ -5378,9 +5224,6 @@
           },
           "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
-          },
-          "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
           },
           "sha256:b5c29663e9ffd460842551c32665c0629f634ad7453f0dc3888f4b07c6f88a71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/podman-4.2.0-1.module+el8.7.0+16772+33343656.x86_64.rpm"
@@ -5682,9 +5525,6 @@
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/timedatex-0.5-3.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d5689e2894c59a375f985b5228b32e78d10b4ceeec9fd7c79f2000480494d368": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/ed-1.14.2-4.el8.x86_64.rpm"
           },
@@ -5696,9 +5536,6 @@
           },
           "sha256:d67580b9b2af79f599f77c35c694714d2d39d2ea01c28e8aaca1312e6ab25184": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libselinux-2.9-6.el8.x86_64.rpm"
-          },
-          "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm"
           },
           "sha256:d805c42ee9293a8ba35f49af63e3f7d813420d4a62ee4cff5ecd7391be851a9b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libtool-ltdl-2.4.6-25.el8.x86_64.rpm"
@@ -6323,15 +6160,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -7929,15 +7757,6 @@
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-      },
-      {
         "name": "bzip2",
         "epoch": 0,
         "version": "1.0.6",
@@ -8496,33 +8315,6 @@
         "checksum": "sha256:d5689e2894c59a375f985b5228b32e78d10b4ceeec9fd7c79f2000480494d368"
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
-      },
-      {
         "name": "elfutils-debuginfod-client",
         "epoch": 0,
         "version": "0.187",
@@ -8692,15 +8484,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm",
         "checksum": "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.8",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fwupd-1.7.8-1.el8.x86_64.rpm",
-        "checksum": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
       },
       {
         "name": "gawk",
@@ -8899,15 +8682,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-common-2.02-142.el8.noarch.rpm",
         "checksum": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "142.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm",
-        "checksum": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
       },
       {
         "name": "grub2-pc",
@@ -9621,15 +9395,6 @@
         "checksum": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -10098,15 +9863,6 @@
         "checksum": "sha256:cfa953b5825141026d5e6cd951f5aca15a88e8998e297e07d537e4aae8da5b21"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -10377,15 +10133,6 @@
         "checksum": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libxslt",
         "epoch": 0,
         "version": "1.1.32",
@@ -10600,15 +10347,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mlocate-0.26-20.el8.x86_64.rpm",
         "checksum": "sha256:48e1edacae05696360d0dd0706b2d3debb617ae15e9f7ce47e528839231a6c25"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "12.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm",
-        "checksum": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
       },
       {
         "name": "mozjs60",
@@ -12067,15 +11805,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shared-mime-info-1.9-3.el8.x86_64.rpm",
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
-        "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
       },
       {
         "name": "slang",

--- a/test/data/manifests/rhel_84-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-ec2-boot.json
@@ -2171,14 +2171,14 @@
                   "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
                 },
                 {
-                  "size": 1024000,
+                  "size": 1048576,
                   "start": 411648,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "CB07C243-BC44-4717-853E-28852021225B"
                 },
                 {
-                  "size": 19535839,
-                  "start": 1435648,
+                  "size": 19511263,
+                  "start": 1460224,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2214,8 +2214,7 @@
           {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
-              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
             },
             "devices": {
               "device": {
@@ -2223,7 +2222,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 411648,
-                  "size": 1024000,
+                  "size": 1048576,
                   "lock": true
                 }
               }
@@ -2240,8 +2239,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1435648,
-                  "size": 19535839,
+                  "start": 1460224,
+                  "size": 19511263,
                   "lock": true
                 }
               }
@@ -2272,7 +2271,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 411648,
-                  "size": 1024000
+                  "size": 1048576
                 }
               },
               "boot.efi": {
@@ -2287,8 +2286,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1435648,
-                  "size": 19535839
+                  "start": 1460224,
+                  "size": 19511263
                 }
               }
             },

--- a/test/data/manifests/rhel_84-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ec2-boot.json
@@ -121,9 +121,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:a70958925902f87c5105a79fb5858e375711c8f101e0755c093b120c6e604dd7"
                   },
                   {
@@ -637,9 +634,6 @@
                 "origin": "org.osbuild.source",
                 "references": [
                   {
-                    "id": "sha256:94fa34d24dec1e26a9d1c1e4e7213c87d792fafaf106d09daecfa25ac928e809"
-                  },
-                  {
                     "id": "sha256:31fb540e3627eb73c3df66dd46cdfcab276a612d1d0949fb2afa3ffdf69fb3ab"
                   },
                   {
@@ -677,9 +671,6 @@
                   },
                   {
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
-                  },
-                  {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
@@ -790,9 +781,6 @@
                     "id": "sha256:406cc8322105f3a1706feaca414609d4be582d4e2290541239077bc39a6307cd"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:a70958925902f87c5105a79fb5858e375711c8f101e0755c093b120c6e604dd7"
                   },
                   {
@@ -812,15 +800,6 @@
                   },
                   {
                     "id": "sha256:435d017c887d981b8f485f94f1efc8342f082e76c64bfb058e7f218dcc8a69dd"
-                  },
-                  {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
                   },
                   {
                     "id": "sha256:13e921e308e602b3527a93dacf0fc9bcada110e9dd3fdc1a338b3fd708b85aac"
@@ -857,9 +836,6 @@
                   },
                   {
                     "id": "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042"
-                  },
-                  {
-                    "id": "sha256:89a735c5fa600fff61f81c198f3a312a7958d3b1adb9d17af30ae5e25a690fb9"
                   },
                   {
                     "id": "sha256:affab770e241d6c70cb271cbe5f84d02a946ad1b4d17d36f74dab74e9ca8fd7f"
@@ -917,9 +893,6 @@
                   },
                   {
                     "id": "sha256:f7b414c1fd118f998d4253a9fdad7aacad7c858f327efdd830b06604a9d65f07"
-                  },
-                  {
-                    "id": "sha256:cf0fc74feaf99f8c57a9ebdc8cb4371e6bcca905fab6f44ba408443a7cfe3651"
                   },
                   {
                     "id": "sha256:ac2bd89f2af4378018de5193b7f0f58c1f93e627fac256c7d5ac21950fe4df17"
@@ -1099,9 +1072,6 @@
                     "id": "sha256:eb3732b52b805b28192463682e961408db8c6449bb27e733081cff62e77194b3"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:d5d4156b88b64a7d7e86ed0a7fdb3adb7bfc815ec413a4aba74d70cf8f831aea"
                   },
                   {
@@ -1112,12 +1082,6 @@
                   },
                   {
                     "id": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-                  },
-                  {
-                    "id": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-                  },
-                  {
-                    "id": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
                   },
                   {
                     "id": "sha256:edb1ddaad8b4559bd271fb99b99395cedbb6290876571f2d4554684b1b8e6547"
@@ -1139,9 +1103,6 @@
                   },
                   {
                     "id": "sha256:01e2b6c30bf5eea790cc1c7a13e403e2afa4f4307b63148788820209a87e3bb8"
-                  },
-                  {
-                    "id": "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a"
                   },
                   {
                     "id": "sha256:cd7c30d21e7240f60f0861c229e17fda43e855ab4c78fab39f47f7ae2be5720e"
@@ -1195,9 +1156,6 @@
                     "id": "sha256:df169d238e43e575b61b9eb02a392d9c2c75fe6b0bb678f8d8ca27e169347372"
                   },
                   {
-                    "id": "sha256:19c4c7dec378a3c21c8f2d4b9940fcf27f06fb1edf773eaeb185f664cb439a52"
-                  },
-                  {
                     "id": "sha256:507442831068c749ba21b22bd96993a1a2a6c74dd53c55f34c7f81a21554c82d"
                   },
                   {
@@ -1232,9 +1190,6 @@
                   },
                   {
                     "id": "sha256:5e8c3337e3ed2e31bab967ae331e58f5d7e5534f10ac4677d97e35ba282ade51"
-                  },
-                  {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
                   },
                   {
                     "id": "sha256:c07cca867b98c959c67cda988ed8bf9f111f9fc61b635d39b2823513811eade4"
@@ -1312,9 +1267,6 @@
                     "id": "sha256:f6eabee17654187308fd32a13de35b2aa1ca88515c1544af88f63893cb19b048"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf"
                   },
                   {
@@ -1348,16 +1300,10 @@
                     "id": "sha256:7b6856dc4dc1d88d9c3c9597fb824b5776af59f045087bdb2713d64045216a36"
                   },
                   {
-                    "id": "sha256:4c701e1403db5d73039735e499674b1ae5dc6750080a505d542c711247f0e5b1"
-                  },
-                  {
                     "id": "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd"
                   },
                   {
                     "id": "sha256:2c695e34267183659e95c654d6ebe2fa979e8afe52fcfb4d698d42fdca588ac5"
-                  },
-                  {
-                    "id": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -1681,9 +1627,6 @@
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
                   },
                   {
-                    "id": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
-                  },
-                  {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
                   },
                   {
@@ -1810,36 +1753,6 @@
                     "id": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
                   },
                   {
-                    "id": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-                  },
-                  {
-                    "id": "sha256:d975cde9db186a1f4b258436bf019237ca8b78ac4ae00f90eddb536689e6210d"
-                  },
-                  {
-                    "id": "sha256:5525219fbc5e4a65a7074d23b25645b930dffa96981e28971d821b62e7a30a0a"
-                  },
-                  {
-                    "id": "sha256:98afa549d41462a811cce159dc06e06840bcf24eca9d784f77e19214d149e7d7"
-                  },
-                  {
-                    "id": "sha256:cd56f00ccd7461260b174616ee0306a54cfb19c05a5637af98d4f876fb8682c9"
-                  },
-                  {
-                    "id": "sha256:9afe10fb4f998fdae77b6f04c7dc923fed6113e8989c575106b443c64e399e8b"
-                  },
-                  {
-                    "id": "sha256:b98e03599e8c2cd67910a3fcfddf42de4eecff18f79b306a7a7a58b89473d8b1"
-                  },
-                  {
-                    "id": "sha256:f65b195bd738fb4a12b7761b868cd9caecaa67a547c927cc27c0762c5da97d03"
-                  },
-                  {
-                    "id": "sha256:5b5618571dd17467bd96a18bd9c57a0b5ea52401eb21299459e6c04ec93fcf8b"
-                  },
-                  {
-                    "id": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-                  },
-                  {
                     "id": "sha256:bfe5c8ea12012936cc59981a10728e95d5fdadd3e893457af7a27c464d8cb6ba"
                   },
                   {
@@ -1849,28 +1762,7 @@
                     "id": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
                   },
                   {
-                    "id": "sha256:fa89bdb6b367bc7bb31ff620202b787fef7efaf4f356c7c4b1f097a95060bb6d"
-                  },
-                  {
                     "id": "sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072"
-                  },
-                  {
-                    "id": "sha256:29902a3f54d6a29167c9111c1a10c9bd2308a198d05fc524db085beecc50f50b"
-                  },
-                  {
-                    "id": "sha256:1b76a3999023a1a118be030f6e3165a925d48399f38302afef555d5327a533e1"
-                  },
-                  {
-                    "id": "sha256:b16406b22409f7572257441e446d717447f0dbbca820249113c386a876aa6d29"
-                  },
-                  {
-                    "id": "sha256:d9e5cea8712d1093241ba300b86d4349b46e51dcecbee4a88692dd2a4027a270"
-                  },
-                  {
-                    "id": "sha256:b748e312645dd47cc314fc4523fdcf7351fe25c12a4d3369e838552bae2393c1"
-                  },
-                  {
-                    "id": "sha256:812063b70caf78ab378defe4fa4dd0215175b58a18666729e86b9ed7b0f4e62e"
                   },
                   {
                     "id": "sha256:0e0f05c3d39f4b3eee6a5786a6aea4c7ef5f5921bc6146489d1f97aa602f7d6d"
@@ -1918,13 +1810,7 @@
                     "id": "sha256:2da4af0a0bcc46163e4d83e85b77f1ac03a15fb10647730b09f5d38b2027370d"
                   },
                   {
-                    "id": "sha256:6161073140cd2b57627c3d98709dfbf50da251ed848768cc26027ffcacfcbce7"
-                  },
-                  {
                     "id": "sha256:6a43c0a0605f6a5e3e155ca1d2e1bfdf5a8986a282b04c1c160d9e0148fb02af"
-                  },
-                  {
-                    "id": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
                   },
                   {
                     "id": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
@@ -1945,9 +1831,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -2128,23 +2012,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -2152,13 +2023,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-305.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -2223,20 +2090,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2253,44 +2108,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -2298,8 +2118,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -2325,28 +2145,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -2356,18 +2160,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -2385,8 +2177,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -2518,9 +2310,6 @@
           "sha256:197b12db401b9a501bc92f6b000be37af4b89d874463810e074fdf6acb563f39": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libblkid-2.32.1-27.el8.x86_64.rpm"
           },
-          "sha256:19c4c7dec378a3c21c8f2d4b9940fcf27f06fb1edf773eaeb185f664cb439a52": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libqmi-1.24.0-1.el8.x86_64.rpm"
-          },
           "sha256:19dba7cb30c3cb598886326df0ec1114c6e195a57c9ce3a8b78b83555e9e8648": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/geolite2-city-20180605-1.el8.noarch.rpm"
           },
@@ -2530,9 +2319,6 @@
           "sha256:1b6fe19e2856f752a2cd8f917db539dbe9fc1b1560fff3341864b13ffb0ccae0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/xz-5.2.4-3.el8.x86_64.rpm"
           },
-          "sha256:1b76a3999023a1a118be030f6e3165a925d48399f38302afef555d5327a533e1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/nss-3.53.1-17.el8_3.x86_64.rpm"
-          },
           "sha256:1b9c2dc9be278b1a3342dc080d55eff0c2fdce806b037682e431af83c534817e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libkcapi-hmaccalc-1.2.0-2.el8.x86_64.rpm"
           },
@@ -2541,9 +2327,6 @@
           },
           "sha256:1d47e465939bba5bcf9c37be2516e60d6c9449ccee70a54a6133df989ac8b1f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libksba-1.3.5-7.el8.x86_64.rpm"
-          },
-          "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libatasmart-0.19-14.el8.x86_64.rpm"
           },
           "sha256:1dc1dbd0aa4dad715b3242468d4841f2f35bf6aa60d8e1928ee692784b12da1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libsecret-0.18.6-1.el8.x86_64.rpm"
@@ -2556,9 +2339,6 @@
           },
           "sha256:206de21c82d76de550bcc1959138472640b0a950a311b753203f5dfe5b201b7b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/ipcalc-0.2.4-4.el8.x86_64.rpm"
-          },
-          "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libmbim-1.20.2-1.el8.x86_64.rpm"
           },
           "sha256:20dec130e4fd0a2146443791ca7ade6e079cea691d93711813d5f483b691c55a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-ethtool-0.14-3.el8.x86_64.rpm"
@@ -2605,9 +2385,6 @@
           "sha256:28ccf9ff472c824f6c5a3c2a0c076bfa221b8e48368e43de9b3c2e83d67e8b5d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/mpfr-3.1.6-1.el8.x86_64.rpm"
           },
-          "sha256:29902a3f54d6a29167c9111c1a10c9bd2308a198d05fc524db085beecc50f50b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/nspr-4.25.0-2.el8_2.x86_64.rpm"
-          },
           "sha256:2a65cec3eb67ba7645dd97cf3f3811cd5fb06eea2526d36a683d3fdaa0f2825e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/cronie-anacron-1.5.2-4.el8.x86_64.rpm"
           },
@@ -2640,15 +2417,6 @@
           },
           "sha256:2f47fe4fe818d6f4eef117287aef700380aa7f1bd50931cada45efc0be05603c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/coreutils-8.30-8.el8.x86_64.rpm"
-          },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
-          "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
           "sha256:30f3eca78f87fb66d9797a252df9217ec755e7a9034edf44deec5943dde4ba54": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/grub2-tools-2.02-99.el8.x86_64.rpm"
@@ -2722,9 +2490,6 @@
           "sha256:3b78a074b7f24acab538bb0dc3296dd465f796a54e32ae3b097668c8e15cfea2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/filesystem-3.8-3.el8.x86_64.rpm"
           },
-          "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
-          },
           "sha256:3dc82857e070870d00a5d44e2ff597bdb3f7eb9784c84807c170086729c61825": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/file-libs-5.33-16.el8_3.1.x86_64.rpm"
           },
@@ -2788,9 +2553,6 @@
           "sha256:474a66a4cf3d5a00286be40c15bad69ea1ac63a9424a1ff44f20a548a7686f7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libfastjson-0.99.8-2.el8.x86_64.rpm"
           },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efivar-libs-37-4.el8.x86_64.rpm"
-          },
           "sha256:482e8619051fd7c027e06c206a016fa53c9b7d49afdc725fd38ff0375ab89318": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/kmod-25-17.el8.x86_64.rpm"
           },
@@ -2829,9 +2591,6 @@
           },
           "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgpg-error-1.31-1.el8.x86_64.rpm"
-          },
-          "sha256:4c701e1403db5d73039735e499674b1ae5dc6750080a505d542c711247f0e5b1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/mdadm-4.1-15.el8.x86_64.rpm"
           },
           "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/bzip2-libs-1.0.6-26.el8.x86_64.rpm"
@@ -2881,9 +2640,6 @@
           "sha256:53d9bb412615966acdf9a6b1c26c5899a9c2c0b76a27f360d3d6076536d2540a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libpng-1.6.34-5.el8.x86_64.rpm"
           },
-          "sha256:5525219fbc5e4a65a7074d23b25645b930dffa96981e28971d821b62e7a30a0a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-crypto-2.24-5.el8.x86_64.rpm"
-          },
           "sha256:5579ecdd5bd802f6aaf445eee712817d356923797f79833cbbe599e8df998bd0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/NetworkManager-cloud-setup-1.30.0-7.el8.x86_64.rpm"
           },
@@ -2904,9 +2660,6 @@
           },
           "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-libsemanage-2.9-6.el8.x86_64.rpm"
-          },
-          "sha256:5b5618571dd17467bd96a18bd9c57a0b5ea52401eb21299459e6c04ec93fcf8b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-utils-2.24-5.el8.x86_64.rpm"
           },
           "sha256:5b861df3b533dad96725ad66609c8aedef77d38b4856aab149b7bfc90cfd9f20": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/subscription-manager-1.28.13-2.el8.x86_64.rpm"
@@ -2931,9 +2684,6 @@
           },
           "sha256:6103a6b9eb69f8b79999371c124bdc21f1bedd64c8d67a73a06daf2f6307956f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-linux-procfs-0.6.3-1.el8.noarch.rpm"
-          },
-          "sha256:6161073140cd2b57627c3d98709dfbf50da251ed848768cc26027ffcacfcbce7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/udisks2-2.9.0-6.el8.x86_64.rpm"
           },
           "sha256:616b23d84d2c4f85463c1b72cf1fcc2c99eeac38e94ade7318a195072d139641": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-setuptools-39.2.0-6.el8.noarch.rpm"
@@ -2997,9 +2747,6 @@
           },
           "sha256:703f78e932f243ccf2890039ab582176b829f4dfc302a4c9a4e48189eb3a0bd2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/ca-certificates-2020.2.41-80.0.el8_2.noarch.rpm"
-          },
-          "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgudev-232-4.el8.x86_64.rpm"
           },
           "sha256:716c655cda9bbb4dc7eea0f8c80888fb9daddc1fc95d3504d4454fcb917e08f8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libuuid-2.32.1-27.el8.x86_64.rpm"
@@ -3073,9 +2820,6 @@
           "sha256:802263173d9c487fc3ca584cc2a5b7b7bb49ac0d12d9026b3246d50fd0888fb1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/dbus-glib-0.110-2.el8.x86_64.rpm"
           },
-          "sha256:812063b70caf78ab378defe4fa4dd0215175b58a18666729e86b9ed7b0f4e62e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/nss-util-3.53.1-17.el8_3.x86_64.rpm"
-          },
           "sha256:8279fe19cca94c3817693378a7d48d420bb9c4dee0775bfb3f9c329193edc237": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/hdparm-9.54-3.el8.x86_64.rpm"
           },
@@ -3106,12 +2850,6 @@
           "sha256:887ab12f323cddd75fa61df9cf3acb0e77be27d0a0dcd5eafb99f68eb74ddbd8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/dnf-4.4.2-11.el8.noarch.rpm"
           },
-          "sha256:89a735c5fa600fff61f81c198f3a312a7958d3b1adb9d17af30ae5e25a690fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/fwupd-1.5.5-3.el8.x86_64.rpm"
-          },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8a85c0adf8b0987359c26fbfedfadba998dd807c5a00751eca768f0e13af7f48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/iproute-5.9.0-4.el8.x86_64.rpm"
           },
@@ -3129,9 +2867,6 @@
           },
           "sha256:8c4b5140b61fa1e491d76462c2137e81d19c5fbc7e0a91329d91c8d8427ea696": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/python3-unbound-1.7.3-15.el8.x86_64.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8d371e753071edc796d2eadb8278980290511be6279fdf46649c81b859497d6a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/prefixdevname-0.1.0-6.el8.x86_64.rpm"
@@ -3172,9 +2907,6 @@
           "sha256:947b4e4eebec21501ca62e2a7ff9baae0e4e7c59584fbba4b6276a402cfbb45b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/vim-minimal-8.0.1763-15.el8.x86_64.rpm"
           },
-          "sha256:94fa34d24dec1e26a9d1c1e4e7213c87d792fafaf106d09daecfa25ac928e809": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/ModemManager-glib-1.10.8-2.el8.x86_64.rpm"
-          },
           "sha256:9560ff328ff89cdea202354f17e852c69fc41de1ed008e5dd1a86ffadb89c6f1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libverto-0.3.0-5.el8.x86_64.rpm"
           },
@@ -3196,9 +2928,6 @@
           "sha256:98a589d7e1cdea9d974aa43f688e55333eed11ce7cb2037d45cc2e69bce579b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/usermode-1.113-1.el8.x86_64.rpm"
           },
-          "sha256:98afa549d41462a811cce159dc06e06840bcf24eca9d784f77e19214d149e7d7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-fs-2.24-5.el8.x86_64.rpm"
-          },
           "sha256:995831ad6397fbd6e91038c6889981a0b7c649c95192999dc184b98c26d48fea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/initscripts-10.00.15-1.el8.x86_64.rpm"
           },
@@ -3213,12 +2942,6 @@
           },
           "sha256:9a9ca6857f517f1249d2eb496fe904590d6203e4a9547a28e0b23f21c4cae24a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/polkit-pkla-compat-0.1-12.el8.x86_64.rpm"
-          },
-          "sha256:9afe10fb4f998fdae77b6f04c7dc923fed6113e8989c575106b443c64e399e8b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-mdraid-2.24-5.el8.x86_64.rpm"
-          },
-          "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/mokutil-0.3.0-11.el8.x86_64.rpm"
           },
           "sha256:9c5594fcac97c0f8813d7a188e2368e3b1095025fc4a0ecbd5d17e54c0c93f97": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libmnl-1.0.4-6.el8.x86_64.rpm"
@@ -3307,20 +3030,11 @@
           "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/rootfiles-8.1-22.el8.noarch.rpm"
           },
-          "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
-          },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
           "sha256:afb86bb3de3f8b6f8ea6be0318f95d6938749ccf91e0cabe5d95c0f197d5de1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/hardlink-1.3-6.el8.x86_64.rpm"
           },
           "sha256:affab770e241d6c70cb271cbe5f84d02a946ad1b4d17d36f74dab74e9ca8fd7f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/gawk-4.2.1-2.el8.x86_64.rpm"
-          },
-          "sha256:b16406b22409f7572257441e446d717447f0dbbca820249113c386a876aa6d29": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/nss-softokn-3.53.1-17.el8_3.x86_64.rpm"
           },
           "sha256:b16b74a33e1cbbdf69ce43d869eafc87b325510de731e07d41f3325aa1645fdb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libdb-utils-5.3.28-40.el8.x86_64.rpm"
@@ -3358,9 +3072,6 @@
           "sha256:b6f01f401d1c040362469c3c7601ee8c139d58703391140da55a037af5f23521": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/platform-python-3.6.8-37.el8.x86_64.rpm"
           },
-          "sha256:b748e312645dd47cc314fc4523fdcf7351fe25c12a4d3369e838552bae2393c1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/nss-sysinit-3.53.1-17.el8_3.x86_64.rpm"
-          },
           "sha256:b7a4c23277095c56526a55d7d21a06cfd5b5581f9d5afcc7822f19209599335f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/cpio-2.12-10.el8.x86_64.rpm"
           },
@@ -3372,9 +3083,6 @@
           },
           "sha256:b9584e6823ffe9ccf79282bd57ee076a1e3a71c4c1020a20b5e1975141a50f14": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/basesystem-11-5.el8.noarch.rpm"
-          },
-          "sha256:b98e03599e8c2cd67910a3fcfddf42de4eecff18f79b306a7a7a58b89473d8b1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-part-2.24-5.el8.x86_64.rpm"
           },
           "sha256:b9d0a4c0e16db4c05b2d0690216d8c5da2db7d67bc765a00ce2a32c5f810c245": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/pkgconf-1.4.2-1.el8.x86_64.rpm"
@@ -3430,9 +3138,6 @@
           "sha256:c4e93daa6d0f0648f4dc694400bd35b8bc01a0d98228054735a9b6bc4c35b920": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/irqbalance-1.4.0-6.el8.x86_64.rpm"
           },
-          "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm"
-          },
           "sha256:c60aede8488f68a001f3495bd6e6d894fc3a44bb488f4550b5970ab5904d0a1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/geolite2-country-20180605-1.el8.noarch.rpm"
           },
@@ -3460,9 +3165,6 @@
           "sha256:ccfdbebdf0575395a80f2fa55e49c8358ca601fdbb0685f37e8c584226264eca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/python3-pytz-2017.2-9.el8.noarch.rpm"
           },
-          "sha256:cd56f00ccd7461260b174616ee0306a54cfb19c05a5637af98d4f876fb8682c9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-loop-2.24-5.el8.x86_64.rpm"
-          },
           "sha256:cd7c30d21e7240f60f0861c229e17fda43e855ab4c78fab39f47f7ae2be5720e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libmetalink-0.1.3-7.el8.x86_64.rpm"
           },
@@ -3471,9 +3173,6 @@
           },
           "sha256:ce7e129103cab9de8081b9752a9990a632b5930e371988892e671bb47d42d14e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/acl-2.2.53-1.el8.x86_64.rpm"
-          },
-          "sha256:cf0fc74feaf99f8c57a9ebdc8cb4371e6bcca905fab6f44ba408443a7cfe3651": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/grub2-efi-x64-2.02-99.el8.x86_64.rpm"
           },
           "sha256:d0006232910077e383b9b960ae54b2e6d7619e1929fe5735d04d505c5369f3fd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libsss_nss_idmap-2.4.0-9.el8.x86_64.rpm"
@@ -3505,9 +3204,6 @@
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/timedatex-0.5-3.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d54be2b80512ce12631ee626114441cecc5b4fd12e96e916ae903336de5c1283": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-subscription-manager-rhsm-1.28.13-2.el8.x86_64.rpm"
           },
@@ -3535,14 +3231,8 @@
           "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
           },
-          "sha256:d975cde9db186a1f4b258436bf019237ca8b78ac4ae00f90eddb536689e6210d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-2.24-5.el8.x86_64.rpm"
-          },
           "sha256:d9dcb469e4c1a90f2e0ed3332d37feb88f804c882aae21fb6dfdeb6564dccfe5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/pciutils-3.7.0-1.el8.x86_64.rpm"
-          },
-          "sha256:d9e5cea8712d1093241ba300b86d4349b46e51dcecbee4a88692dd2a4027a270": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/nss-softokn-freebl-3.53.1-17.el8_3.x86_64.rpm"
           },
           "sha256:db8bc154626bdd906a1f50104031a5042bbe91db7f5a1473657795eedd4158c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-setools-4.3.0-2.el8.x86_64.rpm"
@@ -3664,9 +3354,6 @@
           "sha256:f65164e882881ea96672081f0d990f51372d3d3d8dbeb63360c5b3a28ef6e229": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-libxml2-2.9.7-9.el8.x86_64.rpm"
           },
-          "sha256:f65b195bd738fb4a12b7761b868cd9caecaa67a547c927cc27c0762c5da97d03": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-swap-2.24-5.el8.x86_64.rpm"
-          },
           "sha256:f6eabee17654187308fd32a13de35b2aa1ca88515c1544af88f63893cb19b048": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libxml2-2.9.7-9.el8.x86_64.rpm"
           },
@@ -3691,14 +3378,8 @@
           "sha256:fa38da11fac69d66c239bdd5b723d550a570861e3f8a8187f105828fbdcca4a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/cyrus-sasl-lib-2.1.27-5.el8.x86_64.rpm"
           },
-          "sha256:fa89bdb6b367bc7bb31ff620202b787fef7efaf4f356c7c4b1f097a95060bb6d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libudisks2-2.9.0-6.el8.x86_64.rpm"
-          },
           "sha256:fbfd40e61b1951c777727c2cee2e8d3ef2ba336eeff549059d93aa26e940950b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/kexec-tools-2.0.20-46.el8.x86_64.rpm"
-          },
-          "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
           },
           "sha256:fcf5bc2da92b16f7e8f70837873347b2ac4a4f8ac752caad45898c676c06865a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libnfsidmap-2.3.3-41.el8.x86_64.rpm"
@@ -3966,15 +3647,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -5419,15 +5091,6 @@
     ],
     "os": [
       {
-        "name": "ModemManager-glib",
-        "epoch": 0,
-        "version": "1.10.8",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/ModemManager-glib-1.10.8-2.el8.x86_64.rpm",
-        "checksum": "sha256:94fa34d24dec1e26a9d1c1e4e7213c87d792fafaf106d09daecfa25ac928e809"
-      },
-      {
         "name": "NetworkManager",
         "epoch": 1,
         "version": "1.30.0",
@@ -5543,15 +5206,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/brotli-1.0.6-3.el8.x86_64.rpm",
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
-      },
-      {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
       },
       {
         "name": "bzip2-libs",
@@ -5878,15 +5532,6 @@
         "checksum": "sha256:406cc8322105f3a1706feaca414609d4be582d4e2290541239077bc39a6307cd"
       },
       {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "049",
@@ -5948,33 +5593,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/e2fsprogs-libs-1.45.6-1.el8.x86_64.rpm",
         "checksum": "sha256:435d017c887d981b8f485f94f1efc8342f082e76c64bfb058e7f218dcc8a69dd"
-      },
-      {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
       },
       {
         "name": "elfutils-debuginfod-client",
@@ -6083,15 +5701,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/fuse-libs-2.9.7-12.el8.x86_64.rpm",
         "checksum": "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.5.5",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/fwupd-1.5.5-3.el8.x86_64.rpm",
-        "checksum": "sha256:89a735c5fa600fff61f81c198f3a312a7958d3b1adb9d17af30ae5e25a690fb9"
       },
       {
         "name": "gawk",
@@ -6263,15 +5872,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/grub2-common-2.02-99.el8.noarch.rpm",
         "checksum": "sha256:f7b414c1fd118f998d4253a9fdad7aacad7c858f327efdd830b06604a9d65f07"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "99.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/grub2-efi-x64-2.02-99.el8.x86_64.rpm",
-        "checksum": "sha256:cf0fc74feaf99f8c57a9ebdc8cb4371e6bcca905fab6f44ba408443a7cfe3651"
       },
       {
         "name": "grub2-pc",
@@ -6805,15 +6405,6 @@
         "checksum": "sha256:eb3732b52b805b28192463682e961408db8c6449bb27e733081cff62e77194b3"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.4.1",
@@ -6848,24 +6439,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgpg-error-1.31-1.el8.x86_64.rpm",
         "checksum": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-      },
-      {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "232",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgudev-232-4.el8.x86_64.rpm",
-        "checksum": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgusb-0.3.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
       },
       {
         "name": "libibverbs",
@@ -6929,15 +6502,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libldb-2.2.0-2.el8.x86_64.rpm",
         "checksum": "sha256:01e2b6c30bf5eea790cc1c7a13e403e2afa4f4307b63148788820209a87e3bb8"
-      },
-      {
-        "name": "libmbim",
-        "epoch": 0,
-        "version": "1.20.2",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libmbim-1.20.2-1.el8.x86_64.rpm",
-        "checksum": "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a"
       },
       {
         "name": "libmetalink",
@@ -7093,15 +6657,6 @@
         "checksum": "sha256:df169d238e43e575b61b9eb02a392d9c2c75fe6b0bb678f8d8ca27e169347372"
       },
       {
-        "name": "libqmi",
-        "epoch": 0,
-        "version": "1.24.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libqmi-1.24.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:19c4c7dec378a3c21c8f2d4b9940fcf27f06fb1edf773eaeb185f664cb439a52"
-      },
-      {
         "name": "libref_array",
         "epoch": 0,
         "version": "0.1.5",
@@ -7208,15 +6763,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libsmartcols-2.32.1-27.el8.x86_64.rpm",
         "checksum": "sha256:5e8c3337e3ed2e31bab967ae331e58f5d7e5534f10ac4677d97e35ba282ade51"
-      },
-      {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
       },
       {
         "name": "libsolv",
@@ -7444,15 +6990,6 @@
         "checksum": "sha256:f6eabee17654187308fd32a13de35b2aa1ca88515c1544af88f63893cb19b048"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libyaml",
         "epoch": 0,
         "version": "0.1.7",
@@ -7552,15 +7089,6 @@
         "checksum": "sha256:7b6856dc4dc1d88d9c3c9597fb824b5776af59f045087bdb2713d64045216a36"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "15.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/mdadm-4.1-15.el8.x86_64.rpm",
-        "checksum": "sha256:4c701e1403db5d73039735e499674b1ae5dc6750080a505d542c711247f0e5b1"
-      },
-      {
         "name": "memstrack",
         "epoch": 0,
         "version": "0.1.11",
@@ -7577,15 +7105,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/microcode_ctl-20210216-1.el8.x86_64.rpm",
         "checksum": "sha256:2c695e34267183659e95c654d6ebe2fa979e8afe52fcfb4d698d42fdca588ac5"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/mokutil-0.3.0-11.el8.x86_64.rpm",
-        "checksum": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
       },
       {
         "name": "mozjs60",
@@ -8551,15 +8070,6 @@
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.4",
-        "release": "2.el8_1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm",
-        "checksum": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -8938,96 +8448,6 @@
         "checksum": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "14.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libatasmart-0.19-14.el8.x86_64.rpm",
-        "checksum": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:d975cde9db186a1f4b258436bf019237ca8b78ac4ae00f90eddb536689e6210d"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-crypto-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:5525219fbc5e4a65a7074d23b25645b930dffa96981e28971d821b62e7a30a0a"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-fs-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:98afa549d41462a811cce159dc06e06840bcf24eca9d784f77e19214d149e7d7"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-loop-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:cd56f00ccd7461260b174616ee0306a54cfb19c05a5637af98d4f876fb8682c9"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-mdraid-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:9afe10fb4f998fdae77b6f04c7dc923fed6113e8989c575106b443c64e399e8b"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-part-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:b98e03599e8c2cd67910a3fcfddf42de4eecff18f79b306a7a7a58b89473d8b1"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-swap-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:f65b195bd738fb4a12b7761b868cd9caecaa67a547c927cc27c0762c5da97d03"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-utils-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:5b5618571dd17467bd96a18bd9c57a0b5ea52401eb21299459e6c04ec93fcf8b"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libbytesize-1.4-3.el8.x86_64.rpm",
-        "checksum": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.10",
@@ -9055,15 +8475,6 @@
         "checksum": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
       },
       {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libudisks2-2.9.0-6.el8.x86_64.rpm",
-        "checksum": "sha256:fa89bdb6b367bc7bb31ff620202b787fef7efaf4f356c7c4b1f097a95060bb6d"
-      },
-      {
         "name": "libxkbcommon",
         "epoch": 0,
         "version": "0.9.1",
@@ -9071,60 +8482,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libxkbcommon-0.9.1-1.el8.x86_64.rpm",
         "checksum": "sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072"
-      },
-      {
-        "name": "nspr",
-        "epoch": 0,
-        "version": "4.25.0",
-        "release": "2.el8_2",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/nspr-4.25.0-2.el8_2.x86_64.rpm",
-        "checksum": "sha256:29902a3f54d6a29167c9111c1a10c9bd2308a198d05fc524db085beecc50f50b"
-      },
-      {
-        "name": "nss",
-        "epoch": 0,
-        "version": "3.53.1",
-        "release": "17.el8_3",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/nss-3.53.1-17.el8_3.x86_64.rpm",
-        "checksum": "sha256:1b76a3999023a1a118be030f6e3165a925d48399f38302afef555d5327a533e1"
-      },
-      {
-        "name": "nss-softokn",
-        "epoch": 0,
-        "version": "3.53.1",
-        "release": "17.el8_3",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/nss-softokn-3.53.1-17.el8_3.x86_64.rpm",
-        "checksum": "sha256:b16406b22409f7572257441e446d717447f0dbbca820249113c386a876aa6d29"
-      },
-      {
-        "name": "nss-softokn-freebl",
-        "epoch": 0,
-        "version": "3.53.1",
-        "release": "17.el8_3",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/nss-softokn-freebl-3.53.1-17.el8_3.x86_64.rpm",
-        "checksum": "sha256:d9e5cea8712d1093241ba300b86d4349b46e51dcecbee4a88692dd2a4027a270"
-      },
-      {
-        "name": "nss-sysinit",
-        "epoch": 0,
-        "version": "3.53.1",
-        "release": "17.el8_3",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/nss-sysinit-3.53.1-17.el8_3.x86_64.rpm",
-        "checksum": "sha256:b748e312645dd47cc314fc4523fdcf7351fe25c12a4d3369e838552bae2393c1"
-      },
-      {
-        "name": "nss-util",
-        "epoch": 0,
-        "version": "3.53.1",
-        "release": "17.el8_3",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/nss-util-3.53.1-17.el8_3.x86_64.rpm",
-        "checksum": "sha256:812063b70caf78ab378defe4fa4dd0215175b58a18666729e86b9ed7b0f4e62e"
       },
       {
         "name": "oddjob",
@@ -9262,15 +8619,6 @@
         "checksum": "sha256:2da4af0a0bcc46163e4d83e85b77f1ac03a15fb10647730b09f5d38b2027370d"
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/udisks2-2.9.0-6.el8.x86_64.rpm",
-        "checksum": "sha256:6161073140cd2b57627c3d98709dfbf50da251ed848768cc26027ffcacfcbce7"
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.7.3",
@@ -9278,15 +8626,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/unbound-libs-1.7.3-15.el8.x86_64.rpm",
         "checksum": "sha256:6a43c0a0605f6a5e3e155ca1d2e1bfdf5a8986a282b04c1c160d9e0148fb02af"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.11",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm",
-        "checksum": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
       },
       {
         "name": "xkeyboard-config",

--- a/test/data/manifests/rhel_84-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ec2_ha-boot.json
@@ -130,9 +130,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:a70958925902f87c5105a79fb5858e375711c8f101e0755c093b120c6e604dd7"
                   },
                   {
@@ -647,9 +644,6 @@
                 "origin": "org.osbuild.source",
                 "references": [
                   {
-                    "id": "sha256:94fa34d24dec1e26a9d1c1e4e7213c87d792fafaf106d09daecfa25ac928e809"
-                  },
-                  {
                     "id": "sha256:31fb540e3627eb73c3df66dd46cdfcab276a612d1d0949fb2afa3ffdf69fb3ab"
                   },
                   {
@@ -690,9 +684,6 @@
                   },
                   {
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
-                  },
-                  {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
                     "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
@@ -827,9 +818,6 @@
                     "id": "sha256:406cc8322105f3a1706feaca414609d4be582d4e2290541239077bc39a6307cd"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:a70958925902f87c5105a79fb5858e375711c8f101e0755c093b120c6e604dd7"
                   },
                   {
@@ -849,15 +837,6 @@
                   },
                   {
                     "id": "sha256:435d017c887d981b8f485f94f1efc8342f082e76c64bfb058e7f218dcc8a69dd"
-                  },
-                  {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
                   },
                   {
                     "id": "sha256:13e921e308e602b3527a93dacf0fc9bcada110e9dd3fdc1a338b3fd708b85aac"
@@ -897,9 +876,6 @@
                   },
                   {
                     "id": "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042"
-                  },
-                  {
-                    "id": "sha256:89a735c5fa600fff61f81c198f3a312a7958d3b1adb9d17af30ae5e25a690fb9"
                   },
                   {
                     "id": "sha256:affab770e241d6c70cb271cbe5f84d02a946ad1b4d17d36f74dab74e9ca8fd7f"
@@ -957,9 +933,6 @@
                   },
                   {
                     "id": "sha256:f7b414c1fd118f998d4253a9fdad7aacad7c858f327efdd830b06604a9d65f07"
-                  },
-                  {
-                    "id": "sha256:cf0fc74feaf99f8c57a9ebdc8cb4371e6bcca905fab6f44ba408443a7cfe3651"
                   },
                   {
                     "id": "sha256:ac2bd89f2af4378018de5193b7f0f58c1f93e627fac256c7d5ac21950fe4df17"
@@ -1154,9 +1127,6 @@
                     "id": "sha256:eb3732b52b805b28192463682e961408db8c6449bb27e733081cff62e77194b3"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:d5d4156b88b64a7d7e86ed0a7fdb3adb7bfc815ec413a4aba74d70cf8f831aea"
                   },
                   {
@@ -1167,12 +1137,6 @@
                   },
                   {
                     "id": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-                  },
-                  {
-                    "id": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-                  },
-                  {
-                    "id": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
                   },
                   {
                     "id": "sha256:edb1ddaad8b4559bd271fb99b99395cedbb6290876571f2d4554684b1b8e6547"
@@ -1197,9 +1161,6 @@
                   },
                   {
                     "id": "sha256:01e2b6c30bf5eea790cc1c7a13e403e2afa4f4307b63148788820209a87e3bb8"
-                  },
-                  {
-                    "id": "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a"
                   },
                   {
                     "id": "sha256:cd7c30d21e7240f60f0861c229e17fda43e855ab4c78fab39f47f7ae2be5720e"
@@ -1256,9 +1217,6 @@
                     "id": "sha256:a506765865ee31210532f16af156f54ea9431ba1763269d3a39c9ebf0adf5163"
                   },
                   {
-                    "id": "sha256:19c4c7dec378a3c21c8f2d4b9940fcf27f06fb1edf773eaeb185f664cb439a52"
-                  },
-                  {
                     "id": "sha256:507442831068c749ba21b22bd96993a1a2a6c74dd53c55f34c7f81a21554c82d"
                   },
                   {
@@ -1293,9 +1251,6 @@
                   },
                   {
                     "id": "sha256:5e8c3337e3ed2e31bab967ae331e58f5d7e5534f10ac4677d97e35ba282ade51"
-                  },
-                  {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
                   },
                   {
                     "id": "sha256:c07cca867b98c959c67cda988ed8bf9f111f9fc61b635d39b2823513811eade4"
@@ -1379,9 +1334,6 @@
                     "id": "sha256:f6eabee17654187308fd32a13de35b2aa1ca88515c1544af88f63893cb19b048"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15"
                   },
                   {
@@ -1424,16 +1376,10 @@
                     "id": "sha256:7b6856dc4dc1d88d9c3c9597fb824b5776af59f045087bdb2713d64045216a36"
                   },
                   {
-                    "id": "sha256:4c701e1403db5d73039735e499674b1ae5dc6750080a505d542c711247f0e5b1"
-                  },
-                  {
                     "id": "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd"
                   },
                   {
                     "id": "sha256:2c695e34267183659e95c654d6ebe2fa979e8afe52fcfb4d698d42fdca588ac5"
-                  },
-                  {
-                    "id": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -1892,9 +1838,6 @@
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
                   },
                   {
-                    "id": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
-                  },
-                  {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
                   },
                   {
@@ -2150,36 +2093,6 @@
                     "id": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
                   },
                   {
-                    "id": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-                  },
-                  {
-                    "id": "sha256:d975cde9db186a1f4b258436bf019237ca8b78ac4ae00f90eddb536689e6210d"
-                  },
-                  {
-                    "id": "sha256:5525219fbc5e4a65a7074d23b25645b930dffa96981e28971d821b62e7a30a0a"
-                  },
-                  {
-                    "id": "sha256:98afa549d41462a811cce159dc06e06840bcf24eca9d784f77e19214d149e7d7"
-                  },
-                  {
-                    "id": "sha256:cd56f00ccd7461260b174616ee0306a54cfb19c05a5637af98d4f876fb8682c9"
-                  },
-                  {
-                    "id": "sha256:9afe10fb4f998fdae77b6f04c7dc923fed6113e8989c575106b443c64e399e8b"
-                  },
-                  {
-                    "id": "sha256:b98e03599e8c2cd67910a3fcfddf42de4eecff18f79b306a7a7a58b89473d8b1"
-                  },
-                  {
-                    "id": "sha256:f65b195bd738fb4a12b7761b868cd9caecaa67a547c927cc27c0762c5da97d03"
-                  },
-                  {
-                    "id": "sha256:5b5618571dd17467bd96a18bd9c57a0b5ea52401eb21299459e6c04ec93fcf8b"
-                  },
-                  {
-                    "id": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-                  },
-                  {
                     "id": "sha256:bfe5c8ea12012936cc59981a10728e95d5fdadd3e893457af7a27c464d8cb6ba"
                   },
                   {
@@ -2187,9 +2100,6 @@
                   },
                   {
                     "id": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
-                  },
-                  {
-                    "id": "sha256:fa89bdb6b367bc7bb31ff620202b787fef7efaf4f356c7c4b1f097a95060bb6d"
                   },
                   {
                     "id": "sha256:b1b5660d070a5cf322ecb1c0bf36a8282362f01e0fa4041e11ddbeef1524eef8"
@@ -2375,13 +2285,7 @@
                     "id": "sha256:bafc9ec3dd737b0dbdf179b9d9b4c8a9b5c1a92423eae1e4eb3047522107695e"
                   },
                   {
-                    "id": "sha256:6161073140cd2b57627c3d98709dfbf50da251ed848768cc26027ffcacfcbce7"
-                  },
-                  {
                     "id": "sha256:6a43c0a0605f6a5e3e155ca1d2e1bfdf5a8986a282b04c1c160d9e0148fb02af"
-                  },
-                  {
-                    "id": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
                   },
                   {
                     "id": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
@@ -2463,9 +2367,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -2646,23 +2548,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -2670,13 +2559,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-305.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -2741,20 +2626,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2771,44 +2644,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -2816,8 +2654,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -2843,28 +2681,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -2874,18 +2696,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -2903,8 +2713,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -3084,9 +2894,6 @@
           "sha256:197b12db401b9a501bc92f6b000be37af4b89d874463810e074fdf6acb563f39": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libblkid-2.32.1-27.el8.x86_64.rpm"
           },
-          "sha256:19c4c7dec378a3c21c8f2d4b9940fcf27f06fb1edf773eaeb185f664cb439a52": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libqmi-1.24.0-1.el8.x86_64.rpm"
-          },
           "sha256:19dba7cb30c3cb598886326df0ec1114c6e195a57c9ce3a8b78b83555e9e8648": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/geolite2-city-20180605-1.el8.noarch.rpm"
           },
@@ -3120,9 +2927,6 @@
           "sha256:1d47e465939bba5bcf9c37be2516e60d6c9449ccee70a54a6133df989ac8b1f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libksba-1.3.5-7.el8.x86_64.rpm"
           },
-          "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libatasmart-0.19-14.el8.x86_64.rpm"
-          },
           "sha256:1dc1dbd0aa4dad715b3242468d4841f2f35bf6aa60d8e1928ee692784b12da1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libsecret-0.18.6-1.el8.x86_64.rpm"
           },
@@ -3134,9 +2938,6 @@
           },
           "sha256:206de21c82d76de550bcc1959138472640b0a950a311b753203f5dfe5b201b7b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/ipcalc-0.2.4-4.el8.x86_64.rpm"
-          },
-          "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libmbim-1.20.2-1.el8.x86_64.rpm"
           },
           "sha256:20dec130e4fd0a2146443791ca7ade6e079cea691d93711813d5f483b691c55a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-ethtool-0.14-3.el8.x86_64.rpm"
@@ -3249,15 +3050,6 @@
           "sha256:2f47fe4fe818d6f4eef117287aef700380aa7f1bd50931cada45efc0be05603c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/coreutils-8.30-8.el8.x86_64.rpm"
           },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
-          "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
-          },
           "sha256:30f3eca78f87fb66d9797a252df9217ec755e7a9034edf44deec5943dde4ba54": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/grub2-tools-2.02-99.el8.x86_64.rpm"
           },
@@ -3339,9 +3131,6 @@
           "sha256:3b78a074b7f24acab538bb0dc3296dd465f796a54e32ae3b097668c8e15cfea2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/filesystem-3.8-3.el8.x86_64.rpm"
           },
-          "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
-          },
           "sha256:3dc82857e070870d00a5d44e2ff597bdb3f7eb9784c84807c170086729c61825": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/file-libs-5.33-16.el8_3.1.x86_64.rpm"
           },
@@ -3420,9 +3209,6 @@
           "sha256:4786abf2d8d6db7603e0ab29fd4746fcaf32caffda9976e3d7ee90f513957e30": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/corosynclib-3.1.0-3.el8.x86_64.rpm"
           },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efivar-libs-37-4.el8.x86_64.rpm"
-          },
           "sha256:4811ab95c1d50ef7380e2c5937ae4490f8e28f56cf787c189437d1709e4423fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/perl-podlators-4.11-1.el8.noarch.rpm"
           },
@@ -3482,9 +3268,6 @@
           },
           "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgpg-error-1.31-1.el8.x86_64.rpm"
-          },
-          "sha256:4c701e1403db5d73039735e499674b1ae5dc6750080a505d542c711247f0e5b1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/mdadm-4.1-15.el8.x86_64.rpm"
           },
           "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/bzip2-libs-1.0.6-26.el8.x86_64.rpm"
@@ -3552,9 +3335,6 @@
           "sha256:53d9bb412615966acdf9a6b1c26c5899a9c2c0b76a27f360d3d6076536d2540a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libpng-1.6.34-5.el8.x86_64.rpm"
           },
-          "sha256:5525219fbc5e4a65a7074d23b25645b930dffa96981e28971d821b62e7a30a0a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-crypto-2.24-5.el8.x86_64.rpm"
-          },
           "sha256:5571eef678ca33b3f9b451145c3fa1e5344c4a9b5f2c0245bcbcea4cf225b3c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/fence-agents-rsa-4.2.1-65.el8.noarch.rpm"
           },
@@ -3591,9 +3371,6 @@
           "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-libsemanage-2.9-6.el8.x86_64.rpm"
           },
-          "sha256:5b5618571dd17467bd96a18bd9c57a0b5ea52401eb21299459e6c04ec93fcf8b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-utils-2.24-5.el8.x86_64.rpm"
-          },
           "sha256:5b861df3b533dad96725ad66609c8aedef77d38b4856aab149b7bfc90cfd9f20": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/subscription-manager-1.28.13-2.el8.x86_64.rpm"
           },
@@ -3623,9 +3400,6 @@
           },
           "sha256:6103a6b9eb69f8b79999371c124bdc21f1bedd64c8d67a73a06daf2f6307956f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-linux-procfs-0.6.3-1.el8.noarch.rpm"
-          },
-          "sha256:6161073140cd2b57627c3d98709dfbf50da251ed848768cc26027ffcacfcbce7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/udisks2-2.9.0-6.el8.x86_64.rpm"
           },
           "sha256:616b23d84d2c4f85463c1b72cf1fcc2c99eeac38e94ade7318a195072d139641": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-setuptools-39.2.0-6.el8.noarch.rpm"
@@ -3710,9 +3484,6 @@
           },
           "sha256:703f78e932f243ccf2890039ab582176b829f4dfc302a4c9a4e48189eb3a0bd2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/ca-certificates-2020.2.41-80.0.el8_2.noarch.rpm"
-          },
-          "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgudev-232-4.el8.x86_64.rpm"
           },
           "sha256:716c655cda9bbb4dc7eea0f8c80888fb9daddc1fc95d3504d4454fcb917e08f8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libuuid-2.32.1-27.el8.x86_64.rpm"
@@ -3864,12 +3635,6 @@
           "sha256:887ab12f323cddd75fa61df9cf3acb0e77be27d0a0dcd5eafb99f68eb74ddbd8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/dnf-4.4.2-11.el8.noarch.rpm"
           },
-          "sha256:89a735c5fa600fff61f81c198f3a312a7958d3b1adb9d17af30ae5e25a690fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/fwupd-1.5.5-3.el8.x86_64.rpm"
-          },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8a85c0adf8b0987359c26fbfedfadba998dd807c5a00751eca768f0e13af7f48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/iproute-5.9.0-4.el8.x86_64.rpm"
           },
@@ -3893,9 +3658,6 @@
           },
           "sha256:8c4b5140b61fa1e491d76462c2137e81d19c5fbc7e0a91329d91c8d8427ea696": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/python3-unbound-1.7.3-15.el8.x86_64.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8d371e753071edc796d2eadb8278980290511be6279fdf46649c81b859497d6a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/prefixdevname-0.1.0-6.el8.x86_64.rpm"
@@ -3942,9 +3704,6 @@
           "sha256:947b4e4eebec21501ca62e2a7ff9baae0e4e7c59584fbba4b6276a402cfbb45b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/vim-minimal-8.0.1763-15.el8.x86_64.rpm"
           },
-          "sha256:94fa34d24dec1e26a9d1c1e4e7213c87d792fafaf106d09daecfa25ac928e809": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/ModemManager-glib-1.10.8-2.el8.x86_64.rpm"
-          },
           "sha256:9560ff328ff89cdea202354f17e852c69fc41de1ed008e5dd1a86ffadb89c6f1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libverto-0.3.0-5.el8.x86_64.rpm"
           },
@@ -3969,9 +3728,6 @@
           "sha256:98a589d7e1cdea9d974aa43f688e55333eed11ce7cb2037d45cc2e69bce579b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/usermode-1.113-1.el8.x86_64.rpm"
           },
-          "sha256:98afa549d41462a811cce159dc06e06840bcf24eca9d784f77e19214d149e7d7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-fs-2.24-5.el8.x86_64.rpm"
-          },
           "sha256:995831ad6397fbd6e91038c6889981a0b7c649c95192999dc184b98c26d48fea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/initscripts-10.00.15-1.el8.x86_64.rpm"
           },
@@ -3986,12 +3742,6 @@
           },
           "sha256:9a9ca6857f517f1249d2eb496fe904590d6203e4a9547a28e0b23f21c4cae24a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/polkit-pkla-compat-0.1-12.el8.x86_64.rpm"
-          },
-          "sha256:9afe10fb4f998fdae77b6f04c7dc923fed6113e8989c575106b443c64e399e8b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-mdraid-2.24-5.el8.x86_64.rpm"
-          },
-          "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/mokutil-0.3.0-11.el8.x86_64.rpm"
           },
           "sha256:9c5594fcac97c0f8813d7a188e2368e3b1095025fc4a0ecbd5d17e54c0c93f97": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libmnl-1.0.4-6.el8.x86_64.rpm"
@@ -4125,12 +3875,6 @@
           "sha256:ae227b724debc457222bad34884f3bc43b17a8d0449a6567d557755fa1c95398": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/fence-agents-ipmilan-4.2.1-65.el8.noarch.rpm"
           },
-          "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
-          },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
           "sha256:afb86bb3de3f8b6f8ea6be0318f95d6938749ccf91e0cabe5d95c0f197d5de1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/hardlink-1.3-6.el8.x86_64.rpm"
           },
@@ -4218,9 +3962,6 @@
           "sha256:b9584e6823ffe9ccf79282bd57ee076a1e3a71c4c1020a20b5e1975141a50f14": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/basesystem-11-5.el8.noarch.rpm"
           },
-          "sha256:b98e03599e8c2cd67910a3fcfddf42de4eecff18f79b306a7a7a58b89473d8b1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-part-2.24-5.el8.x86_64.rpm"
-          },
           "sha256:b9d0a4c0e16db4c05b2d0690216d8c5da2db7d67bc765a00ce2a32c5f810c245": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/pkgconf-1.4.2-1.el8.x86_64.rpm"
           },
@@ -4302,9 +4043,6 @@
           "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libxslt-1.1.32-6.el8.x86_64.rpm"
           },
-          "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm"
-          },
           "sha256:c60aede8488f68a001f3495bd6e6d894fc3a44bb488f4550b5970ab5904d0a1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/geolite2-country-20180605-1.el8.noarch.rpm"
           },
@@ -4344,9 +4082,6 @@
           "sha256:ccfdbebdf0575395a80f2fa55e49c8358ca601fdbb0685f37e8c584226264eca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/python3-pytz-2017.2-9.el8.noarch.rpm"
           },
-          "sha256:cd56f00ccd7461260b174616ee0306a54cfb19c05a5637af98d4f876fb8682c9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-loop-2.24-5.el8.x86_64.rpm"
-          },
           "sha256:cd7c30d21e7240f60f0861c229e17fda43e855ab4c78fab39f47f7ae2be5720e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libmetalink-0.1.3-7.el8.x86_64.rpm"
           },
@@ -4361,9 +4096,6 @@
           },
           "sha256:cec7c0d124dc281ef4befe001bceabbeba83c5bf05c9a4430102b490cc8bf8e8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/perl-Socket-2.027-3.el8.x86_64.rpm"
-          },
-          "sha256:cf0fc74feaf99f8c57a9ebdc8cb4371e6bcca905fab6f44ba408443a7cfe3651": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/grub2-efi-x64-2.02-99.el8.x86_64.rpm"
           },
           "sha256:d0006232910077e383b9b960ae54b2e6d7619e1929fe5735d04d505c5369f3fd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libsss_nss_idmap-2.4.0-9.el8.x86_64.rpm"
@@ -4410,9 +4142,6 @@
           "sha256:d5114f76a7ee99c97c34468a1ba936ca3a3e0ab28e8f3a9011dc2ef7d08f0400": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-r8.4-20220705/Packages/libknet1-compress-plugins-all-1.18-1.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d54be2b80512ce12631ee626114441cecc5b4fd12e96e916ae903336de5c1283": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-subscription-manager-rhsm-1.28.13-2.el8.x86_64.rpm"
           },
@@ -4454,9 +4183,6 @@
           },
           "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
-          },
-          "sha256:d975cde9db186a1f4b258436bf019237ca8b78ac4ae00f90eddb536689e6210d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-2.24-5.el8.x86_64.rpm"
           },
           "sha256:d9dcb469e4c1a90f2e0ed3332d37feb88f804c882aae21fb6dfdeb6564dccfe5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/pciutils-3.7.0-1.el8.x86_64.rpm"
@@ -4659,9 +4385,6 @@
           "sha256:f65164e882881ea96672081f0d990f51372d3d3d8dbeb63360c5b3a28ef6e229": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-libxml2-2.9.7-9.el8.x86_64.rpm"
           },
-          "sha256:f65b195bd738fb4a12b7761b868cd9caecaa67a547c927cc27c0762c5da97d03": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-swap-2.24-5.el8.x86_64.rpm"
-          },
           "sha256:f6eab450eba999fc1faab9875201ff07acfbed80c0f5ab361f84725193e6f87a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-r8.4-20220705/Packages/pacemaker-2.0.5-9.el8.x86_64.rpm"
           },
@@ -4695,9 +4418,6 @@
           "sha256:fa38da11fac69d66c239bdd5b723d550a570861e3f8a8187f105828fbdcca4a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/cyrus-sasl-lib-2.1.27-5.el8.x86_64.rpm"
           },
-          "sha256:fa89bdb6b367bc7bb31ff620202b787fef7efaf4f356c7c4b1f097a95060bb6d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libudisks2-2.9.0-6.el8.x86_64.rpm"
-          },
           "sha256:fbc4b08c066f448d213ba5acbcf20a8931c419d2238bc0fe5dd39f71bdf9b30d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/perl-Scalar-List-Utils-1.49-2.el8.x86_64.rpm"
           },
@@ -4706,9 +4426,6 @@
           },
           "sha256:fbfd606dc15511008730584a3849e251010b5abc278b1adfed72488f85b0865e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/fence-agents-ifmib-4.2.1-65.el8.noarch.rpm"
-          },
-          "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
           },
           "sha256:fcf5bc2da92b16f7e8f70837873347b2ac4a4f8ac752caad45898c676c06865a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libnfsidmap-2.3.3-41.el8.x86_64.rpm"
@@ -4982,15 +4699,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -6435,15 +6143,6 @@
     ],
     "os": [
       {
-        "name": "ModemManager-glib",
-        "epoch": 0,
-        "version": "1.10.8",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/ModemManager-glib-1.10.8-2.el8.x86_64.rpm",
-        "checksum": "sha256:94fa34d24dec1e26a9d1c1e4e7213c87d792fafaf106d09daecfa25ac928e809"
-      },
-      {
         "name": "NetworkManager",
         "epoch": 1,
         "version": "1.30.0",
@@ -6568,15 +6267,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/brotli-1.0.6-3.el8.x86_64.rpm",
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
-      },
-      {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
       },
       {
         "name": "bzip2",
@@ -6975,15 +6665,6 @@
         "checksum": "sha256:406cc8322105f3a1706feaca414609d4be582d4e2290541239077bc39a6307cd"
       },
       {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "049",
@@ -7045,33 +6726,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/e2fsprogs-libs-1.45.6-1.el8.x86_64.rpm",
         "checksum": "sha256:435d017c887d981b8f485f94f1efc8342f082e76c64bfb058e7f218dcc8a69dd"
-      },
-      {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
       },
       {
         "name": "elfutils-debuginfod-client",
@@ -7189,15 +6843,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/fuse-libs-2.9.7-12.el8.x86_64.rpm",
         "checksum": "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.5.5",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/fwupd-1.5.5-3.el8.x86_64.rpm",
-        "checksum": "sha256:89a735c5fa600fff61f81c198f3a312a7958d3b1adb9d17af30ae5e25a690fb9"
       },
       {
         "name": "gawk",
@@ -7369,15 +7014,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/grub2-common-2.02-99.el8.noarch.rpm",
         "checksum": "sha256:f7b414c1fd118f998d4253a9fdad7aacad7c858f327efdd830b06604a9d65f07"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "99.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/grub2-efi-x64-2.02-99.el8.x86_64.rpm",
-        "checksum": "sha256:cf0fc74feaf99f8c57a9ebdc8cb4371e6bcca905fab6f44ba408443a7cfe3651"
       },
       {
         "name": "grub2-pc",
@@ -7956,15 +7592,6 @@
         "checksum": "sha256:eb3732b52b805b28192463682e961408db8c6449bb27e733081cff62e77194b3"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.4.1",
@@ -7999,24 +7626,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgpg-error-1.31-1.el8.x86_64.rpm",
         "checksum": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-      },
-      {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "232",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgudev-232-4.el8.x86_64.rpm",
-        "checksum": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgusb-0.3.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
       },
       {
         "name": "libibverbs",
@@ -8089,15 +7698,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libldb-2.2.0-2.el8.x86_64.rpm",
         "checksum": "sha256:01e2b6c30bf5eea790cc1c7a13e403e2afa4f4307b63148788820209a87e3bb8"
-      },
-      {
-        "name": "libmbim",
-        "epoch": 0,
-        "version": "1.20.2",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libmbim-1.20.2-1.el8.x86_64.rpm",
-        "checksum": "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a"
       },
       {
         "name": "libmetalink",
@@ -8262,15 +7862,6 @@
         "checksum": "sha256:a506765865ee31210532f16af156f54ea9431ba1763269d3a39c9ebf0adf5163"
       },
       {
-        "name": "libqmi",
-        "epoch": 0,
-        "version": "1.24.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libqmi-1.24.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:19c4c7dec378a3c21c8f2d4b9940fcf27f06fb1edf773eaeb185f664cb439a52"
-      },
-      {
         "name": "libref_array",
         "epoch": 0,
         "version": "0.1.5",
@@ -8377,15 +7968,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libsmartcols-2.32.1-27.el8.x86_64.rpm",
         "checksum": "sha256:5e8c3337e3ed2e31bab967ae331e58f5d7e5534f10ac4677d97e35ba282ade51"
-      },
-      {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
       },
       {
         "name": "libsolv",
@@ -8631,15 +8213,6 @@
         "checksum": "sha256:f6eabee17654187308fd32a13de35b2aa1ca88515c1544af88f63893cb19b048"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libxslt",
         "epoch": 0,
         "version": "1.1.32",
@@ -8766,15 +8339,6 @@
         "checksum": "sha256:7b6856dc4dc1d88d9c3c9597fb824b5776af59f045087bdb2713d64045216a36"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "15.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/mdadm-4.1-15.el8.x86_64.rpm",
-        "checksum": "sha256:4c701e1403db5d73039735e499674b1ae5dc6750080a505d542c711247f0e5b1"
-      },
-      {
         "name": "memstrack",
         "epoch": 0,
         "version": "0.1.11",
@@ -8791,15 +8355,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/microcode_ctl-20210216-1.el8.x86_64.rpm",
         "checksum": "sha256:2c695e34267183659e95c654d6ebe2fa979e8afe52fcfb4d698d42fdca588ac5"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/mokutil-0.3.0-11.el8.x86_64.rpm",
-        "checksum": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
       },
       {
         "name": "mozjs60",
@@ -10170,15 +9725,6 @@
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.4",
-        "release": "2.el8_1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm",
-        "checksum": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -10944,96 +10490,6 @@
         "checksum": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "14.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libatasmart-0.19-14.el8.x86_64.rpm",
-        "checksum": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:d975cde9db186a1f4b258436bf019237ca8b78ac4ae00f90eddb536689e6210d"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-crypto-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:5525219fbc5e4a65a7074d23b25645b930dffa96981e28971d821b62e7a30a0a"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-fs-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:98afa549d41462a811cce159dc06e06840bcf24eca9d784f77e19214d149e7d7"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-loop-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:cd56f00ccd7461260b174616ee0306a54cfb19c05a5637af98d4f876fb8682c9"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-mdraid-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:9afe10fb4f998fdae77b6f04c7dc923fed6113e8989c575106b443c64e399e8b"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-part-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:b98e03599e8c2cd67910a3fcfddf42de4eecff18f79b306a7a7a58b89473d8b1"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-swap-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:f65b195bd738fb4a12b7761b868cd9caecaa67a547c927cc27c0762c5da97d03"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-utils-2.24-5.el8.x86_64.rpm",
-        "checksum": "sha256:5b5618571dd17467bd96a18bd9c57a0b5ea52401eb21299459e6c04ec93fcf8b"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libbytesize-1.4-3.el8.x86_64.rpm",
-        "checksum": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.10",
@@ -11059,15 +10515,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libmaxminddb-1.2.0-10.el8.x86_64.rpm",
         "checksum": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
-      },
-      {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libudisks2-2.9.0-6.el8.x86_64.rpm",
-        "checksum": "sha256:fa89bdb6b367bc7bb31ff620202b787fef7efaf4f356c7c4b1f097a95060bb6d"
       },
       {
         "name": "libwsman1",
@@ -11619,15 +11066,6 @@
         "checksum": "sha256:bafc9ec3dd737b0dbdf179b9d9b4c8a9b5c1a92423eae1e4eb3047522107695e"
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/udisks2-2.9.0-6.el8.x86_64.rpm",
-        "checksum": "sha256:6161073140cd2b57627c3d98709dfbf50da251ed848768cc26027ffcacfcbce7"
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.7.3",
@@ -11635,15 +11073,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/unbound-libs-1.7.3-15.el8.x86_64.rpm",
         "checksum": "sha256:6a43c0a0605f6a5e3e155ca1d2e1bfdf5a8986a282b04c1c160d9e0148fb02af"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.11",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm",
-        "checksum": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
       },
       {
         "name": "xkeyboard-config",

--- a/test/data/manifests/rhel_84-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ec2_sap-boot.json
@@ -156,9 +156,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:a70958925902f87c5105a79fb5858e375711c8f101e0755c093b120c6e604dd7"
                   },
                   {
@@ -676,9 +673,6 @@
                 "origin": "org.osbuild.source",
                 "references": [
                   {
-                    "id": "sha256:94fa34d24dec1e26a9d1c1e4e7213c87d792fafaf106d09daecfa25ac928e809"
-                  },
-                  {
                     "id": "sha256:31fb540e3627eb73c3df66dd46cdfcab276a612d1d0949fb2afa3ffdf69fb3ab"
                   },
                   {
@@ -752,9 +746,6 @@
                   },
                   {
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
-                  },
-                  {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
                     "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
@@ -943,15 +934,6 @@
                     "id": "sha256:d5689e2894c59a375f985b5228b32e78d10b4ceeec9fd7c79f2000480494d368"
                   },
                   {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
-                  },
-                  {
                     "id": "sha256:13e921e308e602b3527a93dacf0fc9bcada110e9dd3fdc1a338b3fd708b85aac"
                   },
                   {
@@ -1007,9 +989,6 @@
                   },
                   {
                     "id": "sha256:37582049ed88df6e03737825880fee090de4be0e13859b8f055973b6e1828d86"
-                  },
-                  {
-                    "id": "sha256:89a735c5fa600fff61f81c198f3a312a7958d3b1adb9d17af30ae5e25a690fb9"
                   },
                   {
                     "id": "sha256:affab770e241d6c70cb271cbe5f84d02a946ad1b4d17d36f74dab74e9ca8fd7f"
@@ -1073,9 +1052,6 @@
                   },
                   {
                     "id": "sha256:f7b414c1fd118f998d4253a9fdad7aacad7c858f327efdd830b06604a9d65f07"
-                  },
-                  {
-                    "id": "sha256:cf0fc74feaf99f8c57a9ebdc8cb4371e6bcca905fab6f44ba408443a7cfe3651"
                   },
                   {
                     "id": "sha256:ac2bd89f2af4378018de5193b7f0f58c1f93e627fac256c7d5ac21950fe4df17"
@@ -1312,9 +1288,6 @@
                     "id": "sha256:eb3732b52b805b28192463682e961408db8c6449bb27e733081cff62e77194b3"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:d5d4156b88b64a7d7e86ed0a7fdb3adb7bfc815ec413a4aba74d70cf8f831aea"
                   },
                   {
@@ -1361,9 +1334,6 @@
                   },
                   {
                     "id": "sha256:01e2b6c30bf5eea790cc1c7a13e403e2afa4f4307b63148788820209a87e3bb8"
-                  },
-                  {
-                    "id": "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a"
                   },
                   {
                     "id": "sha256:cd7c30d21e7240f60f0861c229e17fda43e855ab4c78fab39f47f7ae2be5720e"
@@ -1435,9 +1405,6 @@
                     "id": "sha256:df169d238e43e575b61b9eb02a392d9c2c75fe6b0bb678f8d8ca27e169347372"
                   },
                   {
-                    "id": "sha256:19c4c7dec378a3c21c8f2d4b9940fcf27f06fb1edf773eaeb185f664cb439a52"
-                  },
-                  {
                     "id": "sha256:507442831068c749ba21b22bd96993a1a2a6c74dd53c55f34c7f81a21554c82d"
                   },
                   {
@@ -1475,9 +1442,6 @@
                   },
                   {
                     "id": "sha256:5f03649d149041787deb87574cc673d7b5fb41ab47adad76a0a5aa5f84fc697a"
-                  },
-                  {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
                   },
                   {
                     "id": "sha256:c07cca867b98c959c67cda988ed8bf9f111f9fc61b635d39b2823513811eade4"
@@ -1573,9 +1537,6 @@
                     "id": "sha256:f6eabee17654187308fd32a13de35b2aa1ca88515c1544af88f63893cb19b048"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15"
                   },
                   {
@@ -1646,9 +1607,6 @@
                   },
                   {
                     "id": "sha256:48e1edacae05696360d0dd0706b2d3debb617ae15e9f7ce47e528839231a6c25"
-                  },
-                  {
-                    "id": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -2141,9 +2099,6 @@
                   },
                   {
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
-                  },
-                  {
-                    "id": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
                   },
                   {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
@@ -3065,9 +3020,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -3365,23 +3318,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -3389,13 +3329,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto processor.max_cstate=1 intel_idle.max_cstate=1",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-305.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -3460,20 +3396,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -3490,44 +3414,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -3535,8 +3424,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -3562,28 +3451,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -3593,18 +3466,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -3622,8 +3483,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -3869,9 +3730,6 @@
           "sha256:197b12db401b9a501bc92f6b000be37af4b89d874463810e074fdf6acb563f39": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libblkid-2.32.1-27.el8.x86_64.rpm"
           },
-          "sha256:19c4c7dec378a3c21c8f2d4b9940fcf27f06fb1edf773eaeb185f664cb439a52": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libqmi-1.24.0-1.el8.x86_64.rpm"
-          },
           "sha256:19dba7cb30c3cb598886326df0ec1114c6e195a57c9ce3a8b78b83555e9e8648": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/geolite2-city-20180605-1.el8.noarch.rpm"
           },
@@ -3925,9 +3783,6 @@
           },
           "sha256:206de21c82d76de550bcc1959138472640b0a950a311b753203f5dfe5b201b7b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/ipcalc-0.2.4-4.el8.x86_64.rpm"
-          },
-          "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libmbim-1.20.2-1.el8.x86_64.rpm"
           },
           "sha256:20dec130e4fd0a2146443791ca7ade6e079cea691d93711813d5f483b691c55a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-ethtool-0.14-3.el8.x86_64.rpm"
@@ -4109,14 +3964,8 @@
           "sha256:2f47fe4fe818d6f4eef117287aef700380aa7f1bd50931cada45efc0be05603c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/coreutils-8.30-8.el8.x86_64.rpm"
           },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
           "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
           "sha256:30f3eca78f87fb66d9797a252df9217ec755e7a9034edf44deec5943dde4ba54": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/grub2-tools-2.02-99.el8.x86_64.rpm"
@@ -4336,9 +4185,6 @@
           },
           "sha256:474a66a4cf3d5a00286be40c15bad69ea1ac63a9424a1ff44f20a548a7686f7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libfastjson-0.99.8-2.el8.x86_64.rpm"
-          },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efivar-libs-37-4.el8.x86_64.rpm"
           },
           "sha256:4811ab95c1d50ef7380e2c5937ae4490f8e28f56cf787c189437d1709e4423fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/perl-podlators-4.11-1.el8.noarch.rpm"
@@ -4925,12 +4771,6 @@
           "sha256:8942bd9f52f391bf7832aa81ebc8ea66f420ed5b4d35310666997567f0ea9351": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/pinfo-0.6.10-18.el8.x86_64.rpm"
           },
-          "sha256:89a735c5fa600fff61f81c198f3a312a7958d3b1adb9d17af30ae5e25a690fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/fwupd-1.5.5-3.el8.x86_64.rpm"
-          },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8a85c0adf8b0987359c26fbfedfadba998dd807c5a00751eca768f0e13af7f48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/iproute-5.9.0-4.el8.x86_64.rpm"
           },
@@ -4951,9 +4791,6 @@
           },
           "sha256:8c4b5140b61fa1e491d76462c2137e81d19c5fbc7e0a91329d91c8d8427ea696": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/python3-unbound-1.7.3-15.el8.x86_64.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8ca5dd4feea941aba58c6d6e981883bca79704dba06583f880c0bf5e0cf4efcf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/desktop-file-utils-0.23-8.el8.x86_64.rpm"
@@ -5023,9 +4860,6 @@
           },
           "sha256:94a62eec408c64e96f0fb85b3266b4740dbd9e5f0e33d8135e21db10a1de3d38": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/vdo-6.2.4.14-14.el8.x86_64.rpm"
-          },
-          "sha256:94fa34d24dec1e26a9d1c1e4e7213c87d792fafaf106d09daecfa25ac928e809": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/ModemManager-glib-1.10.8-2.el8.x86_64.rpm"
           },
           "sha256:95065d7db6f91a57e453beede3f02c80f0b219722667c24cedeedfa44c843850": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libwayland-cursor-1.17.0-1.el8.x86_64.rpm"
@@ -5098,9 +4932,6 @@
           },
           "sha256:9afe10fb4f998fdae77b6f04c7dc923fed6113e8989c575106b443c64e399e8b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libblockdev-mdraid-2.24-5.el8.x86_64.rpm"
-          },
-          "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/mokutil-0.3.0-11.el8.x86_64.rpm"
           },
           "sha256:9b079ce20a6524d8e85d139b2ec2a7dd3f4f79fa283f68208b72b8091e6bde3b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/libXft-2.3.3-1.el8.x86_64.rpm"
@@ -5260,9 +5091,6 @@
           },
           "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
-          },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
           },
           "sha256:af017f523bf816179c5e9de9df7dad22a277531b7741d78871530f45b8288436": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ansible-2-20220705/Packages/a/ansible-2.9.27-1.el8ae.noarch.rpm"
@@ -5474,9 +5302,6 @@
           "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libxslt-1.1.32-6.el8.x86_64.rpm"
           },
-          "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm"
-          },
           "sha256:c60aede8488f68a001f3495bd6e6d894fc3a44bb488f4550b5970ab5904d0a1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/geolite2-country-20180605-1.el8.noarch.rpm"
           },
@@ -5549,9 +5374,6 @@
           "sha256:cec7c0d124dc281ef4befe001bceabbeba83c5bf05c9a4430102b490cc8bf8e8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/perl-Socket-2.027-3.el8.x86_64.rpm"
           },
-          "sha256:cf0fc74feaf99f8c57a9ebdc8cb4371e6bcca905fab6f44ba408443a7cfe3651": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/grub2-efi-x64-2.02-99.el8.x86_64.rpm"
-          },
           "sha256:cf3b992e8f7d04c45bbcd92ba93d70350b6a8a0b920cd11f58d7b808fdb256e0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-sap-r8.4-20220705/Packages/compat-sap-c++-10-10.2.1-1.el8.x86_64.rpm"
           },
@@ -5605,9 +5427,6 @@
           },
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/timedatex-0.5-3.el8.x86_64.rpm"
-          },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efibootmgr-16-1.el8.x86_64.rpm"
           },
           "sha256:d54be2b80512ce12631ee626114441cecc5b4fd12e96e916ae903336de5c1283": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/python3-subscription-manager-rhsm-1.28.13-2.el8.x86_64.rpm"
@@ -6277,15 +6096,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -7730,15 +7540,6 @@
     ],
     "os": [
       {
-        "name": "ModemManager-glib",
-        "epoch": 0,
-        "version": "1.10.8",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/ModemManager-glib-1.10.8-2.el8.x86_64.rpm",
-        "checksum": "sha256:94fa34d24dec1e26a9d1c1e4e7213c87d792fafaf106d09daecfa25ac928e809"
-      },
-      {
         "name": "NetworkManager",
         "epoch": 1,
         "version": "1.30.0",
@@ -7962,15 +7763,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/brotli-1.0.6-3.el8.x86_64.rpm",
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
-      },
-      {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
       },
       {
         "name": "bzip2",
@@ -8531,33 +8323,6 @@
         "checksum": "sha256:d5689e2894c59a375f985b5228b32e78d10b4ceeec9fd7c79f2000480494d368"
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
-      },
-      {
         "name": "elfutils-debuginfod-client",
         "epoch": 0,
         "version": "0.182",
@@ -8727,15 +8492,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/fuse3-libs-3.2.1-12.el8.x86_64.rpm",
         "checksum": "sha256:37582049ed88df6e03737825880fee090de4be0e13859b8f055973b6e1828d86"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.5.5",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/fwupd-1.5.5-3.el8.x86_64.rpm",
-        "checksum": "sha256:89a735c5fa600fff61f81c198f3a312a7958d3b1adb9d17af30ae5e25a690fb9"
       },
       {
         "name": "gawk",
@@ -8925,15 +8681,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/grub2-common-2.02-99.el8.noarch.rpm",
         "checksum": "sha256:f7b414c1fd118f998d4253a9fdad7aacad7c858f327efdd830b06604a9d65f07"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "99.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/grub2-efi-x64-2.02-99.el8.x86_64.rpm",
-        "checksum": "sha256:cf0fc74feaf99f8c57a9ebdc8cb4371e6bcca905fab6f44ba408443a7cfe3651"
       },
       {
         "name": "grub2-pc",
@@ -9638,15 +9385,6 @@
         "checksum": "sha256:eb3732b52b805b28192463682e961408db8c6449bb27e733081cff62e77194b3"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.4.1",
@@ -9789,15 +9527,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libldb-2.2.0-2.el8.x86_64.rpm",
         "checksum": "sha256:01e2b6c30bf5eea790cc1c7a13e403e2afa4f4307b63148788820209a87e3bb8"
-      },
-      {
-        "name": "libmbim",
-        "epoch": 0,
-        "version": "1.20.2",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libmbim-1.20.2-1.el8.x86_64.rpm",
-        "checksum": "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a"
       },
       {
         "name": "libmetalink",
@@ -10007,15 +9736,6 @@
         "checksum": "sha256:df169d238e43e575b61b9eb02a392d9c2c75fe6b0bb678f8d8ca27e169347372"
       },
       {
-        "name": "libqmi",
-        "epoch": 0,
-        "version": "1.24.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libqmi-1.24.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:19c4c7dec378a3c21c8f2d4b9940fcf27f06fb1edf773eaeb185f664cb439a52"
-      },
-      {
         "name": "libref_array",
         "epoch": 0,
         "version": "0.1.5",
@@ -10131,15 +9851,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libsmbclient-4.13.3-3.el8.x86_64.rpm",
         "checksum": "sha256:5f03649d149041787deb87574cc673d7b5fb41ab47adad76a0a5aa5f84fc697a"
-      },
-      {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
       },
       {
         "name": "libsolv",
@@ -10421,15 +10132,6 @@
         "checksum": "sha256:f6eabee17654187308fd32a13de35b2aa1ca88515c1544af88f63893cb19b048"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libxslt",
         "epoch": 0,
         "version": "1.1.32",
@@ -10644,15 +10346,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/mlocate-0.26-20.el8.x86_64.rpm",
         "checksum": "sha256:48e1edacae05696360d0dd0706b2d3debb617ae15e9f7ce47e528839231a6c25"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/mokutil-0.3.0-11.el8.x86_64.rpm",
-        "checksum": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
       },
       {
         "name": "mozjs60",
@@ -12129,15 +11822,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/shared-mime-info-1.9-3.el8.x86_64.rpm",
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.4",
-        "release": "2.el8_1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm",
-        "checksum": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
       },
       {
         "name": "slang",

--- a/test/data/manifests/rhel_85-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ec2-boot.json
@@ -2135,14 +2135,14 @@
                   "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
                 },
                 {
-                  "size": 1024000,
+                  "size": 1048576,
                   "start": 411648,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "CB07C243-BC44-4717-853E-28852021225B"
                 },
                 {
-                  "size": 19535839,
-                  "start": 1435648,
+                  "size": 19511263,
+                  "start": 1460224,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2178,8 +2178,7 @@
           {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
-              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
             },
             "devices": {
               "device": {
@@ -2187,7 +2186,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 411648,
-                  "size": 1024000,
+                  "size": 1048576,
                   "lock": true
                 }
               }
@@ -2204,8 +2203,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1435648,
-                  "size": 19535839,
+                  "start": 1460224,
+                  "size": 19511263,
                   "lock": true
                 }
               }
@@ -2236,7 +2235,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 411648,
-                  "size": 1024000
+                  "size": 1048576
                 }
               },
               "boot.efi": {
@@ -2251,8 +2250,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1435648,
-                  "size": 19535839
+                  "start": 1460224,
+                  "size": 19511263
                 }
               }
             },

--- a/test/data/manifests/rhel_85-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2-boot.json
@@ -120,9 +120,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:f72118d72067987ac1eeded4b04e95e709b263c27877f3eb1112859db33cb403"
                   },
                   {
@@ -609,9 +606,6 @@
                 "origin": "org.osbuild.source",
                 "references": [
                   {
-                    "id": "sha256:ad8cc7be9847717c0cd9b7878d62558817d47c4617f8e63c1d9e0aeb374d211d"
-                  },
-                  {
                     "id": "sha256:9d4cee9c7cdbf21fc4f6983ce07105f585310160e31f9a6bb94d3ce4f4ef3513"
                   },
                   {
@@ -649,9 +643,6 @@
                   },
                   {
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
-                  },
-                  {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
@@ -762,9 +753,6 @@
                     "id": "sha256:e74ce9c11ed27caf661d6fdd5c35234f912309c39da3c6288a017b0a6f3bccc0"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:f72118d72067987ac1eeded4b04e95e709b263c27877f3eb1112859db33cb403"
                   },
                   {
@@ -784,15 +772,6 @@
                   },
                   {
                     "id": "sha256:39f86feba904fc4c4a9a04a54576d6d3b4e9af344155aee9e4321c27b4742f0a"
-                  },
-                  {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
                   },
                   {
                     "id": "sha256:1291973fb1c479d3d3dab62d7dbcda052ab998779a0eb2e45427d0e2257d8db4"
@@ -829,9 +808,6 @@
                   },
                   {
                     "id": "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042"
-                  },
-                  {
-                    "id": "sha256:71ccc266b2790fd64b8f94793b17dfe94f0ec16396441e5364843e25ddfd9c7a"
                   },
                   {
                     "id": "sha256:affab770e241d6c70cb271cbe5f84d02a946ad1b4d17d36f74dab74e9ca8fd7f"
@@ -889,9 +865,6 @@
                   },
                   {
                     "id": "sha256:1136323a37c5940055c3891a260b26782b75ea986fb5fe02ad80364f60527450"
-                  },
-                  {
-                    "id": "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7"
                   },
                   {
                     "id": "sha256:06f6a82e268aa006507fb1f82f01893f996fd47ad1cfa5f839c7861e8fd317cf"
@@ -1071,9 +1044,6 @@
                     "id": "sha256:eb3732b52b805b28192463682e961408db8c6449bb27e733081cff62e77194b3"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:316b614d8b97e93f56a77b035245ada4dbaa8718828f943fe43038330b47726d"
                   },
                   {
@@ -1084,12 +1054,6 @@
                   },
                   {
                     "id": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-                  },
-                  {
-                    "id": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-                  },
-                  {
-                    "id": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
                   },
                   {
                     "id": "sha256:4a62975251933dcaff77fdbd7704e8a12bea0ecb6eaaae5ea5e552bedd6788ec"
@@ -1108,9 +1072,6 @@
                   },
                   {
                     "id": "sha256:8548b32627ba574a7eaf108af37b0dd302049c8c4a2ff8537a5f53260ad2f07c"
-                  },
-                  {
-                    "id": "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a"
                   },
                   {
                     "id": "sha256:9c5594fcac97c0f8813d7a188e2368e3b1095025fc4a0ecbd5d17e54c0c93f97"
@@ -1158,9 +1119,6 @@
                     "id": "sha256:df169d238e43e575b61b9eb02a392d9c2c75fe6b0bb678f8d8ca27e169347372"
                   },
                   {
-                    "id": "sha256:3ad80bb77d17e36bb6127b8552ffa93085321bca2c63e1b12db6136d5d7fee9f"
-                  },
-                  {
                     "id": "sha256:507442831068c749ba21b22bd96993a1a2a6c74dd53c55f34c7f81a21554c82d"
                   },
                   {
@@ -1195,9 +1153,6 @@
                   },
                   {
                     "id": "sha256:289066d1ee27ccac6bec18d021f843c8962ead4b4c940d579bfc429d5583006e"
-                  },
-                  {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
                   },
                   {
                     "id": "sha256:66d7caeabd800bbe2f34163fc4605f5762a6ffc3af94bc275acbfac0b56d66c7"
@@ -1275,9 +1230,6 @@
                     "id": "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf"
                   },
                   {
@@ -1311,16 +1263,10 @@
                     "id": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
                   },
                   {
-                    "id": "sha256:3a040b80f585f55f86b600520949cf321c8c365158dfad55533f22f9bf366050"
-                  },
-                  {
                     "id": "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd"
                   },
                   {
                     "id": "sha256:75027c5ff5527fe7b69e3de665aa44cca6e0ee65094600f88c1fc5e6c6a1037a"
-                  },
-                  {
-                    "id": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -1641,9 +1587,6 @@
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
                   },
                   {
-                    "id": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
-                  },
-                  {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
                   },
                   {
@@ -1770,36 +1713,6 @@
                     "id": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
                   },
                   {
-                    "id": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-                  },
-                  {
-                    "id": "sha256:c0309fbbf048d250de039aca136cc055bfa33faf2056803e18c48a3eba498c2f"
-                  },
-                  {
-                    "id": "sha256:fcaaef0ebc48422e70617c5cdcbe441580b790af9c5647c5b255b35957ec7311"
-                  },
-                  {
-                    "id": "sha256:ca2d9db71ecd56e0c406278bbed639962c27ed01e8206f144719df5c32f9aeb7"
-                  },
-                  {
-                    "id": "sha256:f114254f9dadd3dbedf108ab8d81bbb247d8eb19f9d018454a7c01d919a65c44"
-                  },
-                  {
-                    "id": "sha256:9dfef9a2900c658a3379ad843127609d4cbde7718f4f5b223f207288a978254a"
-                  },
-                  {
-                    "id": "sha256:8b05d986058c83b2041499ed8d1466073bd492319db781a50f8c5f2b9bbe447e"
-                  },
-                  {
-                    "id": "sha256:633e83df6ccdd33642cf71fb84456bb036398919ae21c36217bac19231783996"
-                  },
-                  {
-                    "id": "sha256:db515162530e2c50f9e271c33a4f3852bc92c57b2ec1aa1f7117a3d5f01dd467"
-                  },
-                  {
-                    "id": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-                  },
-                  {
                     "id": "sha256:bfe5c8ea12012936cc59981a10728e95d5fdadd3e893457af7a27c464d8cb6ba"
                   },
                   {
@@ -1809,28 +1722,7 @@
                     "id": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
                   },
                   {
-                    "id": "sha256:2d7bb5cff7b7f741621d92e12e56d3a32143fee999ab96d4ce4b148bcb387a70"
-                  },
-                  {
                     "id": "sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072"
-                  },
-                  {
-                    "id": "sha256:52aed1bbd2aa4041e599a453a9c4323775b26d2b1326ffb98ac6febbcab8c230"
-                  },
-                  {
-                    "id": "sha256:17b847a40817f2d3daead8c90aa4345c81964ca599c95abf02fbf91f7cd56612"
-                  },
-                  {
-                    "id": "sha256:594828a378b02e5cc08a4928382b54ec2b909098ae5bc084118e07bda873e6a4"
-                  },
-                  {
-                    "id": "sha256:308ba0bc3f5d96ace7ec3387e5d9ed43ea3c1a3c3a5c01fce93b3cafb9d8015d"
-                  },
-                  {
-                    "id": "sha256:df17a51144931d9350a2fc41e328969ab2f88fbcf5542c0b752e63c35c7630f1"
-                  },
-                  {
-                    "id": "sha256:9649b49d9992f28fc1e4f5eb95e31e24ba2a126e3192320d36e6e779c624fc6f"
                   },
                   {
                     "id": "sha256:0e0f05c3d39f4b3eee6a5786a6aea4c7ef5f5921bc6146489d1f97aa602f7d6d"
@@ -1878,13 +1770,7 @@
                     "id": "sha256:c7b4850fa0c575c67d7a4a90dd78045c0de7b29045e9710d0a90dc7f028336d2"
                   },
                   {
-                    "id": "sha256:d035722edaf14562b258e0a04aa5a68cff61c23af893c270497a66d74b579b3f"
-                  },
-                  {
                     "id": "sha256:e920a82cda55b110690f3c946ec2cd85f969599c71212463279763afcc33303d"
-                  },
-                  {
-                    "id": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
                   },
                   {
                     "id": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
@@ -1905,9 +1791,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -2088,23 +1972,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -2112,13 +1983,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-348.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -2183,20 +2050,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2213,44 +2068,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -2258,8 +2078,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -2285,28 +2105,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -2316,18 +2120,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -2345,8 +2137,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -2472,9 +2264,6 @@
           "sha256:176cd5cb58307c4a89ed986dbbcb765f306c08da3fa3fe2cb7b3e80076a3d7a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/sudo-1.8.29-7.el8.x86_64.rpm"
           },
-          "sha256:17b847a40817f2d3daead8c90aa4345c81964ca599c95abf02fbf91f7cd56612": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/nss-3.67.0-6.el8_4.x86_64.rpm"
-          },
           "sha256:17bf6351961fba4a5b5df923dcc4de54b5f8059a36f0d6a9f6b446a4e9b018e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-libcomps-0.1.16-2.el8.x86_64.rpm"
           },
@@ -2508,9 +2297,6 @@
           "sha256:1d47e465939bba5bcf9c37be2516e60d6c9449ccee70a54a6133df989ac8b1f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libksba-1.3.5-7.el8.x86_64.rpm"
           },
-          "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libatasmart-0.19-14.el8.x86_64.rpm"
-          },
           "sha256:1dc1dbd0aa4dad715b3242468d4841f2f35bf6aa60d8e1928ee692784b12da1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsecret-0.18.6-1.el8.x86_64.rpm"
           },
@@ -2534,9 +2320,6 @@
           },
           "sha256:206de21c82d76de550bcc1959138472640b0a950a311b753203f5dfe5b201b7b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/ipcalc-0.2.4-4.el8.x86_64.rpm"
-          },
-          "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libmbim-1.20.2-1.el8.x86_64.rpm"
           },
           "sha256:20b51fff03d35f8412666717e3e715642bc0d1e32fb847fd626ad82d75d47891": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/dracut-config-rescue-049-191.git20210920.el8.x86_64.rpm"
@@ -2610,9 +2393,6 @@
           "sha256:2bf6a5835ee856272ad37abc4f695536a157f4c51dcf5621bfcf323d22d091bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-librepo-1.14.0-2.el8.x86_64.rpm"
           },
-          "sha256:2d7bb5cff7b7f741621d92e12e56d3a32143fee999ab96d4ce4b148bcb387a70": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libudisks2-2.9.0-7.el8.x86_64.rpm"
-          },
           "sha256:2e175740ba876aa621422ed4971794320cde1115b01ff018de7ff8186e271e48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/authselect-1.2.2-3.el8.x86_64.rpm"
           },
@@ -2630,18 +2410,6 @@
           },
           "sha256:30028d0e27f207b39028942487bc15d3607db39296f294c51e43204b74bc54bf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/elfutils-libelf-0.185-1.el8.x86_64.rpm"
-          },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
-          "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
-          },
-          "sha256:308ba0bc3f5d96ace7ec3387e5d9ed43ea3c1a3c3a5c01fce93b3cafb9d8015d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/nss-softokn-freebl-3.67.0-6.el8_4.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
           "sha256:316b614d8b97e93f56a77b035245ada4dbaa8718828f943fe43038330b47726d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgcc-8.5.0-3.el8.x86_64.rpm"
@@ -2691,9 +2459,6 @@
           "sha256:39f86feba904fc4c4a9a04a54576d6d3b4e9af344155aee9e4321c27b4742f0a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/e2fsprogs-libs-1.45.6-2.el8.x86_64.rpm"
           },
-          "sha256:3a040b80f585f55f86b600520949cf321c8c365158dfad55533f22f9bf366050": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/mdadm-4.2-rc2.el8.x86_64.rpm"
-          },
           "sha256:3a1058c6ba468722090a74002a3239161771b0d8b444975bff891afd45bb672a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsysfs-2.1.0-24.el8.x86_64.rpm"
           },
@@ -2702,12 +2467,6 @@
           },
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
-          },
-          "sha256:3ad80bb77d17e36bb6127b8552ffa93085321bca2c63e1b12db6136d5d7fee9f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libqmi-1.24.0-3.el8.x86_64.rpm"
-          },
-          "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
           },
           "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm"
@@ -2753,9 +2512,6 @@
           },
           "sha256:47a81f0a9e0c5b33095964e0591d958a0ebfaf797c6890c624affd04dff04132": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/dmidecode-3.2-10.el8.x86_64.rpm"
-          },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/efivar-libs-37-4.el8.x86_64.rpm"
           },
           "sha256:49b6b2a486bd32714619e81782623f126486452bbd2295a2ab1f3e997b97d327": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/crontabs-1.11-17.20190603git.el8.noarch.rpm"
@@ -2829,9 +2585,6 @@
           "sha256:51eb082082e78afa70dd64591219c026d11cf7a6adf3771a36624c80be34dc3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/nettle-3.4.1-7.el8.x86_64.rpm"
           },
-          "sha256:52aed1bbd2aa4041e599a453a9c4323775b26d2b1326ffb98ac6febbcab8c230": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/nspr-4.32.0-1.el8_4.x86_64.rpm"
-          },
           "sha256:53849d779914a944acc126459911030c8ac8310ffcab354c6a7bcc4ef4af5bab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/e2fsprogs-1.45.6-2.el8.x86_64.rpm"
           },
@@ -2861,9 +2614,6 @@
           },
           "sha256:58d5f26daf746cf161e1be4fb6cda4e320ef2a624f0ab7913ee498b26aad8659": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-cryptography-3.2.1-5.el8.x86_64.rpm"
-          },
-          "sha256:594828a378b02e5cc08a4928382b54ec2b909098ae5bc084118e07bda873e6a4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/nss-softokn-3.67.0-6.el8_4.x86_64.rpm"
           },
           "sha256:59bf7b92f9eecb7868e960dc05c269a9df088d2dc71ce85cf77bfad68e206f0b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/python3-jsonschema-2.6.0-4.el8.noarch.rpm"
@@ -2907,9 +2657,6 @@
           "sha256:633b4eb78ff5fa0e9d7ae07a21fda93786d495ba4ee0f74f937051e3521511c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/systemd-239-51.el8.x86_64.rpm"
           },
-          "sha256:633e83df6ccdd33642cf71fb84456bb036398919ae21c36217bac19231783996": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-swap-2.24-7.el8.x86_64.rpm"
-          },
           "sha256:645419874806713b904eed22d9e7dd2ba076452c733f47822d0c05723311a951": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/sqlite-libs-3.26.0-15.el8.x86_64.rpm"
           },
@@ -2951,12 +2698,6 @@
           },
           "sha256:6ff975465dcff2d8b7f6f1efb8c865aff9baed1500e8f48e4a569700fb1208ea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/p11-kit-trust-0.23.22-1.el8.x86_64.rpm"
-          },
-          "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgudev-232-4.el8.x86_64.rpm"
-          },
-          "sha256:71ccc266b2790fd64b8f94793b17dfe94f0ec16396441e5364843e25ddfd9c7a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/fwupd-1.5.9-1.el8.x86_64.rpm"
           },
           "sha256:71cd412b54e9ae8e7718fa3827d8c92be5aad32a85e65e6250e0bd4008b53f7b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libbpf-0.4.0-1.el8.x86_64.rpm"
@@ -3054,12 +2795,6 @@
           "sha256:88783ea87d17ed7173aefeb0145e009220bb3050bbadda04cc00964f5d92820d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/shadow-utils-4.6-14.el8.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
-          "sha256:8b05d986058c83b2041499ed8d1466073bd492319db781a50f8c5f2b9bbe447e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-part-2.24-7.el8.x86_64.rpm"
-          },
           "sha256:8bc50d11af9a2696049cad3081e2efd78443640fd855ce8d4a9f2a5194c892bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/iproute-5.12.0-4.el8.x86_64.rpm"
           },
@@ -3068,9 +2803,6 @@
           },
           "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8d371e753071edc796d2eadb8278980290511be6279fdf46649c81b859497d6a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/prefixdevname-0.1.0-6.el8.x86_64.rpm"
@@ -3132,9 +2864,6 @@
           "sha256:964666dd7642680923e1d188a807119c15bdc4b8a2d9980b6d927e0665626030": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/systemd-pam-239-51.el8.x86_64.rpm"
           },
-          "sha256:9649b49d9992f28fc1e4f5eb95e31e24ba2a126e3192320d36e6e779c624fc6f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/nss-util-3.67.0-6.el8_4.x86_64.rpm"
-          },
           "sha256:9684e567554899e75aa51d3e63b04137cdb4fe84f93dbb4900b906a6dca901b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-libdnf-0.63.0-3.el8.x86_64.rpm"
           },
@@ -3159,9 +2888,6 @@
           "sha256:9a9ca6857f517f1249d2eb496fe904590d6203e4a9547a28e0b23f21c4cae24a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/polkit-pkla-compat-0.1-12.el8.x86_64.rpm"
           },
-          "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/mokutil-0.3.0-11.el8.x86_64.rpm"
-          },
           "sha256:9c5594fcac97c0f8813d7a188e2368e3b1095025fc4a0ecbd5d17e54c0c93f97": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libmnl-1.0.4-6.el8.x86_64.rpm"
           },
@@ -3173,9 +2899,6 @@
           },
           "sha256:9d4cee9c7cdbf21fc4f6983ce07105f585310160e31f9a6bb94d3ce4f4ef3513": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/NetworkManager-1.32.10-4.el8.x86_64.rpm"
-          },
-          "sha256:9dfef9a2900c658a3379ad843127609d4cbde7718f4f5b223f207288a978254a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-mdraid-2.24-7.el8.x86_64.rpm"
           },
           "sha256:9ead0dee2906b44ee3b05f2e57f387af91e3cdd9ad13ac52e1a5334214691068": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/dhcp-client-4.3.6-45.el8.x86_64.rpm"
@@ -3228,17 +2951,8 @@
           "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/rootfiles-8.1-22.el8.noarch.rpm"
           },
-          "sha256:ad8cc7be9847717c0cd9b7878d62558817d47c4617f8e63c1d9e0aeb374d211d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/ModemManager-glib-1.10.8-4.el8.x86_64.rpm"
-          },
           "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libxml2-2.9.7-9.el8_4.2.x86_64.rpm"
-          },
-          "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
-          },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
           },
           "sha256:afb34faa32b75d1c9c1d9c729bd27616c0fd1965a7fca433c56c318bf061df99": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/chrony-4.1-1.el8.x86_64.rpm"
@@ -3285,9 +2999,6 @@
           "sha256:b9d0a4c0e16db4c05b2d0690216d8c5da2db7d67bc765a00ce2a32c5f810c245": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/pkgconf-1.4.2-1.el8.x86_64.rpm"
           },
-          "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/grub2-efi-x64-2.02-106.el8.x86_64.rpm"
-          },
           "sha256:ba59500c8304ec75121cc2c5f9d5917748ff8b293aca3b49c9d1d971feb606f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/file-5.33-20.el8.x86_64.rpm"
           },
@@ -3308,9 +3019,6 @@
           },
           "sha256:bfe5c8ea12012936cc59981a10728e95d5fdadd3e893457af7a27c464d8cb6ba": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libestr-0.1.10-1.el8.x86_64.rpm"
-          },
-          "sha256:c0309fbbf048d250de039aca136cc055bfa33faf2056803e18c48a3eba498c2f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-2.24-7.el8.x86_64.rpm"
           },
           "sha256:c09618fd3dbb6f65f043e481b6e20cae06564bf452681723cab4a2d3b8dc407a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsss_nss_idmap-2.5.2-2.el8.x86_64.rpm"
@@ -3345,9 +3053,6 @@
           "sha256:c4e93daa6d0f0648f4dc694400bd35b8bc01a0d98228054735a9b6bc4c35b920": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/irqbalance-1.4.0-6.el8.x86_64.rpm"
           },
-          "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm"
-          },
           "sha256:c60aede8488f68a001f3495bd6e6d894fc3a44bb488f4550b5970ab5904d0a1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/geolite2-country-20180605-1.el8.noarch.rpm"
           },
@@ -3365,9 +3070,6 @@
           },
           "sha256:c8ee06469228d9321b19061dc6e7f1db48858563b8994224cdcb160f8ca3cedb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/sssd-client-2.5.2-2.el8.x86_64.rpm"
-          },
-          "sha256:ca2d9db71ecd56e0c406278bbed639962c27ed01e8206f144719df5c32f9aeb7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-fs-2.24-7.el8.x86_64.rpm"
           },
           "sha256:ca33ff1cbcd000cf8d7fb1d0e3a18dd9a2e61f321dbe1f83c7242e9684d34818": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libstdc++-8.5.0-3.el8.x86_64.rpm"
@@ -3404,9 +3106,6 @@
           },
           "sha256:d0188d22323619c9069c2de6f85ebe5302c76fde5f52ebd148988e75a75110dc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsigsegv-2.11-5.el8.x86_64.rpm"
-          },
-          "sha256:d035722edaf14562b258e0a04aa5a68cff61c23af893c270497a66d74b579b3f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/udisks2-2.9.0-7.el8.x86_64.rpm"
           },
           "sha256:d05f658981f3152e680010227c9c1e4e74857306ba883b0ddd68ac79fb0cbffe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/grub2-tools-minimal-2.02-106.el8.x86_64.rpm"
@@ -3447,9 +3146,6 @@
           "sha256:d50174632033170dfd1d8125f132962872c0042711e44ed59e91f6d2d26071c0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/polkit-libs-0.115-12.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d53449962dcd9266bab6c0af921875051ccc9fb752f3061f7bd66584824431ec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/sssd-nfs-idmap-2.5.2-2.el8.x86_64.rpm"
           },
@@ -3483,9 +3179,6 @@
           "sha256:daa11530884eae9f2ffdb112e99c2c7817ba4802a87b35a959d50bf5774126a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/grub2-tools-extra-2.02-106.el8.x86_64.rpm"
           },
-          "sha256:db515162530e2c50f9e271c33a4f3852bc92c57b2ec1aa1f7117a3d5f01dd467": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-utils-2.24-7.el8.x86_64.rpm"
-          },
           "sha256:db8bc154626bdd906a1f50104031a5042bbe91db7f5a1473657795eedd4158c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-setools-4.3.0-2.el8.x86_64.rpm"
           },
@@ -3500,9 +3193,6 @@
           },
           "sha256:df169d238e43e575b61b9eb02a392d9c2c75fe6b0bb678f8d8ca27e169347372": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libpwquality-1.4.4-3.el8.x86_64.rpm"
-          },
-          "sha256:df17a51144931d9350a2fc41e328969ab2f88fbcf5542c0b752e63c35c7630f1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/nss-sysinit-3.67.0-6.el8_4.x86_64.rpm"
           },
           "sha256:df49ae83611b2533047732fd1975981316d88e8faf35a64914714b97f8c6a662": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/coreutils-common-8.30-12.el8.x86_64.rpm"
@@ -3588,9 +3278,6 @@
           "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/lz4-libs-1.8.3-3.el8_4.x86_64.rpm"
           },
-          "sha256:f114254f9dadd3dbedf108ab8d81bbb247d8eb19f9d018454a7c01d919a65c44": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-loop-2.24-7.el8.x86_64.rpm"
-          },
           "sha256:f1784b0b9221581d9beac947a7a43cc9f4839ede18f38a0274461185788792a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-ply-3.9-9.el8.noarch.rpm"
           },
@@ -3641,12 +3328,6 @@
           },
           "sha256:fa38da11fac69d66c239bdd5b723d550a570861e3f8a8187f105828fbdcca4a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/cyrus-sasl-lib-2.1.27-5.el8.x86_64.rpm"
-          },
-          "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
-          },
-          "sha256:fcaaef0ebc48422e70617c5cdcbe441580b790af9c5647c5b255b35957ec7311": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-crypto-2.24-7.el8.x86_64.rpm"
           },
           "sha256:fd1f3109bd130e2dbbb57ea2f3a6d3419f9eef7108f1485f0d1386a563437614": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/gnutls-3.6.16-4.el8.x86_64.rpm"
@@ -3914,15 +3595,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -5286,15 +4958,6 @@
     ],
     "os": [
       {
-        "name": "ModemManager-glib",
-        "epoch": 0,
-        "version": "1.10.8",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/ModemManager-glib-1.10.8-4.el8.x86_64.rpm",
-        "checksum": "sha256:ad8cc7be9847717c0cd9b7878d62558817d47c4617f8e63c1d9e0aeb374d211d"
-      },
-      {
         "name": "NetworkManager",
         "epoch": 1,
         "version": "1.32.10",
@@ -5410,15 +5073,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/brotli-1.0.6-3.el8.x86_64.rpm",
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
-      },
-      {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
       },
       {
         "name": "bzip2-libs",
@@ -5745,15 +5399,6 @@
         "checksum": "sha256:e74ce9c11ed27caf661d6fdd5c35234f912309c39da3c6288a017b0a6f3bccc0"
       },
       {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "049",
@@ -5815,33 +5460,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/e2fsprogs-libs-1.45.6-2.el8.x86_64.rpm",
         "checksum": "sha256:39f86feba904fc4c4a9a04a54576d6d3b4e9af344155aee9e4321c27b4742f0a"
-      },
-      {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
       },
       {
         "name": "elfutils-debuginfod-client",
@@ -5950,15 +5568,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/fuse-libs-2.9.7-12.el8.x86_64.rpm",
         "checksum": "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.5.9",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/fwupd-1.5.9-1.el8.x86_64.rpm",
-        "checksum": "sha256:71ccc266b2790fd64b8f94793b17dfe94f0ec16396441e5364843e25ddfd9c7a"
       },
       {
         "name": "gawk",
@@ -6130,15 +5739,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/grub2-common-2.02-106.el8.noarch.rpm",
         "checksum": "sha256:1136323a37c5940055c3891a260b26782b75ea986fb5fe02ad80364f60527450"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "106.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/grub2-efi-x64-2.02-106.el8.x86_64.rpm",
-        "checksum": "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7"
       },
       {
         "name": "grub2-pc",
@@ -6672,15 +6272,6 @@
         "checksum": "sha256:eb3732b52b805b28192463682e961408db8c6449bb27e733081cff62e77194b3"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -6715,24 +6306,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgpg-error-1.31-1.el8.x86_64.rpm",
         "checksum": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-      },
-      {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "232",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgudev-232-4.el8.x86_64.rpm",
-        "checksum": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgusb-0.3.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
       },
       {
         "name": "libidn2",
@@ -6787,15 +6360,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libldb-2.3.0-2.el8.x86_64.rpm",
         "checksum": "sha256:8548b32627ba574a7eaf108af37b0dd302049c8c4a2ff8537a5f53260ad2f07c"
-      },
-      {
-        "name": "libmbim",
-        "epoch": 0,
-        "version": "1.20.2",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libmbim-1.20.2-1.el8.x86_64.rpm",
-        "checksum": "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a"
       },
       {
         "name": "libmnl",
@@ -6933,15 +6497,6 @@
         "checksum": "sha256:df169d238e43e575b61b9eb02a392d9c2c75fe6b0bb678f8d8ca27e169347372"
       },
       {
-        "name": "libqmi",
-        "epoch": 0,
-        "version": "1.24.0",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libqmi-1.24.0-3.el8.x86_64.rpm",
-        "checksum": "sha256:3ad80bb77d17e36bb6127b8552ffa93085321bca2c63e1b12db6136d5d7fee9f"
-      },
-      {
         "name": "libref_array",
         "epoch": 0,
         "version": "0.1.5",
@@ -7048,15 +6603,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsmartcols-2.32.1-28.el8.x86_64.rpm",
         "checksum": "sha256:289066d1ee27ccac6bec18d021f843c8962ead4b4c940d579bfc429d5583006e"
-      },
-      {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
       },
       {
         "name": "libsolv",
@@ -7284,15 +6830,6 @@
         "checksum": "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libyaml",
         "epoch": 0,
         "version": "0.1.7",
@@ -7392,15 +6929,6 @@
         "checksum": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "rc2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/mdadm-4.2-rc2.el8.x86_64.rpm",
-        "checksum": "sha256:3a040b80f585f55f86b600520949cf321c8c365158dfad55533f22f9bf366050"
-      },
-      {
         "name": "memstrack",
         "epoch": 0,
         "version": "0.1.11",
@@ -7417,15 +6945,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/microcode_ctl-20210608-1.el8.x86_64.rpm",
         "checksum": "sha256:75027c5ff5527fe7b69e3de665aa44cca6e0ee65094600f88c1fc5e6c6a1037a"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/mokutil-0.3.0-11.el8.x86_64.rpm",
-        "checksum": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
       },
       {
         "name": "mozjs60",
@@ -8382,15 +7901,6 @@
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.4",
-        "release": "2.el8_1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm",
-        "checksum": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -8769,96 +8279,6 @@
         "checksum": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "14.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libatasmart-0.19-14.el8.x86_64.rpm",
-        "checksum": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:c0309fbbf048d250de039aca136cc055bfa33faf2056803e18c48a3eba498c2f"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-crypto-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:fcaaef0ebc48422e70617c5cdcbe441580b790af9c5647c5b255b35957ec7311"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-fs-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:ca2d9db71ecd56e0c406278bbed639962c27ed01e8206f144719df5c32f9aeb7"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-loop-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:f114254f9dadd3dbedf108ab8d81bbb247d8eb19f9d018454a7c01d919a65c44"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-mdraid-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:9dfef9a2900c658a3379ad843127609d4cbde7718f4f5b223f207288a978254a"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-part-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:8b05d986058c83b2041499ed8d1466073bd492319db781a50f8c5f2b9bbe447e"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-swap-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:633e83df6ccdd33642cf71fb84456bb036398919ae21c36217bac19231783996"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-utils-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:db515162530e2c50f9e271c33a4f3852bc92c57b2ec1aa1f7117a3d5f01dd467"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libbytesize-1.4-3.el8.x86_64.rpm",
-        "checksum": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.10",
@@ -8886,15 +8306,6 @@
         "checksum": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
       },
       {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libudisks2-2.9.0-7.el8.x86_64.rpm",
-        "checksum": "sha256:2d7bb5cff7b7f741621d92e12e56d3a32143fee999ab96d4ce4b148bcb387a70"
-      },
-      {
         "name": "libxkbcommon",
         "epoch": 0,
         "version": "0.9.1",
@@ -8902,60 +8313,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libxkbcommon-0.9.1-1.el8.x86_64.rpm",
         "checksum": "sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072"
-      },
-      {
-        "name": "nspr",
-        "epoch": 0,
-        "version": "4.32.0",
-        "release": "1.el8_4",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/nspr-4.32.0-1.el8_4.x86_64.rpm",
-        "checksum": "sha256:52aed1bbd2aa4041e599a453a9c4323775b26d2b1326ffb98ac6febbcab8c230"
-      },
-      {
-        "name": "nss",
-        "epoch": 0,
-        "version": "3.67.0",
-        "release": "6.el8_4",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/nss-3.67.0-6.el8_4.x86_64.rpm",
-        "checksum": "sha256:17b847a40817f2d3daead8c90aa4345c81964ca599c95abf02fbf91f7cd56612"
-      },
-      {
-        "name": "nss-softokn",
-        "epoch": 0,
-        "version": "3.67.0",
-        "release": "6.el8_4",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/nss-softokn-3.67.0-6.el8_4.x86_64.rpm",
-        "checksum": "sha256:594828a378b02e5cc08a4928382b54ec2b909098ae5bc084118e07bda873e6a4"
-      },
-      {
-        "name": "nss-softokn-freebl",
-        "epoch": 0,
-        "version": "3.67.0",
-        "release": "6.el8_4",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/nss-softokn-freebl-3.67.0-6.el8_4.x86_64.rpm",
-        "checksum": "sha256:308ba0bc3f5d96ace7ec3387e5d9ed43ea3c1a3c3a5c01fce93b3cafb9d8015d"
-      },
-      {
-        "name": "nss-sysinit",
-        "epoch": 0,
-        "version": "3.67.0",
-        "release": "6.el8_4",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/nss-sysinit-3.67.0-6.el8_4.x86_64.rpm",
-        "checksum": "sha256:df17a51144931d9350a2fc41e328969ab2f88fbcf5542c0b752e63c35c7630f1"
-      },
-      {
-        "name": "nss-util",
-        "epoch": 0,
-        "version": "3.67.0",
-        "release": "6.el8_4",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/nss-util-3.67.0-6.el8_4.x86_64.rpm",
-        "checksum": "sha256:9649b49d9992f28fc1e4f5eb95e31e24ba2a126e3192320d36e6e779c624fc6f"
       },
       {
         "name": "oddjob",
@@ -9093,15 +8450,6 @@
         "checksum": "sha256:c7b4850fa0c575c67d7a4a90dd78045c0de7b29045e9710d0a90dc7f028336d2"
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/udisks2-2.9.0-7.el8.x86_64.rpm",
-        "checksum": "sha256:d035722edaf14562b258e0a04aa5a68cff61c23af893c270497a66d74b579b3f"
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.7.3",
@@ -9109,15 +8457,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/unbound-libs-1.7.3-17.el8.x86_64.rpm",
         "checksum": "sha256:e920a82cda55b110690f3c946ec2cd85f969599c71212463279763afcc33303d"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.11",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm",
-        "checksum": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
       },
       {
         "name": "xkeyboard-config",

--- a/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
@@ -128,9 +128,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:f72118d72067987ac1eeded4b04e95e709b263c27877f3eb1112859db33cb403"
                   },
                   {
@@ -618,9 +615,6 @@
                 "origin": "org.osbuild.source",
                 "references": [
                   {
-                    "id": "sha256:ad8cc7be9847717c0cd9b7878d62558817d47c4617f8e63c1d9e0aeb374d211d"
-                  },
-                  {
                     "id": "sha256:9d4cee9c7cdbf21fc4f6983ce07105f585310160e31f9a6bb94d3ce4f4ef3513"
                   },
                   {
@@ -661,9 +655,6 @@
                   },
                   {
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
-                  },
-                  {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
                   },
                   {
                     "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
@@ -798,9 +789,6 @@
                     "id": "sha256:e74ce9c11ed27caf661d6fdd5c35234f912309c39da3c6288a017b0a6f3bccc0"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:f72118d72067987ac1eeded4b04e95e709b263c27877f3eb1112859db33cb403"
                   },
                   {
@@ -820,15 +808,6 @@
                   },
                   {
                     "id": "sha256:39f86feba904fc4c4a9a04a54576d6d3b4e9af344155aee9e4321c27b4742f0a"
-                  },
-                  {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
                   },
                   {
                     "id": "sha256:1291973fb1c479d3d3dab62d7dbcda052ab998779a0eb2e45427d0e2257d8db4"
@@ -868,9 +847,6 @@
                   },
                   {
                     "id": "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042"
-                  },
-                  {
-                    "id": "sha256:71ccc266b2790fd64b8f94793b17dfe94f0ec16396441e5364843e25ddfd9c7a"
                   },
                   {
                     "id": "sha256:affab770e241d6c70cb271cbe5f84d02a946ad1b4d17d36f74dab74e9ca8fd7f"
@@ -928,9 +904,6 @@
                   },
                   {
                     "id": "sha256:1136323a37c5940055c3891a260b26782b75ea986fb5fe02ad80364f60527450"
-                  },
-                  {
-                    "id": "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7"
                   },
                   {
                     "id": "sha256:06f6a82e268aa006507fb1f82f01893f996fd47ad1cfa5f839c7861e8fd317cf"
@@ -1125,9 +1098,6 @@
                     "id": "sha256:eb3732b52b805b28192463682e961408db8c6449bb27e733081cff62e77194b3"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:316b614d8b97e93f56a77b035245ada4dbaa8718828f943fe43038330b47726d"
                   },
                   {
@@ -1138,12 +1108,6 @@
                   },
                   {
                     "id": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-                  },
-                  {
-                    "id": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-                  },
-                  {
-                    "id": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
                   },
                   {
                     "id": "sha256:fe37f767487e0806535a06cda4e302555c27166b6320657ae945d5217b8c36aa"
@@ -1165,9 +1129,6 @@
                   },
                   {
                     "id": "sha256:8548b32627ba574a7eaf108af37b0dd302049c8c4a2ff8537a5f53260ad2f07c"
-                  },
-                  {
-                    "id": "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a"
                   },
                   {
                     "id": "sha256:9c5594fcac97c0f8813d7a188e2368e3b1095025fc4a0ecbd5d17e54c0c93f97"
@@ -1218,9 +1179,6 @@
                     "id": "sha256:a506765865ee31210532f16af156f54ea9431ba1763269d3a39c9ebf0adf5163"
                   },
                   {
-                    "id": "sha256:3ad80bb77d17e36bb6127b8552ffa93085321bca2c63e1b12db6136d5d7fee9f"
-                  },
-                  {
                     "id": "sha256:507442831068c749ba21b22bd96993a1a2a6c74dd53c55f34c7f81a21554c82d"
                   },
                   {
@@ -1255,9 +1213,6 @@
                   },
                   {
                     "id": "sha256:289066d1ee27ccac6bec18d021f843c8962ead4b4c940d579bfc429d5583006e"
-                  },
-                  {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
                   },
                   {
                     "id": "sha256:66d7caeabd800bbe2f34163fc4605f5762a6ffc3af94bc275acbfac0b56d66c7"
@@ -1341,9 +1296,6 @@
                     "id": "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15"
                   },
                   {
@@ -1386,16 +1338,10 @@
                     "id": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
                   },
                   {
-                    "id": "sha256:3a040b80f585f55f86b600520949cf321c8c365158dfad55533f22f9bf366050"
-                  },
-                  {
                     "id": "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd"
                   },
                   {
                     "id": "sha256:75027c5ff5527fe7b69e3de665aa44cca6e0ee65094600f88c1fc5e6c6a1037a"
-                  },
-                  {
-                    "id": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -1851,9 +1797,6 @@
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
                   },
                   {
-                    "id": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
-                  },
-                  {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
                   },
                   {
@@ -2109,36 +2052,6 @@
                     "id": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
                   },
                   {
-                    "id": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-                  },
-                  {
-                    "id": "sha256:c0309fbbf048d250de039aca136cc055bfa33faf2056803e18c48a3eba498c2f"
-                  },
-                  {
-                    "id": "sha256:fcaaef0ebc48422e70617c5cdcbe441580b790af9c5647c5b255b35957ec7311"
-                  },
-                  {
-                    "id": "sha256:ca2d9db71ecd56e0c406278bbed639962c27ed01e8206f144719df5c32f9aeb7"
-                  },
-                  {
-                    "id": "sha256:f114254f9dadd3dbedf108ab8d81bbb247d8eb19f9d018454a7c01d919a65c44"
-                  },
-                  {
-                    "id": "sha256:9dfef9a2900c658a3379ad843127609d4cbde7718f4f5b223f207288a978254a"
-                  },
-                  {
-                    "id": "sha256:8b05d986058c83b2041499ed8d1466073bd492319db781a50f8c5f2b9bbe447e"
-                  },
-                  {
-                    "id": "sha256:633e83df6ccdd33642cf71fb84456bb036398919ae21c36217bac19231783996"
-                  },
-                  {
-                    "id": "sha256:db515162530e2c50f9e271c33a4f3852bc92c57b2ec1aa1f7117a3d5f01dd467"
-                  },
-                  {
-                    "id": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-                  },
-                  {
                     "id": "sha256:bfe5c8ea12012936cc59981a10728e95d5fdadd3e893457af7a27c464d8cb6ba"
                   },
                   {
@@ -2146,9 +2059,6 @@
                   },
                   {
                     "id": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
-                  },
-                  {
-                    "id": "sha256:2d7bb5cff7b7f741621d92e12e56d3a32143fee999ab96d4ce4b148bcb387a70"
                   },
                   {
                     "id": "sha256:b1b5660d070a5cf322ecb1c0bf36a8282362f01e0fa4041e11ddbeef1524eef8"
@@ -2331,13 +2241,7 @@
                     "id": "sha256:bafc9ec3dd737b0dbdf179b9d9b4c8a9b5c1a92423eae1e4eb3047522107695e"
                   },
                   {
-                    "id": "sha256:d035722edaf14562b258e0a04aa5a68cff61c23af893c270497a66d74b579b3f"
-                  },
-                  {
                     "id": "sha256:e920a82cda55b110690f3c946ec2cd85f969599c71212463279763afcc33303d"
-                  },
-                  {
-                    "id": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
                   },
                   {
                     "id": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
@@ -2419,9 +2323,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -2602,23 +2504,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -2626,13 +2515,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-348.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -2697,20 +2582,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2727,44 +2600,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -2772,8 +2610,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -2799,28 +2637,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -2830,18 +2652,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -2859,8 +2669,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -3085,9 +2895,6 @@
           "sha256:1d47e465939bba5bcf9c37be2516e60d6c9449ccee70a54a6133df989ac8b1f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libksba-1.3.5-7.el8.x86_64.rpm"
           },
-          "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libatasmart-0.19-14.el8.x86_64.rpm"
-          },
           "sha256:1dc1dbd0aa4dad715b3242468d4841f2f35bf6aa60d8e1928ee692784b12da1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsecret-0.18.6-1.el8.x86_64.rpm"
           },
@@ -3117,9 +2924,6 @@
           },
           "sha256:206de21c82d76de550bcc1959138472640b0a950a311b753203f5dfe5b201b7b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/ipcalc-0.2.4-4.el8.x86_64.rpm"
-          },
-          "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libmbim-1.20.2-1.el8.x86_64.rpm"
           },
           "sha256:20b51fff03d35f8412666717e3e715642bc0d1e32fb847fd626ad82d75d47891": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/dracut-config-rescue-049-191.git20210920.el8.x86_64.rpm"
@@ -3214,9 +3018,6 @@
           "sha256:2bf6a5835ee856272ad37abc4f695536a157f4c51dcf5621bfcf323d22d091bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-librepo-1.14.0-2.el8.x86_64.rpm"
           },
-          "sha256:2d7bb5cff7b7f741621d92e12e56d3a32143fee999ab96d4ce4b148bcb387a70": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libudisks2-2.9.0-7.el8.x86_64.rpm"
-          },
           "sha256:2e175740ba876aa621422ed4971794320cde1115b01ff018de7ff8186e271e48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/authselect-1.2.2-3.el8.x86_64.rpm"
           },
@@ -3238,17 +3039,8 @@
           "sha256:30028d0e27f207b39028942487bc15d3607db39296f294c51e43204b74bc54bf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/elfutils-libelf-0.185-1.el8.x86_64.rpm"
           },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
-          "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
-          },
           "sha256:308ba0bc3f5d96ace7ec3387e5d9ed43ea3c1a3c3a5c01fce93b3cafb9d8015d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/nss-softokn-freebl-3.67.0-6.el8_4.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
           "sha256:316b614d8b97e93f56a77b035245ada4dbaa8718828f943fe43038330b47726d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgcc-8.5.0-3.el8.x86_64.rpm"
@@ -3310,9 +3102,6 @@
           "sha256:39f86feba904fc4c4a9a04a54576d6d3b4e9af344155aee9e4321c27b4742f0a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/e2fsprogs-libs-1.45.6-2.el8.x86_64.rpm"
           },
-          "sha256:3a040b80f585f55f86b600520949cf321c8c365158dfad55533f22f9bf366050": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/mdadm-4.2-rc2.el8.x86_64.rpm"
-          },
           "sha256:3a1058c6ba468722090a74002a3239161771b0d8b444975bff891afd45bb672a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsysfs-2.1.0-24.el8.x86_64.rpm"
           },
@@ -3322,14 +3111,8 @@
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
           },
-          "sha256:3ad80bb77d17e36bb6127b8552ffa93085321bca2c63e1b12db6136d5d7fee9f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libqmi-1.24.0-3.el8.x86_64.rpm"
-          },
           "sha256:3c3c21bbf64d1a6989e0648c090339b030cd26a72cb39e4eff9f72eca12a39be": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/fence-agents-amt-ws-4.2.1-75.el8.noarch.rpm"
-          },
-          "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
           },
           "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm"
@@ -3396,9 +3179,6 @@
           },
           "sha256:47a81f0a9e0c5b33095964e0591d958a0ebfaf797c6890c624affd04dff04132": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/dmidecode-3.2-10.el8.x86_64.rpm"
-          },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/efivar-libs-37-4.el8.x86_64.rpm"
           },
           "sha256:4811ab95c1d50ef7380e2c5937ae4490f8e28f56cf787c189437d1709e4423fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/perl-podlators-4.11-1.el8.noarch.rpm"
@@ -3607,9 +3387,6 @@
           "sha256:633b4eb78ff5fa0e9d7ae07a21fda93786d495ba4ee0f74f937051e3521511c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/systemd-239-51.el8.x86_64.rpm"
           },
-          "sha256:633e83df6ccdd33642cf71fb84456bb036398919ae21c36217bac19231783996": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-swap-2.24-7.el8.x86_64.rpm"
-          },
           "sha256:645419874806713b904eed22d9e7dd2ba076452c733f47822d0c05723311a951": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/sqlite-libs-3.26.0-15.el8.x86_64.rpm"
           },
@@ -3670,14 +3447,8 @@
           "sha256:70cdde0bcaf62a95fcb059756b9c1fffc5b865bd52a8d8cf95f4703eb732397b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/corosynclib-3.1.5-1.el8.x86_64.rpm"
           },
-          "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgudev-232-4.el8.x86_64.rpm"
-          },
           "sha256:71690288b8933861b2eb37062725ad9328da431e7f9024951c43d8811ff33104": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/cups-libs-2.2.6-40.el8.x86_64.rpm"
-          },
-          "sha256:71ccc266b2790fd64b8f94793b17dfe94f0ec16396441e5364843e25ddfd9c7a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/fwupd-1.5.9-1.el8.x86_64.rpm"
           },
           "sha256:71cd412b54e9ae8e7718fa3827d8c92be5aad32a85e65e6250e0bd4008b53f7b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libbpf-0.4.0-1.el8.x86_64.rpm"
@@ -3832,12 +3603,6 @@
           "sha256:88783ea87d17ed7173aefeb0145e009220bb3050bbadda04cc00964f5d92820d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/shadow-utils-4.6-14.el8.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
-          "sha256:8b05d986058c83b2041499ed8d1466073bd492319db781a50f8c5f2b9bbe447e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-part-2.24-7.el8.x86_64.rpm"
-          },
           "sha256:8bc50d11af9a2696049cad3081e2efd78443640fd855ce8d4a9f2a5194c892bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/iproute-5.12.0-4.el8.x86_64.rpm"
           },
@@ -3846,9 +3611,6 @@
           },
           "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8d371e753071edc796d2eadb8278980290511be6279fdf46649c81b859497d6a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/prefixdevname-0.1.0-6.el8.x86_64.rpm"
@@ -3952,9 +3714,6 @@
           "sha256:9a9ca6857f517f1249d2eb496fe904590d6203e4a9547a28e0b23f21c4cae24a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/polkit-pkla-compat-0.1-12.el8.x86_64.rpm"
           },
-          "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/mokutil-0.3.0-11.el8.x86_64.rpm"
-          },
           "sha256:9c5594fcac97c0f8813d7a188e2368e3b1095025fc4a0ecbd5d17e54c0c93f97": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libmnl-1.0.4-6.el8.x86_64.rpm"
           },
@@ -3966,9 +3725,6 @@
           },
           "sha256:9d4cee9c7cdbf21fc4f6983ce07105f585310160e31f9a6bb94d3ce4f4ef3513": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/NetworkManager-1.32.10-4.el8.x86_64.rpm"
-          },
-          "sha256:9dfef9a2900c658a3379ad843127609d4cbde7718f4f5b223f207288a978254a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-mdraid-2.24-7.el8.x86_64.rpm"
           },
           "sha256:9e90e6054da06f5c8c2733c3b66987693a58ddc1f05d95b23ca0a464e26a2b22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/perl-Digest-1.17-395.el8.noarch.rpm"
@@ -4057,17 +3813,8 @@
           "sha256:ad060f60303b6764e08657436147cc24cfc4bb1ccc1431796407ba005a7bcec0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/rootfiles-8.1-22.el8.noarch.rpm"
           },
-          "sha256:ad8cc7be9847717c0cd9b7878d62558817d47c4617f8e63c1d9e0aeb374d211d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/ModemManager-glib-1.10.8-4.el8.x86_64.rpm"
-          },
           "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libxml2-2.9.7-9.el8_4.2.x86_64.rpm"
-          },
-          "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
-          },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
           },
           "sha256:af7cf43b6ad25abf824d7540a5bd16bac9c773ffa23d9876e3f5666385a24f02": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/fence-agents-scsi-4.2.1-75.el8.noarch.rpm"
@@ -4138,9 +3885,6 @@
           "sha256:b9d0a4c0e16db4c05b2d0690216d8c5da2db7d67bc765a00ce2a32c5f810c245": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/pkgconf-1.4.2-1.el8.x86_64.rpm"
           },
-          "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/grub2-efi-x64-2.02-106.el8.x86_64.rpm"
-          },
           "sha256:ba28d199a2b71ee55b8a78fc1f6dbc9d487690047a0a5c2d41ff121c5de46f6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-r8.5-20220504/Packages/libknet1-compress-lzo2-plugin-1.18-2.el8_4.x86_64.rpm"
           },
@@ -4179,9 +3923,6 @@
           },
           "sha256:bfe5c8ea12012936cc59981a10728e95d5fdadd3e893457af7a27c464d8cb6ba": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libestr-0.1.10-1.el8.x86_64.rpm"
-          },
-          "sha256:c0309fbbf048d250de039aca136cc055bfa33faf2056803e18c48a3eba498c2f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-2.24-7.el8.x86_64.rpm"
           },
           "sha256:c09618fd3dbb6f65f043e481b6e20cae06564bf452681723cab4a2d3b8dc407a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsss_nss_idmap-2.5.2-2.el8.x86_64.rpm"
@@ -4225,9 +3966,6 @@
           "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libxslt-1.1.32-6.el8.x86_64.rpm"
           },
-          "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm"
-          },
           "sha256:c60aede8488f68a001f3495bd6e6d894fc3a44bb488f4550b5970ab5904d0a1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/geolite2-country-20180605-1.el8.noarch.rpm"
           },
@@ -4260,9 +3998,6 @@
           },
           "sha256:c8f68851825d14d3d10270323ae7b33ccddc447e8842f8577107c030cc0a2766": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/rubygem-openssl-2.1.2-107.module+el8.4.0+10822+fe4fffb1.x86_64.rpm"
-          },
-          "sha256:ca2d9db71ecd56e0c406278bbed639962c27ed01e8206f144719df5c32f9aeb7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-fs-2.24-7.el8.x86_64.rpm"
           },
           "sha256:ca33ff1cbcd000cf8d7fb1d0e3a18dd9a2e61f321dbe1f83c7242e9684d34818": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libstdc++-8.5.0-3.el8.x86_64.rpm"
@@ -4312,9 +4047,6 @@
           "sha256:d0188d22323619c9069c2de6f85ebe5302c76fde5f52ebd148988e75a75110dc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsigsegv-2.11-5.el8.x86_64.rpm"
           },
-          "sha256:d035722edaf14562b258e0a04aa5a68cff61c23af893c270497a66d74b579b3f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/udisks2-2.9.0-7.el8.x86_64.rpm"
-          },
           "sha256:d05f658981f3152e680010227c9c1e4e74857306ba883b0ddd68ac79fb0cbffe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/grub2-tools-minimal-2.02-106.el8.x86_64.rpm"
           },
@@ -4359,9 +4091,6 @@
           },
           "sha256:d50174632033170dfd1d8125f132962872c0042711e44ed59e91f6d2d26071c0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/polkit-libs-0.115-12.el8.x86_64.rpm"
-          },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/efibootmgr-16-1.el8.x86_64.rpm"
           },
           "sha256:d53449962dcd9266bab6c0af921875051ccc9fb752f3061f7bd66584824431ec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/sssd-nfs-idmap-2.5.2-2.el8.x86_64.rpm"
@@ -4419,9 +4148,6 @@
           },
           "sha256:db1fad3c2d8735e69084bd4b09ea963938e4dde2f2e096dc7a4ce146f18b7ab0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/fontpackages-filesystem-1.44-22.el8.noarch.rpm"
-          },
-          "sha256:db515162530e2c50f9e271c33a4f3852bc92c57b2ec1aa1f7117a3d5f01dd467": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-utils-2.24-7.el8.x86_64.rpm"
           },
           "sha256:db8bc154626bdd906a1f50104031a5042bbe91db7f5a1473657795eedd4158c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-setools-4.3.0-2.el8.x86_64.rpm"
@@ -4573,9 +4299,6 @@
           "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/lz4-libs-1.8.3-3.el8_4.x86_64.rpm"
           },
-          "sha256:f114254f9dadd3dbedf108ab8d81bbb247d8eb19f9d018454a7c01d919a65c44": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-loop-2.24-7.el8.x86_64.rpm"
-          },
           "sha256:f1784b0b9221581d9beac947a7a43cc9f4839ede18f38a0274461185788792a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-ply-3.9-9.el8.noarch.rpm"
           },
@@ -4647,12 +4370,6 @@
           },
           "sha256:fc3d96149a838aeea9fbd82cdbac78f83dfe5b21c1a5c0a703abb847fd7b5a2c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/fence-agents-ipdu-4.2.1-75.el8.noarch.rpm"
-          },
-          "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
-          },
-          "sha256:fcaaef0ebc48422e70617c5cdcbe441580b790af9c5647c5b255b35957ec7311": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-crypto-2.24-7.el8.x86_64.rpm"
           },
           "sha256:fd1f3109bd130e2dbbb57ea2f3a6d3419f9eef7108f1485f0d1386a563437614": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/gnutls-3.6.16-4.el8.x86_64.rpm"
@@ -4923,15 +4640,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -6295,15 +6003,6 @@
     ],
     "os": [
       {
-        "name": "ModemManager-glib",
-        "epoch": 0,
-        "version": "1.10.8",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/ModemManager-glib-1.10.8-4.el8.x86_64.rpm",
-        "checksum": "sha256:ad8cc7be9847717c0cd9b7878d62558817d47c4617f8e63c1d9e0aeb374d211d"
-      },
-      {
         "name": "NetworkManager",
         "epoch": 1,
         "version": "1.32.10",
@@ -6428,15 +6127,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/brotli-1.0.6-3.el8.x86_64.rpm",
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
-      },
-      {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
       },
       {
         "name": "bzip2",
@@ -6835,15 +6525,6 @@
         "checksum": "sha256:e74ce9c11ed27caf661d6fdd5c35234f912309c39da3c6288a017b0a6f3bccc0"
       },
       {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "049",
@@ -6905,33 +6586,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/e2fsprogs-libs-1.45.6-2.el8.x86_64.rpm",
         "checksum": "sha256:39f86feba904fc4c4a9a04a54576d6d3b4e9af344155aee9e4321c27b4742f0a"
-      },
-      {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
       },
       {
         "name": "elfutils-debuginfod-client",
@@ -7049,15 +6703,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/fuse-libs-2.9.7-12.el8.x86_64.rpm",
         "checksum": "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.5.9",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/fwupd-1.5.9-1.el8.x86_64.rpm",
-        "checksum": "sha256:71ccc266b2790fd64b8f94793b17dfe94f0ec16396441e5364843e25ddfd9c7a"
       },
       {
         "name": "gawk",
@@ -7229,15 +6874,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/grub2-common-2.02-106.el8.noarch.rpm",
         "checksum": "sha256:1136323a37c5940055c3891a260b26782b75ea986fb5fe02ad80364f60527450"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "106.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/grub2-efi-x64-2.02-106.el8.x86_64.rpm",
-        "checksum": "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7"
       },
       {
         "name": "grub2-pc",
@@ -7816,15 +7452,6 @@
         "checksum": "sha256:eb3732b52b805b28192463682e961408db8c6449bb27e733081cff62e77194b3"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -7859,24 +7486,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgpg-error-1.31-1.el8.x86_64.rpm",
         "checksum": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-      },
-      {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "232",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgudev-232-4.el8.x86_64.rpm",
-        "checksum": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libgusb-0.3.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
       },
       {
         "name": "libicu",
@@ -7940,15 +7549,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libldb-2.3.0-2.el8.x86_64.rpm",
         "checksum": "sha256:8548b32627ba574a7eaf108af37b0dd302049c8c4a2ff8537a5f53260ad2f07c"
-      },
-      {
-        "name": "libmbim",
-        "epoch": 0,
-        "version": "1.20.2",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libmbim-1.20.2-1.el8.x86_64.rpm",
-        "checksum": "sha256:208dcd6b67c5d9569f64bcc259b365db3abdd0e786494a50a556dbf65355cd9a"
       },
       {
         "name": "libmnl",
@@ -8095,15 +7695,6 @@
         "checksum": "sha256:a506765865ee31210532f16af156f54ea9431ba1763269d3a39c9ebf0adf5163"
       },
       {
-        "name": "libqmi",
-        "epoch": 0,
-        "version": "1.24.0",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libqmi-1.24.0-3.el8.x86_64.rpm",
-        "checksum": "sha256:3ad80bb77d17e36bb6127b8552ffa93085321bca2c63e1b12db6136d5d7fee9f"
-      },
-      {
         "name": "libref_array",
         "epoch": 0,
         "version": "0.1.5",
@@ -8210,15 +7801,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsmartcols-2.32.1-28.el8.x86_64.rpm",
         "checksum": "sha256:289066d1ee27ccac6bec18d021f843c8962ead4b4c940d579bfc429d5583006e"
-      },
-      {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
       },
       {
         "name": "libsolv",
@@ -8464,15 +8046,6 @@
         "checksum": "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libxslt",
         "epoch": 0,
         "version": "1.1.32",
@@ -8599,15 +8172,6 @@
         "checksum": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "rc2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/mdadm-4.2-rc2.el8.x86_64.rpm",
-        "checksum": "sha256:3a040b80f585f55f86b600520949cf321c8c365158dfad55533f22f9bf366050"
-      },
-      {
         "name": "memstrack",
         "epoch": 0,
         "version": "0.1.11",
@@ -8624,15 +8188,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/microcode_ctl-20210608-1.el8.x86_64.rpm",
         "checksum": "sha256:75027c5ff5527fe7b69e3de665aa44cca6e0ee65094600f88c1fc5e6c6a1037a"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/mokutil-0.3.0-11.el8.x86_64.rpm",
-        "checksum": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
       },
       {
         "name": "mozjs60",
@@ -9994,15 +9549,6 @@
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.4",
-        "release": "2.el8_1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm",
-        "checksum": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -10768,96 +10314,6 @@
         "checksum": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "14.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libatasmart-0.19-14.el8.x86_64.rpm",
-        "checksum": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:c0309fbbf048d250de039aca136cc055bfa33faf2056803e18c48a3eba498c2f"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-crypto-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:fcaaef0ebc48422e70617c5cdcbe441580b790af9c5647c5b255b35957ec7311"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-fs-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:ca2d9db71ecd56e0c406278bbed639962c27ed01e8206f144719df5c32f9aeb7"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-loop-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:f114254f9dadd3dbedf108ab8d81bbb247d8eb19f9d018454a7c01d919a65c44"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-mdraid-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:9dfef9a2900c658a3379ad843127609d4cbde7718f4f5b223f207288a978254a"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-part-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:8b05d986058c83b2041499ed8d1466073bd492319db781a50f8c5f2b9bbe447e"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-swap-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:633e83df6ccdd33642cf71fb84456bb036398919ae21c36217bac19231783996"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libblockdev-utils-2.24-7.el8.x86_64.rpm",
-        "checksum": "sha256:db515162530e2c50f9e271c33a4f3852bc92c57b2ec1aa1f7117a3d5f01dd467"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libbytesize-1.4-3.el8.x86_64.rpm",
-        "checksum": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.10",
@@ -10883,15 +10339,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libmaxminddb-1.2.0-10.el8.x86_64.rpm",
         "checksum": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
-      },
-      {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/libudisks2-2.9.0-7.el8.x86_64.rpm",
-        "checksum": "sha256:2d7bb5cff7b7f741621d92e12e56d3a32143fee999ab96d4ce4b148bcb387a70"
       },
       {
         "name": "libwsman1",
@@ -11434,15 +10881,6 @@
         "checksum": "sha256:bafc9ec3dd737b0dbdf179b9d9b4c8a9b5c1a92423eae1e4eb3047522107695e"
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "7.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/udisks2-2.9.0-7.el8.x86_64.rpm",
-        "checksum": "sha256:d035722edaf14562b258e0a04aa5a68cff61c23af893c270497a66d74b579b3f"
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.7.3",
@@ -11450,15 +10888,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/unbound-libs-1.7.3-17.el8.x86_64.rpm",
         "checksum": "sha256:e920a82cda55b110690f3c946ec2cd85f969599c71212463279763afcc33303d"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.11",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm",
-        "checksum": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
       },
       {
         "name": "xkeyboard-config",

--- a/test/data/manifests/rhel_86-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ec2-boot.json
@@ -2138,14 +2138,14 @@
                   "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
                 },
                 {
-                  "size": 1024000,
+                  "size": 1048576,
                   "start": 411648,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "CB07C243-BC44-4717-853E-28852021225B"
                 },
                 {
-                  "size": 19535839,
-                  "start": 1435648,
+                  "size": 19511263,
+                  "start": 1460224,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2181,8 +2181,7 @@
           {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
-              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
             },
             "devices": {
               "device": {
@@ -2190,7 +2189,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 411648,
-                  "size": 1024000,
+                  "size": 1048576,
                   "lock": true
                 }
               }
@@ -2207,8 +2206,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1435648,
-                  "size": 19535839,
+                  "start": 1460224,
+                  "size": 19511263,
                   "lock": true
                 }
               }
@@ -2239,7 +2238,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 411648,
-                  "size": 1024000
+                  "size": 1048576
                 }
               },
               "boot.efi": {
@@ -2254,8 +2253,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1435648,
-                  "size": 19535839
+                  "start": 1460224,
+                  "size": 19511263
                 }
               }
             },

--- a/test/data/manifests/rhel_86-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2-boot.json
@@ -121,9 +121,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:f72118d72067987ac1eeded4b04e95e709b263c27877f3eb1112859db33cb403"
                   },
                   {
@@ -652,9 +649,6 @@
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
                   },
                   {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-                  },
-                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -763,9 +757,6 @@
                     "id": "sha256:6670032db2178dacda1bcd490e45a5e69df6f9f39933c4968694ca61229b9255"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:f72118d72067987ac1eeded4b04e95e709b263c27877f3eb1112859db33cb403"
                   },
                   {
@@ -785,15 +776,6 @@
                   },
                   {
                     "id": "sha256:39f86feba904fc4c4a9a04a54576d6d3b4e9af344155aee9e4321c27b4742f0a"
-                  },
-                  {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
                   },
                   {
                     "id": "sha256:d51fac44d322890f636097d85a8fd0bec3af5cc22d83440a13308b7b7ea5723b"
@@ -830,9 +812,6 @@
                   },
                   {
                     "id": "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042"
-                  },
-                  {
-                    "id": "sha256:26e654b600b832d80eb184c0e17846f67e24c220ee5c850176d8ac91f7b08b6d"
                   },
                   {
                     "id": "sha256:affab770e241d6c70cb271cbe5f84d02a946ad1b4d17d36f74dab74e9ca8fd7f"
@@ -890,9 +869,6 @@
                   },
                   {
                     "id": "sha256:1136323a37c5940055c3891a260b26782b75ea986fb5fe02ad80364f60527450"
-                  },
-                  {
-                    "id": "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7"
                   },
                   {
                     "id": "sha256:06f6a82e268aa006507fb1f82f01893f996fd47ad1cfa5f839c7861e8fd317cf"
@@ -1072,9 +1048,6 @@
                     "id": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:1f8f65210aeb7df3b8ebeaebab89ce4c9a6d01c8566d7c482ac833f9a5ffc3e2"
                   },
                   {
@@ -1085,12 +1058,6 @@
                   },
                   {
                     "id": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-                  },
-                  {
-                    "id": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-                  },
-                  {
-                    "id": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
                   },
                   {
                     "id": "sha256:4a62975251933dcaff77fdbd7704e8a12bea0ecb6eaaae5ea5e552bedd6788ec"
@@ -1192,9 +1159,6 @@
                     "id": "sha256:ce810948b525e851c88a7c5ba71f8c070d91b84c8531a50dc8ea6650f115b3b5"
                   },
                   {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-                  },
-                  {
                     "id": "sha256:9f9feb77c731a460cba4720ca92e8cbc266c4c2c7ffa22a53b90c2d1ad23dc6c"
                   },
                   {
@@ -1270,9 +1234,6 @@
                     "id": "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf"
                   },
                   {
@@ -1306,16 +1267,10 @@
                     "id": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
                   },
                   {
-                    "id": "sha256:b6050db00772299f827781e272f3b93f17687d164ded25cf795128567b539032"
-                  },
-                  {
                     "id": "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd"
                   },
                   {
                     "id": "sha256:75027c5ff5527fe7b69e3de665aa44cca6e0ee65094600f88c1fc5e6c6a1037a"
-                  },
-                  {
-                    "id": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -1436,9 +1391,6 @@
                   },
                   {
                     "id": "sha256:49f89e7b459eaa297e518c0e55d81d1b0d8181959346673babb158103422652d"
-                  },
-                  {
-                    "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
                   },
                   {
                     "id": "sha256:e22840ee14aa1993e75fd690749c01dbb7d4419c2b210fef173ff99a76f61ff6"
@@ -1639,9 +1591,6 @@
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
                   },
                   {
-                    "id": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
-                  },
-                  {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
                   },
                   {
@@ -1771,36 +1720,6 @@
                     "id": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
                   },
                   {
-                    "id": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-                  },
-                  {
-                    "id": "sha256:70e42cbbd3b21cf9e670a3aaadf55105e45ef0a4aa9d4fc021930f441a87d396"
-                  },
-                  {
-                    "id": "sha256:f63ad13c6fc281b01c48fb1e516dfb9540034899aac1aacd81a569016d28940a"
-                  },
-                  {
-                    "id": "sha256:c8192b0eb0496d79d1a3925c1d7eb95abde0d4a4a2c44a86a9a78f8de6dab2d9"
-                  },
-                  {
-                    "id": "sha256:dc28397f174b147917ff788379672663ebe4c89eff4bae329c32c88272d59c45"
-                  },
-                  {
-                    "id": "sha256:0af9f72ce36d8b1c779691db1edc2cbb82ca84e86a2df0608cf753e5f5ee5893"
-                  },
-                  {
-                    "id": "sha256:6907ac56fe2c2e7228077544308620b97ef7a71e9068173eff94c2df84b322ae"
-                  },
-                  {
-                    "id": "sha256:4969e01de0186db1dd8523e81ba82b6a4f43a3b31d253f4cf1b82803bc16699f"
-                  },
-                  {
-                    "id": "sha256:15e42b06b36f9c09a3983aa03eb9f7f7f2b94f7e588eeb8cb943a17a9578ea38"
-                  },
-                  {
-                    "id": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-                  },
-                  {
                     "id": "sha256:bfe5c8ea12012936cc59981a10728e95d5fdadd3e893457af7a27c464d8cb6ba"
                   },
                   {
@@ -1810,28 +1729,7 @@
                     "id": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
                   },
                   {
-                    "id": "sha256:1edca93bf9c19054d98f90ed292b8856d88df415a437bef8c29dda787a0a53f8"
-                  },
-                  {
                     "id": "sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072"
-                  },
-                  {
-                    "id": "sha256:52aed1bbd2aa4041e599a453a9c4323775b26d2b1326ffb98ac6febbcab8c230"
-                  },
-                  {
-                    "id": "sha256:83bbe96f5585514ea848a8d33605d52da1c7f32b229a1f6f9fd05f088aa897d2"
-                  },
-                  {
-                    "id": "sha256:1c138f1fa051cad977a6933da79f226f12970c25913d37af69bb86f3fece2850"
-                  },
-                  {
-                    "id": "sha256:84b775933e1b27597d1f12fd5370734f34ba54e97743bf32d7d5e10c922a0bfe"
-                  },
-                  {
-                    "id": "sha256:7ebd6b189663e2ec911e153f2246221737e25978ef88d6b0595a486ca58a31a5"
-                  },
-                  {
-                    "id": "sha256:584b98ef37799bd7395a09a4aa5e046613fef0e9a46bcde32926ba94031ad2cc"
                   },
                   {
                     "id": "sha256:0e0f05c3d39f4b3eee6a5786a6aea4c7ef5f5921bc6146489d1f97aa602f7d6d"
@@ -1882,13 +1780,7 @@
                     "id": "sha256:455427f911eabe523f4b9403bc9da03d916c9615c8367c64efa893bff7548260"
                   },
                   {
-                    "id": "sha256:0a63475f53acf618c0ef3a35300277923486d778f42edc360f0a4a7824086222"
-                  },
-                  {
                     "id": "sha256:e920a82cda55b110690f3c946ec2cd85f969599c71212463279763afcc33303d"
-                  },
-                  {
-                    "id": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
                   },
                   {
                     "id": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
@@ -1909,9 +1801,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -2092,23 +1982,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -2116,13 +1993,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-361.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -2187,20 +2060,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2217,44 +2078,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -2262,8 +2088,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -2289,28 +2115,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -2320,18 +2130,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -2349,8 +2147,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -2419,9 +2217,6 @@
           "sha256:0a59c5a145344642e54dd11689ae7dcc76a4229f3e4cbca0c2a17e0b9d5f9606": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-dnf-plugins-core-4.0.21-8.el8.noarch.rpm"
           },
-          "sha256:0a63475f53acf618c0ef3a35300277923486d778f42edc360f0a4a7824086222": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/udisks2-2.9.0-8.el8.x86_64.rpm"
-          },
           "sha256:0a8f049e1b9df452e0fd9977310c53d905dcb84f060ceefd970f7e31e67dee20": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/kernel-modules-4.18.0-361.el8.x86_64.rpm"
           },
@@ -2433,9 +2228,6 @@
           },
           "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dnf-data-4.7.0-5.el8.noarch.rpm"
-          },
-          "sha256:0af9f72ce36d8b1c779691db1edc2cbb82ca84e86a2df0608cf753e5f5ee5893": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-mdraid-2.24-8.el8.x86_64.rpm"
           },
           "sha256:0b4118e4f4aec595982dbb9f4b48999284e9e51dfd45d251d930f1541d8a8020": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/expat-2.2.5-4.el8.x86_64.rpm"
@@ -2488,9 +2280,6 @@
           "sha256:150e9dbb5a19483c85c25c722ff63a08d9411023c40faf88f42843fdf68ea275": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/popt-1.18-1.el8.x86_64.rpm"
           },
-          "sha256:15e42b06b36f9c09a3983aa03eb9f7f7f2b94f7e588eeb8cb943a17a9578ea38": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-utils-2.24-8.el8.x86_64.rpm"
-          },
           "sha256:17c1fcfda1c7367e5bddeafa29193379ce8712958d4b735e2227e7a07950e858": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/iproute-5.15.0-2.el8.x86_64.rpm"
           },
@@ -2518,17 +2307,11 @@
           "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm"
           },
-          "sha256:1c138f1fa051cad977a6933da79f226f12970c25913d37af69bb86f3fece2850": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/nss-softokn-3.67.0-7.el8_5.x86_64.rpm"
-          },
           "sha256:1c4a8674eafc31d36030f3fd0c081326d4301570d4e35b59d6f6ef1e163f655b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/pkgconf-pkg-config-1.4.2-1.el8.x86_64.rpm"
           },
           "sha256:1d47e465939bba5bcf9c37be2516e60d6c9449ccee70a54a6133df989ac8b1f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libksba-1.3.5-7.el8.x86_64.rpm"
-          },
-          "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libatasmart-0.19-14.el8.x86_64.rpm"
           },
           "sha256:1dc1dbd0aa4dad715b3242468d4841f2f35bf6aa60d8e1928ee692784b12da1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsecret-0.18.6-1.el8.x86_64.rpm"
@@ -2538,9 +2321,6 @@
           },
           "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm"
-          },
-          "sha256:1edca93bf9c19054d98f90ed292b8856d88df415a437bef8c29dda787a0a53f8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libudisks2-2.9.0-8.el8.x86_64.rpm"
           },
           "sha256:1eec9822d1dee41a2e3faae10258858687a63dd6af921937f469399e5e15edd2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/redhat-release-eula-8.6-0.0.el8.x86_64.rpm"
@@ -2596,9 +2376,6 @@
           "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/brotli-1.0.6-3.el8.x86_64.rpm"
           },
-          "sha256:26e654b600b832d80eb184c0e17846f67e24c220ee5c850176d8ac91f7b08b6d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/fwupd-1.7.1-1.el8.x86_64.rpm"
-          },
           "sha256:27067f9c284cd9da72436cc6598e405796e28ace5ed99d22e6b0641c9e711050": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/systemd-239-56.el8.x86_64.rpm"
           },
@@ -2643,15 +2420,6 @@
           },
           "sha256:2f465049e10abac1680ed833f15b565ecdb5f3775a4e3c41510ccfbf4324d44a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-tools-2.02-106.el8.x86_64.rpm"
-          },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
-          "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
           "sha256:32fdd4d597a1b36c710420682f5de6d4c7975f0fab00004460d7e2894916b4cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/tuned-2.16.0-1.el8.noarch.rpm"
@@ -2703,9 +2471,6 @@
           },
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
-          },
-          "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
           },
           "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm"
@@ -2764,14 +2529,8 @@
           "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libzstd-1.4.4-1.el8.x86_64.rpm"
           },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efivar-libs-37-4.el8.x86_64.rpm"
-          },
           "sha256:48e0e5143bf28f7220fc3c31db376c1ef0ed129fd3d2f82e3ce8531528924fd6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dnf-plugin-subscription-manager-1.28.25-1.el8.x86_64.rpm"
-          },
-          "sha256:4969e01de0186db1dd8523e81ba82b6a4f43a3b31d253f4cf1b82803bc16699f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-swap-2.24-8.el8.x86_64.rpm"
           },
           "sha256:49b6b2a486bd32714619e81782623f126486452bbd2295a2ab1f3e997b97d327": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/crontabs-1.11-17.20190603git.el8.noarch.rpm"
@@ -2845,9 +2604,6 @@
           "sha256:51eb082082e78afa70dd64591219c026d11cf7a6adf3771a36624c80be34dc3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/nettle-3.4.1-7.el8.x86_64.rpm"
           },
-          "sha256:52aed1bbd2aa4041e599a453a9c4323775b26d2b1326ffb98ac6febbcab8c230": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/nspr-4.32.0-1.el8_4.x86_64.rpm"
-          },
           "sha256:53849d779914a944acc126459911030c8ac8310ffcab354c6a7bcc4ef4af5bab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/e2fsprogs-1.45.6-2.el8.x86_64.rpm"
           },
@@ -2868,9 +2624,6 @@
           },
           "sha256:57ec379830cbfb310ae02166b02768a042fb06c888d56bfc89736298187c5ae3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libcurl-7.61.1-22.el8.x86_64.rpm"
-          },
-          "sha256:584b98ef37799bd7395a09a4aa5e046613fef0e9a46bcde32926ba94031ad2cc": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/nss-util-3.67.0-7.el8_5.x86_64.rpm"
           },
           "sha256:589fa333c866d9a59bc607ec6c45b7df30c8602c80c16b2aac2c0f916ebed6e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-decorator-4.2.1-2.el8.noarch.rpm"
@@ -2947,9 +2700,6 @@
           "sha256:689d17a67a9010b48cf8f22ccb14e0723602c0f215b0c3bc5adc25d77619d54b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/selinux-policy-targeted-3.14.3-89.el8.noarch.rpm"
           },
-          "sha256:6907ac56fe2c2e7228077544308620b97ef7a71e9068173eff94c2df84b322ae": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-part-2.24-8.el8.x86_64.rpm"
-          },
           "sha256:6ac86e716545bfde2c56ca9632aa35d211386a94251aecd44749f3998dbe4732": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-magic-5.33-20.el8.noarch.rpm"
           },
@@ -2979,12 +2729,6 @@
           },
           "sha256:70d76d9f1ed43efa346f634d5237c8a533b7e6209c36a9c6f0754afd1ddfc539": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dhcp-common-4.3.6-47.el8.noarch.rpm"
-          },
-          "sha256:70e42cbbd3b21cf9e670a3aaadf55105e45ef0a4aa9d4fc021930f441a87d396": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-2.24-8.el8.x86_64.rpm"
-          },
-          "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgudev-232-4.el8.x86_64.rpm"
           },
           "sha256:723963983258ad5c85fc708c519361f4668db7703f8dbfeae6901c1459bd1010": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bind-export-libs-9.11.36-2.el8.x86_64.rpm"
@@ -3055,9 +2799,6 @@
           "sha256:7eb899e531b473af1148fe749aca852e85667a5ba0ca06e01047cfbb3bb9ae2a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libmount-2.32.1-32.el8.x86_64.rpm"
           },
-          "sha256:7ebd6b189663e2ec911e153f2246221737e25978ef88d6b0595a486ca58a31a5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/nss-sysinit-3.67.0-7.el8_5.x86_64.rpm"
-          },
           "sha256:7f6127ebd8edf8e588a29a990eae291eae3dcab05286a29cf224f0fe597b9b1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libfdisk-2.32.1-32.el8.x86_64.rpm"
           },
@@ -3070,14 +2811,8 @@
           "sha256:82228fd3ceae25d76cf1b9d9aa1e7151120885bbacd1c910a7dc9d628e0e027d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/librepo-1.14.2-1.el8.x86_64.rpm"
           },
-          "sha256:83bbe96f5585514ea848a8d33605d52da1c7f32b229a1f6f9fd05f088aa897d2": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/nss-3.67.0-7.el8_5.x86_64.rpm"
-          },
           "sha256:83e568e3bb4f68f552f26dd517df374eaef0b2204205ba78a855607525a96b92": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-3-20220201/Packages/rh-amazon-rhui-client-3.0.45-1.el8.noarch.rpm"
-          },
-          "sha256:84b775933e1b27597d1f12fd5370734f34ba54e97743bf32d7d5e10c922a0bfe": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/nss-softokn-freebl-3.67.0-7.el8_5.x86_64.rpm"
           },
           "sha256:862e75a1cf6aa5be750a530c8ce8b999d0b2efe9737e20f37f9f9153a82e56fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libassuan-2.5.1-3.el8.x86_64.rpm"
@@ -3094,9 +2829,6 @@
           "sha256:88590efc37e205ae9b2048fcfea719157c5a3c7a9b7a650d0b7afb131e479a8b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsemanage-2.9-6.el8.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8b04c8eb33a3af6b22e143b11fc887db47ff188eac5f0a1d80fb99f8a9bf3d44": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libstdc++-8.5.0-10.el8.x86_64.rpm"
           },
@@ -3105,9 +2837,6 @@
           },
           "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8d145155b38c4c12869b95f24bbb0ee49f3ea09978362a4bc9aba2972144c16d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/glibc-gconv-extra-2.28-184.el8.x86_64.rpm"
@@ -3157,9 +2886,6 @@
           "sha256:98030945b250d0149887dacc87655f1d8d01861c1a752236674e588785b78246": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pip-9.0.3-22.el8.noarch.rpm"
           },
-          "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm"
-          },
           "sha256:98daaa0ba7c4c91b8f0fe4d2e1117d23495f7ec5899dddbc2117f76b7e7550dd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-hawkey-0.63.0-5.el8.x86_64.rpm"
           },
@@ -3180,9 +2906,6 @@
           },
           "sha256:9a9ca6857f517f1249d2eb496fe904590d6203e4a9547a28e0b23f21c4cae24a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/polkit-pkla-compat-0.1-12.el8.x86_64.rpm"
-          },
-          "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mokutil-0.3.0-11.el8.x86_64.rpm"
           },
           "sha256:9b1251422cfd498da3569583dea926198827e6e5fcf2a3d3d9c5521401ad0fc9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/redhat-release-8.6-0.0.el8.x86_64.rpm"
@@ -3259,12 +2982,6 @@
           "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libxml2-2.9.7-9.el8_4.2.x86_64.rpm"
           },
-          "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
-          },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
           "sha256:afb34faa32b75d1c9c1d9c729bd27616c0fd1965a7fca433c56c318bf061df99": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/chrony-4.1-1.el8.x86_64.rpm"
           },
@@ -3301,9 +3018,6 @@
           "sha256:b4babe48d93eccce4f0249ba34d592bfc306c3b14b40df7a5cc9eaec2eaae20f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/numactl-libs-2.0.12-13.el8.x86_64.rpm"
           },
-          "sha256:b6050db00772299f827781e272f3b93f17687d164ded25cf795128567b539032": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mdadm-4.2-rc3.el8.x86_64.rpm"
-          },
           "sha256:b76f0d3effc681142bb33052acb44a406b9af4ff524658b0ef9b475dbd587975": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/insights-client-3.1.7-1.el8.noarch.rpm"
           },
@@ -3324,9 +3038,6 @@
           },
           "sha256:b9d0a4c0e16db4c05b2d0690216d8c5da2db7d67bc765a00ce2a32c5f810c245": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/pkgconf-1.4.2-1.el8.x86_64.rpm"
-          },
-          "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-efi-x64-2.02-106.el8.x86_64.rpm"
           },
           "sha256:ba59500c8304ec75121cc2c5f9d5917748ff8b293aca3b49c9d1d971feb606f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/file-5.33-20.el8.x86_64.rpm"
@@ -3391,9 +3102,6 @@
           "sha256:c4e93daa6d0f0648f4dc694400bd35b8bc01a0d98228054735a9b6bc4c35b920": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/irqbalance-1.4.0-6.el8.x86_64.rpm"
           },
-          "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm"
-          },
           "sha256:c60aede8488f68a001f3495bd6e6d894fc3a44bb488f4550b5970ab5904d0a1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/geolite2-country-20180605-1.el8.noarch.rpm"
           },
@@ -3402,9 +3110,6 @@
           },
           "sha256:c6c7aa6efa4b965ce11fd74268378a02918b970611d5621e4a1b05af128b3f86": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/platform-python-3.6.8-45.el8.x86_64.rpm"
-          },
-          "sha256:c8192b0eb0496d79d1a3925c1d7eb95abde0d4a4a2c44a86a9a78f8de6dab2d9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-fs-2.24-8.el8.x86_64.rpm"
           },
           "sha256:c8653e199fdea0852a124ed24df2f7b3aa7e0aa6a1258147d89c39692a420c84": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-linux-procfs-0.7.0-1.el8.noarch.rpm"
@@ -3487,9 +3192,6 @@
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/timedatex-0.5-3.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d51fac44d322890f636097d85a8fd0bec3af5cc22d83440a13308b7b7ea5723b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/elfutils-debuginfod-client-0.186-1.el8.x86_64.rpm"
           },
@@ -3516,9 +3218,6 @@
           },
           "sha256:dc0e2e71435cc36ddb20b9c5c0a32566d3aad2f18efca3614efc9dd56cf5ed80": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libcomps-0.1.18-1.el8.x86_64.rpm"
-          },
-          "sha256:dc28397f174b147917ff788379672663ebe4c89eff4bae329c32c88272d59c45": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-loop-2.24-8.el8.x86_64.rpm"
           },
           "sha256:dd1590cec04ac5a59f21caf17aa3990aa582cc68a03c2909021a0960244cc0b7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/openssh-clients-8.0p1-13.el8.x86_64.rpm"
@@ -3619,9 +3318,6 @@
           "sha256:f52434c2edd4de318b4dde9eb47941de86f805d096145277eb9a2f31e1ebe315": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/squashfs-tools-4.3-20.el8.x86_64.rpm"
           },
-          "sha256:f63ad13c6fc281b01c48fb1e516dfb9540034899aac1aacd81a569016d28940a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-crypto-2.24-8.el8.x86_64.rpm"
-          },
           "sha256:f72118d72067987ac1eeded4b04e95e709b263c27877f3eb1112859db33cb403": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dracut-049-191.git20210920.el8.x86_64.rpm"
           },
@@ -3648,9 +3344,6 @@
           },
           "sha256:fc13e92624ab175be13398d4501cf5e810e8a4a89983fa59083640689f78d5b1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsss_idmap-2.6.2-3.el8.x86_64.rpm"
-          },
-          "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
           },
           "sha256:fd1f3109bd130e2dbbb57ea2f3a6d3419f9eef7108f1485f0d1386a563437614": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/gnutls-3.6.16-4.el8.x86_64.rpm"
@@ -3918,15 +3611,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -5416,15 +5100,6 @@
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-      },
-      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -5749,15 +5424,6 @@
         "checksum": "sha256:6670032db2178dacda1bcd490e45a5e69df6f9f39933c4968694ca61229b9255"
       },
       {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "049",
@@ -5819,33 +5485,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/e2fsprogs-libs-1.45.6-2.el8.x86_64.rpm",
         "checksum": "sha256:39f86feba904fc4c4a9a04a54576d6d3b4e9af344155aee9e4321c27b4742f0a"
-      },
-      {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
       },
       {
         "name": "elfutils-debuginfod-client",
@@ -5954,15 +5593,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/fuse-libs-2.9.7-12.el8.x86_64.rpm",
         "checksum": "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/fwupd-1.7.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:26e654b600b832d80eb184c0e17846f67e24c220ee5c850176d8ac91f7b08b6d"
       },
       {
         "name": "gawk",
@@ -6134,15 +5764,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-common-2.02-106.el8.noarch.rpm",
         "checksum": "sha256:1136323a37c5940055c3891a260b26782b75ea986fb5fe02ad80364f60527450"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "106.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-efi-x64-2.02-106.el8.x86_64.rpm",
-        "checksum": "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7"
       },
       {
         "name": "grub2-pc",
@@ -6676,15 +6297,6 @@
         "checksum": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -6719,24 +6331,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgpg-error-1.31-1.el8.x86_64.rpm",
         "checksum": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-      },
-      {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "232",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgudev-232-4.el8.x86_64.rpm",
-        "checksum": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgusb-0.3.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
       },
       {
         "name": "libidn2",
@@ -7036,15 +6630,6 @@
         "checksum": "sha256:ce810948b525e851c88a7c5ba71f8c070d91b84c8531a50dc8ea6650f115b3b5"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -7270,15 +6855,6 @@
         "checksum": "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libyaml",
         "epoch": 0,
         "version": "0.1.7",
@@ -7378,15 +6954,6 @@
         "checksum": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "rc3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mdadm-4.2-rc3.el8.x86_64.rpm",
-        "checksum": "sha256:b6050db00772299f827781e272f3b93f17687d164ded25cf795128567b539032"
-      },
-      {
         "name": "memstrack",
         "epoch": 0,
         "version": "0.1.11",
@@ -7403,15 +6970,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/microcode_ctl-20210608-1.el8.x86_64.rpm",
         "checksum": "sha256:75027c5ff5527fe7b69e3de665aa44cca6e0ee65094600f88c1fc5e6c6a1037a"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mokutil-0.3.0-11.el8.x86_64.rpm",
-        "checksum": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
       },
       {
         "name": "mozjs60",
@@ -7772,15 +7330,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/procps-ng-3.3.15-6.el8.x86_64.rpm",
         "checksum": "sha256:49f89e7b459eaa297e518c0e55d81d1b0d8181959346673babb158103422652d"
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.0",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
-        "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
       },
       {
         "name": "psmisc",
@@ -8377,15 +7926,6 @@
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.4",
-        "release": "2.el8_1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm",
-        "checksum": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -8773,96 +8313,6 @@
         "checksum": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "14.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libatasmart-0.19-14.el8.x86_64.rpm",
-        "checksum": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:70e42cbbd3b21cf9e670a3aaadf55105e45ef0a4aa9d4fc021930f441a87d396"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-crypto-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:f63ad13c6fc281b01c48fb1e516dfb9540034899aac1aacd81a569016d28940a"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-fs-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:c8192b0eb0496d79d1a3925c1d7eb95abde0d4a4a2c44a86a9a78f8de6dab2d9"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-loop-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:dc28397f174b147917ff788379672663ebe4c89eff4bae329c32c88272d59c45"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-mdraid-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:0af9f72ce36d8b1c779691db1edc2cbb82ca84e86a2df0608cf753e5f5ee5893"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-part-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:6907ac56fe2c2e7228077544308620b97ef7a71e9068173eff94c2df84b322ae"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-swap-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:4969e01de0186db1dd8523e81ba82b6a4f43a3b31d253f4cf1b82803bc16699f"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-utils-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:15e42b06b36f9c09a3983aa03eb9f7f7f2b94f7e588eeb8cb943a17a9578ea38"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libbytesize-1.4-3.el8.x86_64.rpm",
-        "checksum": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.10",
@@ -8890,15 +8340,6 @@
         "checksum": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
       },
       {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libudisks2-2.9.0-8.el8.x86_64.rpm",
-        "checksum": "sha256:1edca93bf9c19054d98f90ed292b8856d88df415a437bef8c29dda787a0a53f8"
-      },
-      {
         "name": "libxkbcommon",
         "epoch": 0,
         "version": "0.9.1",
@@ -8906,60 +8347,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libxkbcommon-0.9.1-1.el8.x86_64.rpm",
         "checksum": "sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072"
-      },
-      {
-        "name": "nspr",
-        "epoch": 0,
-        "version": "4.32.0",
-        "release": "1.el8_4",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/nspr-4.32.0-1.el8_4.x86_64.rpm",
-        "checksum": "sha256:52aed1bbd2aa4041e599a453a9c4323775b26d2b1326ffb98ac6febbcab8c230"
-      },
-      {
-        "name": "nss",
-        "epoch": 0,
-        "version": "3.67.0",
-        "release": "7.el8_5",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/nss-3.67.0-7.el8_5.x86_64.rpm",
-        "checksum": "sha256:83bbe96f5585514ea848a8d33605d52da1c7f32b229a1f6f9fd05f088aa897d2"
-      },
-      {
-        "name": "nss-softokn",
-        "epoch": 0,
-        "version": "3.67.0",
-        "release": "7.el8_5",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/nss-softokn-3.67.0-7.el8_5.x86_64.rpm",
-        "checksum": "sha256:1c138f1fa051cad977a6933da79f226f12970c25913d37af69bb86f3fece2850"
-      },
-      {
-        "name": "nss-softokn-freebl",
-        "epoch": 0,
-        "version": "3.67.0",
-        "release": "7.el8_5",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/nss-softokn-freebl-3.67.0-7.el8_5.x86_64.rpm",
-        "checksum": "sha256:84b775933e1b27597d1f12fd5370734f34ba54e97743bf32d7d5e10c922a0bfe"
-      },
-      {
-        "name": "nss-sysinit",
-        "epoch": 0,
-        "version": "3.67.0",
-        "release": "7.el8_5",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/nss-sysinit-3.67.0-7.el8_5.x86_64.rpm",
-        "checksum": "sha256:7ebd6b189663e2ec911e153f2246221737e25978ef88d6b0595a486ca58a31a5"
-      },
-      {
-        "name": "nss-util",
-        "epoch": 0,
-        "version": "3.67.0",
-        "release": "7.el8_5",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/nss-util-3.67.0-7.el8_5.x86_64.rpm",
-        "checksum": "sha256:584b98ef37799bd7395a09a4aa5e046613fef0e9a46bcde32926ba94031ad2cc"
       },
       {
         "name": "oddjob",
@@ -9106,15 +8493,6 @@
         "checksum": "sha256:455427f911eabe523f4b9403bc9da03d916c9615c8367c64efa893bff7548260"
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/udisks2-2.9.0-8.el8.x86_64.rpm",
-        "checksum": "sha256:0a63475f53acf618c0ef3a35300277923486d778f42edc360f0a4a7824086222"
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.7.3",
@@ -9122,15 +8500,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/unbound-libs-1.7.3-17.el8.x86_64.rpm",
         "checksum": "sha256:e920a82cda55b110690f3c946ec2cd85f969599c71212463279763afcc33303d"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.11",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm",
-        "checksum": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
       },
       {
         "name": "xkeyboard-config",

--- a/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
@@ -130,9 +130,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:f72118d72067987ac1eeded4b04e95e709b263c27877f3eb1112859db33cb403"
                   },
                   {
@@ -665,9 +662,6 @@
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
                   },
                   {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-                  },
-                  {
                     "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
                   },
                   {
@@ -800,9 +794,6 @@
                     "id": "sha256:6670032db2178dacda1bcd490e45a5e69df6f9f39933c4968694ca61229b9255"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:f72118d72067987ac1eeded4b04e95e709b263c27877f3eb1112859db33cb403"
                   },
                   {
@@ -822,15 +813,6 @@
                   },
                   {
                     "id": "sha256:39f86feba904fc4c4a9a04a54576d6d3b4e9af344155aee9e4321c27b4742f0a"
-                  },
-                  {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
                   },
                   {
                     "id": "sha256:d51fac44d322890f636097d85a8fd0bec3af5cc22d83440a13308b7b7ea5723b"
@@ -870,9 +852,6 @@
                   },
                   {
                     "id": "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042"
-                  },
-                  {
-                    "id": "sha256:26e654b600b832d80eb184c0e17846f67e24c220ee5c850176d8ac91f7b08b6d"
                   },
                   {
                     "id": "sha256:affab770e241d6c70cb271cbe5f84d02a946ad1b4d17d36f74dab74e9ca8fd7f"
@@ -930,9 +909,6 @@
                   },
                   {
                     "id": "sha256:1136323a37c5940055c3891a260b26782b75ea986fb5fe02ad80364f60527450"
-                  },
-                  {
-                    "id": "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7"
                   },
                   {
                     "id": "sha256:06f6a82e268aa006507fb1f82f01893f996fd47ad1cfa5f839c7861e8fd317cf"
@@ -1127,9 +1103,6 @@
                     "id": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:1f8f65210aeb7df3b8ebeaebab89ce4c9a6d01c8566d7c482ac833f9a5ffc3e2"
                   },
                   {
@@ -1140,12 +1113,6 @@
                   },
                   {
                     "id": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-                  },
-                  {
-                    "id": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-                  },
-                  {
-                    "id": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
                   },
                   {
                     "id": "sha256:fe37f767487e0806535a06cda4e302555c27166b6320657ae945d5217b8c36aa"
@@ -1253,9 +1220,6 @@
                     "id": "sha256:ce810948b525e851c88a7c5ba71f8c070d91b84c8531a50dc8ea6650f115b3b5"
                   },
                   {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-                  },
-                  {
                     "id": "sha256:9f9feb77c731a460cba4720ca92e8cbc266c4c2c7ffa22a53b90c2d1ad23dc6c"
                   },
                   {
@@ -1337,9 +1301,6 @@
                     "id": "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15"
                   },
                   {
@@ -1382,16 +1343,10 @@
                     "id": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
                   },
                   {
-                    "id": "sha256:b6050db00772299f827781e272f3b93f17687d164ded25cf795128567b539032"
-                  },
-                  {
                     "id": "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd"
                   },
                   {
                     "id": "sha256:75027c5ff5527fe7b69e3de665aa44cca6e0ee65094600f88c1fc5e6c6a1037a"
-                  },
-                  {
-                    "id": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -1622,9 +1577,6 @@
                     "id": "sha256:49f89e7b459eaa297e518c0e55d81d1b0d8181959346673babb158103422652d"
                   },
                   {
-                    "id": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
-                  },
-                  {
                     "id": "sha256:e22840ee14aa1993e75fd690749c01dbb7d4419c2b210fef173ff99a76f61ff6"
                   },
                   {
@@ -1848,9 +1800,6 @@
                   },
                   {
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
-                  },
-                  {
-                    "id": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
                   },
                   {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
@@ -2111,36 +2060,6 @@
                     "id": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
                   },
                   {
-                    "id": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-                  },
-                  {
-                    "id": "sha256:70e42cbbd3b21cf9e670a3aaadf55105e45ef0a4aa9d4fc021930f441a87d396"
-                  },
-                  {
-                    "id": "sha256:f63ad13c6fc281b01c48fb1e516dfb9540034899aac1aacd81a569016d28940a"
-                  },
-                  {
-                    "id": "sha256:c8192b0eb0496d79d1a3925c1d7eb95abde0d4a4a2c44a86a9a78f8de6dab2d9"
-                  },
-                  {
-                    "id": "sha256:dc28397f174b147917ff788379672663ebe4c89eff4bae329c32c88272d59c45"
-                  },
-                  {
-                    "id": "sha256:0af9f72ce36d8b1c779691db1edc2cbb82ca84e86a2df0608cf753e5f5ee5893"
-                  },
-                  {
-                    "id": "sha256:6907ac56fe2c2e7228077544308620b97ef7a71e9068173eff94c2df84b322ae"
-                  },
-                  {
-                    "id": "sha256:4969e01de0186db1dd8523e81ba82b6a4f43a3b31d253f4cf1b82803bc16699f"
-                  },
-                  {
-                    "id": "sha256:15e42b06b36f9c09a3983aa03eb9f7f7f2b94f7e588eeb8cb943a17a9578ea38"
-                  },
-                  {
-                    "id": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-                  },
-                  {
                     "id": "sha256:bfe5c8ea12012936cc59981a10728e95d5fdadd3e893457af7a27c464d8cb6ba"
                   },
                   {
@@ -2148,9 +2067,6 @@
                   },
                   {
                     "id": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
-                  },
-                  {
-                    "id": "sha256:1edca93bf9c19054d98f90ed292b8856d88df415a437bef8c29dda787a0a53f8"
                   },
                   {
                     "id": "sha256:b1b5660d070a5cf322ecb1c0bf36a8282362f01e0fa4041e11ddbeef1524eef8"
@@ -2336,13 +2252,7 @@
                     "id": "sha256:bafc9ec3dd737b0dbdf179b9d9b4c8a9b5c1a92423eae1e4eb3047522107695e"
                   },
                   {
-                    "id": "sha256:0a63475f53acf618c0ef3a35300277923486d778f42edc360f0a4a7824086222"
-                  },
-                  {
                     "id": "sha256:e920a82cda55b110690f3c946ec2cd85f969599c71212463279763afcc33303d"
-                  },
-                  {
-                    "id": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
                   },
                   {
                     "id": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
@@ -2424,9 +2334,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -2607,23 +2515,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -2631,13 +2526,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-361.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -2702,20 +2593,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2732,44 +2611,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -2777,8 +2621,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -2804,28 +2648,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -2835,18 +2663,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -2864,8 +2680,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -2946,9 +2762,6 @@
           "sha256:0a59c5a145344642e54dd11689ae7dcc76a4229f3e4cbca0c2a17e0b9d5f9606": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-dnf-plugins-core-4.0.21-8.el8.noarch.rpm"
           },
-          "sha256:0a63475f53acf618c0ef3a35300277923486d778f42edc360f0a4a7824086222": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/udisks2-2.9.0-8.el8.x86_64.rpm"
-          },
           "sha256:0a7e46bae339a5926877f16306a6d4ee106cafa08f54b3eaf0dfa593516ccda3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/fence-agents-vmware-soap-4.2.1-85.el8.noarch.rpm"
           },
@@ -2963,9 +2776,6 @@
           },
           "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dnf-data-4.7.0-5.el8.noarch.rpm"
-          },
-          "sha256:0af9f72ce36d8b1c779691db1edc2cbb82ca84e86a2df0608cf753e5f5ee5893": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-mdraid-2.24-8.el8.x86_64.rpm"
           },
           "sha256:0b4118e4f4aec595982dbb9f4b48999284e9e51dfd45d251d930f1541d8a8020": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/expat-2.2.5-4.el8.x86_64.rpm"
@@ -3042,9 +2852,6 @@
           "sha256:1586c9ed66080454a3664ec618544e4c655d299e76178dd4a8c916e6fe29f93b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/samba-common-4.15.4-0.el8.noarch.rpm"
           },
-          "sha256:15e42b06b36f9c09a3983aa03eb9f7f7f2b94f7e588eeb8cb943a17a9578ea38": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-utils-2.24-8.el8.x86_64.rpm"
-          },
           "sha256:16405e1b13143205cd548df708bdae05683c56e2bef89484317b40112a46f42c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/pacemaker-schemas-2.1.2-4.el8.noarch.rpm"
           },
@@ -3105,9 +2912,6 @@
           "sha256:1d47e465939bba5bcf9c37be2516e60d6c9449ccee70a54a6133df989ac8b1f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libksba-1.3.5-7.el8.x86_64.rpm"
           },
-          "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libatasmart-0.19-14.el8.x86_64.rpm"
-          },
           "sha256:1dc1dbd0aa4dad715b3242468d4841f2f35bf6aa60d8e1928ee692784b12da1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsecret-0.18.6-1.el8.x86_64.rpm"
           },
@@ -3119,9 +2923,6 @@
           },
           "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm"
-          },
-          "sha256:1edca93bf9c19054d98f90ed292b8856d88df415a437bef8c29dda787a0a53f8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libudisks2-2.9.0-8.el8.x86_64.rpm"
           },
           "sha256:1eec9822d1dee41a2e3faae10258858687a63dd6af921937f469399e5e15edd2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/redhat-release-eula-8.6-0.0.el8.x86_64.rpm"
@@ -3198,9 +2999,6 @@
           "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/brotli-1.0.6-3.el8.x86_64.rpm"
           },
-          "sha256:26e654b600b832d80eb184c0e17846f67e24c220ee5c850176d8ac91f7b08b6d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/fwupd-1.7.1-1.el8.x86_64.rpm"
-          },
           "sha256:27067f9c284cd9da72436cc6598e405796e28ace5ed99d22e6b0641c9e711050": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/systemd-239-56.el8.x86_64.rpm"
           },
@@ -3263,15 +3061,6 @@
           },
           "sha256:2f465049e10abac1680ed833f15b565ecdb5f3775a4e3c41510ccfbf4324d44a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-tools-2.02-106.el8.x86_64.rpm"
-          },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
-          "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
           "sha256:32d14d3243c148eb665139c737607f28eb1eea80f0478439a6e09b44dc222562": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/fence-agents-amt-ws-4.2.1-85.el8.noarch.rpm"
@@ -3338,9 +3127,6 @@
           },
           "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
-          },
-          "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
           },
           "sha256:3d60bc4a8b2910d391ba3dad97051839ab0219c9a1aaeb114f272d6642edb5c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-n8.6-20220201/Packages/libknet1-plugins-all-1.22-1.el8.x86_64.rpm"
@@ -3411,9 +3197,6 @@
           "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libzstd-1.4.4-1.el8.x86_64.rpm"
           },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efivar-libs-37-4.el8.x86_64.rpm"
-          },
           "sha256:4811ab95c1d50ef7380e2c5937ae4490f8e28f56cf787c189437d1709e4423fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/perl-podlators-4.11-1.el8.noarch.rpm"
           },
@@ -3422,9 +3205,6 @@
           },
           "sha256:48e0e5143bf28f7220fc3c31db376c1ef0ed129fd3d2f82e3ce8531528924fd6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dnf-plugin-subscription-manager-1.28.25-1.el8.x86_64.rpm"
-          },
-          "sha256:4969e01de0186db1dd8523e81ba82b6a4f43a3b31d253f4cf1b82803bc16699f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-swap-2.24-8.el8.x86_64.rpm"
           },
           "sha256:49b6b2a486bd32714619e81782623f126486452bbd2295a2ab1f3e997b97d327": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/crontabs-1.11-17.20190603git.el8.noarch.rpm"
@@ -3645,9 +3425,6 @@
           "sha256:689d17a67a9010b48cf8f22ccb14e0723602c0f215b0c3bc5adc25d77619d54b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/selinux-policy-targeted-3.14.3-89.el8.noarch.rpm"
           },
-          "sha256:6907ac56fe2c2e7228077544308620b97ef7a71e9068173eff94c2df84b322ae": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-part-2.24-8.el8.x86_64.rpm"
-          },
           "sha256:6a1e0d10b570d901d96addafb4bc57d42c44f1989387b7cf44015b0375b7c2c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/ipmitool-1.8.18-18.el8.x86_64.rpm"
           },
@@ -3692,12 +3469,6 @@
           },
           "sha256:70d76d9f1ed43efa346f634d5237c8a533b7e6209c36a9c6f0754afd1ddfc539": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dhcp-common-4.3.6-47.el8.noarch.rpm"
-          },
-          "sha256:70e42cbbd3b21cf9e670a3aaadf55105e45ef0a4aa9d4fc021930f441a87d396": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-2.24-8.el8.x86_64.rpm"
-          },
-          "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgudev-232-4.el8.x86_64.rpm"
           },
           "sha256:723963983258ad5c85fc708c519361f4668db7703f8dbfeae6901c1459bd1010": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bind-export-libs-9.11.36-2.el8.x86_64.rpm"
@@ -3864,9 +3635,6 @@
           "sha256:89a36dc42a2597af0d3031bba6bc950e2c6c7bc23940249a226c73c63120d4ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/rubygem-psych-3.0.2-107.module+el8.5.0+13840+ec418553.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8a77b0b6d35a1b0407570e6890b7961d5ed1ce88b3bfd2d5032d66432b4275d9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-n8.6-20220201/Packages/libknet1-crypto-nss-plugin-1.22-1.el8.x86_64.rpm"
           },
@@ -3884,9 +3652,6 @@
           },
           "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8cc4f1625500336caa392a818b7ead0688e98d63f000e0da7274b27b652f78a5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-n8.6-20220201/Packages/libknet1-compress-lz4-plugin-1.22-1.el8.x86_64.rpm"
@@ -3957,9 +3722,6 @@
           "sha256:98030945b250d0149887dacc87655f1d8d01861c1a752236674e588785b78246": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pip-9.0.3-22.el8.noarch.rpm"
           },
-          "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm"
-          },
           "sha256:98daaa0ba7c4c91b8f0fe4d2e1117d23495f7ec5899dddbc2117f76b7e7550dd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-hawkey-0.63.0-5.el8.x86_64.rpm"
           },
@@ -3989,9 +3751,6 @@
           },
           "sha256:9aaf89fd8b11bd756d0bc4869f3a07d43755da5c31470f554224949256ffe289": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/fence-agents-mpath-4.2.1-85.el8.noarch.rpm"
-          },
-          "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mokutil-0.3.0-11.el8.x86_64.rpm"
           },
           "sha256:9b1251422cfd498da3569583dea926198827e6e5fcf2a3d3d9c5521401ad0fc9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/redhat-release-8.6-0.0.el8.x86_64.rpm"
@@ -4107,12 +3866,6 @@
           "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libxml2-2.9.7-9.el8_4.2.x86_64.rpm"
           },
-          "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
-          },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
           "sha256:afb34faa32b75d1c9c1d9c729bd27616c0fd1965a7fca433c56c318bf061df99": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/chrony-4.1-1.el8.x86_64.rpm"
           },
@@ -4167,9 +3920,6 @@
           "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
           },
-          "sha256:b6050db00772299f827781e272f3b93f17687d164ded25cf795128567b539032": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mdadm-4.2-rc3.el8.x86_64.rpm"
-          },
           "sha256:b76f0d3effc681142bb33052acb44a406b9af4ff524658b0ef9b475dbd587975": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/insights-client-3.1.7-1.el8.noarch.rpm"
           },
@@ -4193,9 +3943,6 @@
           },
           "sha256:b9d0a4c0e16db4c05b2d0690216d8c5da2db7d67bc765a00ce2a32c5f810c245": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/pkgconf-1.4.2-1.el8.x86_64.rpm"
-          },
-          "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-efi-x64-2.02-106.el8.x86_64.rpm"
           },
           "sha256:ba59500c8304ec75121cc2c5f9d5917748ff8b293aca3b49c9d1d971feb606f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/file-5.33-20.el8.x86_64.rpm"
@@ -4278,9 +4025,6 @@
           "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libxslt-1.1.32-6.el8.x86_64.rpm"
           },
-          "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm"
-          },
           "sha256:c60aede8488f68a001f3495bd6e6d894fc3a44bb488f4550b5970ab5904d0a1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/geolite2-country-20180605-1.el8.noarch.rpm"
           },
@@ -4289,9 +4033,6 @@
           },
           "sha256:c6c7aa6efa4b965ce11fd74268378a02918b970611d5621e4a1b05af128b3f86": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/platform-python-3.6.8-45.el8.x86_64.rpm"
-          },
-          "sha256:c8192b0eb0496d79d1a3925c1d7eb95abde0d4a4a2c44a86a9a78f8de6dab2d9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-fs-2.24-8.el8.x86_64.rpm"
           },
           "sha256:c8653e199fdea0852a124ed24df2f7b3aa7e0aa6a1258147d89c39692a420c84": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-linux-procfs-0.7.0-1.el8.noarch.rpm"
@@ -4395,9 +4136,6 @@
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/timedatex-0.5-3.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d51fac44d322890f636097d85a8fd0bec3af5cc22d83440a13308b7b7ea5723b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/elfutils-debuginfod-client-0.186-1.el8.x86_64.rpm"
           },
@@ -4454,9 +4192,6 @@
           },
           "sha256:dc1ae7a1011705164487dae39f656665a6b18d8c36cd402bd9328825ba473c2b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-ptyprocess-0.5.2-4.el8.noarch.rpm"
-          },
-          "sha256:dc28397f174b147917ff788379672663ebe4c89eff4bae329c32c88272d59c45": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-loop-2.24-8.el8.x86_64.rpm"
           },
           "sha256:dd1590cec04ac5a59f21caf17aa3990aa582cc68a03c2909021a0960244cc0b7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/openssh-clients-8.0p1-13.el8.x86_64.rpm"
@@ -4602,9 +4337,6 @@
           "sha256:f57fced1d7f6ccbad04c15cb2cc66615a560327eb7b086c0d544e3df4ab79d34": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/rubygem-rdoc-6.0.1.1-107.module+el8.5.0+13840+ec418553.noarch.rpm"
           },
-          "sha256:f63ad13c6fc281b01c48fb1e516dfb9540034899aac1aacd81a569016d28940a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-crypto-2.24-8.el8.x86_64.rpm"
-          },
           "sha256:f69231742cabcba835a55dcfe91b6458ac14531d6afd24ad14fe3c0b2d856c85": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/fence-agents-common-4.2.1-85.el8.noarch.rpm"
           },
@@ -4643,9 +4375,6 @@
           },
           "sha256:fc13e92624ab175be13398d4501cf5e810e8a4a89983fa59083640689f78d5b1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsss_idmap-2.6.2-3.el8.x86_64.rpm"
-          },
-          "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
           },
           "sha256:fccc3b9ebbf072a573ad786070f33dc06d408d435d7c62781bbdb67cd8713ca0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/fence-agents-scsi-4.2.1-85.el8.noarch.rpm"
@@ -4928,15 +4657,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -6435,15 +6155,6 @@
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-      },
-      {
         "name": "bzip2",
         "epoch": 0,
         "version": "1.0.6",
@@ -6840,15 +6551,6 @@
         "checksum": "sha256:6670032db2178dacda1bcd490e45a5e69df6f9f39933c4968694ca61229b9255"
       },
       {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "049",
@@ -6910,33 +6612,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/e2fsprogs-libs-1.45.6-2.el8.x86_64.rpm",
         "checksum": "sha256:39f86feba904fc4c4a9a04a54576d6d3b4e9af344155aee9e4321c27b4742f0a"
-      },
-      {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
       },
       {
         "name": "elfutils-debuginfod-client",
@@ -7054,15 +6729,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/fuse-libs-2.9.7-12.el8.x86_64.rpm",
         "checksum": "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/fwupd-1.7.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:26e654b600b832d80eb184c0e17846f67e24c220ee5c850176d8ac91f7b08b6d"
       },
       {
         "name": "gawk",
@@ -7234,15 +6900,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-common-2.02-106.el8.noarch.rpm",
         "checksum": "sha256:1136323a37c5940055c3891a260b26782b75ea986fb5fe02ad80364f60527450"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "106.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-efi-x64-2.02-106.el8.x86_64.rpm",
-        "checksum": "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7"
       },
       {
         "name": "grub2-pc",
@@ -7821,15 +7478,6 @@
         "checksum": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -7864,24 +7512,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgpg-error-1.31-1.el8.x86_64.rpm",
         "checksum": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-      },
-      {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "232",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgudev-232-4.el8.x86_64.rpm",
-        "checksum": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgusb-0.3.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
       },
       {
         "name": "libicu",
@@ -8199,15 +7829,6 @@
         "checksum": "sha256:ce810948b525e851c88a7c5ba71f8c070d91b84c8531a50dc8ea6650f115b3b5"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -8451,15 +8072,6 @@
         "checksum": "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libxslt",
         "epoch": 0,
         "version": "1.1.32",
@@ -8586,15 +8198,6 @@
         "checksum": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "rc3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mdadm-4.2-rc3.el8.x86_64.rpm",
-        "checksum": "sha256:b6050db00772299f827781e272f3b93f17687d164ded25cf795128567b539032"
-      },
-      {
         "name": "memstrack",
         "epoch": 0,
         "version": "0.1.11",
@@ -8611,15 +8214,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/microcode_ctl-20210608-1.el8.x86_64.rpm",
         "checksum": "sha256:75027c5ff5527fe7b69e3de665aa44cca6e0ee65094600f88c1fc5e6c6a1037a"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mokutil-0.3.0-11.el8.x86_64.rpm",
-        "checksum": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
       },
       {
         "name": "mozjs60",
@@ -9306,15 +8900,6 @@
         "checksum": "sha256:49f89e7b459eaa297e518c0e55d81d1b0d8181959346673babb158103422652d"
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.0",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/protobuf-c-1.3.0-6.el8.x86_64.rpm",
-        "checksum": "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4"
-      },
-      {
         "name": "psmisc",
         "epoch": 0,
         "version": "23.1",
@@ -9988,15 +9573,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shared-mime-info-1.9-3.el8.x86_64.rpm",
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.4",
-        "release": "2.el8_1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm",
-        "checksum": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
       },
       {
         "name": "slang",
@@ -10773,96 +10349,6 @@
         "checksum": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "14.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libatasmart-0.19-14.el8.x86_64.rpm",
-        "checksum": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:70e42cbbd3b21cf9e670a3aaadf55105e45ef0a4aa9d4fc021930f441a87d396"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-crypto-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:f63ad13c6fc281b01c48fb1e516dfb9540034899aac1aacd81a569016d28940a"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-fs-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:c8192b0eb0496d79d1a3925c1d7eb95abde0d4a4a2c44a86a9a78f8de6dab2d9"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-loop-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:dc28397f174b147917ff788379672663ebe4c89eff4bae329c32c88272d59c45"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-mdraid-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:0af9f72ce36d8b1c779691db1edc2cbb82ca84e86a2df0608cf753e5f5ee5893"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-part-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:6907ac56fe2c2e7228077544308620b97ef7a71e9068173eff94c2df84b322ae"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-swap-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:4969e01de0186db1dd8523e81ba82b6a4f43a3b31d253f4cf1b82803bc16699f"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-utils-2.24-8.el8.x86_64.rpm",
-        "checksum": "sha256:15e42b06b36f9c09a3983aa03eb9f7f7f2b94f7e588eeb8cb943a17a9578ea38"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libbytesize-1.4-3.el8.x86_64.rpm",
-        "checksum": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.10",
@@ -10888,15 +10374,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libmaxminddb-1.2.0-10.el8.x86_64.rpm",
         "checksum": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
-      },
-      {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libudisks2-2.9.0-8.el8.x86_64.rpm",
-        "checksum": "sha256:1edca93bf9c19054d98f90ed292b8856d88df415a437bef8c29dda787a0a53f8"
       },
       {
         "name": "libwsman1",
@@ -11448,15 +10925,6 @@
         "checksum": "sha256:bafc9ec3dd737b0dbdf179b9d9b4c8a9b5c1a92423eae1e4eb3047522107695e"
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "8.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/udisks2-2.9.0-8.el8.x86_64.rpm",
-        "checksum": "sha256:0a63475f53acf618c0ef3a35300277923486d778f42edc360f0a4a7824086222"
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.7.3",
@@ -11464,15 +10932,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/unbound-libs-1.7.3-17.el8.x86_64.rpm",
         "checksum": "sha256:e920a82cda55b110690f3c946ec2cd85f969599c71212463279763afcc33303d"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.11",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm",
-        "checksum": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
       },
       {
         "name": "xkeyboard-config",

--- a/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
@@ -156,9 +156,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:f72118d72067987ac1eeded4b04e95e709b263c27877f3eb1112859db33cb403"
                   },
                   {
@@ -727,9 +724,6 @@
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
                   },
                   {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-                  },
-                  {
                     "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
                   },
                   {
@@ -916,15 +910,6 @@
                     "id": "sha256:d5689e2894c59a375f985b5228b32e78d10b4ceeec9fd7c79f2000480494d368"
                   },
                   {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
-                  },
-                  {
                     "id": "sha256:d51fac44d322890f636097d85a8fd0bec3af5cc22d83440a13308b7b7ea5723b"
                   },
                   {
@@ -980,9 +965,6 @@
                   },
                   {
                     "id": "sha256:37582049ed88df6e03737825880fee090de4be0e13859b8f055973b6e1828d86"
-                  },
-                  {
-                    "id": "sha256:26e654b600b832d80eb184c0e17846f67e24c220ee5c850176d8ac91f7b08b6d"
                   },
                   {
                     "id": "sha256:affab770e241d6c70cb271cbe5f84d02a946ad1b4d17d36f74dab74e9ca8fd7f"
@@ -1046,9 +1028,6 @@
                   },
                   {
                     "id": "sha256:1136323a37c5940055c3891a260b26782b75ea986fb5fe02ad80364f60527450"
-                  },
-                  {
-                    "id": "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7"
                   },
                   {
                     "id": "sha256:06f6a82e268aa006507fb1f82f01893f996fd47ad1cfa5f839c7861e8fd317cf"
@@ -1288,9 +1267,6 @@
                     "id": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:1f8f65210aeb7df3b8ebeaebab89ce4c9a6d01c8566d7c482ac833f9a5ffc3e2"
                   },
                   {
@@ -1447,9 +1423,6 @@
                     "id": "sha256:0fecd6b03e12a176d1d3508d3cf2ceb5a2c25185bec31d69b294363807478045"
                   },
                   {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-                  },
-                  {
                     "id": "sha256:9f9feb77c731a460cba4720ca92e8cbc266c4c2c7ffa22a53b90c2d1ad23dc6c"
                   },
                   {
@@ -1543,9 +1516,6 @@
                     "id": "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15"
                   },
                   {
@@ -1616,9 +1586,6 @@
                   },
                   {
                     "id": "sha256:48e1edacae05696360d0dd0706b2d3debb617ae15e9f7ce47e528839231a6c25"
-                  },
-                  {
-                    "id": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -2108,9 +2075,6 @@
                   },
                   {
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
-                  },
-                  {
-                    "id": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
                   },
                   {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
@@ -3110,9 +3074,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -3410,23 +3372,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -3434,13 +3383,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto processor.max_cstate=1 intel_idle.max_cstate=1",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-361.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -3505,20 +3450,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -3535,44 +3468,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -3580,8 +3478,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -3607,28 +3505,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -3638,18 +3520,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -3667,8 +3537,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -4076,9 +3946,6 @@
           "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/brotli-1.0.6-3.el8.x86_64.rpm"
           },
-          "sha256:26e654b600b832d80eb184c0e17846f67e24c220ee5c850176d8ac91f7b08b6d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/fwupd-1.7.1-1.el8.x86_64.rpm"
-          },
           "sha256:27067f9c284cd9da72436cc6598e405796e28ace5ed99d22e6b0641c9e711050": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/systemd-239-56.el8.x86_64.rpm"
           },
@@ -4184,14 +4051,8 @@
           "sha256:2f465049e10abac1680ed833f15b565ecdb5f3775a4e3c41510ccfbf4324d44a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-tools-2.02-106.el8.x86_64.rpm"
           },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
           "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
           "sha256:3245158fd6bdfeba1ef9f402b5ea509e99e909bddb79e9a283fefa59d6392c67": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/iptables-1.8.4-22.el8.x86_64.rpm"
@@ -4393,9 +4254,6 @@
           },
           "sha256:468b540f98263d7b274c722a7b8f18ac1ab9d88783cfca6561c85e56b36afeee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/PackageKit-glib-1.1.12-6.el8.x86_64.rpm"
-          },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efivar-libs-37-4.el8.x86_64.rpm"
           },
           "sha256:47d5786c78a2a50f5ce67af5a6fd73665c446ca6c66c75e80d0ad79188753d18": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libibverbs-37.2-1.el8.x86_64.rpm"
@@ -4979,9 +4837,6 @@
           "sha256:89bac8488569b012c198f87a3589b0147bd220ec5e37b7e22b27ef8dbafe1b2a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/setroubleshoot-server-3.3.26-1.el8.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8a994138b4d4bbcc5663ba464b85c9a9a0112bf9bad7e1ac3302559b69e7fa55": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/gtk2-2.24.32-5.el8.x86_64.rpm"
           },
@@ -4996,9 +4851,6 @@
           },
           "sha256:8c81bb15456e441250d2ed53b223bf85c21a9b25b6a36ab09953cc831f9e7109": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/tcsh-6.20.00-15.el8.x86_64.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8ca5dd4feea941aba58c6d6e981883bca79704dba06583f880c0bf5e0cf4efcf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/desktop-file-utils-0.23-8.el8.x86_64.rpm"
@@ -5155,9 +5007,6 @@
           },
           "sha256:9a9ca6857f517f1249d2eb496fe904590d6203e4a9547a28e0b23f21c4cae24a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/polkit-pkla-compat-0.1-12.el8.x86_64.rpm"
-          },
-          "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mokutil-0.3.0-11.el8.x86_64.rpm"
           },
           "sha256:9b079ce20a6524d8e85d139b2ec2a7dd3f4f79fa283f68208b72b8091e6bde3b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libXft-2.3.3-1.el8.x86_64.rpm"
@@ -5336,9 +5185,6 @@
           "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
           },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
           "sha256:af2aab47c6624608df3d8eb9721c78573377a8bfc5843f93a8ff4d9952a41b3c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/ledmon-0.95-1.el8.x86_64.rpm"
           },
@@ -5459,9 +5305,6 @@
           "sha256:b9d0a4c0e16db4c05b2d0690216d8c5da2db7d67bc765a00ce2a32c5f810c245": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/pkgconf-1.4.2-1.el8.x86_64.rpm"
           },
-          "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-efi-x64-2.02-106.el8.x86_64.rpm"
-          },
           "sha256:ba59500c8304ec75121cc2c5f9d5917748ff8b293aca3b49c9d1d971feb606f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/file-5.33-20.el8.x86_64.rpm"
           },
@@ -5572,9 +5415,6 @@
           },
           "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libxslt-1.1.32-6.el8.x86_64.rpm"
-          },
-          "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm"
           },
           "sha256:c60aede8488f68a001f3495bd6e6d894fc3a44bb488f4550b5970ab5904d0a1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/geolite2-country-20180605-1.el8.noarch.rpm"
@@ -5734,9 +5574,6 @@
           },
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/timedatex-0.5-3.el8.x86_64.rpm"
-          },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efibootmgr-16-1.el8.x86_64.rpm"
           },
           "sha256:d51fac44d322890f636097d85a8fd0bec3af5cc22d83440a13308b7b7ea5723b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/elfutils-debuginfod-client-0.186-1.el8.x86_64.rpm"
@@ -6391,15 +6228,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -7997,15 +7825,6 @@
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-      },
-      {
         "name": "bzip2",
         "epoch": 0,
         "version": "1.0.6",
@@ -8564,33 +8383,6 @@
         "checksum": "sha256:d5689e2894c59a375f985b5228b32e78d10b4ceeec9fd7c79f2000480494d368"
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
-      },
-      {
         "name": "elfutils-debuginfod-client",
         "epoch": 0,
         "version": "0.186",
@@ -8760,15 +8552,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/fuse3-libs-3.2.1-12.el8.x86_64.rpm",
         "checksum": "sha256:37582049ed88df6e03737825880fee090de4be0e13859b8f055973b6e1828d86"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/fwupd-1.7.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:26e654b600b832d80eb184c0e17846f67e24c220ee5c850176d8ac91f7b08b6d"
       },
       {
         "name": "gawk",
@@ -8958,15 +8741,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-common-2.02-106.el8.noarch.rpm",
         "checksum": "sha256:1136323a37c5940055c3891a260b26782b75ea986fb5fe02ad80364f60527450"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "106.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-efi-x64-2.02-106.el8.x86_64.rpm",
-        "checksum": "sha256:b9d57c8cf9df7601855f5e6fbb3f9d7de96721edc8270bedcd32768e4e774aa7"
       },
       {
         "name": "grub2-pc",
@@ -9680,15 +9454,6 @@
         "checksum": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -10157,15 +9922,6 @@
         "checksum": "sha256:0fecd6b03e12a176d1d3508d3cf2ceb5a2c25185bec31d69b294363807478045"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -10445,15 +10201,6 @@
         "checksum": "sha256:aeb381f969689e8b9a07fdf6133cefe69cb46e28a58849682bccd2961da7f90e"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libxslt",
         "epoch": 0,
         "version": "1.1.32",
@@ -10668,15 +10415,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mlocate-0.26-20.el8.x86_64.rpm",
         "checksum": "sha256:48e1edacae05696360d0dd0706b2d3debb617ae15e9f7ce47e528839231a6c25"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/mokutil-0.3.0-11.el8.x86_64.rpm",
-        "checksum": "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59"
       },
       {
         "name": "mozjs60",
@@ -12144,15 +11882,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shared-mime-info-1.9-3.el8.x86_64.rpm",
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.4",
-        "release": "2.el8_1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm",
-        "checksum": "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306"
       },
       {
         "name": "slang",

--- a/test/data/manifests/rhel_87-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-ec2-boot.json
@@ -2119,14 +2119,14 @@
                   "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
                 },
                 {
-                  "size": 1024000,
+                  "size": 1048576,
                   "start": 411648,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "CB07C243-BC44-4717-853E-28852021225B"
                 },
                 {
-                  "size": 19535839,
-                  "start": 1435648,
+                  "size": 19511263,
+                  "start": 1460224,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2162,8 +2162,7 @@
           {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
-              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
             },
             "devices": {
               "device": {
@@ -2171,7 +2170,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 411648,
-                  "size": 1024000,
+                  "size": 1048576,
                   "lock": true
                 }
               }
@@ -2188,8 +2187,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1435648,
-                  "size": 19535839,
+                  "start": 1460224,
+                  "size": 19511263,
                   "lock": true
                 }
               }
@@ -2220,7 +2219,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 411648,
-                  "size": 1024000
+                  "size": 1048576
                 }
               },
               "boot.efi": {
@@ -2235,8 +2234,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1435648,
-                  "size": 19535839
+                  "start": 1460224,
+                  "size": 19511263
                 }
               }
             },

--- a/test/data/manifests/rhel_87-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ec2-boot.json
@@ -121,9 +121,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -646,9 +643,6 @@
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
                   },
                   {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-                  },
-                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -757,9 +751,6 @@
                     "id": "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -779,15 +770,6 @@
                   },
                   {
                     "id": "sha256:8e0e23d6a9399d9016d721467181d9abd3e888894149767b631889f1aeddf755"
-                  },
-                  {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
                   },
                   {
                     "id": "sha256:45c47f5146e39f50ca18d1561821607bc582c5fd4de0bf05bc06a5e0eb33df34"
@@ -824,9 +806,6 @@
                   },
                   {
                     "id": "sha256:be62c3c22fe4351a434d5b971061e512db199d763205dd8aaf4c6faa35a9be42"
-                  },
-                  {
-                    "id": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
                   },
                   {
                     "id": "sha256:59b3cff57ffbea4c4c011e6a81341a1203c18b91569fff019c93b756331300f8"
@@ -887,9 +866,6 @@
                   },
                   {
                     "id": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-                  },
-                  {
-                    "id": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
                   },
                   {
                     "id": "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d"
@@ -1069,9 +1045,6 @@
                     "id": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:7145b8d179b6c72e61de2b822551b343209adb63b76023fe26e7162d4ff6c107"
                   },
                   {
@@ -1082,12 +1055,6 @@
                   },
                   {
                     "id": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-                  },
-                  {
-                    "id": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-                  },
-                  {
-                    "id": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
                   },
                   {
                     "id": "sha256:4a62975251933dcaff77fdbd7704e8a12bea0ecb6eaaae5ea5e552bedd6788ec"
@@ -1189,9 +1156,6 @@
                     "id": "sha256:d15c8594702ab51f8aa792a6c0ebae49ddefc8740289397b2cd8cb6e4a711187"
                   },
                   {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-                  },
-                  {
                     "id": "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8"
                   },
                   {
@@ -1267,9 +1231,6 @@
                     "id": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf"
                   },
                   {
@@ -1303,16 +1264,10 @@
                     "id": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
                   },
                   {
-                    "id": "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de"
-                  },
-                  {
                     "id": "sha256:ca6208d771fbbfc703217b0f4314d214a866da86b105f222753a6efeb12d6f69"
                   },
                   {
                     "id": "sha256:d3e15db6aaa6d8ba4587408d87863b2f94092024bbb94893faa95c5d259a97d4"
-                  },
-                  {
-                    "id": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -1633,9 +1588,6 @@
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
                   },
                   {
-                    "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
-                  },
-                  {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
                   },
                   {
@@ -1762,36 +1714,6 @@
                     "id": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
                   },
                   {
-                    "id": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-                  },
-                  {
-                    "id": "sha256:91303cb921c3727203c4a25c12524356a2afb2e3fd594bdd12301a7b5edabaa3"
-                  },
-                  {
-                    "id": "sha256:cbca89c39db7fd80dc71deefdcfb15262e2aed69117e66a15632ac581c82b8b6"
-                  },
-                  {
-                    "id": "sha256:95a340a62ae433f5a5cb30e8929b9b4167d2d204bef99beea487ad65e451c2b9"
-                  },
-                  {
-                    "id": "sha256:8ed24bf92f4a389d82399a2dfcdcd2b8812b354d32e50807ddf557b978532756"
-                  },
-                  {
-                    "id": "sha256:5bea1ad0a4491ab6ae8607f741388c983dc471747176a3e82302e94addba6d44"
-                  },
-                  {
-                    "id": "sha256:74789339d67c8fd8545def02ae4a0f5dbbb9c0ee71aee54ee166b633563fe85d"
-                  },
-                  {
-                    "id": "sha256:859c0fe81e8a3e297664c62d725d3224ec6f35bf5078a2993484b35328c16fdd"
-                  },
-                  {
-                    "id": "sha256:fe6788ebe68e3bc8d6e9784c569c3bc5916e5c445a88fb0247ee1243018cfc8c"
-                  },
-                  {
-                    "id": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-                  },
-                  {
                     "id": "sha256:d16252dcb91c3e581ecb29234180fb99ac3199a052a89d0e23603cb6054bee16"
                   },
                   {
@@ -1801,28 +1723,7 @@
                     "id": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
                   },
                   {
-                    "id": "sha256:68e0dfe4bc893170e61539b648f41ef10aa8174a884de6ff91dcb87abc7d03ce"
-                  },
-                  {
                     "id": "sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072"
-                  },
-                  {
-                    "id": "sha256:82cd233003b87e6b810070eead73ec44073050aabccec9a619309074a1868fe9"
-                  },
-                  {
-                    "id": "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a"
-                  },
-                  {
-                    "id": "sha256:319d3d51dfc09875cdbb61518410fe2963887228089d4a9de8f673acc7a2ff82"
-                  },
-                  {
-                    "id": "sha256:4bcbfd3229e3fd2d6e1adfe46bc233872c4184838de40b2e61a9ba84fcb81512"
-                  },
-                  {
-                    "id": "sha256:507c1a196520e4263a0581e70b669c352097d6bdc7a5409ae748ee3942e71f5c"
-                  },
-                  {
-                    "id": "sha256:94d5c3946873b079aa5af985e31501981fef1cb3065024e9f41f70c40fc9b975"
                   },
                   {
                     "id": "sha256:4f542ac06b9101e66033210648ba4bcc86c23f508a194d3a6ccba2966e4ade73"
@@ -1876,13 +1777,7 @@
                     "id": "sha256:37ca74f003d06ada0528d353bdc0df49193a058cece3c51173dc8b9c80f410e5"
                   },
                   {
-                    "id": "sha256:c72fcb71cb08b0e21e56c9b3238cac42bfa90fa43b2e5bfb218e4b22b957f12f"
-                  },
-                  {
                     "id": "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3"
-                  },
-                  {
-                    "id": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
                   },
                   {
                     "id": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
@@ -1903,9 +1798,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -2073,23 +1966,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -2097,13 +1977,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-425.3.1.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -2168,20 +2044,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2198,44 +2062,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -2243,8 +2072,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -2270,28 +2099,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -2301,18 +2114,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -2330,8 +2131,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -2490,9 +2291,6 @@
           "sha256:1d47e465939bba5bcf9c37be2516e60d6c9449ccee70a54a6133df989ac8b1f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libksba-1.3.5-7.el8.x86_64.rpm"
           },
-          "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.x86_64.rpm"
-          },
           "sha256:1dc1dbd0aa4dad715b3242468d4841f2f35bf6aa60d8e1928ee692784b12da1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsecret-0.18.6-1.el8.x86_64.rpm"
           },
@@ -2541,9 +2339,6 @@
           "sha256:2733570f8ea94551f3381538f9c8642c88532c800b384c07b4db02f6b8896c3f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libattr-2.4.48-3.el8.x86_64.rpm"
           },
-          "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fwupd-1.7.8-1.el8.x86_64.rpm"
-          },
           "sha256:283285b4c414c5d0614849e64971730af9d0037e62e535adb538166051e52e1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libdhash-0.5.0-40.el8.x86_64.rpm"
           },
@@ -2580,23 +2375,11 @@
           "sha256:2ff643bfe17476a8dfa94ea900ddf9d89ed0e5f56839f18209f8304a0e31bb2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dmidecode-3.3-4.el8.x86_64.rpm"
           },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
-          "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
-          },
           "sha256:30c6dbc7d2dd8024a16fe2d00b01fa71f4a1ea9d4af5519dc092695d4fa735cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libss-1.45.6-5.el8.x86_64.rpm"
           },
           "sha256:30e0334ada8f6453cd8c2335ac40417f636cdae7d7dc744b6d2bff78785013de": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-all-langpacks-2.28-211.el8.x86_64.rpm"
-          },
-          "sha256:319d3d51dfc09875cdbb61518410fe2963887228089d4a9de8f673acc7a2ff82": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-softokn-3.79.0-10.el8_6.x86_64.rpm"
           },
           "sha256:3267605bdad55274cd02ce3e656edb83048c740fa709452b3fe6ed98f5f5bbbe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/rpm-4.14.3-24.el8_6.x86_64.rpm"
@@ -2670,9 +2453,6 @@
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
           },
-          "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
-          },
           "sha256:3d6a5eeb0da36ce36cd6ddc5e3c2d2bc36cd5962d1450077c5c5754b8f5ac02c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glib2-2.56.4-159.el8.x86_64.rpm"
           },
@@ -2705,9 +2485,6 @@
           },
           "sha256:4658cf807723123b513587887bf226d0b3daf69049c13951c5f88f6196acbb7d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsss_sudo-2.7.3-4.el8.x86_64.rpm"
-          },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efivar-libs-37-4.el8.x86_64.rpm"
           },
           "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-pc-2.02-142.el8.x86_64.rpm"
@@ -2751,9 +2528,6 @@
           "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/man-db-2.7.6.1-18.el8.x86_64.rpm"
           },
-          "sha256:4bcbfd3229e3fd2d6e1adfe46bc233872c4184838de40b2e61a9ba84fcb81512": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-softokn-freebl-3.79.0-10.el8_6.x86_64.rpm"
-          },
           "sha256:4bdac8b052ea5031f85f17e8f8499d491cc2ea8d5110467c5a0e4ec7b7763c2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/authselect-compat-1.2.5-1.el8.x86_64.rpm"
           },
@@ -2786,9 +2560,6 @@
           },
           "sha256:50603f9a5c2a643252949c922d656c83194047469116a33c3c265871bfd0a531": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dnf-data-4.7.0-11.el8.noarch.rpm"
-          },
-          "sha256:507c1a196520e4263a0581e70b669c352097d6bdc7a5409ae748ee3942e71f5c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-sysinit-3.79.0-10.el8_6.x86_64.rpm"
           },
           "sha256:51eb082082e78afa70dd64591219c026d11cf7a6adf3771a36624c80be34dc3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/nettle-3.4.1-7.el8.x86_64.rpm"
@@ -2844,9 +2615,6 @@
           "sha256:5baf694f0ba6606307a449ca22cc62e85d38cd8ae870fac133e3f5df3d710dfc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-pc-modules-2.02-142.el8.noarch.rpm"
           },
-          "sha256:5bea1ad0a4491ab6ae8607f741388c983dc471747176a3e82302e94addba6d44": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-mdraid-2.24-11.el8.x86_64.rpm"
-          },
           "sha256:5d9c5b3341e9b10091a5bc66c08455ce7d9c62911fac6b759b847a46749a1adf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm"
           },
@@ -2880,9 +2648,6 @@
           "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsolv-0.7.20-3.el8.x86_64.rpm"
           },
-          "sha256:68e0dfe4bc893170e61539b648f41ef10aa8174a884de6ff91dcb87abc7d03ce": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libudisks2-2.9.0-9.el8.x86_64.rpm"
-          },
           "sha256:6950a3136327480137b0c3ed7555bd36d107ebb39b687354d2d34c5542e19d2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dbus-1.12.8-23.el8.x86_64.rpm"
           },
@@ -2900,9 +2665,6 @@
           },
           "sha256:6d7a41fb238610416349a53d024cc505ab7f3f6e9953cc2244abb663ec404dad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/ncurses-6.1-9.20180224.el8.x86_64.rpm"
-          },
-          "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm"
           },
           "sha256:6dcdb3c2afc64822ed6945bf9607cd0406197bd9764718beef51f5332edd7c05": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-gconv-extra-2.28-211.el8.x86_64.rpm"
@@ -2925,9 +2687,6 @@
           "sha256:709fb09876846df58d761b2ddb973bbf2b870d995452648ef929a2cdf3ea8216": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libarchive-3.3.3-4.el8.x86_64.rpm"
           },
-          "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgudev-232-4.el8.x86_64.rpm"
-          },
           "sha256:7145b8d179b6c72e61de2b822551b343209adb63b76023fe26e7162d4ff6c107": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcc-8.5.0-15.el8.x86_64.rpm"
           },
@@ -2939,9 +2698,6 @@
           },
           "sha256:73c29baa2cd94f1ae6a1d1333818969a281b16dd4262f413ad284c5333719a4d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/groff-base-1.22.3-18.el8.x86_64.rpm"
-          },
-          "sha256:74789339d67c8fd8545def02ae4a0f5dbbb9c0ee71aee54ee166b633563fe85d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-part-2.24-11.el8.x86_64.rpm"
           },
           "sha256:74cdb3a60d777eb0de980bfc902005757fc16ef0af7db01c1ade1cc56c3852c9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/elfutils-libs-0.187-4.el8.x86_64.rpm"
@@ -3009,17 +2765,11 @@
           "sha256:821923c32f6cd4c764ea7e97bee3335993d405694aa81b923cf1ef46c9e03cf9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/rhc-0.2.1-9.el8.x86_64.rpm"
           },
-          "sha256:82cd233003b87e6b810070eead73ec44073050aabccec9a619309074a1868fe9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nspr-4.34.0-3.el8_6.x86_64.rpm"
-          },
           "sha256:830940ac1860e506f78be51323f21144a40e6244eff2331c1648da06baee9ea6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dhcp-libs-4.3.6-48.el8.x86_64.rpm"
           },
           "sha256:84c4a7d89325e5d405712dff6db06ef55996a09faf7490c1693d032171730777": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/procps-ng-3.3.15-9.el8.x86_64.rpm"
-          },
-          "sha256:859c0fe81e8a3e297664c62d725d3224ec6f35bf5078a2993484b35328c16fdd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-swap-2.24-11.el8.x86_64.rpm"
           },
           "sha256:862e75a1cf6aa5be750a530c8ce8b999d0b2efe9737e20f37f9f9153a82e56fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libassuan-2.5.1-3.el8.x86_64.rpm"
@@ -3039,9 +2789,6 @@
           "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-audit-3.0.7-4.el8.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8a631d059089724f11aed2114ddaf7511c9771f415f638ed5b3a135bb90f2a31": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/coreutils-8.30-13.el8.x86_64.rpm"
           },
@@ -3053,9 +2800,6 @@
           },
           "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8d371e753071edc796d2eadb8278980290511be6279fdf46649c81b859497d6a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/prefixdevname-0.1.0-6.el8.x86_64.rpm"
@@ -3072,9 +2816,6 @@
           "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/snappy-1.1.8-3.el8.x86_64.rpm"
           },
-          "sha256:8ed24bf92f4a389d82399a2dfcdcd2b8812b354d32e50807ddf557b978532756": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-loop-2.24-11.el8.x86_64.rpm"
-          },
           "sha256:8efc0d874bbba80e64c99732956704826ce93ddd1476809c43b4d0b240f1e401": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/authselect-1.2.5-1.el8.x86_64.rpm"
           },
@@ -3086,9 +2827,6 @@
           },
           "sha256:912ff00d4f533a0fc8342910586ecc83f566e43f53e150c5cb7c1a6274dd1ba7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/tzdata-2022d-1.el8.noarch.rpm"
-          },
-          "sha256:91303cb921c3727203c4a25c12524356a2afb2e3fd594bdd12301a7b5edabaa3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-2.24-11.el8.x86_64.rpm"
           },
           "sha256:9137a707b7793567b38e7d8dba78fcf3f70c39320e68a9ee0b745b3a77f182ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/teamd-1.31-2.el8.x86_64.rpm"
@@ -3113,12 +2851,6 @@
           },
           "sha256:9461fa7a5e74bfd8d9e9961af9d3003d9d2b496830c2fd6b0641ae8b8bc8e178": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libacl-2.2.53-1.el8.x86_64.rpm"
-          },
-          "sha256:94d5c3946873b079aa5af985e31501981fef1cb3065024e9f41f70c40fc9b975": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-util-3.79.0-10.el8_6.x86_64.rpm"
-          },
-          "sha256:95a340a62ae433f5a5cb30e8929b9b4167d2d204bef99beea487ad65e451c2b9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-fs-2.24-11.el8.x86_64.rpm"
           },
           "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/unbound-libs-1.16.2-2.el8.x86_64.rpm"
@@ -3234,15 +2966,6 @@
           "sha256:ae6dd4ea3852d1ce30a0988bde8d35e91a8b0709615e3ac64c65a5e24e68fefa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/device-mapper-libs-1.02.181-6.el8.x86_64.rpm"
           },
-          "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
-          },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
-          "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-3.79.0-10.el8_6.x86_64.rpm"
-          },
           "sha256:afb86bb3de3f8b6f8ea6be0318f95d6938749ccf91e0cabe5d95c0f197d5de1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/hardlink-1.3-6.el8.x86_64.rpm"
           },
@@ -3278,9 +3001,6 @@
           },
           "sha256:b4babe48d93eccce4f0249ba34d592bfc306c3b14b40df7a5cc9eaec2eaae20f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/numactl-libs-2.0.12-13.el8.x86_64.rpm"
-          },
-          "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
           },
           "sha256:b76a180508132aaceb8dcebc5de9cec87d3459a39e4749f9af342d242c410dab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/oddjob-mkhomedir-0.34.7-2.el8.x86_64.rpm"
@@ -3351,9 +3071,6 @@
           "sha256:c637ccd812d6458885af67910db0e6698917abd8c397a34ebaf7b66052914433": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-langpack-en-2.28-211.el8.x86_64.rpm"
           },
-          "sha256:c72fcb71cb08b0e21e56c9b3238cac42bfa90fa43b2e5bfb218e4b22b957f12f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/udisks2-2.9.0-9.el8.x86_64.rpm"
-          },
           "sha256:c759f74a96a42a539568a16805461352f84c7e1766f41faccb519ac14a8825d3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/pam-1.3.1-22.el8.x86_64.rpm"
           },
@@ -3371,9 +3088,6 @@
           },
           "sha256:cb849487fb29d658b714045a4afe4886324e4add7d47a7296ae0ee89e3477014": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libini_config-1.3.1-40.el8.x86_64.rpm"
-          },
-          "sha256:cbca89c39db7fd80dc71deefdcfb15262e2aed69117e66a15632ac581c82b8b6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-crypto-2.24-11.el8.x86_64.rpm"
           },
           "sha256:cccb98acc0ead0737b2f7406c48a2039165276a129de1c7c840e412078437f1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libbasicobjects-0.1.1-40.el8.x86_64.rpm"
@@ -3456,17 +3170,11 @@
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/timedatex-0.5-3.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d570af0578f5b2c6225f1f2354404f65bccf91c3974e98dcbc0c7b55a61b9b46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grep-3.1-6.el8.x86_64.rpm"
           },
           "sha256:d67580b9b2af79f599f77c35c694714d2d39d2ea01c28e8aaca1312e6ab25184": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libselinux-2.9-6.el8.x86_64.rpm"
-          },
-          "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm"
           },
           "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
@@ -3503,9 +3211,6 @@
           },
           "sha256:e29131b502b6a199003ed61e27eb3e5cb3d46f4b4a3f8ca1034945a406dcfe80": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsemanage-2.9-9.el8.x86_64.rpm"
-          },
-          "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mdadm-4.2-5.el8.x86_64.rpm"
           },
           "sha256:e4f799b634299835dc1a8e79adcfb223d13b369bd033cbdb14170f845c9464ad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/ethtool-5.13-2.el8.x86_64.rpm"
@@ -3630,9 +3335,6 @@
           "sha256:fc46ac94289cd660db8452aa7093c446b0f087cda089b3c3aeeb988286d80ee2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/systemd-239-68.el8.x86_64.rpm"
           },
-          "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
-          },
           "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
@@ -3644,9 +3346,6 @@
           },
           "sha256:fe1a3e821eab7aafd11152c5d5b9f6cf57de36d8ef3b517e0e2f2315b062742c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm"
-          },
-          "sha256:fe6788ebe68e3bc8d6e9784c569c3bc5916e5c445a88fb0247ee1243018cfc8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-utils-2.24-11.el8.x86_64.rpm"
           },
           "sha256:fec32d37b2f34c891a64a8c5e2faf3d08de25d144289b6f2b7f5fafdd5eec4d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/parted-3.2-39.el8.x86_64.rpm"
@@ -3899,15 +3598,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -5379,15 +5069,6 @@
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-      },
-      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -5712,15 +5393,6 @@
         "checksum": "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711"
       },
       {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "049",
@@ -5782,33 +5454,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/e2fsprogs-libs-1.45.6-5.el8.x86_64.rpm",
         "checksum": "sha256:8e0e23d6a9399d9016d721467181d9abd3e888894149767b631889f1aeddf755"
-      },
-      {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
       },
       {
         "name": "elfutils-debuginfod-client",
@@ -5917,15 +5562,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse-libs-2.9.7-16.el8.x86_64.rpm",
         "checksum": "sha256:be62c3c22fe4351a434d5b971061e512db199d763205dd8aaf4c6faa35a9be42"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.8",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fwupd-1.7.8-1.el8.x86_64.rpm",
-        "checksum": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
       },
       {
         "name": "gawk",
@@ -6106,15 +5742,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-common-2.02-142.el8.noarch.rpm",
         "checksum": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "142.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm",
-        "checksum": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
       },
       {
         "name": "grub2-pc",
@@ -6648,15 +6275,6 @@
         "checksum": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -6691,24 +6309,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgpg-error-1.31-1.el8.x86_64.rpm",
         "checksum": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-      },
-      {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "232",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgudev-232-4.el8.x86_64.rpm",
-        "checksum": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
       },
       {
         "name": "libidn2",
@@ -7008,15 +6608,6 @@
         "checksum": "sha256:d15c8594702ab51f8aa792a6c0ebae49ddefc8740289397b2cd8cb6e4a711187"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -7242,15 +6833,6 @@
         "checksum": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libyaml",
         "epoch": 0,
         "version": "0.1.7",
@@ -7350,15 +6932,6 @@
         "checksum": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mdadm-4.2-5.el8.x86_64.rpm",
-        "checksum": "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de"
-      },
-      {
         "name": "memstrack",
         "epoch": 0,
         "version": "0.2.4",
@@ -7375,15 +6948,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/microcode_ctl-20220809-1.el8.x86_64.rpm",
         "checksum": "sha256:d3e15db6aaa6d8ba4587408d87863b2f94092024bbb94893faa95c5d259a97d4"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "12.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm",
-        "checksum": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
       },
       {
         "name": "mozjs60",
@@ -8340,15 +7904,6 @@
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
-        "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -8727,96 +8282,6 @@
         "checksum": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "14.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.x86_64.rpm",
-        "checksum": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:91303cb921c3727203c4a25c12524356a2afb2e3fd594bdd12301a7b5edabaa3"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-crypto-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:cbca89c39db7fd80dc71deefdcfb15262e2aed69117e66a15632ac581c82b8b6"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-fs-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:95a340a62ae433f5a5cb30e8929b9b4167d2d204bef99beea487ad65e451c2b9"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-loop-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:8ed24bf92f4a389d82399a2dfcdcd2b8812b354d32e50807ddf557b978532756"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-mdraid-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:5bea1ad0a4491ab6ae8607f741388c983dc471747176a3e82302e94addba6d44"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-part-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:74789339d67c8fd8545def02ae4a0f5dbbb9c0ee71aee54ee166b633563fe85d"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-swap-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:859c0fe81e8a3e297664c62d725d3224ec6f35bf5078a2993484b35328c16fdd"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-utils-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:fe6788ebe68e3bc8d6e9784c569c3bc5916e5c445a88fb0247ee1243018cfc8c"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libbytesize-1.4-3.el8.x86_64.rpm",
-        "checksum": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.10",
@@ -8844,15 +8309,6 @@
         "checksum": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
       },
       {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "9.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libudisks2-2.9.0-9.el8.x86_64.rpm",
-        "checksum": "sha256:68e0dfe4bc893170e61539b648f41ef10aa8174a884de6ff91dcb87abc7d03ce"
-      },
-      {
         "name": "libxkbcommon",
         "epoch": 0,
         "version": "0.9.1",
@@ -8860,60 +8316,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libxkbcommon-0.9.1-1.el8.x86_64.rpm",
         "checksum": "sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072"
-      },
-      {
-        "name": "nspr",
-        "epoch": 0,
-        "version": "4.34.0",
-        "release": "3.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nspr-4.34.0-3.el8_6.x86_64.rpm",
-        "checksum": "sha256:82cd233003b87e6b810070eead73ec44073050aabccec9a619309074a1868fe9"
-      },
-      {
-        "name": "nss",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a"
-      },
-      {
-        "name": "nss-softokn",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-softokn-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:319d3d51dfc09875cdbb61518410fe2963887228089d4a9de8f673acc7a2ff82"
-      },
-      {
-        "name": "nss-softokn-freebl",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-softokn-freebl-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:4bcbfd3229e3fd2d6e1adfe46bc233872c4184838de40b2e61a9ba84fcb81512"
-      },
-      {
-        "name": "nss-sysinit",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-sysinit-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:507c1a196520e4263a0581e70b669c352097d6bdc7a5409ae748ee3942e71f5c"
-      },
-      {
-        "name": "nss-util",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-util-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:94d5c3946873b079aa5af985e31501981fef1cb3065024e9f41f70c40fc9b975"
       },
       {
         "name": "oddjob",
@@ -9069,15 +8471,6 @@
         "checksum": "sha256:37ca74f003d06ada0528d353bdc0df49193a058cece3c51173dc8b9c80f410e5"
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "9.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/udisks2-2.9.0-9.el8.x86_64.rpm",
-        "checksum": "sha256:c72fcb71cb08b0e21e56c9b3238cac42bfa90fa43b2e5bfb218e4b22b957f12f"
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.16.2",
@@ -9085,15 +8478,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/unbound-libs-1.16.2-2.el8.x86_64.rpm",
         "checksum": "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.11",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm",
-        "checksum": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
       },
       {
         "name": "xkeyboard-config",

--- a/test/data/manifests/rhel_87-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ec2_ha-boot.json
@@ -130,9 +130,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -659,9 +656,6 @@
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
                   },
                   {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-                  },
-                  {
                     "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
                   },
                   {
@@ -791,9 +785,6 @@
                     "id": "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -813,15 +804,6 @@
                   },
                   {
                     "id": "sha256:8e0e23d6a9399d9016d721467181d9abd3e888894149767b631889f1aeddf755"
-                  },
-                  {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
                   },
                   {
                     "id": "sha256:45c47f5146e39f50ca18d1561821607bc582c5fd4de0bf05bc06a5e0eb33df34"
@@ -861,9 +843,6 @@
                   },
                   {
                     "id": "sha256:be62c3c22fe4351a434d5b971061e512db199d763205dd8aaf4c6faa35a9be42"
-                  },
-                  {
-                    "id": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
                   },
                   {
                     "id": "sha256:59b3cff57ffbea4c4c011e6a81341a1203c18b91569fff019c93b756331300f8"
@@ -924,9 +903,6 @@
                   },
                   {
                     "id": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-                  },
-                  {
-                    "id": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
                   },
                   {
                     "id": "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d"
@@ -1121,9 +1097,6 @@
                     "id": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:7145b8d179b6c72e61de2b822551b343209adb63b76023fe26e7162d4ff6c107"
                   },
                   {
@@ -1134,12 +1107,6 @@
                   },
                   {
                     "id": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-                  },
-                  {
-                    "id": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-                  },
-                  {
-                    "id": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
                   },
                   {
                     "id": "sha256:fe37f767487e0806535a06cda4e302555c27166b6320657ae945d5217b8c36aa"
@@ -1247,9 +1214,6 @@
                     "id": "sha256:d15c8594702ab51f8aa792a6c0ebae49ddefc8740289397b2cd8cb6e4a711187"
                   },
                   {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-                  },
-                  {
                     "id": "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8"
                   },
                   {
@@ -1328,9 +1292,6 @@
                     "id": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15"
                   },
                   {
@@ -1373,16 +1334,10 @@
                     "id": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
                   },
                   {
-                    "id": "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de"
-                  },
-                  {
                     "id": "sha256:ca6208d771fbbfc703217b0f4314d214a866da86b105f222753a6efeb12d6f69"
                   },
                   {
                     "id": "sha256:d3e15db6aaa6d8ba4587408d87863b2f94092024bbb94893faa95c5d259a97d4"
-                  },
-                  {
-                    "id": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -1838,9 +1793,6 @@
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
                   },
                   {
-                    "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
-                  },
-                  {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
                   },
                   {
@@ -2096,36 +2048,6 @@
                     "id": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
                   },
                   {
-                    "id": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-                  },
-                  {
-                    "id": "sha256:91303cb921c3727203c4a25c12524356a2afb2e3fd594bdd12301a7b5edabaa3"
-                  },
-                  {
-                    "id": "sha256:cbca89c39db7fd80dc71deefdcfb15262e2aed69117e66a15632ac581c82b8b6"
-                  },
-                  {
-                    "id": "sha256:95a340a62ae433f5a5cb30e8929b9b4167d2d204bef99beea487ad65e451c2b9"
-                  },
-                  {
-                    "id": "sha256:8ed24bf92f4a389d82399a2dfcdcd2b8812b354d32e50807ddf557b978532756"
-                  },
-                  {
-                    "id": "sha256:5bea1ad0a4491ab6ae8607f741388c983dc471747176a3e82302e94addba6d44"
-                  },
-                  {
-                    "id": "sha256:74789339d67c8fd8545def02ae4a0f5dbbb9c0ee71aee54ee166b633563fe85d"
-                  },
-                  {
-                    "id": "sha256:859c0fe81e8a3e297664c62d725d3224ec6f35bf5078a2993484b35328c16fdd"
-                  },
-                  {
-                    "id": "sha256:fe6788ebe68e3bc8d6e9784c569c3bc5916e5c445a88fb0247ee1243018cfc8c"
-                  },
-                  {
-                    "id": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-                  },
-                  {
                     "id": "sha256:d16252dcb91c3e581ecb29234180fb99ac3199a052a89d0e23603cb6054bee16"
                   },
                   {
@@ -2136,9 +2058,6 @@
                   },
                   {
                     "id": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
-                  },
-                  {
-                    "id": "sha256:68e0dfe4bc893170e61539b648f41ef10aa8174a884de6ff91dcb87abc7d03ce"
                   },
                   {
                     "id": "sha256:34001e2596b82803f289adefe1a263b61917e8a67ff8e45d9ff5fc1ca150eb57"
@@ -2330,13 +2249,7 @@
                     "id": "sha256:bafc9ec3dd737b0dbdf179b9d9b4c8a9b5c1a92423eae1e4eb3047522107695e"
                   },
                   {
-                    "id": "sha256:c72fcb71cb08b0e21e56c9b3238cac42bfa90fa43b2e5bfb218e4b22b957f12f"
-                  },
-                  {
                     "id": "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3"
-                  },
-                  {
-                    "id": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
                   },
                   {
                     "id": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
@@ -2418,9 +2331,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -2588,23 +2499,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -2612,13 +2510,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-425.3.1.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -2683,20 +2577,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2713,44 +2595,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -2758,8 +2605,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -2785,28 +2632,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -2816,18 +2647,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -2845,8 +2664,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -3065,9 +2884,6 @@
           "sha256:1d47e465939bba5bcf9c37be2516e60d6c9449ccee70a54a6133df989ac8b1f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libksba-1.3.5-7.el8.x86_64.rpm"
           },
-          "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.x86_64.rpm"
-          },
           "sha256:1dc1dbd0aa4dad715b3242468d4841f2f35bf6aa60d8e1928ee692784b12da1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsecret-0.18.6-1.el8.x86_64.rpm"
           },
@@ -3134,9 +2950,6 @@
           "sha256:2733570f8ea94551f3381538f9c8642c88532c800b384c07b4db02f6b8896c3f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libattr-2.4.48-3.el8.x86_64.rpm"
           },
-          "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fwupd-1.7.8-1.el8.x86_64.rpm"
-          },
           "sha256:27efba5e62430987380ca7f2e4185e1d27c517a6f8d22958dd3fd0bc2591d3fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/rubygem-io-console-0.4.6-110.module+el8.6.0+15956+aa803fc1.x86_64.rpm"
           },
@@ -3196,15 +3009,6 @@
           },
           "sha256:2ff643bfe17476a8dfa94ea900ddf9d89ed0e5f56839f18209f8304a0e31bb2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dmidecode-3.3-4.el8.x86_64.rpm"
-          },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
-          "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
           "sha256:30c6dbc7d2dd8024a16fe2d00b01fa71f4a1ea9d4af5519dc092695d4fa735cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libss-1.45.6-5.el8.x86_64.rpm"
@@ -3296,9 +3100,6 @@
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
           },
-          "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
-          },
           "sha256:3d6a5eeb0da36ce36cd6ddc5e3c2d2bc36cd5962d1450077c5c5754b8f5ac02c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glib2-2.56.4-159.el8.x86_64.rpm"
           },
@@ -3358,9 +3159,6 @@
           },
           "sha256:46ed1904100326d5ded33a027840de37cf90d3dffe8d1fa88a8f01654539a322": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/fence-agents-hpblade-4.2.1-103.el8.noarch.rpm"
-          },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efivar-libs-37-4.el8.x86_64.rpm"
           },
           "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-pc-2.02-142.el8.x86_64.rpm"
@@ -3536,9 +3334,6 @@
           "sha256:5baf694f0ba6606307a449ca22cc62e85d38cd8ae870fac133e3f5df3d710dfc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-pc-modules-2.02-142.el8.noarch.rpm"
           },
-          "sha256:5bea1ad0a4491ab6ae8607f741388c983dc471747176a3e82302e94addba6d44": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-mdraid-2.24-11.el8.x86_64.rpm"
-          },
           "sha256:5d9c5b3341e9b10091a5bc66c08455ce7d9c62911fac6b759b847a46749a1adf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm"
           },
@@ -3578,9 +3373,6 @@
           "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsolv-0.7.20-3.el8.x86_64.rpm"
           },
-          "sha256:68e0dfe4bc893170e61539b648f41ef10aa8174a884de6ff91dcb87abc7d03ce": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libudisks2-2.9.0-9.el8.x86_64.rpm"
-          },
           "sha256:6950a3136327480137b0c3ed7555bd36d107ebb39b687354d2d34c5542e19d2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dbus-1.12.8-23.el8.x86_64.rpm"
           },
@@ -3605,9 +3397,6 @@
           "sha256:6d7a41fb238610416349a53d024cc505ab7f3f6e9953cc2244abb663ec404dad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/ncurses-6.1-9.20180224.el8.x86_64.rpm"
           },
-          "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm"
-          },
           "sha256:6dcdb3c2afc64822ed6945bf9607cd0406197bd9764718beef51f5332edd7c05": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-gconv-extra-2.28-211.el8.x86_64.rpm"
           },
@@ -3628,9 +3417,6 @@
           },
           "sha256:709fb09876846df58d761b2ddb973bbf2b870d995452648ef929a2cdf3ea8216": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libarchive-3.3.3-4.el8.x86_64.rpm"
-          },
-          "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgudev-232-4.el8.x86_64.rpm"
           },
           "sha256:7145b8d179b6c72e61de2b822551b343209adb63b76023fe26e7162d4ff6c107": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcc-8.5.0-15.el8.x86_64.rpm"
@@ -3655,9 +3441,6 @@
           },
           "sha256:746243a941d8d8299e220e75bed360debcb7f27df661a5f7637deb21cdd67976": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-n8.7-20221015/Packages/libknet1-crypto-nss-plugin-1.24-2.el8.x86_64.rpm"
-          },
-          "sha256:74789339d67c8fd8545def02ae4a0f5dbbb9c0ee71aee54ee166b633563fe85d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-part-2.24-11.el8.x86_64.rpm"
           },
           "sha256:74c60aed4f76cf297ec7fc218763d5b8b87c03280ed94d216f1a71100441ed3f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-n8.7-20221015/Packages/libknet1-compress-lz4-plugin-1.24-2.el8.x86_64.rpm"
@@ -3770,9 +3553,6 @@
           "sha256:84c4a7d89325e5d405712dff6db06ef55996a09faf7490c1693d032171730777": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/procps-ng-3.3.15-9.el8.x86_64.rpm"
           },
-          "sha256:859c0fe81e8a3e297664c62d725d3224ec6f35bf5078a2993484b35328c16fdd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-swap-2.24-11.el8.x86_64.rpm"
-          },
           "sha256:862e75a1cf6aa5be750a530c8ce8b999d0b2efe9737e20f37f9f9153a82e56fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libassuan-2.5.1-3.el8.x86_64.rpm"
           },
@@ -3794,9 +3574,6 @@
           "sha256:891b4ffa90ef5369b7a846fabe4ce87e0d7e604fa31a43104b93c7f5654bbb7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libwbclient-4.16.4-2.el8.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8a631d059089724f11aed2114ddaf7511c9771f415f638ed5b3a135bb90f2a31": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/coreutils-8.30-13.el8.x86_64.rpm"
           },
@@ -3808,9 +3585,6 @@
           },
           "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8d371e753071edc796d2eadb8278980290511be6279fdf46649c81b859497d6a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/prefixdevname-0.1.0-6.el8.x86_64.rpm"
@@ -3827,9 +3601,6 @@
           "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/snappy-1.1.8-3.el8.x86_64.rpm"
           },
-          "sha256:8ed24bf92f4a389d82399a2dfcdcd2b8812b354d32e50807ddf557b978532756": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-loop-2.24-11.el8.x86_64.rpm"
-          },
           "sha256:8efc0d874bbba80e64c99732956704826ce93ddd1476809c43b4d0b240f1e401": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/authselect-1.2.5-1.el8.x86_64.rpm"
           },
@@ -3844,9 +3615,6 @@
           },
           "sha256:912ff00d4f533a0fc8342910586ecc83f566e43f53e150c5cb7c1a6274dd1ba7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/tzdata-2022d-1.el8.noarch.rpm"
-          },
-          "sha256:91303cb921c3727203c4a25c12524356a2afb2e3fd594bdd12301a7b5edabaa3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-2.24-11.el8.x86_64.rpm"
           },
           "sha256:9137a707b7793567b38e7d8dba78fcf3f70c39320e68a9ee0b745b3a77f182ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/teamd-1.31-2.el8.x86_64.rpm"
@@ -3877,9 +3645,6 @@
           },
           "sha256:94d5c3946873b079aa5af985e31501981fef1cb3065024e9f41f70c40fc9b975": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-util-3.79.0-10.el8_6.x86_64.rpm"
-          },
-          "sha256:95a340a62ae433f5a5cb30e8929b9b4167d2d204bef99beea487ad65e451c2b9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-fs-2.24-11.el8.x86_64.rpm"
           },
           "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/unbound-libs-1.16.2-2.el8.x86_64.rpm"
@@ -4049,12 +3814,6 @@
           "sha256:ae6dd4ea3852d1ce30a0988bde8d35e91a8b0709615e3ac64c65a5e24e68fefa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/device-mapper-libs-1.02.181-6.el8.x86_64.rpm"
           },
-          "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
-          },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
           "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-3.79.0-10.el8_6.x86_64.rpm"
           },
@@ -4108,9 +3867,6 @@
           },
           "sha256:b516896f3b3a83a1a5c9d0d6e84b025ecdb8d3676cbb195751b44224ad720078": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-n8.7-20221015/Packages/pacemaker-cli-2.1.4-5.el8.x86_64.rpm"
-          },
-          "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
           },
           "sha256:b5ceaedb078fd24f7b1c8c739c2492ba3c187ac139ee751578b6bae1564c8ca5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/device-mapper-multipath-0.8.4-28.el8.x86_64.rpm"
@@ -4217,9 +3973,6 @@
           "sha256:c65f150b84982102e17a772d66b2db460f74caaa4f56086322efc31ad7121fa7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/device-mapper-event-1.02.181-6.el8.x86_64.rpm"
           },
-          "sha256:c72fcb71cb08b0e21e56c9b3238cac42bfa90fa43b2e5bfb218e4b22b957f12f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/udisks2-2.9.0-9.el8.x86_64.rpm"
-          },
           "sha256:c759f74a96a42a539568a16805461352f84c7e1766f41faccb519ac14a8825d3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/pam-1.3.1-22.el8.x86_64.rpm"
           },
@@ -4255,9 +4008,6 @@
           },
           "sha256:cbc9960daa473a381ebac94367a9f4acb633e603fba4683010c4a040ef7f9f57": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/fence-agents-heuristics-ping-4.2.1-103.el8.noarch.rpm"
-          },
-          "sha256:cbca89c39db7fd80dc71deefdcfb15262e2aed69117e66a15632ac581c82b8b6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-crypto-2.24-11.el8.x86_64.rpm"
           },
           "sha256:cccb98acc0ead0737b2f7406c48a2039165276a129de1c7c840e412078437f1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libbasicobjects-0.1.1-40.el8.x86_64.rpm"
@@ -4358,17 +4108,11 @@
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/timedatex-0.5-3.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d570af0578f5b2c6225f1f2354404f65bccf91c3974e98dcbc0c7b55a61b9b46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grep-3.1-6.el8.x86_64.rpm"
           },
           "sha256:d67580b9b2af79f599f77c35c694714d2d39d2ea01c28e8aaca1312e6ab25184": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libselinux-2.9-6.el8.x86_64.rpm"
-          },
-          "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm"
           },
           "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
@@ -4444,9 +4188,6 @@
           },
           "sha256:e33a380e981f44fb1e1987142e4a41bf3dbeb452490f2030876d221640c52e14": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/samba-client-libs-4.16.4-2.el8.x86_64.rpm"
-          },
-          "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mdadm-4.2-5.el8.x86_64.rpm"
           },
           "sha256:e4f799b634299835dc1a8e79adcfb223d13b369bd033cbdb14170f845c9464ad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/ethtool-5.13-2.el8.x86_64.rpm"
@@ -4631,9 +4372,6 @@
           "sha256:fc46ac94289cd660db8452aa7093c446b0f087cda089b3c3aeeb988286d80ee2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/systemd-239-68.el8.x86_64.rpm"
           },
-          "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
-          },
           "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
           },
@@ -4648,9 +4386,6 @@
           },
           "sha256:fe37f767487e0806535a06cda4e302555c27166b6320657ae945d5217b8c36aa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libicu-60.3-2.el8_1.x86_64.rpm"
-          },
-          "sha256:fe6788ebe68e3bc8d6e9784c569c3bc5916e5c445a88fb0247ee1243018cfc8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-utils-2.24-11.el8.x86_64.rpm"
           },
           "sha256:fe7cfd8d7281295cbc16dd06dcb79f80c1d18679b4eafe8bb22f61bffec2ca25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/fence-agents-ipmilan-4.2.1-103.el8.noarch.rpm"
@@ -4909,15 +4644,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -6398,15 +6124,6 @@
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-      },
-      {
         "name": "bzip2",
         "epoch": 0,
         "version": "1.0.6",
@@ -6794,15 +6511,6 @@
         "checksum": "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711"
       },
       {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "049",
@@ -6864,33 +6572,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/e2fsprogs-libs-1.45.6-5.el8.x86_64.rpm",
         "checksum": "sha256:8e0e23d6a9399d9016d721467181d9abd3e888894149767b631889f1aeddf755"
-      },
-      {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
       },
       {
         "name": "elfutils-debuginfod-client",
@@ -7008,15 +6689,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse-libs-2.9.7-16.el8.x86_64.rpm",
         "checksum": "sha256:be62c3c22fe4351a434d5b971061e512db199d763205dd8aaf4c6faa35a9be42"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.8",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fwupd-1.7.8-1.el8.x86_64.rpm",
-        "checksum": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
       },
       {
         "name": "gawk",
@@ -7197,15 +6869,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-common-2.02-142.el8.noarch.rpm",
         "checksum": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "142.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm",
-        "checksum": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
       },
       {
         "name": "grub2-pc",
@@ -7784,15 +7447,6 @@
         "checksum": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -7827,24 +7481,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgpg-error-1.31-1.el8.x86_64.rpm",
         "checksum": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-      },
-      {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "232",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgudev-232-4.el8.x86_64.rpm",
-        "checksum": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
       },
       {
         "name": "libicu",
@@ -8162,15 +7798,6 @@
         "checksum": "sha256:d15c8594702ab51f8aa792a6c0ebae49ddefc8740289397b2cd8cb6e4a711187"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -8405,15 +8032,6 @@
         "checksum": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libxslt",
         "epoch": 0,
         "version": "1.1.32",
@@ -8540,15 +8158,6 @@
         "checksum": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mdadm-4.2-5.el8.x86_64.rpm",
-        "checksum": "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de"
-      },
-      {
         "name": "memstrack",
         "epoch": 0,
         "version": "0.2.4",
@@ -8565,15 +8174,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/microcode_ctl-20220809-1.el8.x86_64.rpm",
         "checksum": "sha256:d3e15db6aaa6d8ba4587408d87863b2f94092024bbb94893faa95c5d259a97d4"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "12.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm",
-        "checksum": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
       },
       {
         "name": "mozjs60",
@@ -9935,15 +9535,6 @@
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
-        "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -10709,96 +10300,6 @@
         "checksum": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "14.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libatasmart-0.19-14.el8.x86_64.rpm",
-        "checksum": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:91303cb921c3727203c4a25c12524356a2afb2e3fd594bdd12301a7b5edabaa3"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-crypto-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:cbca89c39db7fd80dc71deefdcfb15262e2aed69117e66a15632ac581c82b8b6"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-fs-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:95a340a62ae433f5a5cb30e8929b9b4167d2d204bef99beea487ad65e451c2b9"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-loop-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:8ed24bf92f4a389d82399a2dfcdcd2b8812b354d32e50807ddf557b978532756"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-mdraid-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:5bea1ad0a4491ab6ae8607f741388c983dc471747176a3e82302e94addba6d44"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-part-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:74789339d67c8fd8545def02ae4a0f5dbbb9c0ee71aee54ee166b633563fe85d"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-swap-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:859c0fe81e8a3e297664c62d725d3224ec6f35bf5078a2993484b35328c16fdd"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.24",
-        "release": "11.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libblockdev-utils-2.24-11.el8.x86_64.rpm",
-        "checksum": "sha256:fe6788ebe68e3bc8d6e9784c569c3bc5916e5c445a88fb0247ee1243018cfc8c"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libbytesize-1.4-3.el8.x86_64.rpm",
-        "checksum": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.10",
@@ -10833,15 +10334,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libmaxminddb-1.2.0-10.el8.x86_64.rpm",
         "checksum": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
-      },
-      {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "9.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/libudisks2-2.9.0-9.el8.x86_64.rpm",
-        "checksum": "sha256:68e0dfe4bc893170e61539b648f41ef10aa8174a884de6ff91dcb87abc7d03ce"
       },
       {
         "name": "libverto-libev",
@@ -11411,15 +10903,6 @@
         "checksum": "sha256:bafc9ec3dd737b0dbdf179b9d9b4c8a9b5c1a92423eae1e4eb3047522107695e"
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "9.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/udisks2-2.9.0-9.el8.x86_64.rpm",
-        "checksum": "sha256:c72fcb71cb08b0e21e56c9b3238cac42bfa90fa43b2e5bfb218e4b22b957f12f"
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.16.2",
@@ -11427,15 +10910,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/unbound-libs-1.16.2-2.el8.x86_64.rpm",
         "checksum": "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.11",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm",
-        "checksum": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
       },
       {
         "name": "xkeyboard-config",

--- a/test/data/manifests/rhel_87-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ec2_sap-boot.json
@@ -155,9 +155,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -726,9 +723,6 @@
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
                   },
                   {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-                  },
-                  {
                     "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
                   },
                   {
@@ -915,15 +909,6 @@
                     "id": "sha256:d5689e2894c59a375f985b5228b32e78d10b4ceeec9fd7c79f2000480494d368"
                   },
                   {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
-                  },
-                  {
                     "id": "sha256:45c47f5146e39f50ca18d1561821607bc582c5fd4de0bf05bc06a5e0eb33df34"
                   },
                   {
@@ -979,9 +964,6 @@
                   },
                   {
                     "id": "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987"
-                  },
-                  {
-                    "id": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
                   },
                   {
                     "id": "sha256:59b3cff57ffbea4c4c011e6a81341a1203c18b91569fff019c93b756331300f8"
@@ -1048,9 +1030,6 @@
                   },
                   {
                     "id": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-                  },
-                  {
-                    "id": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
                   },
                   {
                     "id": "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d"
@@ -1290,9 +1269,6 @@
                     "id": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:7145b8d179b6c72e61de2b822551b343209adb63b76023fe26e7162d4ff6c107"
                   },
                   {
@@ -1449,9 +1425,6 @@
                     "id": "sha256:cfa953b5825141026d5e6cd951f5aca15a88e8998e297e07d537e4aae8da5b21"
                   },
                   {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-                  },
-                  {
                     "id": "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8"
                   },
                   {
@@ -1542,9 +1515,6 @@
                     "id": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15"
                   },
                   {
@@ -1615,9 +1585,6 @@
                   },
                   {
                     "id": "sha256:48e1edacae05696360d0dd0706b2d3debb617ae15e9f7ce47e528839231a6c25"
-                  },
-                  {
-                    "id": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -2104,9 +2071,6 @@
                   },
                   {
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
-                  },
-                  {
-                    "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
                   },
                   {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
@@ -3082,9 +3046,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -3369,23 +3331,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -3393,13 +3342,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto processor.max_cstate=1 intel_idle.max_cstate=1",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-425.3.1.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -3464,20 +3409,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -3494,44 +3427,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -3539,8 +3437,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -3566,28 +3464,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -3597,18 +3479,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -3626,8 +3496,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -3993,9 +3863,6 @@
           "sha256:273c756dce0c543a12e1a6c3ccf745235397430ab9258bb13cb34d3a79e215e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python39-libs-3.9.13-1.module+el8.7.0+15656+ffd4a257.x86_64.rpm"
           },
-          "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fwupd-1.7.8-1.el8.x86_64.rpm"
-          },
           "sha256:27d04a9a33eb9300a55a8ec7623c02da13d19185278e367b60422c8fe70279e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sssd-common-pac-2.7.3-4.el8.x86_64.rpm"
           },
@@ -4086,17 +3953,11 @@
           "sha256:2ff643bfe17476a8dfa94ea900ddf9d89ed0e5f56839f18209f8304a0e31bb2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dmidecode-3.3-4.el8.x86_64.rpm"
           },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
           "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
           "sha256:308c79a13fac07e1884dbbe056ce39bdd68348b8e4dd3c1914f4c0038e898434": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sos-4.3-5.el8.noarch.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
           "sha256:30c6dbc7d2dd8024a16fe2d00b01fa71f4a1ea9d4af5519dc092695d4fa735cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libss-1.45.6-5.el8.x86_64.rpm"
@@ -4295,9 +4156,6 @@
           },
           "sha256:471930ec9d0e115809eaae8aa5c888bc07104c600ff49b55ab746701691c7c0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/iptables-libs-1.8.4-23.el8.x86_64.rpm"
-          },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efivar-libs-37-4.el8.x86_64.rpm"
           },
           "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-pc-2.02-142.el8.x86_64.rpm"
@@ -4638,9 +4496,6 @@
           "sha256:6d7a41fb238610416349a53d024cc505ab7f3f6e9953cc2244abb663ec404dad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/ncurses-6.1-9.20180224.el8.x86_64.rpm"
           },
-          "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm"
-          },
           "sha256:6dcdb3c2afc64822ed6945bf9607cd0406197bd9764718beef51f5332edd7c05": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/glibc-gconv-extra-2.28-211.el8.x86_64.rpm"
           },
@@ -4914,9 +4769,6 @@
           "sha256:8942bd9f52f391bf7832aa81ebc8ea66f420ed5b4d35310666997567f0ea9351": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/pinfo-0.6.10-18.el8.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8a3d3e06022e15746a023ace227a8ab3737b468b651cd20f01b5959afa4de75c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/cockpit-podman-53-1.module+el8.7.0+16772+33343656.noarch.rpm"
           },
@@ -4937,9 +4789,6 @@
           },
           "sha256:8c81bb15456e441250d2ed53b223bf85c21a9b25b6a36ab09953cc831f9e7109": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/tcsh-6.20.00-15.el8.x86_64.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8ca5dd4feea941aba58c6d6e981883bca79704dba06583f880c0bf5e0cf4efcf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/desktop-file-utils-0.23-8.el8.x86_64.rpm"
@@ -5295,9 +5144,6 @@
           "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
           },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
           "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/nss-3.79.0-10.el8_6.x86_64.rpm"
           },
@@ -5378,9 +5224,6 @@
           },
           "sha256:b50ed1c4095445fbb87d3f3b21abad7ace7fb2cbbac8f38e19b7f1e0caf28b4d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/python3-pexpect-4.3.1-3.el8.noarch.rpm"
-          },
-          "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
           },
           "sha256:b5c29663e9ffd460842551c32665c0629f634ad7453f0dc3888f4b07c6f88a71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/podman-4.2.0-1.module+el8.7.0+16772+33343656.x86_64.rpm"
@@ -5682,9 +5525,6 @@
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/timedatex-0.5-3.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d5689e2894c59a375f985b5228b32e78d10b4ceeec9fd7c79f2000480494d368": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/ed-1.14.2-4.el8.x86_64.rpm"
           },
@@ -5696,9 +5536,6 @@
           },
           "sha256:d67580b9b2af79f599f77c35c694714d2d39d2ea01c28e8aaca1312e6ab25184": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/python3-libselinux-2.9-6.el8.x86_64.rpm"
-          },
-          "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm"
           },
           "sha256:d805c42ee9293a8ba35f49af63e3f7d813420d4a62ee4cff5ecd7391be851a9b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libtool-ltdl-2.4.6-25.el8.x86_64.rpm"
@@ -6323,15 +6160,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -7929,15 +7757,6 @@
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-      },
-      {
         "name": "bzip2",
         "epoch": 0,
         "version": "1.0.6",
@@ -8496,33 +8315,6 @@
         "checksum": "sha256:d5689e2894c59a375f985b5228b32e78d10b4ceeec9fd7c79f2000480494d368"
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
-      },
-      {
         "name": "elfutils-debuginfod-client",
         "epoch": 0,
         "version": "0.187",
@@ -8692,15 +8484,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm",
         "checksum": "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.8",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/fwupd-1.7.8-1.el8.x86_64.rpm",
-        "checksum": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
       },
       {
         "name": "gawk",
@@ -8899,15 +8682,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-common-2.02-142.el8.noarch.rpm",
         "checksum": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "142.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm",
-        "checksum": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
       },
       {
         "name": "grub2-pc",
@@ -9621,15 +9395,6 @@
         "checksum": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -10098,15 +9863,6 @@
         "checksum": "sha256:cfa953b5825141026d5e6cd951f5aca15a88e8998e297e07d537e4aae8da5b21"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -10377,15 +10133,6 @@
         "checksum": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libxslt",
         "epoch": 0,
         "version": "1.1.32",
@@ -10600,15 +10347,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mlocate-0.26-20.el8.x86_64.rpm",
         "checksum": "sha256:48e1edacae05696360d0dd0706b2d3debb617ae15e9f7ce47e528839231a6c25"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "12.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/mokutil-0.3.0-12.el8.x86_64.rpm",
-        "checksum": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
       },
       {
         "name": "mozjs60",
@@ -12067,15 +11805,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shared-mime-info-1.9-3.el8.x86_64.rpm",
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
-        "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
       },
       {
         "name": "slang",

--- a/test/data/manifests/rhel_88-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-ec2-boot.json
@@ -2119,14 +2119,14 @@
                   "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
                 },
                 {
-                  "size": 1024000,
+                  "size": 1048576,
                   "start": 411648,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "CB07C243-BC44-4717-853E-28852021225B"
                 },
                 {
-                  "size": 19535839,
-                  "start": 1435648,
+                  "size": 19511263,
+                  "start": 1460224,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2162,8 +2162,7 @@
           {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
-              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
             },
             "devices": {
               "device": {
@@ -2171,7 +2170,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 411648,
-                  "size": 1024000,
+                  "size": 1048576,
                   "lock": true
                 }
               }
@@ -2188,8 +2187,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1435648,
-                  "size": 19535839,
+                  "start": 1460224,
+                  "size": 19511263,
                   "lock": true
                 }
               }
@@ -2220,7 +2219,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 411648,
-                  "size": 1024000
+                  "size": 1048576
                 }
               },
               "boot.efi": {
@@ -2235,8 +2234,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1435648,
-                  "size": 19535839
+                  "start": 1460224,
+                  "size": 19511263
                 }
               }
             },

--- a/test/data/manifests/rhel_88-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-ec2-boot.json
@@ -121,9 +121,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -646,9 +643,6 @@
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
                   },
                   {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-                  },
-                  {
                     "id": "sha256:4d1be1a327a1ef7f0fa6a0005f32b962d446597febebae80b21d8f8f1355a8aa"
                   },
                   {
@@ -757,9 +751,6 @@
                     "id": "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -779,15 +770,6 @@
                   },
                   {
                     "id": "sha256:8e0e23d6a9399d9016d721467181d9abd3e888894149767b631889f1aeddf755"
-                  },
-                  {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
                   },
                   {
                     "id": "sha256:45c47f5146e39f50ca18d1561821607bc582c5fd4de0bf05bc06a5e0eb33df34"
@@ -824,9 +806,6 @@
                   },
                   {
                     "id": "sha256:be62c3c22fe4351a434d5b971061e512db199d763205dd8aaf4c6faa35a9be42"
-                  },
-                  {
-                    "id": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
                   },
                   {
                     "id": "sha256:59b3cff57ffbea4c4c011e6a81341a1203c18b91569fff019c93b756331300f8"
@@ -887,9 +866,6 @@
                   },
                   {
                     "id": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-                  },
-                  {
-                    "id": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
                   },
                   {
                     "id": "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d"
@@ -1069,9 +1045,6 @@
                     "id": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:2cd7f54b726250042483f37e513645c240beec147cbfa959cd689b306d36d103"
                   },
                   {
@@ -1082,12 +1055,6 @@
                   },
                   {
                     "id": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-                  },
-                  {
-                    "id": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-                  },
-                  {
-                    "id": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
                   },
                   {
                     "id": "sha256:4a62975251933dcaff77fdbd7704e8a12bea0ecb6eaaae5ea5e552bedd6788ec"
@@ -1189,9 +1156,6 @@
                     "id": "sha256:d15c8594702ab51f8aa792a6c0ebae49ddefc8740289397b2cd8cb6e4a711187"
                   },
                   {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-                  },
-                  {
                     "id": "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8"
                   },
                   {
@@ -1267,9 +1231,6 @@
                     "id": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf"
                   },
                   {
@@ -1303,16 +1264,10 @@
                     "id": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
                   },
                   {
-                    "id": "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de"
-                  },
-                  {
                     "id": "sha256:ca6208d771fbbfc703217b0f4314d214a866da86b105f222753a6efeb12d6f69"
                   },
                   {
                     "id": "sha256:d3e15db6aaa6d8ba4587408d87863b2f94092024bbb94893faa95c5d259a97d4"
-                  },
-                  {
-                    "id": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -1633,9 +1588,6 @@
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
                   },
                   {
-                    "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
-                  },
-                  {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
                   },
                   {
@@ -1762,36 +1714,6 @@
                     "id": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
                   },
                   {
-                    "id": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-                  },
-                  {
-                    "id": "sha256:694ba7edf36a3cf125b914dd638de18fa4d0928f046da1bda32f78c8f94439e2"
-                  },
-                  {
-                    "id": "sha256:2c3eeba223c5b9742d31138aa4adc585bd65a89bc9ccc723bbe721d997d9c11c"
-                  },
-                  {
-                    "id": "sha256:44447cbfdf0236f20f68d31e1541d43ffcc878da80b7a74691ea71819181fcef"
-                  },
-                  {
-                    "id": "sha256:0cb4318603418836dbbb30db39430ea5d89f4fac40f641bc91d6515fc4ef08cd"
-                  },
-                  {
-                    "id": "sha256:85d03de6ce794c8ce61c85ba84a79df6d49559cccc1b1deb572aa3c8e52f7c1b"
-                  },
-                  {
-                    "id": "sha256:144fb6ba0e48ba305d5654d849671c24ac82f3661557f0991f6c548e54086a32"
-                  },
-                  {
-                    "id": "sha256:00ecb47f6d186624b15d7064eacd55e9ad5c9f9e7fba7275d0659d3f228b826b"
-                  },
-                  {
-                    "id": "sha256:0a466ad35225cbf85b0c942450b2dd4ce942d6e5111624708ff90542d051acdc"
-                  },
-                  {
-                    "id": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-                  },
-                  {
                     "id": "sha256:d16252dcb91c3e581ecb29234180fb99ac3199a052a89d0e23603cb6054bee16"
                   },
                   {
@@ -1801,28 +1723,7 @@
                     "id": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
                   },
                   {
-                    "id": "sha256:2350cfe649d5156bbba7fd3be4f13dd3945243facebc8bad01db1707fd276145"
-                  },
-                  {
                     "id": "sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072"
-                  },
-                  {
-                    "id": "sha256:82cd233003b87e6b810070eead73ec44073050aabccec9a619309074a1868fe9"
-                  },
-                  {
-                    "id": "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a"
-                  },
-                  {
-                    "id": "sha256:319d3d51dfc09875cdbb61518410fe2963887228089d4a9de8f673acc7a2ff82"
-                  },
-                  {
-                    "id": "sha256:4bcbfd3229e3fd2d6e1adfe46bc233872c4184838de40b2e61a9ba84fcb81512"
-                  },
-                  {
-                    "id": "sha256:507c1a196520e4263a0581e70b669c352097d6bdc7a5409ae748ee3942e71f5c"
-                  },
-                  {
-                    "id": "sha256:94d5c3946873b079aa5af985e31501981fef1cb3065024e9f41f70c40fc9b975"
                   },
                   {
                     "id": "sha256:4f542ac06b9101e66033210648ba4bcc86c23f508a194d3a6ccba2966e4ade73"
@@ -1876,13 +1777,7 @@
                     "id": "sha256:37ca74f003d06ada0528d353bdc0df49193a058cece3c51173dc8b9c80f410e5"
                   },
                   {
-                    "id": "sha256:608502ce18d504a5c666f3779ff8b7106db7171664c3816458fe65c1680f19ee"
-                  },
-                  {
                     "id": "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3"
-                  },
-                  {
-                    "id": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
                   },
                   {
                     "id": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
@@ -1903,9 +1798,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -2073,23 +1966,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -2097,13 +1977,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-431.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -2168,20 +2044,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2198,44 +2062,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -2243,8 +2072,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -2270,28 +2099,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -2301,18 +2114,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -2330,8 +2131,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -2364,9 +2165,6 @@
     "sources": {
       "org.osbuild.curl": {
         "items": {
-          "sha256:00ecb47f6d186624b15d7064eacd55e9ad5c9f9e7fba7275d0659d3f228b826b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-swap-2.28-1.el8.x86_64.rpm"
-          },
           "sha256:017b2cf6bf46ca560b4ff8878bfa37f882c7f2589235c1f5ed20e38e69657a30": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libndp-1.7-6.el8.x86_64.rpm"
           },
@@ -2421,9 +2219,6 @@
           "sha256:09b3f89134b71bc6ed65d92628cb8161a4f3d34a16475ab3c5bbb32b33a7029b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/pam-1.3.1-24.el8.x86_64.rpm"
           },
-          "sha256:0a466ad35225cbf85b0c942450b2dd4ce942d6e5111624708ff90542d051acdc": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-utils-2.28-1.el8.x86_64.rpm"
-          },
           "sha256:0aa18121749a7e7056ebaf2a7f588127e2af309ed127b95be75a66b8f2ecc5c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/trousers-lib-0.3.15-1.el8.x86_64.rpm"
           },
@@ -2432,9 +2227,6 @@
           },
           "sha256:0c0fca928fce9b38762624ef06e6672189a386dbb15b28ddbfdb51492357b09c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libmodulemd-2.13.0-1.el8.x86_64.rpm"
-          },
-          "sha256:0cb4318603418836dbbb30db39430ea5d89f4fac40f641bc91d6515fc4ef08cd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-loop-2.28-1.el8.x86_64.rpm"
           },
           "sha256:0d710c1d1c2b63cdc54993c268441a420f3311a2f84a30e77c7431268ea5bdcb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/audit-3.0.7-4.el8.x86_64.rpm"
@@ -2465,9 +2257,6 @@
           },
           "sha256:14175dab807188a8261298dc3ba7b7cd19a9fbf36d0ee5b5c6cacc7e424998e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libssh-config-0.9.6-3.el8.noarch.rpm"
-          },
-          "sha256:144fb6ba0e48ba305d5654d849671c24ac82f3661557f0991f6c548e54086a32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-part-2.28-1.el8.x86_64.rpm"
           },
           "sha256:150e9dbb5a19483c85c25c722ff63a08d9411023c40faf88f42843fdf68ea275": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/popt-1.18-1.el8.x86_64.rpm"
@@ -2508,9 +2297,6 @@
           "sha256:1cfdaa7f1de88dfb1a409b1930e2bb2fe74375d0fbfe00938a2371f81d88c56f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/NetworkManager-tui-1.40.2-1.el8.x86_64.rpm"
           },
-          "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libatasmart-0.19-14.el8.x86_64.rpm"
-          },
           "sha256:1dc1dbd0aa4dad715b3242468d4841f2f35bf6aa60d8e1928ee692784b12da1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libsecret-0.18.6-1.el8.x86_64.rpm"
           },
@@ -2528,9 +2314,6 @@
           },
           "sha256:226b4efe6fb8e19d17cf4ffed266a413dac4801ad804887e5e00f7fb8e6c2ef9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/platform-python-setuptools-39.2.0-6.el8.noarch.rpm"
-          },
-          "sha256:2350cfe649d5156bbba7fd3be4f13dd3945243facebc8bad01db1707fd276145": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libudisks2-2.9.0-12.el8.x86_64.rpm"
           },
           "sha256:240b40a71d01005c0c8f780e5589e3999e3d6aa34e2a5e4eaf6f845fd21c7b5b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/keyutils-libs-1.5.10-9.el8.x86_64.rpm"
@@ -2565,9 +2348,6 @@
           "sha256:2733570f8ea94551f3381538f9c8642c88532c800b384c07b4db02f6b8896c3f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libattr-2.4.48-3.el8.x86_64.rpm"
           },
-          "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fwupd-1.7.8-1.el8.x86_64.rpm"
-          },
           "sha256:283285b4c414c5d0614849e64971730af9d0037e62e535adb538166051e52e1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libdhash-0.5.0-40.el8.x86_64.rpm"
           },
@@ -2589,9 +2369,6 @@
           "sha256:2bfb6eaf479f97a61db16efa6e6828468d3b5c6086358d88a46491a4ff6c78f8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dbus-common-1.12.8-23.el8.noarch.rpm"
           },
-          "sha256:2c3eeba223c5b9742d31138aa4adc585bd65a89bc9ccc723bbe721d997d9c11c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-crypto-2.28-1.el8.x86_64.rpm"
-          },
           "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dnf-plugins-core-4.0.21-14.1.el8.noarch.rpm"
           },
@@ -2607,26 +2384,14 @@
           "sha256:2ff643bfe17476a8dfa94ea900ddf9d89ed0e5f56839f18209f8304a0e31bb2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dmidecode-3.3-4.el8.x86_64.rpm"
           },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
           "sha256:304d7d8d6a590a1afcd651cccd6158da0af801b5c22aa5c63e692df622b22bc0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/redhat-release-eula-8.8-0.1.el8.x86_64.rpm"
-          },
-          "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
           },
           "sha256:306bd571a6c8617903bc4cc5b89b65abaab50be1f98f69b860eee77e31c9b05d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-perf-4.18.0-431.el8.x86_64.rpm"
           },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
-          },
           "sha256:30c6dbc7d2dd8024a16fe2d00b01fa71f4a1ea9d4af5519dc092695d4fa735cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libss-1.45.6-5.el8.x86_64.rpm"
-          },
-          "sha256:319d3d51dfc09875cdbb61518410fe2963887228089d4a9de8f673acc7a2ff82": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-softokn-3.79.0-10.el8_6.x86_64.rpm"
           },
           "sha256:321ab15562ad78bd1d9a87c9bda23b8a2f530ad1d09aa937e24d5ecb366fe6f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/NetworkManager-cloud-setup-1.40.2-1.el8.x86_64.rpm"
@@ -2700,9 +2465,6 @@
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
           },
-          "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
-          },
           "sha256:3d6a5eeb0da36ce36cd6ddc5e3c2d2bc36cd5962d1450077c5c5754b8f5ac02c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/glib2-2.56.4-159.el8.x86_64.rpm"
           },
@@ -2718,9 +2480,6 @@
           "sha256:4177e933095bfb14489e60f93134ba827f285a1235b60e07d6823f81a0a2091d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dbus-libs-1.12.8-23.el8.x86_64.rpm"
           },
-          "sha256:44447cbfdf0236f20f68d31e1541d43ffcc878da80b7a74691ea71819181fcef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-fs-2.28-1.el8.x86_64.rpm"
-          },
           "sha256:44f0d32c5f8ddf64ec80f8881272908601282dbad0642a087058e1b1ec24d669": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-libcomps-0.1.18-1.el8.x86_64.rpm"
           },
@@ -2732,9 +2491,6 @@
           },
           "sha256:4658cf807723123b513587887bf226d0b3daf69049c13951c5f88f6196acbb7d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libsss_sudo-2.7.3-4.el8.x86_64.rpm"
-          },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efivar-libs-37-4.el8.x86_64.rpm"
           },
           "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grub2-pc-2.02-142.el8.x86_64.rpm"
@@ -2778,9 +2534,6 @@
           "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/man-db-2.7.6.1-18.el8.x86_64.rpm"
           },
-          "sha256:4bcbfd3229e3fd2d6e1adfe46bc233872c4184838de40b2e61a9ba84fcb81512": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-softokn-freebl-3.79.0-10.el8_6.x86_64.rpm"
-          },
           "sha256:4bdac8b052ea5031f85f17e8f8499d491cc2ea8d5110467c5a0e4ec7b7763c2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/authselect-compat-1.2.5-1.el8.x86_64.rpm"
           },
@@ -2813,9 +2566,6 @@
           },
           "sha256:50603f9a5c2a643252949c922d656c83194047469116a33c3c265871bfd0a531": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dnf-data-4.7.0-11.el8.noarch.rpm"
-          },
-          "sha256:507c1a196520e4263a0581e70b669c352097d6bdc7a5409ae748ee3942e71f5c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-sysinit-3.79.0-10.el8_6.x86_64.rpm"
           },
           "sha256:51eb082082e78afa70dd64591219c026d11cf7a6adf3771a36624c80be34dc3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/nettle-3.4.1-7.el8.x86_64.rpm"
@@ -2877,9 +2627,6 @@
           "sha256:5ffaf4869bdd844266a156b9f1fda9d64e4f79db592384a145bf064aaca47b41": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/lshw-B.02.19.2-6.el8.x86_64.rpm"
           },
-          "sha256:608502ce18d504a5c666f3779ff8b7106db7171664c3816458fe65c1680f19ee": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/udisks2-2.9.0-12.el8.x86_64.rpm"
-          },
           "sha256:60fe236d60faf42f2685db44f40508f7bf036d3ff5624e2727d5c50436a87c56": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgomp-8.5.0-17.el8.x86_64.rpm"
           },
@@ -2916,9 +2663,6 @@
           "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libsolv-0.7.20-3.el8.x86_64.rpm"
           },
-          "sha256:694ba7edf36a3cf125b914dd638de18fa4d0928f046da1bda32f78c8f94439e2": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-2.28-1.el8.x86_64.rpm"
-          },
           "sha256:6950a3136327480137b0c3ed7555bd36d107ebb39b687354d2d34c5542e19d2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dbus-1.12.8-23.el8.x86_64.rpm"
           },
@@ -2937,9 +2681,6 @@
           "sha256:6d7a41fb238610416349a53d024cc505ab7f3f6e9953cc2244abb663ec404dad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/ncurses-6.1-9.20180224.el8.x86_64.rpm"
           },
-          "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm"
-          },
           "sha256:6dec9fcb8adb571e5de0e5c0c7bcc71a1142fcf2466394304102cf17b349513f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libdnf-0.63.0-11.1.el8.x86_64.rpm"
           },
@@ -2957,9 +2698,6 @@
           },
           "sha256:709fb09876846df58d761b2ddb973bbf2b870d995452648ef929a2cdf3ea8216": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libarchive-3.3.3-4.el8.x86_64.rpm"
-          },
-          "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgudev-232-4.el8.x86_64.rpm"
           },
           "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm"
@@ -3048,17 +2786,11 @@
           "sha256:821923c32f6cd4c764ea7e97bee3335993d405694aa81b923cf1ef46c9e03cf9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/rhc-0.2.1-9.el8.x86_64.rpm"
           },
-          "sha256:82cd233003b87e6b810070eead73ec44073050aabccec9a619309074a1868fe9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nspr-4.34.0-3.el8_6.x86_64.rpm"
-          },
           "sha256:830940ac1860e506f78be51323f21144a40e6244eff2331c1648da06baee9ea6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dhcp-libs-4.3.6-48.el8.x86_64.rpm"
           },
           "sha256:84c4a7d89325e5d405712dff6db06ef55996a09faf7490c1693d032171730777": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/procps-ng-3.3.15-9.el8.x86_64.rpm"
-          },
-          "sha256:85d03de6ce794c8ce61c85ba84a79df6d49559cccc1b1deb572aa3c8e52f7c1b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-mdraid-2.28-1.el8.x86_64.rpm"
           },
           "sha256:862e75a1cf6aa5be750a530c8ce8b999d0b2efe9737e20f37f9f9153a82e56fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libassuan-2.5.1-3.el8.x86_64.rpm"
@@ -3081,9 +2813,6 @@
           "sha256:88f6945f8c7875f85a8f6befdfee8f3460f6f929fc6fb64eba1411bf8c2c6361": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-audit-3.0.7-4.el8.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8af1caa726c0b3b398eed421511ff26222f3ddfa131b90fedaa4fe464216338c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgcrypt-1.8.5-7.el8_6.x86_64.rpm"
           },
@@ -3092,9 +2821,6 @@
           },
           "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8d371e753071edc796d2eadb8278980290511be6279fdf46649c81b859497d6a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/prefixdevname-0.1.0-6.el8.x86_64.rpm"
@@ -3140,9 +2866,6 @@
           },
           "sha256:9461fa7a5e74bfd8d9e9961af9d3003d9d2b496830c2fd6b0641ae8b8bc8e178": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libacl-2.2.53-1.el8.x86_64.rpm"
-          },
-          "sha256:94d5c3946873b079aa5af985e31501981fef1cb3065024e9f41f70c40fc9b975": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-util-3.79.0-10.el8_6.x86_64.rpm"
           },
           "sha256:95a49f92900d79b2d02c879e1eef3d92947e7f3294d65044b31ebb435f7ac705": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/glibc-2.28-216.el8.x86_64.rpm"
@@ -3255,15 +2978,6 @@
           "sha256:ae6dd4ea3852d1ce30a0988bde8d35e91a8b0709615e3ac64c65a5e24e68fefa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/device-mapper-libs-1.02.181-6.el8.x86_64.rpm"
           },
-          "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
-          },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
-          "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-3.79.0-10.el8_6.x86_64.rpm"
-          },
           "sha256:af00ed7ea481e1fadd410520c479e751fa3b58d00b7dc93af8da937ae9d9528d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/selinux-policy-targeted-3.14.3-109.el8.noarch.rpm"
           },
@@ -3302,9 +3016,6 @@
           },
           "sha256:b4babe48d93eccce4f0249ba34d592bfc306c3b14b40df7a5cc9eaec2eaae20f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/numactl-libs-2.0.12-13.el8.x86_64.rpm"
-          },
-          "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
           },
           "sha256:b76a180508132aaceb8dcebc5de9cec87d3459a39e4749f9af342d242c410dab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/oddjob-mkhomedir-0.34.7-2.el8.x86_64.rpm"
@@ -3474,17 +3185,11 @@
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/timedatex-0.5-3.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d570af0578f5b2c6225f1f2354404f65bccf91c3974e98dcbc0c7b55a61b9b46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grep-3.1-6.el8.x86_64.rpm"
           },
           "sha256:d67580b9b2af79f599f77c35c694714d2d39d2ea01c28e8aaca1312e6ab25184": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-libselinux-2.9-6.el8.x86_64.rpm"
-          },
-          "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/shim-x64-15.6-1.el8.x86_64.rpm"
           },
           "sha256:d94ea399f82d4f9537af1098a588c5cc9a80454ba7c1de9b26dd11cb5c730d8a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm"
@@ -3518,9 +3223,6 @@
           },
           "sha256:e29131b502b6a199003ed61e27eb3e5cb3d46f4b4a3f8ca1034945a406dcfe80": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libsemanage-2.9-9.el8.x86_64.rpm"
-          },
-          "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mdadm-4.2-5.el8.x86_64.rpm"
           },
           "sha256:e4f799b634299835dc1a8e79adcfb223d13b369bd033cbdb14170f845c9464ad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/ethtool-5.13-2.el8.x86_64.rpm"
@@ -3632,9 +3334,6 @@
           },
           "sha256:fc46ac94289cd660db8452aa7093c446b0f087cda089b3c3aeeb988286d80ee2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/systemd-239-68.el8.x86_64.rpm"
-          },
-          "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
           },
           "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
@@ -3899,15 +3598,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -5379,15 +5069,6 @@
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-      },
-      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.6",
@@ -5712,15 +5393,6 @@
         "checksum": "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711"
       },
       {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "049",
@@ -5782,33 +5454,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/e2fsprogs-libs-1.45.6-5.el8.x86_64.rpm",
         "checksum": "sha256:8e0e23d6a9399d9016d721467181d9abd3e888894149767b631889f1aeddf755"
-      },
-      {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
       },
       {
         "name": "elfutils-debuginfod-client",
@@ -5917,15 +5562,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fuse-libs-2.9.7-16.el8.x86_64.rpm",
         "checksum": "sha256:be62c3c22fe4351a434d5b971061e512db199d763205dd8aaf4c6faa35a9be42"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.8",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fwupd-1.7.8-1.el8.x86_64.rpm",
-        "checksum": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
       },
       {
         "name": "gawk",
@@ -6106,15 +5742,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grub2-common-2.02-142.el8.noarch.rpm",
         "checksum": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "142.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm",
-        "checksum": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
       },
       {
         "name": "grub2-pc",
@@ -6648,15 +6275,6 @@
         "checksum": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -6691,24 +6309,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgpg-error-1.31-1.el8.x86_64.rpm",
         "checksum": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-      },
-      {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "232",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgudev-232-4.el8.x86_64.rpm",
-        "checksum": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgusb-0.3.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
       },
       {
         "name": "libidn2",
@@ -7008,15 +6608,6 @@
         "checksum": "sha256:d15c8594702ab51f8aa792a6c0ebae49ddefc8740289397b2cd8cb6e4a711187"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -7242,15 +6833,6 @@
         "checksum": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libyaml",
         "epoch": 0,
         "version": "0.1.7",
@@ -7350,15 +6932,6 @@
         "checksum": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mdadm-4.2-5.el8.x86_64.rpm",
-        "checksum": "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de"
-      },
-      {
         "name": "memstrack",
         "epoch": 0,
         "version": "0.2.4",
@@ -7375,15 +6948,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/microcode_ctl-20220809-1.el8.x86_64.rpm",
         "checksum": "sha256:d3e15db6aaa6d8ba4587408d87863b2f94092024bbb94893faa95c5d259a97d4"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "12.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mokutil-0.3.0-12.el8.x86_64.rpm",
-        "checksum": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
       },
       {
         "name": "mozjs60",
@@ -8340,15 +7904,6 @@
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
-        "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -8727,96 +8282,6 @@
         "checksum": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "14.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libatasmart-0.19-14.el8.x86_64.rpm",
-        "checksum": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:694ba7edf36a3cf125b914dd638de18fa4d0928f046da1bda32f78c8f94439e2"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-crypto-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:2c3eeba223c5b9742d31138aa4adc585bd65a89bc9ccc723bbe721d997d9c11c"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-fs-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:44447cbfdf0236f20f68d31e1541d43ffcc878da80b7a74691ea71819181fcef"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-loop-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:0cb4318603418836dbbb30db39430ea5d89f4fac40f641bc91d6515fc4ef08cd"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-mdraid-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:85d03de6ce794c8ce61c85ba84a79df6d49559cccc1b1deb572aa3c8e52f7c1b"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-part-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:144fb6ba0e48ba305d5654d849671c24ac82f3661557f0991f6c548e54086a32"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-swap-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:00ecb47f6d186624b15d7064eacd55e9ad5c9f9e7fba7275d0659d3f228b826b"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-utils-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:0a466ad35225cbf85b0c942450b2dd4ce942d6e5111624708ff90542d051acdc"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libbytesize-1.4-3.el8.x86_64.rpm",
-        "checksum": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.10",
@@ -8844,15 +8309,6 @@
         "checksum": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
       },
       {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "12.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libudisks2-2.9.0-12.el8.x86_64.rpm",
-        "checksum": "sha256:2350cfe649d5156bbba7fd3be4f13dd3945243facebc8bad01db1707fd276145"
-      },
-      {
         "name": "libxkbcommon",
         "epoch": 0,
         "version": "0.9.1",
@@ -8860,60 +8316,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libxkbcommon-0.9.1-1.el8.x86_64.rpm",
         "checksum": "sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072"
-      },
-      {
-        "name": "nspr",
-        "epoch": 0,
-        "version": "4.34.0",
-        "release": "3.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nspr-4.34.0-3.el8_6.x86_64.rpm",
-        "checksum": "sha256:82cd233003b87e6b810070eead73ec44073050aabccec9a619309074a1868fe9"
-      },
-      {
-        "name": "nss",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a"
-      },
-      {
-        "name": "nss-softokn",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-softokn-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:319d3d51dfc09875cdbb61518410fe2963887228089d4a9de8f673acc7a2ff82"
-      },
-      {
-        "name": "nss-softokn-freebl",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-softokn-freebl-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:4bcbfd3229e3fd2d6e1adfe46bc233872c4184838de40b2e61a9ba84fcb81512"
-      },
-      {
-        "name": "nss-sysinit",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-sysinit-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:507c1a196520e4263a0581e70b669c352097d6bdc7a5409ae748ee3942e71f5c"
-      },
-      {
-        "name": "nss-util",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "10.el8_6",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-util-3.79.0-10.el8_6.x86_64.rpm",
-        "checksum": "sha256:94d5c3946873b079aa5af985e31501981fef1cb3065024e9f41f70c40fc9b975"
       },
       {
         "name": "oddjob",
@@ -9069,15 +8471,6 @@
         "checksum": "sha256:37ca74f003d06ada0528d353bdc0df49193a058cece3c51173dc8b9c80f410e5"
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "12.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/udisks2-2.9.0-12.el8.x86_64.rpm",
-        "checksum": "sha256:608502ce18d504a5c666f3779ff8b7106db7171664c3816458fe65c1680f19ee"
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.16.2",
@@ -9085,15 +8478,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/unbound-libs-1.16.2-2.el8.x86_64.rpm",
         "checksum": "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.11",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm",
-        "checksum": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
       },
       {
         "name": "xkeyboard-config",

--- a/test/data/manifests/rhel_88-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-ec2_ha-boot.json
@@ -130,9 +130,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -659,9 +656,6 @@
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
                   },
                   {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-                  },
-                  {
                     "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
                   },
                   {
@@ -791,9 +785,6 @@
                     "id": "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -813,15 +804,6 @@
                   },
                   {
                     "id": "sha256:8e0e23d6a9399d9016d721467181d9abd3e888894149767b631889f1aeddf755"
-                  },
-                  {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
                   },
                   {
                     "id": "sha256:45c47f5146e39f50ca18d1561821607bc582c5fd4de0bf05bc06a5e0eb33df34"
@@ -861,9 +843,6 @@
                   },
                   {
                     "id": "sha256:be62c3c22fe4351a434d5b971061e512db199d763205dd8aaf4c6faa35a9be42"
-                  },
-                  {
-                    "id": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
                   },
                   {
                     "id": "sha256:59b3cff57ffbea4c4c011e6a81341a1203c18b91569fff019c93b756331300f8"
@@ -924,9 +903,6 @@
                   },
                   {
                     "id": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-                  },
-                  {
-                    "id": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
                   },
                   {
                     "id": "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d"
@@ -1121,9 +1097,6 @@
                     "id": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:2cd7f54b726250042483f37e513645c240beec147cbfa959cd689b306d36d103"
                   },
                   {
@@ -1134,12 +1107,6 @@
                   },
                   {
                     "id": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-                  },
-                  {
-                    "id": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-                  },
-                  {
-                    "id": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
                   },
                   {
                     "id": "sha256:fe37f767487e0806535a06cda4e302555c27166b6320657ae945d5217b8c36aa"
@@ -1247,9 +1214,6 @@
                     "id": "sha256:d15c8594702ab51f8aa792a6c0ebae49ddefc8740289397b2cd8cb6e4a711187"
                   },
                   {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-                  },
-                  {
                     "id": "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8"
                   },
                   {
@@ -1328,9 +1292,6 @@
                     "id": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15"
                   },
                   {
@@ -1373,16 +1334,10 @@
                     "id": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
                   },
                   {
-                    "id": "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de"
-                  },
-                  {
                     "id": "sha256:ca6208d771fbbfc703217b0f4314d214a866da86b105f222753a6efeb12d6f69"
                   },
                   {
                     "id": "sha256:d3e15db6aaa6d8ba4587408d87863b2f94092024bbb94893faa95c5d259a97d4"
-                  },
-                  {
-                    "id": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -1838,9 +1793,6 @@
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
                   },
                   {
-                    "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
-                  },
-                  {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
                   },
                   {
@@ -2096,36 +2048,6 @@
                     "id": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
                   },
                   {
-                    "id": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-                  },
-                  {
-                    "id": "sha256:694ba7edf36a3cf125b914dd638de18fa4d0928f046da1bda32f78c8f94439e2"
-                  },
-                  {
-                    "id": "sha256:2c3eeba223c5b9742d31138aa4adc585bd65a89bc9ccc723bbe721d997d9c11c"
-                  },
-                  {
-                    "id": "sha256:44447cbfdf0236f20f68d31e1541d43ffcc878da80b7a74691ea71819181fcef"
-                  },
-                  {
-                    "id": "sha256:0cb4318603418836dbbb30db39430ea5d89f4fac40f641bc91d6515fc4ef08cd"
-                  },
-                  {
-                    "id": "sha256:85d03de6ce794c8ce61c85ba84a79df6d49559cccc1b1deb572aa3c8e52f7c1b"
-                  },
-                  {
-                    "id": "sha256:144fb6ba0e48ba305d5654d849671c24ac82f3661557f0991f6c548e54086a32"
-                  },
-                  {
-                    "id": "sha256:00ecb47f6d186624b15d7064eacd55e9ad5c9f9e7fba7275d0659d3f228b826b"
-                  },
-                  {
-                    "id": "sha256:0a466ad35225cbf85b0c942450b2dd4ce942d6e5111624708ff90542d051acdc"
-                  },
-                  {
-                    "id": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-                  },
-                  {
                     "id": "sha256:d16252dcb91c3e581ecb29234180fb99ac3199a052a89d0e23603cb6054bee16"
                   },
                   {
@@ -2136,9 +2058,6 @@
                   },
                   {
                     "id": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
-                  },
-                  {
-                    "id": "sha256:2350cfe649d5156bbba7fd3be4f13dd3945243facebc8bad01db1707fd276145"
                   },
                   {
                     "id": "sha256:34001e2596b82803f289adefe1a263b61917e8a67ff8e45d9ff5fc1ca150eb57"
@@ -2330,13 +2249,7 @@
                     "id": "sha256:bafc9ec3dd737b0dbdf179b9d9b4c8a9b5c1a92423eae1e4eb3047522107695e"
                   },
                   {
-                    "id": "sha256:608502ce18d504a5c666f3779ff8b7106db7171664c3816458fe65c1680f19ee"
-                  },
-                  {
                     "id": "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3"
-                  },
-                  {
-                    "id": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
                   },
                   {
                     "id": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
@@ -2418,9 +2331,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -2588,23 +2499,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -2612,13 +2510,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-431.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -2683,20 +2577,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -2713,44 +2595,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -2758,8 +2605,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -2785,28 +2632,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -2816,18 +2647,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -2845,8 +2664,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -2879,9 +2698,6 @@
     "sources": {
       "org.osbuild.curl": {
         "items": {
-          "sha256:00ecb47f6d186624b15d7064eacd55e9ad5c9f9e7fba7275d0659d3f228b826b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-swap-2.28-1.el8.x86_64.rpm"
-          },
           "sha256:0178d3f292043e23199cf363579499565ede01af6214902f4a737fb5c28caa0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/fence-agents-ipdu-4.2.1-107.el8.noarch.rpm"
           },
@@ -2945,9 +2761,6 @@
           "sha256:0a308d1d53d328b959ad035797d7614c020e78bc5a970fe705924c3e97625858": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/pacemaker-schemas-2.1.4-5.el8.noarch.rpm"
           },
-          "sha256:0a466ad35225cbf85b0c942450b2dd4ce942d6e5111624708ff90542d051acdc": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-utils-2.28-1.el8.x86_64.rpm"
-          },
           "sha256:0a7bb0319bedac10e172b6241902c7bc1859d867b030f8d80d36df39890e1e06": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/pacemaker-cluster-libs-2.1.4-5.el8.x86_64.rpm"
           },
@@ -2962,9 +2775,6 @@
           },
           "sha256:0c0fca928fce9b38762624ef06e6672189a386dbb15b28ddbfdb51492357b09c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libmodulemd-2.13.0-1.el8.x86_64.rpm"
-          },
-          "sha256:0cb4318603418836dbbb30db39430ea5d89f4fac40f641bc91d6515fc4ef08cd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-loop-2.28-1.el8.x86_64.rpm"
           },
           "sha256:0d3f8e14265aa162bfcec4aff8064fa26188f1e51e897f20760bab906a9f9e5e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/perl-threads-2.21-2.el8.x86_64.rpm"
@@ -3029,9 +2839,6 @@
           "sha256:14175dab807188a8261298dc3ba7b7cd19a9fbf36d0ee5b5c6cacc7e424998e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libssh-config-0.9.6-3.el8.noarch.rpm"
           },
-          "sha256:144fb6ba0e48ba305d5654d849671c24ac82f3661557f0991f6c548e54086a32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-part-2.28-1.el8.x86_64.rpm"
-          },
           "sha256:14bdf3842e51213afe2488cd83c274f239e77535210c137d438ac7bd6b299f65": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/lvm2-libs-2.03.14-6.el8.x86_64.rpm"
           },
@@ -3092,9 +2899,6 @@
           "sha256:1cfdaa7f1de88dfb1a409b1930e2bb2fe74375d0fbfe00938a2371f81d88c56f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/NetworkManager-tui-1.40.2-1.el8.x86_64.rpm"
           },
-          "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libatasmart-0.19-14.el8.x86_64.rpm"
-          },
           "sha256:1dc1dbd0aa4dad715b3242468d4841f2f35bf6aa60d8e1928ee692784b12da1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libsecret-0.18.6-1.el8.x86_64.rpm"
           },
@@ -3121,9 +2925,6 @@
           },
           "sha256:22d4d64559350664aa77d4534ee82dcfc26b4146d738af14ef87d2f4dfb3af90": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/rubygems-2.7.6.3-110.module+el8.6.0+15956+aa803fc1.noarch.rpm"
-          },
-          "sha256:2350cfe649d5156bbba7fd3be4f13dd3945243facebc8bad01db1707fd276145": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libudisks2-2.9.0-12.el8.x86_64.rpm"
           },
           "sha256:240b40a71d01005c0c8f780e5589e3999e3d6aa34e2a5e4eaf6f845fd21c7b5b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/keyutils-libs-1.5.10-9.el8.x86_64.rpm"
@@ -3167,9 +2968,6 @@
           "sha256:2733570f8ea94551f3381538f9c8642c88532c800b384c07b4db02f6b8896c3f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libattr-2.4.48-3.el8.x86_64.rpm"
           },
-          "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fwupd-1.7.8-1.el8.x86_64.rpm"
-          },
           "sha256:27efba5e62430987380ca7f2e4185e1d27c517a6f8d22958dd3fd0bc2591d3fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/rubygem-io-console-0.4.6-110.module+el8.6.0+15956+aa803fc1.x86_64.rpm"
           },
@@ -3209,9 +3007,6 @@
           "sha256:2bfb6eaf479f97a61db16efa6e6828468d3b5c6086358d88a46491a4ff6c78f8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dbus-common-1.12.8-23.el8.noarch.rpm"
           },
-          "sha256:2c3eeba223c5b9742d31138aa4adc585bd65a89bc9ccc723bbe721d997d9c11c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-crypto-2.28-1.el8.x86_64.rpm"
-          },
           "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dnf-plugins-core-4.0.21-14.1.el8.noarch.rpm"
           },
@@ -3230,20 +3025,11 @@
           "sha256:2ff643bfe17476a8dfa94ea900ddf9d89ed0e5f56839f18209f8304a0e31bb2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dmidecode-3.3-4.el8.x86_64.rpm"
           },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
           "sha256:304d7d8d6a590a1afcd651cccd6158da0af801b5c22aa5c63e692df622b22bc0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/redhat-release-eula-8.8-0.1.el8.x86_64.rpm"
           },
-          "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgusb-0.3.0-1.el8.x86_64.rpm"
-          },
           "sha256:306bd571a6c8617903bc4cc5b89b65abaab50be1f98f69b860eee77e31c9b05d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-perf-4.18.0-431.el8.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
           "sha256:30c6dbc7d2dd8024a16fe2d00b01fa71f4a1ea9d4af5519dc092695d4fa735cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libss-1.45.6-5.el8.x86_64.rpm"
@@ -3335,9 +3121,6 @@
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
           },
-          "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
-          },
           "sha256:3d6a5eeb0da36ce36cd6ddc5e3c2d2bc36cd5962d1450077c5c5754b8f5ac02c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/glib2-2.56.4-159.el8.x86_64.rpm"
           },
@@ -3374,9 +3157,6 @@
           "sha256:4361f417458cf707b9018d51a87ad76ec90b410cff38d232f3a83ac9f2a3f4b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/fence-agents-hpblade-4.2.1-107.el8.noarch.rpm"
           },
-          "sha256:44447cbfdf0236f20f68d31e1541d43ffcc878da80b7a74691ea71819181fcef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-fs-2.28-1.el8.x86_64.rpm"
-          },
           "sha256:44f0d32c5f8ddf64ec80f8881272908601282dbad0642a087058e1b1ec24d669": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-libcomps-0.1.18-1.el8.x86_64.rpm"
           },
@@ -3394,9 +3174,6 @@
           },
           "sha256:46e8d326546d5850b837e4fb1a9b77f58ba498956c23ac078f79ea7f15181c69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/ruby-libs-2.5.9-110.module+el8.6.0+15956+aa803fc1.x86_64.rpm"
-          },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efivar-libs-37-4.el8.x86_64.rpm"
           },
           "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grub2-pc-2.02-142.el8.x86_64.rpm"
@@ -3584,9 +3361,6 @@
           "sha256:5ffaf4869bdd844266a156b9f1fda9d64e4f79db592384a145bf064aaca47b41": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/lshw-B.02.19.2-6.el8.x86_64.rpm"
           },
-          "sha256:608502ce18d504a5c666f3779ff8b7106db7171664c3816458fe65c1680f19ee": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/udisks2-2.9.0-12.el8.x86_64.rpm"
-          },
           "sha256:60fe236d60faf42f2685db44f40508f7bf036d3ff5624e2727d5c50436a87c56": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgomp-8.5.0-17.el8.x86_64.rpm"
           },
@@ -3635,9 +3409,6 @@
           "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libsolv-0.7.20-3.el8.x86_64.rpm"
           },
-          "sha256:694ba7edf36a3cf125b914dd638de18fa4d0928f046da1bda32f78c8f94439e2": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-2.28-1.el8.x86_64.rpm"
-          },
           "sha256:6950a3136327480137b0c3ed7555bd36d107ebb39b687354d2d34c5542e19d2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dbus-1.12.8-23.el8.x86_64.rpm"
           },
@@ -3665,9 +3436,6 @@
           "sha256:6d7a41fb238610416349a53d024cc505ab7f3f6e9953cc2244abb663ec404dad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/ncurses-6.1-9.20180224.el8.x86_64.rpm"
           },
-          "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm"
-          },
           "sha256:6dd24bbdf5a94e53c5e1ccc1164eed48cafebdd27da5154e7648bf1b36f2bd7d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/fence-agents-ifmib-4.2.1-107.el8.noarch.rpm"
           },
@@ -3691,9 +3459,6 @@
           },
           "sha256:709fb09876846df58d761b2ddb973bbf2b870d995452648ef929a2cdf3ea8216": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libarchive-3.3.3-4.el8.x86_64.rpm"
-          },
-          "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgudev-232-4.el8.x86_64.rpm"
           },
           "sha256:71676aca45858e9e25878e4153d08e31beef91a916b85547105c8f911e4c29ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-policycoreutils-2.9-20.el8.noarch.rpm"
@@ -3845,9 +3610,6 @@
           "sha256:84c4a7d89325e5d405712dff6db06ef55996a09faf7490c1693d032171730777": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/procps-ng-3.3.15-9.el8.x86_64.rpm"
           },
-          "sha256:85d03de6ce794c8ce61c85ba84a79df6d49559cccc1b1deb572aa3c8e52f7c1b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-mdraid-2.28-1.el8.x86_64.rpm"
-          },
           "sha256:862aa5c98f0bd869f0868281e52a6f8819b3f9e9d632bc902d6deb88f8acc51a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/fence-agents-intelmodular-4.2.1-107.el8.noarch.rpm"
           },
@@ -3875,9 +3637,6 @@
           "sha256:891b4ffa90ef5369b7a846fabe4ce87e0d7e604fa31a43104b93c7f5654bbb7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libwbclient-4.16.4-2.el8.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8af1caa726c0b3b398eed421511ff26222f3ddfa131b90fedaa4fe464216338c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgcrypt-1.8.5-7.el8_6.x86_64.rpm"
           },
@@ -3886,9 +3645,6 @@
           },
           "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8d371e753071edc796d2eadb8278980290511be6279fdf46649c81b859497d6a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/prefixdevname-0.1.0-6.el8.x86_64.rpm"
@@ -4106,12 +3862,6 @@
           "sha256:ae6dd4ea3852d1ce30a0988bde8d35e91a8b0709615e3ac64c65a5e24e68fefa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/device-mapper-libs-1.02.181-6.el8.x86_64.rpm"
           },
-          "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
-          },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
           "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-3.79.0-10.el8_6.x86_64.rpm"
           },
@@ -4171,9 +3921,6 @@
           },
           "sha256:b516896f3b3a83a1a5c9d0d6e84b025ecdb8d3676cbb195751b44224ad720078": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-n8.8-20221025/Packages/pacemaker-cli-2.1.4-5.el8.x86_64.rpm"
-          },
-          "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
           },
           "sha256:b76a180508132aaceb8dcebc5de9cec87d3459a39e4749f9af342d242c410dab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/oddjob-mkhomedir-0.34.7-2.el8.x86_64.rpm"
@@ -4400,9 +4147,6 @@
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/timedatex-0.5-3.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d570af0578f5b2c6225f1f2354404f65bccf91c3974e98dcbc0c7b55a61b9b46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grep-3.1-6.el8.x86_64.rpm"
           },
@@ -4411,9 +4155,6 @@
           },
           "sha256:d71e828ca8bf6bfe31ff87d8b30861e16d1767fa18f9ff0fd4056170ed874065": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/fence-virt-1.0.0-3.el8.x86_64.rpm"
-          },
-          "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/shim-x64-15.6-1.el8.x86_64.rpm"
           },
           "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
@@ -4474,9 +4215,6 @@
           },
           "sha256:e33a380e981f44fb1e1987142e4a41bf3dbeb452490f2030876d221640c52e14": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/samba-client-libs-4.16.4-2.el8.x86_64.rpm"
-          },
-          "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mdadm-4.2-5.el8.x86_64.rpm"
           },
           "sha256:e4f799b634299835dc1a8e79adcfb223d13b369bd033cbdb14170f845c9464ad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/ethtool-5.13-2.el8.x86_64.rpm"
@@ -4639,9 +4377,6 @@
           },
           "sha256:fc46ac94289cd660db8452aa7093c446b0f087cda089b3c3aeeb988286d80ee2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/systemd-239-68.el8.x86_64.rpm"
-          },
-          "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dosfstools-4.1-6.el8.x86_64.rpm"
           },
           "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm"
@@ -4909,15 +4644,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -6398,15 +6124,6 @@
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-      },
-      {
         "name": "bzip2",
         "epoch": 0,
         "version": "1.0.6",
@@ -6794,15 +6511,6 @@
         "checksum": "sha256:2c64abeeb3befc3f627cc10a1a6ef5b0bfc194d4698195c73162b64228882711"
       },
       {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "049",
@@ -6864,33 +6572,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/e2fsprogs-libs-1.45.6-5.el8.x86_64.rpm",
         "checksum": "sha256:8e0e23d6a9399d9016d721467181d9abd3e888894149767b631889f1aeddf755"
-      },
-      {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
       },
       {
         "name": "elfutils-debuginfod-client",
@@ -7008,15 +6689,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fuse-libs-2.9.7-16.el8.x86_64.rpm",
         "checksum": "sha256:be62c3c22fe4351a434d5b971061e512db199d763205dd8aaf4c6faa35a9be42"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.8",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fwupd-1.7.8-1.el8.x86_64.rpm",
-        "checksum": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
       },
       {
         "name": "gawk",
@@ -7197,15 +6869,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grub2-common-2.02-142.el8.noarch.rpm",
         "checksum": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "142.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm",
-        "checksum": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
       },
       {
         "name": "grub2-pc",
@@ -7784,15 +7447,6 @@
         "checksum": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -7827,24 +7481,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgpg-error-1.31-1.el8.x86_64.rpm",
         "checksum": "sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9"
-      },
-      {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "232",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgudev-232-4.el8.x86_64.rpm",
-        "checksum": "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgusb-0.3.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728"
       },
       {
         "name": "libicu",
@@ -8162,15 +7798,6 @@
         "checksum": "sha256:d15c8594702ab51f8aa792a6c0ebae49ddefc8740289397b2cd8cb6e4a711187"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -8405,15 +8032,6 @@
         "checksum": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libxslt",
         "epoch": 0,
         "version": "1.1.32",
@@ -8540,15 +8158,6 @@
         "checksum": "sha256:4ba395fa52087932606da98e076eb94b8d766ee11d0a60bc09bc8bd57ff6e479"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mdadm-4.2-5.el8.x86_64.rpm",
-        "checksum": "sha256:e42b1e17b93e68510f5140bc010bfdd2f746caa6b52ebd3071bda8d4001af9de"
-      },
-      {
         "name": "memstrack",
         "epoch": 0,
         "version": "0.2.4",
@@ -8565,15 +8174,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/microcode_ctl-20220809-1.el8.x86_64.rpm",
         "checksum": "sha256:d3e15db6aaa6d8ba4587408d87863b2f94092024bbb94893faa95c5d259a97d4"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "12.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mokutil-0.3.0-12.el8.x86_64.rpm",
-        "checksum": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
       },
       {
         "name": "mozjs60",
@@ -9935,15 +9535,6 @@
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
-        "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -10709,96 +10300,6 @@
         "checksum": "sha256:38affe91361bf56b84490d97c7e3f815965cf8d2bbb222c6c045af4bf2dff736"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "14.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libatasmart-0.19-14.el8.x86_64.rpm",
-        "checksum": "sha256:1dac1f15a0b4e95d69e8903e7f8fb77e2f02318462490e3c30f3eeebd4cba37e"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:694ba7edf36a3cf125b914dd638de18fa4d0928f046da1bda32f78c8f94439e2"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-crypto-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:2c3eeba223c5b9742d31138aa4adc585bd65a89bc9ccc723bbe721d997d9c11c"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-fs-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:44447cbfdf0236f20f68d31e1541d43ffcc878da80b7a74691ea71819181fcef"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-loop-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:0cb4318603418836dbbb30db39430ea5d89f4fac40f641bc91d6515fc4ef08cd"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-mdraid-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:85d03de6ce794c8ce61c85ba84a79df6d49559cccc1b1deb572aa3c8e52f7c1b"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-part-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:144fb6ba0e48ba305d5654d849671c24ac82f3661557f0991f6c548e54086a32"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-swap-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:00ecb47f6d186624b15d7064eacd55e9ad5c9f9e7fba7275d0659d3f228b826b"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libblockdev-utils-2.28-1.el8.x86_64.rpm",
-        "checksum": "sha256:0a466ad35225cbf85b0c942450b2dd4ce942d6e5111624708ff90542d051acdc"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "3.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libbytesize-1.4-3.el8.x86_64.rpm",
-        "checksum": "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.10",
@@ -10833,15 +10334,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libmaxminddb-1.2.0-10.el8.x86_64.rpm",
         "checksum": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
-      },
-      {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "12.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/libudisks2-2.9.0-12.el8.x86_64.rpm",
-        "checksum": "sha256:2350cfe649d5156bbba7fd3be4f13dd3945243facebc8bad01db1707fd276145"
       },
       {
         "name": "libverto-libev",
@@ -11411,15 +10903,6 @@
         "checksum": "sha256:bafc9ec3dd737b0dbdf179b9d9b4c8a9b5c1a92423eae1e4eb3047522107695e"
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.0",
-        "release": "12.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/udisks2-2.9.0-12.el8.x86_64.rpm",
-        "checksum": "sha256:608502ce18d504a5c666f3779ff8b7106db7171664c3816458fe65c1680f19ee"
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.16.2",
@@ -11427,15 +10910,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/unbound-libs-1.16.2-2.el8.x86_64.rpm",
         "checksum": "sha256:95b90e970f76a3ef6581c9e789fc9976ef8921f6ba58844f56c7e42e6c1786e3"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.11",
-        "release": "5.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm",
-        "checksum": "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c"
       },
       {
         "name": "xkeyboard-config",

--- a/test/data/manifests/rhel_88-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-ec2_sap-boot.json
@@ -155,9 +155,6 @@
                     "id": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
                   },
                   {
-                    "id": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
-                  },
-                  {
                     "id": "sha256:296e764bb6e34fff539d6efdb5ffbcc2f3649e97989ed9a39bd2aaecf1598c80"
                   },
                   {
@@ -726,9 +723,6 @@
                     "id": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
                   },
                   {
-                    "id": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-                  },
-                  {
                     "id": "sha256:ac5e4942921cee7c931186db79f14c54ddda3d98756e37bd6bb5b0a1024f0e82"
                   },
                   {
@@ -915,15 +909,6 @@
                     "id": "sha256:d5689e2894c59a375f985b5228b32e78d10b4ceeec9fd7c79f2000480494d368"
                   },
                   {
-                    "id": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-                  },
-                  {
-                    "id": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-                  },
-                  {
-                    "id": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
-                  },
-                  {
                     "id": "sha256:45c47f5146e39f50ca18d1561821607bc582c5fd4de0bf05bc06a5e0eb33df34"
                   },
                   {
@@ -979,9 +964,6 @@
                   },
                   {
                     "id": "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987"
-                  },
-                  {
-                    "id": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
                   },
                   {
                     "id": "sha256:59b3cff57ffbea4c4c011e6a81341a1203c18b91569fff019c93b756331300f8"
@@ -1048,9 +1030,6 @@
                   },
                   {
                     "id": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-                  },
-                  {
-                    "id": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
                   },
                   {
                     "id": "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d"
@@ -1290,9 +1269,6 @@
                     "id": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
                   },
                   {
-                    "id": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-                  },
-                  {
                     "id": "sha256:2cd7f54b726250042483f37e513645c240beec147cbfa959cd689b306d36d103"
                   },
                   {
@@ -1449,9 +1425,6 @@
                     "id": "sha256:cfa953b5825141026d5e6cd951f5aca15a88e8998e297e07d537e4aae8da5b21"
                   },
                   {
-                    "id": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-                  },
-                  {
                     "id": "sha256:68b01bee73a8421c1e1134e206bd765118c93595c2d894081453e49d194cc9e8"
                   },
                   {
@@ -1542,9 +1515,6 @@
                     "id": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
                   },
                   {
-                    "id": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-                  },
-                  {
                     "id": "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15"
                   },
                   {
@@ -1615,9 +1585,6 @@
                   },
                   {
                     "id": "sha256:48e1edacae05696360d0dd0706b2d3debb617ae15e9f7ce47e528839231a6c25"
-                  },
-                  {
-                    "id": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
                   },
                   {
                     "id": "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f"
@@ -2104,9 +2071,6 @@
                   },
                   {
                     "id": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
-                  },
-                  {
-                    "id": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
                   },
                   {
                     "id": "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26"
@@ -3082,9 +3046,7 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {
-              "prefix": ""
-            }
+            "options": {}
           },
           {
             "type": "org.osbuild.locale",
@@ -3369,23 +3331,10 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
-                },
-                {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "7B77-95E7",
-                  "vfs_type": "vfat",
-                  "path": "/boot/efi",
-                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-                  "passno": 2
                 }
               ]
             }
@@ -3393,13 +3342,9 @@
           {
             "type": "org.osbuild.grub2",
             "options": {
-              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto processor.max_cstate=1 intel_idle.max_cstate=1",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat"
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-431.el8.x86_64",
               "config": {
                 "default": "saved"
@@ -3464,20 +3409,8 @@
                   "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
                 },
                 {
-                  "size": 409600,
+                  "size": 20967391,
                   "start": 4096,
-                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
-                },
-                {
-                  "size": 1024000,
-                  "start": 413696,
-                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
-                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
-                },
-                {
-                  "size": 19533791,
-                  "start": 1437696,
                   "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
@@ -3494,44 +3427,9 @@
             }
           },
           {
-            "type": "org.osbuild.mkfs.fat",
-            "options": {
-              "volid": "7B7795E7"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "label": "boot"
-            },
-            "devices": {
-              "device": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000,
-                  "lock": true
-                }
-              }
-            }
-          },
-          {
-            "type": "org.osbuild.mkfs.xfs",
-            "options": {
-              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "label": "root"
             },
             "devices": {
@@ -3539,8 +3437,8 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791,
+                  "start": 4096,
+                  "size": 20967391,
                   "lock": true
                 }
               }
@@ -3566,28 +3464,12 @@
               ]
             },
             "devices": {
-              "boot": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 413696,
-                  "size": 1024000
-                }
-              },
-              "boot.efi": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                  "filename": "disk.img",
-                  "start": 4096,
-                  "size": 409600
-                }
-              },
               "root": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 1437696,
-                  "size": 19533791
+                  "start": 4096,
+                  "size": 20967391
                 }
               }
             },
@@ -3597,18 +3479,6 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
-              },
-              {
-                "name": "boot",
-                "type": "org.osbuild.xfs",
-                "source": "boot",
-                "target": "/boot"
-              },
-              {
-                "name": "boot.efi",
-                "type": "org.osbuild.fat",
-                "source": "boot.efi",
-                "target": "/boot/efi"
               }
             ]
           },
@@ -3626,8 +3496,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/grub2"
+                "number": 1,
+                "path": "/boot/grub2"
               }
             }
           }
@@ -4014,9 +3884,6 @@
           "sha256:2733570f8ea94551f3381538f9c8642c88532c800b384c07b4db02f6b8896c3f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libattr-2.4.48-3.el8.x86_64.rpm"
           },
-          "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fwupd-1.7.8-1.el8.x86_64.rpm"
-          },
           "sha256:27d04a9a33eb9300a55a8ec7623c02da13d19185278e367b60422c8fe70279e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/sssd-common-pac-2.7.3-4.el8.x86_64.rpm"
           },
@@ -4116,9 +3983,6 @@
           "sha256:2ff643bfe17476a8dfa94ea900ddf9d89ed0e5f56839f18209f8304a0e31bb2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dmidecode-3.3-4.el8.x86_64.rpm"
           },
-          "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm"
-          },
           "sha256:304d7d8d6a590a1afcd651cccd6158da0af801b5c22aa5c63e692df622b22bc0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/redhat-release-eula-8.8-0.1.el8.x86_64.rpm"
           },
@@ -4127,9 +3991,6 @@
           },
           "sha256:306bd571a6c8617903bc4cc5b89b65abaab50be1f98f69b860eee77e31c9b05d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-perf-4.18.0-431.el8.x86_64.rpm"
-          },
-          "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgcab1-1.1-1.el8.x86_64.rpm"
           },
           "sha256:30c6dbc7d2dd8024a16fe2d00b01fa71f4a1ea9d4af5519dc092695d4fa735cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libss-1.45.6-5.el8.x86_64.rpm"
@@ -4325,9 +4186,6 @@
           },
           "sha256:471930ec9d0e115809eaae8aa5c888bc07104c600ff49b55ab746701691c7c0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/iptables-libs-1.8.4-23.el8.x86_64.rpm"
-          },
-          "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efivar-libs-37-4.el8.x86_64.rpm"
           },
           "sha256:47f150f7e5879e1d58afa8669173d69847f2666d4688807863bcf1df8e468f0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grub2-pc-2.02-142.el8.x86_64.rpm"
@@ -4674,9 +4532,6 @@
           "sha256:6d7a41fb238610416349a53d024cc505ab7f3f6e9953cc2244abb663ec404dad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/ncurses-6.1-9.20180224.el8.x86_64.rpm"
           },
-          "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm"
-          },
           "sha256:6dec9fcb8adb571e5de0e5c0c7bcc71a1142fcf2466394304102cf17b349513f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libdnf-0.63.0-11.1.el8.x86_64.rpm"
           },
@@ -4953,9 +4808,6 @@
           "sha256:8942bd9f52f391bf7832aa81ebc8ea66f420ed5b4d35310666997567f0ea9351": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/pinfo-0.6.10-18.el8.x86_64.rpm"
           },
-          "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm"
-          },
           "sha256:8a994138b4d4bbcc5663ba464b85c9a9a0112bf9bad7e1ac3302559b69e7fa55": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/gtk2-2.24.32-5.el8.x86_64.rpm"
           },
@@ -4970,9 +4822,6 @@
           },
           "sha256:8c81bb15456e441250d2ed53b223bf85c21a9b25b6a36ab09953cc831f9e7109": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/tcsh-6.20.00-15.el8.x86_64.rpm"
-          },
-          "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
           "sha256:8ca5dd4feea941aba58c6d6e981883bca79704dba06583f880c0bf5e0cf4efcf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/desktop-file-utils-0.23-8.el8.x86_64.rpm"
@@ -5310,9 +5159,6 @@
           "sha256:aeb7478365d6c1bba4f23c8899a9988c3a8b366d573c590cd7fa49f906c4cb8c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/volume_key-libs-0.3.11-5.el8.x86_64.rpm"
           },
-          "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm"
-          },
           "sha256:aedb18b6816f6aaf53ea7eedfac2337e86d9913fb4f855ba11200997b1dfa01a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/nss-3.79.0-10.el8_6.x86_64.rpm"
           },
@@ -5396,9 +5242,6 @@
           },
           "sha256:b57ccdca83b3f0f54a1bc887d26ac390f782ab122e31c4f59689897ee7d5c83d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libsoup-2.62.3-3.el8.x86_64.rpm"
-          },
-          "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mokutil-0.3.0-12.el8.x86_64.rpm"
           },
           "sha256:b6cc9474c830cf8059b3a60dde46416d2ece114835c8d2a22ef609dbc2974420": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/adobe-mappings-pdf-20180407-1.el8.noarch.rpm"
@@ -5697,9 +5540,6 @@
           "sha256:d4dc248be7aacad57e6684036d48d7fc1697bb0f1aa880c2a77dbd3ed714c642": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/timedatex-0.5-3.el8.x86_64.rpm"
           },
-          "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efibootmgr-16-1.el8.x86_64.rpm"
-          },
           "sha256:d5689e2894c59a375f985b5228b32e78d10b4ceeec9fd7c79f2000480494d368": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/ed-1.14.2-4.el8.x86_64.rpm"
           },
@@ -5711,9 +5551,6 @@
           },
           "sha256:d67580b9b2af79f599f77c35c694714d2d39d2ea01c28e8aaca1312e6ab25184": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/python3-libselinux-2.9-6.el8.x86_64.rpm"
-          },
-          "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/shim-x64-15.6-1.el8.x86_64.rpm"
           },
           "sha256:d805c42ee9293a8ba35f49af63e3f7d813420d4a62ee4cff5ecd7391be851a9b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libtool-ltdl-2.4.6-25.el8.x86_64.rpm"
@@ -6323,15 +6160,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/diffutils-3.6-6.el8.x86_64.rpm",
         "checksum": "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce"
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.1",
-        "release": "6.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/dosfstools-4.1-6.el8.x86_64.rpm",
-        "checksum": "sha256:fc6f294d87c32dd80d09ad1e31005a6c379c476539fec9cd52b51f0bbc3384e3"
       },
       {
         "name": "dracut",
@@ -7929,15 +7757,6 @@
         "checksum": "sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.0",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/bubblewrap-0.4.0-1.el8.x86_64.rpm",
-        "checksum": "sha256:302bbd7fb5f0a8472eb5ddd24452d67d866c28d7467c58b577f2229e5be4a2b5"
-      },
-      {
         "name": "bzip2",
         "epoch": 0,
         "version": "1.0.6",
@@ -8496,33 +8315,6 @@
         "checksum": "sha256:d5689e2894c59a375f985b5228b32e78d10b4ceeec9fd7c79f2000480494d368"
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "3",
-        "release": "3.el8",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efi-filesystem-3-3.el8.noarch.rpm",
-        "checksum": "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efibootmgr-16-1.el8.x86_64.rpm",
-        "checksum": "sha256:d5130266a054d7cc7cbfe68f84a7dd8d1668518d87361235d12a993bc0750a5d"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "4.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/efivar-libs-37-4.el8.x86_64.rpm",
-        "checksum": "sha256:47b0a16a1305e23104da6f2f29ee2e7cbede921528e5a35a9df080c085a04d78"
-      },
-      {
         "name": "elfutils-debuginfod-client",
         "epoch": 0,
         "version": "0.187",
@@ -8692,15 +8484,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fuse3-libs-3.3.0-16.el8.x86_64.rpm",
         "checksum": "sha256:c33debf1cedf1a6c38ed7e2bc37416a3b2c26d27c0ced755fd640cb49db95987"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.8",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/fwupd-1.7.8-1.el8.x86_64.rpm",
-        "checksum": "sha256:276d4a91295e1796fa088ff1d40a209750996c974dd4b482bd4cd43662f347e7"
       },
       {
         "name": "gawk",
@@ -8899,15 +8682,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grub2-common-2.02-142.el8.noarch.rpm",
         "checksum": "sha256:ff33f6c8ac7066ace875ef208625faa4e30ba9d792e2fdc94bc019aec2ecfeef"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.02",
-        "release": "142.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/grub2-efi-x64-2.02-142.el8.x86_64.rpm",
-        "checksum": "sha256:6da93684ea75c01ef19caf548714d25238ab05d4aecc09c780e1e9123ca2550b"
       },
       {
         "name": "grub2-pc",
@@ -9621,15 +9395,6 @@
         "checksum": "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.1",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libgcab1-1.1-1.el8.x86_64.rpm",
-        "checksum": "sha256:30a2e433b8dace2788780dd1924f2928a3111e7934733a9d3fdd0ff4a16e7e32"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "8.5.0",
@@ -10098,15 +9863,6 @@
         "checksum": "sha256:cfa953b5825141026d5e6cd951f5aca15a88e8998e297e07d537e4aae8da5b21"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.1",
-        "release": "2.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libsmbios-2.4.1-2.el8.x86_64.rpm",
-        "checksum": "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -10377,15 +10133,6 @@
         "checksum": "sha256:9911a687cf9fa747a7c9c35d6d166289f76af411462c9f0a3502b72e74f211db"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.1.15",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/libxmlb-0.1.15-1.el8.x86_64.rpm",
-        "checksum": "sha256:aecd902d4dd2636c381d15ed39eb556d828c16dd3ce7d53e5a8ff92c499ba080"
-      },
-      {
         "name": "libxslt",
         "epoch": 0,
         "version": "1.1.32",
@@ -10600,15 +10347,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mlocate-0.26-20.el8.x86_64.rpm",
         "checksum": "sha256:48e1edacae05696360d0dd0706b2d3debb617ae15e9f7ce47e528839231a6c25"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 1,
-        "version": "0.3.0",
-        "release": "12.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/mokutil-0.3.0-12.el8.x86_64.rpm",
-        "checksum": "sha256:b59e97f5c35fce51487c41981e7c08becbd7be0736a7a82f4e1ca2ffde109c15"
       },
       {
         "name": "mozjs60",
@@ -12067,15 +11805,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/shared-mime-info-1.9-3.el8.x86_64.rpm",
         "checksum": "sha256:4e468750831505a71d52553acee82dd9091d30f6c39f6dcf717fed544714c3c3"
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/shim-x64-15.6-1.el8.x86_64.rpm",
-        "checksum": "sha256:d725cc71c0cb795b4e42e5595ede9460419e8924635802dcf8415cc1c7004358"
       },
       {
         "name": "slang",

--- a/test/data/manifests/rhel_9-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-ec2-boot.json
@@ -1430,14 +1430,6 @@
                     }
                   },
                   {
-                    "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -1758,30 +1750,6 @@
                     }
                   },
                   {
-                    "id": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd8f32a588f83b75183a94e40f895ec9640bfba4ba1768f1e86b57c18cec3e47",
                     "options": {
                       "metadata": {
@@ -1863,14 +1831,6 @@
                   },
                   {
                     "id": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2007,14 +1967,6 @@
                   },
                   {
                     "id": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2526,14 +2478,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:056c6e51fa98dae4381725ca9510ced292703ec225adf9637a61eb752d1a3a0a",
                     "options": {
                       "metadata": {
@@ -2566,22 +2510,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8d0b54556cefa3f2e9e0f8d01e0727d31559fd3f0b67cc570dec26ff38d61b84",
                     "options": {
                       "metadata": {
@@ -2599,14 +2527,6 @@
                   },
                   {
                     "id": "sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2846,14 +2766,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f70762594db38ab18ba1db1ce92e9ede5a40ca5d5c3cc93c6bd92686556472c8",
                     "options": {
                       "metadata": {
@@ -2982,14 +2894,6 @@
                     }
                   },
                   {
-                    "id": "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:32c933de69b8fae782d4e7c7a1132eaf256e73b455199a7c617bc315f3e97e7a",
                     "options": {
                       "metadata": {
@@ -3031,14 +2935,6 @@
                   },
                   {
                     "id": "sha256:26bee2c6124e4047f5b6261589bbd7a801603ca12dc90b64b0cd178911e25cbb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3142,23 +3038,7 @@
                     }
                   },
                   {
-                    "id": "sha256:dfdaa5afa228685c56e65edd92d2a7aba162c7e1e16cce2053767e246fef6076",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3878,22 +3758,6 @@
                     }
                   },
                   {
-                    "id": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:4b7c4822f92e7ba97b78893d273b01161e411151ccc627b076d13719ad404a69",
                     "options": {
                       "metadata": {
@@ -4206,22 +4070,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c1fcc71c1cc1160d58ace4b60cc6733b68d6f6d406e5ec5ce24327787f452cd1",
                     "options": {
                       "metadata": {
@@ -4286,86 +4134,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fa3e8480793608d79e85ec366280e031470976e7c25e1c75252cad489369ec4a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce7a47da96b91cb7a50a9876fe2931f472e84ad71b72827001c5631c25e30e10",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:aa805098a888939a75c1f9ed46ff281c2c2fcdd282a8d18d37852bd8b0085151",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:88a824609ad38bee5ea8037eb18a6477f6e6b313af6deda6311286406d1065a7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:25536d6377e24d4cb7d95a76ccfc16de8b81c053ea77ad5a0961087ed52cf4c0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ee53fb84a91d66355c438c47593d677df32222be79a856cd406dd73c1e719b25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2671d507c8f07af10dfc20de9695e62c2c8dc9ed3b8cee7e464d47932ac24e97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:774a7de97ac6cdec24de0f2a9be666492b5830d317ae5f5cfe9223c50e3da0c4",
                     "options": {
                       "metadata": {
@@ -4390,63 +4158,7 @@
                     }
                   },
                   {
-                    "id": "sha256:f03e357435c8b27e81ce6cb440992bd911e11a9fa0b211af1401280013651d01",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2fb3471163091eca166f66fb3f69d17dede5f0a3bb51784ab18959dcdc5f7f71",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:81138535e5e487dcb7620946f4494a3d85e38be7c1395af7241498568acd0321",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0d965a214074a7d349497e9aac3ddfa4080e6ddad3e9affeab307cd2b109aed5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9f559003724cf2c43919dfee9c83cee56adcc686b803a35e5609b9d231b066eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5d8010a420803df4e2947d34e40b068405441f9dd2a991a1f339c4f9c792aa4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6c11ea9d03bb1d375559824617b03aea47a4e17ebdbe29a55235722a358740dd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4647,22 +4359,6 @@
                   },
                   {
                     "id": "sha256:8ec4556ce5b7fe7036928025846be69d5cd6597b0428271427b607d45a8e04e5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0dcd6624357942ada8b2ebf933ee47e11b1cbdc4eaee545519c43420adb6f46b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4888,10 +4584,6 @@
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat",
-                "unified": true
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,
               "config": {
@@ -5193,12 +4885,6 @@
           "sha256:0c8f8e301f75c77a24821cc9170596a799edb33c1bf58b6490aa97c8ed7d5996": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/gmp-6.2.0-10.el9.x86_64.rpm"
           },
-          "sha256:0d965a214074a7d349497e9aac3ddfa4080e6ddad3e9affeab307cd2b109aed5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-softokn-3.79.0-14.el9_0.x86_64.rpm"
-          },
-          "sha256:0dcd6624357942ada8b2ebf933ee47e11b1cbdc4eaee545519c43420adb6f46b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/udisks2-2.9.4-3.el9.x86_64.rpm"
-          },
           "sha256:0e5de5b828060e128ee9c0e57cb38a4f72692a2f1f11ed208439c4c07dcf192d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-tools-minimal-2.06-46.el9.x86_64.rpm"
           },
@@ -5307,12 +4993,6 @@
           "sha256:24983ca0db3271a80dfb9fc7282964eec863f155691333f265cd083654dac2da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/virt-what-1.25-1.el9.x86_64.rpm"
           },
-          "sha256:25536d6377e24d4cb7d95a76ccfc16de8b81c053ea77ad5a0961087ed52cf4c0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-part-2.25-14.el9.x86_64.rpm"
-          },
-          "sha256:2671d507c8f07af10dfc20de9695e62c2c8dc9ed3b8cee7e464d47932ac24e97": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-utils-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:26bee2c6124e4047f5b6261589bbd7a801603ca12dc90b64b0cd178911e25cbb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxml2-2.9.13-2.el9.x86_64.rpm"
           },
@@ -5324,9 +5004,6 @@
           },
           "sha256:28a5f98e7922427c7f69d36773c6cd2079812c93442e8116af14fc8dbb139201": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/krb5-libs-1.19.1-22.el9.x86_64.rpm"
-          },
-          "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fwupd-1.7.9-1.el9.x86_64.rpm"
           },
           "sha256:29826b32a7c4a7849f26290be47b4aa41fe14de69550f30da10ebf7d5782a133": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/which-2.21-28.el9.x86_64.rpm"
@@ -5361,12 +5038,6 @@
           "sha256:2ee58b038ff185adf06194e5211b69800ba1efe502158cec867a41b3901cb420": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/logrotate-3.18.0-7.el9.x86_64.rpm"
           },
-          "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgudev-237-1.el9.x86_64.rpm"
-          },
-          "sha256:2fb3471163091eca166f66fb3f69d17dede5f0a3bb51784ab18959dcdc5f7f71": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nspr-4.34.0-14.el9_0.x86_64.rpm"
-          },
           "sha256:2fbc615bf6c839633f51a802e980af5cd4540a7fe3bb7685ee7ce143af29a782": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-librepo-1.14.2-3.el9.x86_64.rpm"
           },
@@ -5381,9 +5052,6 @@
           },
           "sha256:322dd1e3f213b4a90de07a584259b9fa8f058cdfcd3bc38ecf3b5b79175835a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libfdisk-2.37.4-9.el9.x86_64.rpm"
-          },
-          "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm"
           },
           "sha256:32c933de69b8fae782d4e7c7a1132eaf256e73b455199a7c617bc315f3e97e7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libuser-0.63-11.el9.x86_64.rpm"
@@ -5402,9 +5070,6 @@
           },
           "sha256:37b1d60e8acd198f6fd474326524c6467de01f42400ea57f8622861cc2ba34ef": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/hdparm-9.62-2.el9.x86_64.rpm"
-          },
-          "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libusbx-1.0.26-1.el9.x86_64.rpm"
           },
           "sha256:39ada507d193a14f8ee3d5226966dca1b5a6e9b591a1a4b11a059445596db7e0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/linux-firmware-whence-20220708-127.el9.noarch.rpm"
@@ -5468,9 +5133,6 @@
           },
           "sha256:43d40891623256b30a7d08d8db21a3d94d94756ecade355845e52c64f5af7765": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libevent-2.1.12-6.el9.x86_64.rpm"
-          },
-          "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shared-mime-info-2.1-4.el9.x86_64.rpm"
           },
           "sha256:44b4ebb0b3cc5a733d477b684082c23d8b4230953f192113353a6aa664e83624": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/gpgme-1.15.1-6.el9.x86_64.rpm"
@@ -5541,9 +5203,6 @@
           "sha256:50b10ed9964a5824b705a04d3937bc2e22f29751fba66a97b991c429bbb3664c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/nettle-3.8-3.el9_0.x86_64.rpm"
           },
-          "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm"
-          },
           "sha256:533af82d1a7a83f87ccfb9e6dd894043aa05a467a7888651b8d8097251fea75f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-pc-2.06-46.el9.x86_64.rpm"
           },
@@ -5562,9 +5221,6 @@
           "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/langpacks-en-3.0-16.el9.noarch.rpm"
           },
-          "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efivar-libs-38-2.el9.x86_64.rpm"
-          },
           "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm"
           },
@@ -5577,17 +5233,11 @@
           "sha256:563d301817a83d6959469f6117ec1e8fa21aa7aafe8ae0f99ab71a62dbb05ba0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/tuned-2.19.0-1.el9.noarch.rpm"
           },
-          "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
-          },
           "sha256:587284378eec54fded45c8eb778a7afb9d9c3a74201c5e9068ac3030bdca02e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/redhat-release-eula-9.1-1.9.el9.x86_64.rpm"
           },
           "sha256:588e8736af3376abfb3cdf372c10baef02c40d916a55958f3bee9767f9ad8526": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libcbor-0.7.0-5.el9.x86_64.rpm"
-          },
-          "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libjcat-0.1.6-3.el9.x86_64.rpm"
           },
           "sha256:5b62843c5829eedbf04e26d526aa0dc918afdbe4121c9575c7b1b4c92f77a87f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-setuptools-53.0.0-10.el9.noarch.rpm"
@@ -5637,9 +5287,6 @@
           "sha256:644ed9b3264a546abac89fdd40c0140911ed8ceef6e05d7594f84e0f570c6347": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libffi-3.4.2-7.el9.x86_64.rpm"
           },
-          "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgusb-0.3.8-1.el9.x86_64.rpm"
-          },
           "sha256:6477fb3c3285158f676360e228057e13dc6e983f453c7c74ed4ab140357f9a0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libunistring-0.9.10-15.el9.x86_64.rpm"
           },
@@ -5670,9 +5317,6 @@
           "sha256:6aa68f23ec0848d9fcdb836a95764ffbc2f669841ba7d9defde7ffda7af060bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-dnf-plugins-core-4.1.0-3.el9.noarch.rpm"
           },
-          "sha256:6c11ea9d03bb1d375559824617b03aea47a4e17ebdbe29a55235722a358740dd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-util-3.79.0-14.el9_0.x86_64.rpm"
-          },
           "sha256:6d4b71d340f8719afcf3de062ebc415130ce6c12fdaa70baf2737ab35461e9e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libselinux-3.4-3.el9.x86_64.rpm"
           },
@@ -5681,9 +5325,6 @@
           },
           "sha256:6da6e13deb7badafaa4e10bc8f7a81acd40e4cba3c34b4590826e8eb9a329f3d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libnl3-3.7.0-1.el9.x86_64.rpm"
-          },
-          "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efibootmgr-16-12.el9.x86_64.rpm"
           },
           "sha256:6ea4966a7336839fc47ae6308c8a00f69e4126bc1ff0832899c9a0eaa0661d19": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libcap-2.48-8.el9.x86_64.rpm"
@@ -5715,9 +5356,6 @@
           "sha256:722e3c6fb3dff112298025a33c36da22a5283ce05003aee216ba6bfe740df6b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/pciutils-libs-3.7.0-5.el9.x86_64.rpm"
           },
-          "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efi-filesystem-6-2.el9_0.noarch.rpm"
-          },
           "sha256:737a278cdf7c292337d4b54dff0479c1cb88c74200179d2ae0caf6d766ea5d00": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/chrony-4.2-1.el9.x86_64.rpm"
           },
@@ -5729,9 +5367,6 @@
           },
           "sha256:74e68fba2f9e510dd674766800eb0df8ca0ea546fcc20264d92ed9cd5beaee9a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/oddjob-0.34.7-6.el9.x86_64.rpm"
-          },
-          "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libatasmart-0.19-22.el9.x86_64.rpm"
           },
           "sha256:75da9e9faf295a7cdc1e8aede617c5468860ed03750f5543eb1ed00ca1d6c1e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libcollection-0.7.0-53.el9.x86_64.rpm"
@@ -5811,9 +5446,6 @@
           "sha256:80fadaa3c82e156ae8977136ff16b10a6dee28778c96ae5803c153ad717a265c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/e2fsprogs-libs-1.46.5-3.el9.x86_64.rpm"
           },
-          "sha256:81138535e5e487dcb7620946f4494a3d85e38be7c1395af7241498568acd0321": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-3.79.0-14.el9_0.x86_64.rpm"
-          },
           "sha256:813ac40aec3af348c8b4a457b437f3cfe336eacfb7329af8d2848e0d7d9f281e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/checkpolicy-3.4-1.el9.x86_64.rpm"
           },
@@ -5843,9 +5475,6 @@
           },
           "sha256:877a6bc8658f919581b93af9eb01437cbb35d752b4c3587b9e90aa46a58a7aea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/cyrus-sasl-lib-2.1.27-20.el9.x86_64.rpm"
-          },
-          "sha256:88a824609ad38bee5ea8037eb18a6477f6e6b313af6deda6311286406d1065a7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-mdraid-2.25-14.el9.x86_64.rpm"
           },
           "sha256:88f123ca2fd9a3a5c59f4065500ccc2e94e64502035e65a524e1e55574a7df75": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libdnf-plugin-subscription-manager-1.29.30-1.el9.x86_64.rpm"
@@ -5919,9 +5548,6 @@
           "sha256:9658da838021711f687cf283368664984bfb1c8b9176897d7d477a724a11a731": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/lz4-libs-1.9.3-5.el9.x86_64.rpm"
           },
-          "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mokutil-0.4.0-9.el9.x86_64.rpm"
-          },
           "sha256:995b180dbfa3173ca0792c1c72ba8e4c9d8e41bf92850ca0503f2784a4ffdb4d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsysfs-2.1.1-10.el9.x86_64.rpm"
           },
@@ -5946,9 +5572,6 @@
           "sha256:9c332f10871fa27bcf99d7afcea2220fe50227cd8c943b295f83081d44ad6ebf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/NetworkManager-tui-1.40.0-1.el9.x86_64.rpm"
           },
-          "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm"
-          },
           "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-linux-procfs-0.7.0-1.el9.noarch.rpm"
           },
@@ -5957,9 +5580,6 @@
           },
           "sha256:9efda7f39456e3d6689124af5dd18f28710e851eb68702d849bb071a81f5aa0e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/glibc-gconv-extra-2.34-40.el9.x86_64.rpm"
-          },
-          "sha256:9f559003724cf2c43919dfee9c83cee56adcc686b803a35e5609b9d231b066eb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-softokn-freebl-3.79.0-14.el9_0.x86_64.rpm"
           },
           "sha256:9f640485eb1df3b8d8759b3051bb1651b264fd0ca139b90c85ad919e365b0f22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/json-glib-1.6.6-1.el9.x86_64.rpm"
@@ -5988,9 +5608,6 @@
           "sha256:a50bb26a28ee7e6379c86b5b91285299b71569fa87ea968d800a56090b7a179d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxcrypt-4.4.18-3.el9.x86_64.rpm"
           },
-          "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fwupd-plugin-flashrom-1.7.9-1.el9.x86_64.rpm"
-          },
           "sha256:a62889efb540a272b234cd60c68cb610944a1ebcf148171861e07be0d8245b07": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/dracut-squash-057-13.git20220816.el9.x86_64.rpm"
           },
@@ -6014,9 +5631,6 @@
           },
           "sha256:aa6105f1cefa12a2509fd24d8825bf17328339531144dc192ac7900298be3ab7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/polkit-0.117-10.el9_0.x86_64.rpm"
-          },
-          "sha256:aa805098a888939a75c1f9ed46ff281c2c2fcdd282a8d18d37852bd8b0085151": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-loop-2.25-14.el9.x86_64.rpm"
           },
           "sha256:aaa17904b12fe5e7df830fb9c512d971f29221dec19a3e421307b41526696f5e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/pciutils-3.7.0-5.el9.x86_64.rpm"
@@ -6114,9 +5728,6 @@
           "sha256:beed55d3ab1e8dd1207e1bd67e40e180c53a001198b9a7186f4bf07c042b377e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openldap-compat-2.6.2-3.el9.x86_64.rpm"
           },
-          "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/flashrom-1.2-10.el9.x86_64.rpm"
-          },
           "sha256:bf3baf444e49eba4189e57d562a7522ab714132d2960db87ef9b99f1b46a3cc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sed-4.8-9.el9.x86_64.rpm"
           },
@@ -6156,9 +5767,6 @@
           "sha256:c972030a8fbaa2d981f0e5fdfc42d6d5173dd047c94d86ab7732e3e53fc4e97a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libpipeline-1.5.3-4.el9.x86_64.rpm"
           },
-          "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:cb07b2cabae7305f5e4e5784530a75a8f91c57a79da1ae7ff7808ce23917ebd3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libedit-3.1-37.20210216cvs.el9.x86_64.rpm"
           },
@@ -6179,9 +5787,6 @@
           },
           "sha256:ce6dcb35f56a067393e94e5d49299a9ab256ad4949e6f86ac27e6b58516b18a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/kmod-libs-28-7.el9.x86_64.rpm"
-          },
-          "sha256:ce7a47da96b91cb7a50a9876fe2931f472e84ad71b72827001c5631c25e30e10": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-crypto-2.25-14.el9.x86_64.rpm"
           },
           "sha256:cf0662ef00d4e84727fafc79cee6941f865e0cb657332dd7448759b2f83a4809": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libss-1.46.5-3.el9.x86_64.rpm"
@@ -6222,9 +5827,6 @@
           "sha256:d57aae86bd30b4dc8578f3eb7ef39679ef4917d21a71ebb70831b4c84bace71a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libstdc++-11.3.1-2.1.el9.x86_64.rpm"
           },
-          "sha256:d5d8010a420803df4e2947d34e40b068405441f9dd2a991a1f339c4f9c792aa4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-sysinit-3.79.0-14.el9_0.x86_64.rpm"
-          },
           "sha256:d5ff4d9d43f6c32797e80e0518bb3656ae46643069bdc0ef9b8749d912cd74ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/inih-49-6.el9.x86_64.rpm"
           },
@@ -6233,9 +5835,6 @@
           },
           "sha256:d763e4d9e98fd3aac3db1828ed0de1f4b5ff46c939a207597db05fe60af52832": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/cloud-utils-growpart-0.31-10.el9.x86_64.rpm"
-          },
-          "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm"
           },
           "sha256:d9b53fda4b8757fd63b53a415f533ab876c18c28a94fd21d10658de85978f254": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/cpio-2.13-16.el9.x86_64.rpm"
@@ -6264,14 +5863,8 @@
           "sha256:de9869c08df7f6952787d0335b9bf1a09b328bea920556a59af07c8e085dd3cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/dbus-broker-28-7.el9.x86_64.rpm"
           },
-          "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm"
-          },
           "sha256:df2ab474c2d513ed863d2265efbdbb32ce9c1b1dd00365f041f6539ec36dd80d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmartcols-2.37.4-9.el9.x86_64.rpm"
-          },
-          "sha256:dfdaa5afa228685c56e65edd92d2a7aba162c7e1e16cce2053767e246fef6076": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mdadm-4.2-6.el9.x86_64.rpm"
           },
           "sha256:e069efd411901c3d1be3fa6898d18cc8a787722a6fbeb71f56b59890073ca6e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libdnf-0.67.0-3.el9.x86_64.rpm"
@@ -6290,9 +5883,6 @@
           },
           "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/snappy-1.1.8-8.el9.x86_64.rpm"
-          },
-          "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm"
           },
           "sha256:e5c4efec2d4e9e7bb461b5880efc09ba6b5c42c2fab6cc2b784ed2f79a79ca1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-dnf-4.12.0-4.el9.noarch.rpm"
@@ -6330,9 +5920,6 @@
           "sha256:ebddfc188d1ddbb0d6a238583cbc02dcb9fc0bd063a850b22d48980899976628": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libcap-ng-0.8.2-7.el9.x86_64.rpm"
           },
-          "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libbytesize-2.5-3.el9.x86_64.rpm"
-          },
           "sha256:ed4bfb8d96a13bad9b85dde758d6f481fa62abd56595760134e3ea195e63806e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libpath_utils-0.2.1-53.el9.x86_64.rpm"
           },
@@ -6345,9 +5932,6 @@
           "sha256:ee1368739d142d7c46836f2efd86e91a648bae68e46114f00596f819ad08ea31": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-pc-modules-2.06-46.el9.noarch.rpm"
           },
-          "sha256:ee53fb84a91d66355c438c47593d677df32222be79a856cd406dd73c1e719b25": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-swap-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:ee84863d757bd2084b084aa768b80c47753922ecf0b767796399920ea8057f9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/util-linux-2.37.4-9.el9.x86_64.rpm"
           },
@@ -6356,9 +5940,6 @@
           },
           "sha256:ef6eb3e28612b850c9ae97b260d6a38a7fa77e8b9170516079baaa0f1154c09a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/ca-certificates-2022.2.54-90.2.el9_0.noarch.rpm"
-          },
-          "sha256:f03e357435c8b27e81ce6cb440992bd911e11a9fa0b211af1401280013651d01": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.x86_64.rpm"
           },
           "sha256:f148b83396b3a3cc002058225447b4f6fd799eee2627c95e1b24138cf3a0b224": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libselinux-utils-3.4-3.el9.x86_64.rpm"
@@ -6392,9 +5973,6 @@
           },
           "sha256:fa3abe9c3196c58b2a2943bd759eb30542962d3464970ce4171627e741160f28": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/python3-oauthlib-3.1.1-2.el9.noarch.rpm"
-          },
-          "sha256:fa3e8480793608d79e85ec366280e031470976e7c25e1c75252cad489369ec4a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-2.25-14.el9.x86_64.rpm"
           },
           "sha256:fca369324a356c6a9322689fc8c443d742ca8fb820ab2450ed10311f16882668": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-perf-5.14.0-162.6.1.el9_1.x86_64.rpm"
@@ -8100,16 +7678,6 @@
         "check_gpg": true
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.1",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
-        "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
-        "check_gpg": true
-      },
-      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -8510,36 +8078,6 @@
         "check_gpg": true
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "6",
-        "release": "2.el9_0",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efi-filesystem-6-2.el9_0.noarch.rpm",
-        "checksum": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-        "check_gpg": true
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "12.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efibootmgr-16-12.el9.x86_64.rpm",
-        "checksum": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-        "check_gpg": true
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "38",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efivar-libs-38-2.el9.x86_64.rpm",
-        "checksum": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-        "check_gpg": true
-      },
-      {
         "name": "elfutils-default-yama-scope",
         "epoch": 0,
         "version": "0.187",
@@ -8647,16 +8185,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm",
         "checksum": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.9",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fwupd-1.7.9-1.el9.x86_64.rpm",
-        "checksum": "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3",
         "check_gpg": true
       },
       {
@@ -8827,16 +8355,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-common-2.06-46.el9.noarch.rpm",
         "checksum": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "46.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm",
-        "checksum": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
         "check_gpg": true
       },
       {
@@ -9470,16 +8988,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm",
-        "checksum": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.3.1",
@@ -9520,26 +9028,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "237",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgudev-237-1.el9.x86_64.rpm",
-        "checksum": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671",
-        "check_gpg": true
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.8",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgusb-0.3.8-1.el9.x86_64.rpm",
-        "checksum": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39",
-        "check_gpg": true
-      },
-      {
         "name": "libibverbs",
         "epoch": 0,
         "version": "41.0",
@@ -9567,16 +9055,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libini_config-1.3.1-53.el9.x86_64.rpm",
         "checksum": "sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35",
-        "check_gpg": true
-      },
-      {
-        "name": "libjcat",
-        "epoch": 0,
-        "version": "0.1.6",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libjcat-0.1.6-3.el9.x86_64.rpm",
-        "checksum": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
         "check_gpg": true
       },
       {
@@ -9870,16 +9348,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.3",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm",
-        "checksum": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-        "check_gpg": true
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.22",
@@ -10040,16 +9508,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.26",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libusbx-1.0.26-1.el9.x86_64.rpm",
-        "checksum": "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7",
-        "check_gpg": true
-      },
-      {
         "name": "libuser",
         "epoch": 0,
         "version": "0.63",
@@ -10107,16 +9565,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxml2-2.9.13-2.el9.x86_64.rpm",
         "checksum": "sha256:26bee2c6124e4047f5b6261589bbd7a801603ca12dc90b64b0cd178911e25cbb",
-        "check_gpg": true
-      },
-      {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.3.3",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm",
-        "checksum": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3",
         "check_gpg": true
       },
       {
@@ -10240,16 +9688,6 @@
         "check_gpg": true
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mdadm-4.2-6.el9.x86_64.rpm",
-        "checksum": "sha256:dfdaa5afa228685c56e65edd92d2a7aba162c7e1e16cce2053767e246fef6076",
-        "check_gpg": true
-      },
-      {
         "name": "microcode_ctl",
         "epoch": 4,
         "version": "20220809",
@@ -10257,16 +9695,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/microcode_ctl-20220809-1.el9.noarch.rpm",
         "checksum": "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88",
-        "check_gpg": true
-      },
-      {
-        "name": "mokutil",
-        "epoch": 2,
-        "version": "0.4.0",
-        "release": "9.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mokutil-0.4.0-9.el9.x86_64.rpm",
-        "checksum": "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e",
         "check_gpg": true
       },
       {
@@ -11160,26 +10588,6 @@
         "check_gpg": true
       },
       {
-        "name": "shared-mime-info",
-        "epoch": 0,
-        "version": "2.1",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shared-mime-info-2.1-4.el9.x86_64.rpm",
-        "checksum": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a",
-        "check_gpg": true
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
-        "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-        "check_gpg": true
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -11570,26 +10978,6 @@
         "check_gpg": true
       },
       {
-        "name": "flashrom",
-        "epoch": 0,
-        "version": "1.2",
-        "release": "10.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/flashrom-1.2-10.el9.x86_64.rpm",
-        "checksum": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd-plugin-flashrom",
-        "epoch": 0,
-        "version": "1.7.9",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fwupd-plugin-flashrom-1.7.9-1.el9.x86_64.rpm",
-        "checksum": "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c",
-        "check_gpg": true
-      },
-      {
         "name": "gawk-all-langpacks",
         "epoch": 0,
         "version": "5.1.0",
@@ -11670,106 +11058,6 @@
         "check_gpg": true
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "22.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libatasmart-0.19-22.el9.x86_64.rpm",
-        "checksum": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:fa3e8480793608d79e85ec366280e031470976e7c25e1c75252cad489369ec4a",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-crypto-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:ce7a47da96b91cb7a50a9876fe2931f472e84ad71b72827001c5631c25e30e10",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-loop-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:aa805098a888939a75c1f9ed46ff281c2c2fcdd282a8d18d37852bd8b0085151",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-mdraid-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:88a824609ad38bee5ea8037eb18a6477f6e6b313af6deda6311286406d1065a7",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-part-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:25536d6377e24d4cb7d95a76ccfc16de8b81c053ea77ad5a0961087ed52cf4c0",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-swap-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:ee53fb84a91d66355c438c47593d677df32222be79a856cd406dd73c1e719b25",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-utils-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:2671d507c8f07af10dfc20de9695e62c2c8dc9ed3b8cee7e464d47932ac24e97",
-        "check_gpg": true
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "2.5",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libbytesize-2.5-3.el9.x86_64.rpm",
-        "checksum": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974",
-        "check_gpg": true
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.11",
@@ -11800,16 +11088,6 @@
         "check_gpg": true
       },
       {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.x86_64.rpm",
-        "checksum": "sha256:f03e357435c8b27e81ce6cb440992bd911e11a9fa0b211af1401280013651d01",
-        "check_gpg": true
-      },
-      {
         "name": "libxcrypt-compat",
         "epoch": 0,
         "version": "4.4.18",
@@ -11817,66 +11095,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm",
         "checksum": "sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a",
-        "check_gpg": true
-      },
-      {
-        "name": "nspr",
-        "epoch": 0,
-        "version": "4.34.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nspr-4.34.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:2fb3471163091eca166f66fb3f69d17dede5f0a3bb51784ab18959dcdc5f7f71",
-        "check_gpg": true
-      },
-      {
-        "name": "nss",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:81138535e5e487dcb7620946f4494a3d85e38be7c1395af7241498568acd0321",
-        "check_gpg": true
-      },
-      {
-        "name": "nss-softokn",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-softokn-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:0d965a214074a7d349497e9aac3ddfa4080e6ddad3e9affeab307cd2b109aed5",
-        "check_gpg": true
-      },
-      {
-        "name": "nss-softokn-freebl",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-softokn-freebl-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:9f559003724cf2c43919dfee9c83cee56adcc686b803a35e5609b9d231b066eb",
-        "check_gpg": true
-      },
-      {
-        "name": "nss-sysinit",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-sysinit-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:d5d8010a420803df4e2947d34e40b068405441f9dd2a991a1f339c4f9c792aa4",
-        "check_gpg": true
-      },
-      {
-        "name": "nss-util",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-util-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:6c11ea9d03bb1d375559824617b03aea47a4e17ebdbe29a55235722a358740dd",
         "check_gpg": true
       },
       {
@@ -12127,26 +11345,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/rsyslog-logrotate-8.2102.0-105.el9.x86_64.rpm",
         "checksum": "sha256:8ec4556ce5b7fe7036928025846be69d5cd6597b0428271427b607d45a8e04e5",
-        "check_gpg": true
-      },
-      {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/udisks2-2.9.4-3.el9.x86_64.rpm",
-        "checksum": "sha256:0dcd6624357942ada8b2ebf933ee47e11b1cbdc4eaee545519c43420adb6f46b",
-        "check_gpg": true
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.12",
-        "release": "15.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
-        "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_9-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-ec2_ha-boot.json
@@ -1441,14 +1441,6 @@
                     }
                   },
                   {
-                    "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
                     "options": {
                       "metadata": {
@@ -1817,30 +1809,6 @@
                     }
                   },
                   {
-                    "id": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd8f32a588f83b75183a94e40f895ec9640bfba4ba1768f1e86b57c18cec3e47",
                     "options": {
                       "metadata": {
@@ -1922,14 +1890,6 @@
                   },
                   {
                     "id": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2066,14 +2026,6 @@
                   },
                   {
                     "id": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2617,14 +2569,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:056c6e51fa98dae4381725ca9510ced292703ec225adf9637a61eb752d1a3a0a",
                     "options": {
                       "metadata": {
@@ -2657,22 +2601,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8d0b54556cefa3f2e9e0f8d01e0727d31559fd3f0b67cc570dec26ff38d61b84",
                     "options": {
                       "metadata": {
@@ -2690,14 +2618,6 @@
                   },
                   {
                     "id": "sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2953,14 +2873,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f70762594db38ab18ba1db1ce92e9ede5a40ca5d5c3cc93c6bd92686556472c8",
                     "options": {
                       "metadata": {
@@ -3097,14 +3009,6 @@
                     }
                   },
                   {
-                    "id": "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:32c933de69b8fae782d4e7c7a1132eaf256e73b455199a7c617bc315f3e97e7a",
                     "options": {
                       "metadata": {
@@ -3154,14 +3058,6 @@
                   },
                   {
                     "id": "sha256:26bee2c6124e4047f5b6261589bbd7a801603ca12dc90b64b0cd178911e25cbb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3281,23 +3177,7 @@
                     }
                   },
                   {
-                    "id": "sha256:dfdaa5afa228685c56e65edd92d2a7aba162c7e1e16cce2053767e246fef6076",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4097,22 +3977,6 @@
                     }
                   },
                   {
-                    "id": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:4b7c4822f92e7ba97b78893d273b01161e411151ccc627b076d13719ad404a69",
                     "options": {
                       "metadata": {
@@ -4457,22 +4321,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c1fcc71c1cc1160d58ace4b60cc6733b68d6f6d406e5ec5ce24327787f452cd1",
                     "options": {
                       "metadata": {
@@ -4561,86 +4409,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fa3e8480793608d79e85ec366280e031470976e7c25e1c75252cad489369ec4a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce7a47da96b91cb7a50a9876fe2931f472e84ad71b72827001c5631c25e30e10",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:aa805098a888939a75c1f9ed46ff281c2c2fcdd282a8d18d37852bd8b0085151",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:88a824609ad38bee5ea8037eb18a6477f6e6b313af6deda6311286406d1065a7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:25536d6377e24d4cb7d95a76ccfc16de8b81c053ea77ad5a0961087ed52cf4c0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ee53fb84a91d66355c438c47593d677df32222be79a856cd406dd73c1e719b25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2671d507c8f07af10dfc20de9695e62c2c8dc9ed3b8cee7e464d47932ac24e97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:774a7de97ac6cdec24de0f2a9be666492b5830d317ae5f5cfe9223c50e3da0c4",
                     "options": {
                       "metadata": {
@@ -4666,14 +4434,6 @@
                   },
                   {
                     "id": "sha256:38c2923779bae32c37a5138ac06231c8de5bd7499f5148b5065c12faa92c5b3c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f03e357435c8b27e81ce6cb440992bd911e11a9fa0b211af1401280013651d01",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5585,23 +5345,7 @@
                     }
                   },
                   {
-                    "id": "sha256:0dcd6624357942ada8b2ebf933ee47e11b1cbdc4eaee545519c43420adb6f46b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c52563ef6ba99cd8806b2fde878357f1c9ce092a098a85086e9bc39054cb54e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6284,10 +6028,6 @@
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat",
-                "unified": true
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,
               "config": {
@@ -6637,9 +6377,6 @@
           "sha256:0d965a214074a7d349497e9aac3ddfa4080e6ddad3e9affeab307cd2b109aed5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-softokn-3.79.0-14.el9_0.x86_64.rpm"
           },
-          "sha256:0dcd6624357942ada8b2ebf933ee47e11b1cbdc4eaee545519c43420adb6f46b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/udisks2-2.9.4-3.el9.x86_64.rpm"
-          },
           "sha256:0e5de5b828060e128ee9c0e57cb38a4f72692a2f1f11ed208439c4c07dcf192d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-tools-minimal-2.06-46.el9.x86_64.rpm"
           },
@@ -6790,14 +6527,8 @@
           "sha256:24983ca0db3271a80dfb9fc7282964eec863f155691333f265cd083654dac2da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/virt-what-1.25-1.el9.x86_64.rpm"
           },
-          "sha256:25536d6377e24d4cb7d95a76ccfc16de8b81c053ea77ad5a0961087ed52cf4c0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-part-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:261fc6bda6cc98f638b572e93b611c850f4b44e4c93d7c07e02bccbf9dca946a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.1-20221015/Packages/fence-agents-rsa-4.10.0-30.el9.noarch.rpm"
-          },
-          "sha256:2671d507c8f07af10dfc20de9695e62c2c8dc9ed3b8cee7e464d47932ac24e97": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-utils-2.25-14.el9.x86_64.rpm"
           },
           "sha256:26bee2c6124e4047f5b6261589bbd7a801603ca12dc90b64b0cd178911e25cbb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxml2-2.9.13-2.el9.x86_64.rpm"
@@ -6813,9 +6544,6 @@
           },
           "sha256:28a5f98e7922427c7f69d36773c6cd2079812c93442e8116af14fc8dbb139201": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/krb5-libs-1.19.1-22.el9.x86_64.rpm"
-          },
-          "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fwupd-1.7.9-1.el9.x86_64.rpm"
           },
           "sha256:29826b32a7c4a7849f26290be47b4aa41fe14de69550f30da10ebf7d5782a133": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/which-2.21-28.el9.x86_64.rpm"
@@ -6871,9 +6599,6 @@
           "sha256:2f3ad8da0aa342fcc7343b0a7963aba93e1253f4109a18f46d5a02ac9e030766": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/python3-lxml-4.6.5-3.el9.x86_64.rpm"
           },
-          "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgudev-237-1.el9.x86_64.rpm"
-          },
           "sha256:2fb3471163091eca166f66fb3f69d17dede5f0a3bb51784ab18959dcdc5f7f71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nspr-4.34.0-14.el9_0.x86_64.rpm"
           },
@@ -6897,9 +6622,6 @@
           },
           "sha256:322dd1e3f213b4a90de07a584259b9fa8f058cdfcd3bc38ecf3b5b79175835a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libfdisk-2.37.4-9.el9.x86_64.rpm"
-          },
-          "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm"
           },
           "sha256:32c933de69b8fae782d4e7c7a1132eaf256e73b455199a7c617bc315f3e97e7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libuser-0.63-11.el9.x86_64.rpm"
@@ -6927,9 +6649,6 @@
           },
           "sha256:39146b9a69e244c59a9a41cfaab20fedcf890c640e04ed0d993e4473e7443106": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libpkgconf-1.7.3-9.el9.x86_64.rpm"
-          },
-          "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libusbx-1.0.26-1.el9.x86_64.rpm"
           },
           "sha256:395eafb58304cec0d88c4e2de4ceaa954eac756c441783e7a46df6d88f049bcd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/telnet-0.17-85.el9.x86_64.rpm"
@@ -7020,9 +6739,6 @@
           },
           "sha256:43d40891623256b30a7d08d8db21a3d94d94756ecade355845e52c64f5af7765": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libevent-2.1.12-6.el9.x86_64.rpm"
-          },
-          "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shared-mime-info-2.1-4.el9.x86_64.rpm"
           },
           "sha256:44b4ebb0b3cc5a733d477b684082c23d8b4230953f192113353a6aa664e83624": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/gpgme-1.15.1-6.el9.x86_64.rpm"
@@ -7135,9 +6851,6 @@
           "sha256:50b10ed9964a5824b705a04d3937bc2e22f29751fba66a97b991c429bbb3664c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/nettle-3.8-3.el9_0.x86_64.rpm"
           },
-          "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm"
-          },
           "sha256:5246e2b08f6c120e3c2fc418c18fcd1db17c9fdc53fe51cd763fabfbe5b6c4fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/pkgconf-pkg-config-1.7.3-9.el9.x86_64.rpm"
           },
@@ -7165,9 +6878,6 @@
           "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/langpacks-en-3.0-16.el9.noarch.rpm"
           },
-          "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efivar-libs-38-2.el9.x86_64.rpm"
-          },
           "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm"
           },
@@ -7180,9 +6890,6 @@
           "sha256:563d301817a83d6959469f6117ec1e8fa21aa7aafe8ae0f99ab71a62dbb05ba0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/tuned-2.19.0-1.el9.noarch.rpm"
           },
-          "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
-          },
           "sha256:587284378eec54fded45c8eb778a7afb9d9c3a74201c5e9068ac3030bdca02e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/redhat-release-eula-9.1-1.9.el9.x86_64.rpm"
           },
@@ -7191,9 +6898,6 @@
           },
           "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm"
-          },
-          "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libjcat-0.1.6-3.el9.x86_64.rpm"
           },
           "sha256:5a43c616c3f06fbba7d45ea4cdd87ca58cc46102908e089a14604de5d55a0393": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/redhat-logos-90.4-1.el9.x86_64.rpm"
@@ -7264,9 +6968,6 @@
           "sha256:644ed9b3264a546abac89fdd40c0140911ed8ceef6e05d7594f84e0f570c6347": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libffi-3.4.2-7.el9.x86_64.rpm"
           },
-          "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgusb-0.3.8-1.el9.x86_64.rpm"
-          },
           "sha256:6477fb3c3285158f676360e228057e13dc6e983f453c7c74ed4ab140357f9a0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libunistring-0.9.10-15.el9.x86_64.rpm"
           },
@@ -7333,9 +7034,6 @@
           "sha256:6da6e13deb7badafaa4e10bc8f7a81acd40e4cba3c34b4590826e8eb9a329f3d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libnl3-3.7.0-1.el9.x86_64.rpm"
           },
-          "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efibootmgr-16-12.el9.x86_64.rpm"
-          },
           "sha256:6ea4966a7336839fc47ae6308c8a00f69e4126bc1ff0832899c9a0eaa0661d19": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libcap-2.48-8.el9.x86_64.rpm"
           },
@@ -7384,9 +7082,6 @@
           "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-vars-1.05-479.el9.noarch.rpm"
           },
-          "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efi-filesystem-6-2.el9_0.noarch.rpm"
-          },
           "sha256:737a278cdf7c292337d4b54dff0479c1cb88c74200179d2ae0caf6d766ea5d00": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/chrony-4.2-1.el9.x86_64.rpm"
           },
@@ -7398,9 +7093,6 @@
           },
           "sha256:74e68fba2f9e510dd674766800eb0df8ca0ea546fcc20264d92ed9cd5beaee9a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/oddjob-0.34.7-6.el9.x86_64.rpm"
-          },
-          "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libatasmart-0.19-22.el9.x86_64.rpm"
           },
           "sha256:75da9e9faf295a7cdc1e8aede617c5468860ed03750f5543eb1ed00ca1d6c1e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libcollection-0.7.0-53.el9.x86_64.rpm"
@@ -7543,9 +7235,6 @@
           "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-Exporter-5.74-461.el9.noarch.rpm"
           },
-          "sha256:88a824609ad38bee5ea8037eb18a6477f6e6b313af6deda6311286406d1065a7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-mdraid-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:88f123ca2fd9a3a5c59f4065500ccc2e94e64502035e65a524e1e55574a7df75": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libdnf-plugin-subscription-manager-1.29.30-1.el9.x86_64.rpm"
           },
@@ -7645,9 +7334,6 @@
           "sha256:973f31bf9aa9e53671d12df1a65c441f7e719455a7cd64d8af9446aaf6d56407": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.1-20221015/Packages/fence-agents-amt-ws-4.10.0-30.el9.noarch.rpm"
           },
-          "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mokutil-0.4.0-9.el9.x86_64.rpm"
-          },
           "sha256:98feca993ba0ce005b91ee5a2123c6a107c0c0154b893c6edc69beed651529e6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.1-20221015/Packages/fence-agents-emerson-4.10.0-30.el9.noarch.rpm"
           },
@@ -7683,9 +7369,6 @@
           },
           "sha256:9c332f10871fa27bcf99d7afcea2220fe50227cd8c943b295f83081d44ad6ebf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/NetworkManager-tui-1.40.0-1.el9.x86_64.rpm"
-          },
-          "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm"
           },
           "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-linux-procfs-0.7.0-1.el9.noarch.rpm"
@@ -7732,9 +7415,6 @@
           "sha256:a50bb26a28ee7e6379c86b5b91285299b71569fa87ea968d800a56090b7a179d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxcrypt-4.4.18-3.el9.x86_64.rpm"
           },
-          "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fwupd-plugin-flashrom-1.7.9-1.el9.x86_64.rpm"
-          },
           "sha256:a62889efb540a272b234cd60c68cb610944a1ebcf148171861e07be0d8245b07": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/dracut-squash-057-13.git20220816.el9.x86_64.rpm"
           },
@@ -7770,9 +7450,6 @@
           },
           "sha256:aa6105f1cefa12a2509fd24d8825bf17328339531144dc192ac7900298be3ab7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/polkit-0.117-10.el9_0.x86_64.rpm"
-          },
-          "sha256:aa805098a888939a75c1f9ed46ff281c2c2fcdd282a8d18d37852bd8b0085151": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-loop-2.25-14.el9.x86_64.rpm"
           },
           "sha256:aaa17904b12fe5e7df830fb9c512d971f29221dec19a3e421307b41526696f5e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/pciutils-3.7.0-5.el9.x86_64.rpm"
@@ -7912,9 +7589,6 @@
           "sha256:beed55d3ab1e8dd1207e1bd67e40e180c53a001198b9a7186f4bf07c042b377e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openldap-compat-2.6.2-3.el9.x86_64.rpm"
           },
-          "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/flashrom-1.2-10.el9.x86_64.rpm"
-          },
           "sha256:bf3baf444e49eba4189e57d562a7522ab714132d2960db87ef9b99f1b46a3cc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sed-4.8-9.el9.x86_64.rpm"
           },
@@ -7981,9 +7655,6 @@
           "sha256:c972030a8fbaa2d981f0e5fdfc42d6d5173dd047c94d86ab7732e3e53fc4e97a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libpipeline-1.5.3-4.el9.x86_64.rpm"
           },
-          "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:cb07b2cabae7305f5e4e5784530a75a8f91c57a79da1ae7ff7808ce23917ebd3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libedit-3.1-37.20210216cvs.el9.x86_64.rpm"
           },
@@ -8004,9 +7675,6 @@
           },
           "sha256:ce6dcb35f56a067393e94e5d49299a9ab256ad4949e6f86ac27e6b58516b18a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/kmod-libs-28-7.el9.x86_64.rpm"
-          },
-          "sha256:ce7a47da96b91cb7a50a9876fe2931f472e84ad71b72827001c5631c25e30e10": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-crypto-2.25-14.el9.x86_64.rpm"
           },
           "sha256:cf0662ef00d4e84727fafc79cee6941f865e0cb657332dd7448759b2f83a4809": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libss-1.46.5-3.el9.x86_64.rpm"
@@ -8092,9 +7760,6 @@
           "sha256:d89db8105e710c721bf12a6419ee394572fa880eaba11237898eb91e4acd0348": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/python3-pycparser-2.20-6.el9.noarch.rpm"
           },
-          "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm"
-          },
           "sha256:d9b53fda4b8757fd63b53a415f533ab876c18c28a94fd21d10658de85978f254": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/cpio-2.13-16.el9.x86_64.rpm"
           },
@@ -8131,14 +7796,8 @@
           "sha256:decaeac8fa883ddd631a32aaf55eb6175ab6e328150d66dfcf8e322b26da258f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/corosynclib-3.1.5-4.el9.x86_64.rpm"
           },
-          "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm"
-          },
           "sha256:df2ab474c2d513ed863d2265efbdbb32ce9c1b1dd00365f041f6539ec36dd80d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmartcols-2.37.4-9.el9.x86_64.rpm"
-          },
-          "sha256:dfdaa5afa228685c56e65edd92d2a7aba162c7e1e16cce2053767e246fef6076": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mdadm-4.2-6.el9.x86_64.rpm"
           },
           "sha256:e069efd411901c3d1be3fa6898d18cc8a787722a6fbeb71f56b59890073ca6e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libdnf-0.67.0-3.el9.x86_64.rpm"
@@ -8163,9 +7822,6 @@
           },
           "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/snappy-1.1.8-8.el9.x86_64.rpm"
-          },
-          "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm"
           },
           "sha256:e5c4efec2d4e9e7bb461b5880efc09ba6b5c42c2fab6cc2b784ed2f79a79ca1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-dnf-4.12.0-4.el9.noarch.rpm"
@@ -8227,9 +7883,6 @@
           "sha256:ec162bbce74978ac450bfcc60e74fe090cdef2e096214cc223117ddafe983ac7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-NDBM_File-1.15-479.el9.x86_64.rpm"
           },
-          "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libbytesize-2.5-3.el9.x86_64.rpm"
-          },
           "sha256:ed4bfb8d96a13bad9b85dde758d6f481fa62abd56595760134e3ea195e63806e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libpath_utils-0.2.1-53.el9.x86_64.rpm"
           },
@@ -8242,9 +7895,6 @@
           "sha256:ee1368739d142d7c46836f2efd86e91a648bae68e46114f00596f819ad08ea31": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-pc-modules-2.06-46.el9.noarch.rpm"
           },
-          "sha256:ee53fb84a91d66355c438c47593d677df32222be79a856cd406dd73c1e719b25": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-swap-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:ee84863d757bd2084b084aa768b80c47753922ecf0b767796399920ea8057f9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/util-linux-2.37.4-9.el9.x86_64.rpm"
           },
@@ -8256,9 +7906,6 @@
           },
           "sha256:ef6eb3e28612b850c9ae97b260d6a38a7fa77e8b9170516079baaa0f1154c09a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/ca-certificates-2022.2.54-90.2.el9_0.noarch.rpm"
-          },
-          "sha256:f03e357435c8b27e81ce6cb440992bd911e11a9fa0b211af1401280013651d01": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.x86_64.rpm"
           },
           "sha256:f0f60e63cb2bcfcf16d4b4bf6948ab0529da8b61f77c1780dd3587354f19fefe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.1-20221015/Packages/libknet1-crypto-nss-plugin-1.24-2.el9.x86_64.rpm"
@@ -8301,9 +7948,6 @@
           },
           "sha256:fa3abe9c3196c58b2a2943bd759eb30542962d3464970ce4171627e741160f28": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/python3-oauthlib-3.1.1-2.el9.noarch.rpm"
-          },
-          "sha256:fa3e8480793608d79e85ec366280e031470976e7c25e1c75252cad489369ec4a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-2.25-14.el9.x86_64.rpm"
           },
           "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm"
@@ -10015,16 +9659,6 @@
         "check_gpg": true
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.1",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
-        "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
-        "check_gpg": true
-      },
-      {
         "name": "bzip2",
         "epoch": 0,
         "version": "1.0.8",
@@ -10485,36 +10119,6 @@
         "check_gpg": true
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "6",
-        "release": "2.el9_0",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efi-filesystem-6-2.el9_0.noarch.rpm",
-        "checksum": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-        "check_gpg": true
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "12.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efibootmgr-16-12.el9.x86_64.rpm",
-        "checksum": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-        "check_gpg": true
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "38",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efivar-libs-38-2.el9.x86_64.rpm",
-        "checksum": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-        "check_gpg": true
-      },
-      {
         "name": "elfutils-default-yama-scope",
         "epoch": 0,
         "version": "0.187",
@@ -10622,16 +10226,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm",
         "checksum": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.9",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fwupd-1.7.9-1.el9.x86_64.rpm",
-        "checksum": "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3",
         "check_gpg": true
       },
       {
@@ -10802,16 +10396,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-common-2.06-46.el9.noarch.rpm",
         "checksum": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "46.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm",
-        "checksum": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
         "check_gpg": true
       },
       {
@@ -11485,16 +11069,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm",
-        "checksum": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.3.1",
@@ -11535,26 +11109,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "237",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgudev-237-1.el9.x86_64.rpm",
-        "checksum": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671",
-        "check_gpg": true
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.8",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgusb-0.3.8-1.el9.x86_64.rpm",
-        "checksum": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39",
-        "check_gpg": true
-      },
-      {
         "name": "libibverbs",
         "epoch": 0,
         "version": "41.0",
@@ -11582,16 +11136,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libini_config-1.3.1-53.el9.x86_64.rpm",
         "checksum": "sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35",
-        "check_gpg": true
-      },
-      {
-        "name": "libjcat",
-        "epoch": 0,
-        "version": "0.1.6",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libjcat-0.1.6-3.el9.x86_64.rpm",
-        "checksum": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
         "check_gpg": true
       },
       {
@@ -11905,16 +11449,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.3",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm",
-        "checksum": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-        "check_gpg": true
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.22",
@@ -12085,16 +11619,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.26",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libusbx-1.0.26-1.el9.x86_64.rpm",
-        "checksum": "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7",
-        "check_gpg": true
-      },
-      {
         "name": "libuser",
         "epoch": 0,
         "version": "0.63",
@@ -12162,16 +11686,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxml2-2.9.13-2.el9.x86_64.rpm",
         "checksum": "sha256:26bee2c6124e4047f5b6261589bbd7a801603ca12dc90b64b0cd178911e25cbb",
-        "check_gpg": true
-      },
-      {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.3.3",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm",
-        "checksum": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3",
         "check_gpg": true
       },
       {
@@ -12315,16 +11829,6 @@
         "check_gpg": true
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mdadm-4.2-6.el9.x86_64.rpm",
-        "checksum": "sha256:dfdaa5afa228685c56e65edd92d2a7aba162c7e1e16cce2053767e246fef6076",
-        "check_gpg": true
-      },
-      {
         "name": "microcode_ctl",
         "epoch": 4,
         "version": "20220809",
@@ -12332,16 +11836,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/microcode_ctl-20220809-1.el9.noarch.rpm",
         "checksum": "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88",
-        "check_gpg": true
-      },
-      {
-        "name": "mokutil",
-        "epoch": 2,
-        "version": "0.4.0",
-        "release": "9.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mokutil-0.4.0-9.el9.x86_64.rpm",
-        "checksum": "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e",
         "check_gpg": true
       },
       {
@@ -13335,26 +12829,6 @@
         "check_gpg": true
       },
       {
-        "name": "shared-mime-info",
-        "epoch": 0,
-        "version": "2.1",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shared-mime-info-2.1-4.el9.x86_64.rpm",
-        "checksum": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a",
-        "check_gpg": true
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
-        "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-        "check_gpg": true
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -13785,26 +13259,6 @@
         "check_gpg": true
       },
       {
-        "name": "flashrom",
-        "epoch": 0,
-        "version": "1.2",
-        "release": "10.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/flashrom-1.2-10.el9.x86_64.rpm",
-        "checksum": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd-plugin-flashrom",
-        "epoch": 0,
-        "version": "1.7.9",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fwupd-plugin-flashrom-1.7.9-1.el9.x86_64.rpm",
-        "checksum": "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c",
-        "check_gpg": true
-      },
-      {
         "name": "gawk-all-langpacks",
         "epoch": 0,
         "version": "5.1.0",
@@ -13915,106 +13369,6 @@
         "check_gpg": true
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "22.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libatasmart-0.19-22.el9.x86_64.rpm",
-        "checksum": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:fa3e8480793608d79e85ec366280e031470976e7c25e1c75252cad489369ec4a",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-crypto-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:ce7a47da96b91cb7a50a9876fe2931f472e84ad71b72827001c5631c25e30e10",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-loop-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:aa805098a888939a75c1f9ed46ff281c2c2fcdd282a8d18d37852bd8b0085151",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-mdraid-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:88a824609ad38bee5ea8037eb18a6477f6e6b313af6deda6311286406d1065a7",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-part-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:25536d6377e24d4cb7d95a76ccfc16de8b81c053ea77ad5a0961087ed52cf4c0",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-swap-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:ee53fb84a91d66355c438c47593d677df32222be79a856cd406dd73c1e719b25",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-utils-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:2671d507c8f07af10dfc20de9695e62c2c8dc9ed3b8cee7e464d47932ac24e97",
-        "check_gpg": true
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "2.5",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libbytesize-2.5-3.el9.x86_64.rpm",
-        "checksum": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974",
-        "check_gpg": true
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.11",
@@ -14052,16 +13406,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libqb-2.0.6-1.el9.x86_64.rpm",
         "checksum": "sha256:38c2923779bae32c37a5138ac06231c8de5bd7499f5148b5065c12faa92c5b3c",
-        "check_gpg": true
-      },
-      {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.x86_64.rpm",
-        "checksum": "sha256:f03e357435c8b27e81ce6cb440992bd911e11a9fa0b211af1401280013651d01",
         "check_gpg": true
       },
       {
@@ -15195,16 +14539,6 @@
         "check_gpg": true
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/udisks2-2.9.4-3.el9.x86_64.rpm",
-        "checksum": "sha256:0dcd6624357942ada8b2ebf933ee47e11b1cbdc4eaee545519c43420adb6f46b",
-        "check_gpg": true
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.16.2",
@@ -15212,16 +14546,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/unbound-libs-1.16.2-2.el9.x86_64.rpm",
         "checksum": "sha256:3c52563ef6ba99cd8806b2fde878357f1c9ce092a098a85086e9bc39054cb54e",
-        "check_gpg": true
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.12",
-        "release": "15.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
-        "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_9-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-ec2_sap-boot.json
@@ -2045,30 +2045,6 @@
                     }
                   },
                   {
-                    "id": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:68a8e7a042e8e2f9574db0b684997c3e3c38b3ba95fc45762a2c04befb4acfcf",
                     "options": {
                       "metadata": {
@@ -2182,14 +2158,6 @@
                   },
                   {
                     "id": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2342,14 +2310,6 @@
                   },
                   {
                     "id": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3021,14 +2981,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:056c6e51fa98dae4381725ca9510ced292703ec225adf9637a61eb752d1a3a0a",
                     "options": {
                       "metadata": {
@@ -3110,14 +3062,6 @@
                   },
                   {
                     "id": "sha256:3f36bb46fddf18961d9851da351aef75be8191ef7a634a79199f5abf9979cd8d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3437,14 +3381,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f70762594db38ab18ba1db1ce92e9ede5a40ca5d5c3cc93c6bd92686556472c8",
                     "options": {
                       "metadata": {
@@ -3653,14 +3589,6 @@
                     }
                   },
                   {
-                    "id": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:409beeb1faf626a882e95763ec4892d514077289e6074d3b61bef1b90739ad66",
                     "options": {
                       "metadata": {
@@ -3822,14 +3750,6 @@
                   },
                   {
                     "id": "sha256:27bc149f91c6740d37eb11b8e8e3c113092b7de231a11bc5552f3e0db78ae07e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4773,14 +4693,6 @@
                     }
                   },
                   {
-                    "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:4b7c4822f92e7ba97b78893d273b01161e411151ccc627b076d13719ad404a69",
                     "options": {
                       "metadata": {
@@ -5685,14 +5597,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:21edb6cf19c08c1d100e329d2b7f99b85692f23a518b1b2a1887ee1682d28880",
                     "options": {
                       "metadata": {
@@ -5774,14 +5678,6 @@
                   },
                   {
                     "id": "sha256:a7ba2bb451678b22e4e58cc7b235554e7dee87e6ec01438d512ce1a9c9d46aa1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -8687,10 +8583,6 @@
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 processor.max_cstate=1 intel_idle.max_cstate=1",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat",
-                "unified": true
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,
               "config": {
@@ -9322,9 +9214,6 @@
           "sha256:28a5f98e7922427c7f69d36773c6cd2079812c93442e8116af14fc8dbb139201": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/krb5-libs-1.19.1-22.el9.x86_64.rpm"
           },
-          "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fwupd-1.7.9-1.el9.x86_64.rpm"
-          },
           "sha256:29826b32a7c4a7849f26290be47b4aa41fe14de69550f30da10ebf7d5782a133": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/which-2.21-28.el9.x86_64.rpm"
           },
@@ -9775,9 +9664,6 @@
           "sha256:50b10ed9964a5824b705a04d3937bc2e22f29751fba66a97b991c429bbb3664c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/nettle-3.8-3.el9_0.x86_64.rpm"
           },
-          "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm"
-          },
           "sha256:5236df95b2d813cf2218310327e1fb10a4bf36ee645f5373a987780c9fab06bf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/avahi-glib-0.8-12.el9.x86_64.rpm"
           },
@@ -9808,9 +9694,6 @@
           "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/langpacks-en-3.0-16.el9.noarch.rpm"
           },
-          "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efivar-libs-38-2.el9.x86_64.rpm"
-          },
           "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm"
           },
@@ -9832,9 +9715,6 @@
           "sha256:571e34c4445cce70faecd1ac1bee18a36b1559eb83b2d52d3b5a8a3b7d8a5bfa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libtracker-sparql-3.1.2-2.el9.x86_64.rpm"
           },
-          "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
-          },
           "sha256:583c5975a04bdcd968cd160468430a3d3bcabbc864071c3c150240c2ff9e43d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libappstream-glib-0.7.18-4.el9.x86_64.rpm"
           },
@@ -9849,9 +9729,6 @@
           },
           "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm"
-          },
-          "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libjcat-0.1.6-3.el9.x86_64.rpm"
           },
           "sha256:595961072f69a1c947e3fe0b14bb5ce160172edb8481961257bda3a8c00b2fdd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/kpatch-0.9.4-3.el9.noarch.rpm"
@@ -10066,9 +9943,6 @@
           "sha256:6dadd44b2e84b1a99d81c260533f1aa8aef7c3338f31aa720509defe3a5cd7c7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/cockpit-system-276.1-1.el9.noarch.rpm"
           },
-          "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efibootmgr-16-12.el9.x86_64.rpm"
-          },
           "sha256:6e449ce10dec4eed41ec10549c0a0131d3152171b2abe1016266c8e34ecf0566": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/bind-libs-9.16.23-5.el9_1.x86_64.rpm"
           },
@@ -10131,9 +10005,6 @@
           },
           "sha256:7290d5c6c200a2c98be30c3f0d9cf58462d0bc1ddb7940a8c7c35ca4f7e090ce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fstrm-0.6.1-3.el9.x86_64.rpm"
-          },
-          "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efi-filesystem-6-2.el9_0.noarch.rpm"
           },
           "sha256:737a278cdf7c292337d4b54dff0479c1cb88c74200179d2ae0caf6d766ea5d00": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/chrony-4.2-1.el9.x86_64.rpm"
@@ -10528,9 +10399,6 @@
           "sha256:9658da838021711f687cf283368664984bfb1c8b9176897d7d477a724a11a731": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/lz4-libs-1.9.3-5.el9.x86_64.rpm"
           },
-          "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mokutil-0.4.0-9.el9.x86_64.rpm"
-          },
           "sha256:979857c9789008c57b121256bc92ec35d1e3a9aaeaca998373c19f34d8b3c84e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/openjpeg2-2.4.0-7.el9.x86_64.rpm"
           },
@@ -10584,9 +10452,6 @@
           },
           "sha256:9c47a3d7531f2619e7636baaccca1ffd3b7893537d0107a335ae639475c96dab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sssd-proxy-2.7.3-4.el9.x86_64.rpm"
-          },
-          "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm"
           },
           "sha256:9ddcf4c8e5463a1b75b22be070ae8c67264ffd8bc035e3942791184b4f4b34d7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/jbig2dec-libs-0.19-6.el9.x86_64.rpm"
@@ -10674,9 +10539,6 @@
           },
           "sha256:a50bb26a28ee7e6379c86b5b91285299b71569fa87ea968d800a56090b7a179d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxcrypt-4.4.18-3.el9.x86_64.rpm"
-          },
-          "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fwupd-plugin-flashrom-1.7.9-1.el9.x86_64.rpm"
           },
           "sha256:a62889efb540a272b234cd60c68cb610944a1ebcf148171861e07be0d8245b07": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/dracut-squash-057-13.git20220816.el9.x86_64.rpm"
@@ -10977,9 +10839,6 @@
           },
           "sha256:beed55d3ab1e8dd1207e1bd67e40e180c53a001198b9a7186f4bf07c042b377e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openldap-compat-2.6.2-3.el9.x86_64.rpm"
-          },
-          "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/flashrom-1.2-10.el9.x86_64.rpm"
           },
           "sha256:bf3baf444e49eba4189e57d562a7522ab714132d2960db87ef9b99f1b46a3cc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sed-4.8-9.el9.x86_64.rpm"
@@ -11299,9 +11158,6 @@
           "sha256:de9869c08df7f6952787d0335b9bf1a09b328bea920556a59af07c8e085dd3cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/dbus-broker-28-7.el9.x86_64.rpm"
           },
-          "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm"
-          },
           "sha256:df2ab474c2d513ed863d2265efbdbb32ce9c1b1dd00365f041f6539ec36dd80d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmartcols-2.37.4-9.el9.x86_64.rpm"
           },
@@ -11343,9 +11199,6 @@
           },
           "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/snappy-1.1.8-8.el9.x86_64.rpm"
-          },
-          "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm"
           },
           "sha256:e5c4efec2d4e9e7bb461b5880efc09ba6b5c42c2fab6cc2b784ed2f79a79ca1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-dnf-4.12.0-4.el9.noarch.rpm"
@@ -13991,36 +13844,6 @@
         "check_gpg": true
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "6",
-        "release": "2.el9_0",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efi-filesystem-6-2.el9_0.noarch.rpm",
-        "checksum": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-        "check_gpg": true
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "12.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efibootmgr-16-12.el9.x86_64.rpm",
-        "checksum": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-        "check_gpg": true
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "38",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efivar-libs-38-2.el9.x86_64.rpm",
-        "checksum": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-        "check_gpg": true
-      },
-      {
         "name": "elfutils-debuginfod-client",
         "epoch": 0,
         "version": "0.187",
@@ -14168,16 +13991,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm",
         "checksum": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.9",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fwupd-1.7.9-1.el9.x86_64.rpm",
-        "checksum": "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3",
         "check_gpg": true
       },
       {
@@ -14368,16 +14181,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-common-2.06-46.el9.noarch.rpm",
         "checksum": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "46.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm",
-        "checksum": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
         "check_gpg": true
       },
       {
@@ -15211,16 +15014,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm",
-        "checksum": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.3.1",
@@ -15328,16 +15121,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libipa_hbac-2.7.3-4.el9.x86_64.rpm",
         "checksum": "sha256:3f36bb46fddf18961d9851da351aef75be8191ef7a634a79199f5abf9979cd8d",
-        "check_gpg": true
-      },
-      {
-        "name": "libjcat",
-        "epoch": 0,
-        "version": "0.1.6",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libjcat-0.1.6-3.el9.x86_64.rpm",
-        "checksum": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
         "check_gpg": true
       },
       {
@@ -15731,16 +15514,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.3",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm",
-        "checksum": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-        "check_gpg": true
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.22",
@@ -16001,16 +15774,6 @@
         "check_gpg": true
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.3.3",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm",
-        "checksum": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3",
-        "check_gpg": true
-      },
-      {
         "name": "libyaml",
         "epoch": 0,
         "version": "0.2.5",
@@ -16218,16 +15981,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mlocate-0.26-30.el9.x86_64.rpm",
         "checksum": "sha256:27bc149f91c6740d37eb11b8e8e3c113092b7de231a11bc5552f3e0db78ae07e",
-        "check_gpg": true
-      },
-      {
-        "name": "mokutil",
-        "epoch": 2,
-        "version": "0.4.0",
-        "release": "9.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mokutil-0.4.0-9.el9.x86_64.rpm",
-        "checksum": "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e",
         "check_gpg": true
       },
       {
@@ -17401,16 +17154,6 @@
         "check_gpg": true
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
-        "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-        "check_gpg": true
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -18541,16 +18284,6 @@
         "check_gpg": true
       },
       {
-        "name": "flashrom",
-        "epoch": 0,
-        "version": "1.2",
-        "release": "10.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/flashrom-1.2-10.el9.x86_64.rpm",
-        "checksum": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-        "check_gpg": true
-      },
-      {
         "name": "flatpak",
         "epoch": 0,
         "version": "1.12.7",
@@ -18658,16 +18391,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fuse3-libs-3.10.2-5.el9.x86_64.rpm",
         "checksum": "sha256:a7ba2bb451678b22e4e58cc7b235554e7dee87e6ec01438d512ce1a9c9d46aa1",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd-plugin-flashrom",
-        "epoch": 0,
-        "version": "1.7.9",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fwupd-plugin-flashrom-1.7.9-1.el9.x86_64.rpm",
-        "checksum": "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_90-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2-boot.json
@@ -599,9 +599,6 @@
                     "id": "sha256:f835cc738fa003147087d68427c407e17c08587156ae961d641b2dfcee1fe7af"
                   },
                   {
-                    "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
-                  },
-                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b"
                   },
                   {
@@ -722,15 +719,6 @@
                     "id": "sha256:07a6ff3d4ef4f04c7dc7f006a68795e030057745d10ea2a251e724e1d726e49b"
                   },
                   {
-                    "id": "sha256:0e5a1e3e42ff063ac8914f58d1c0e21dcd1ecf36840916c5d4e78838b49b5c2f"
-                  },
-                  {
-                    "id": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a"
-                  },
-                  {
-                    "id": "sha256:f91b3de89d9598092e093d262e35c4d7ac0ec9b2f8d3c5ea0cbdd620c47664d6"
-                  },
-                  {
                     "id": "sha256:7493224a1482e44507df3a479b7664a8776b9506a288b6f53a3713bf4298f1b2"
                   },
                   {
@@ -762,9 +750,6 @@
                   },
                   {
                     "id": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee"
-                  },
-                  {
-                    "id": "sha256:598ab332a213d929861baaec1eb4fdd110a495e6ecee182a0726b6d11f2acc76"
                   },
                   {
                     "id": "sha256:ad90074a6bbde7976ef7dff3fac045b74281a8118e7d7714f5b1b9086a12d182"
@@ -816,9 +801,6 @@
                   },
                   {
                     "id": "sha256:f2b7c3a5c800e3c670c6943672a9fc323c507ab12ade4dc9b7c956572966fc29"
-                  },
-                  {
-                    "id": "sha256:51734fbc7cc766ec9fd8ce87f29edc5db13e2135d6bd38d09b8376daf1f94fc7"
                   },
                   {
                     "id": "sha256:82c5216384a8882635744aaf883f2dd36e7f60cae0bb675beaa3728e7aa796d8"
@@ -1001,9 +983,6 @@
                     "id": "sha256:8a57200f0c0b94cb84751b35fa70b111c264186937ca9bda93448dac1a5166d6"
                   },
                   {
-                    "id": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5"
-                  },
-                  {
                     "id": "sha256:632b52c724d66439336804d332c1d497025889de660ef6c31e77f331ade8d2b8"
                   },
                   {
@@ -1016,12 +995,6 @@
                     "id": "sha256:8248e20d7a253aa9c0dc7dc3d56b42e1def4fd5753ce8e8b9e980aa664fc9068"
                   },
                   {
-                    "id": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671"
-                  },
-                  {
-                    "id": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39"
-                  },
-                  {
                     "id": "sha256:038fa32c8fbbc1278525a7e91c9645597f09bca2ab83ffd4aeff58bbfc396036"
                   },
                   {
@@ -1029,9 +1002,6 @@
                   },
                   {
                     "id": "sha256:c432790f9b6cf33ef8c6e3618b209e8922b409de79f0519cc9679b1ad6cb20ed"
-                  },
-                  {
-                    "id": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf"
                   },
                   {
                     "id": "sha256:3a4b2718744919d0e09981523d00527051b3eabd8c18bc55cb14181a00e307d6"
@@ -1121,9 +1091,6 @@
                     "id": "sha256:d9f2166d5f2f5ecad7c49fc2f6bf49d6014b0df0a266b3ee6522959eeb13ed3f"
                   },
                   {
-                    "id": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3"
-                  },
-                  {
                     "id": "sha256:f1afff374ac49b11d0d48bfee8e8ec59a329aba00a19630b09e4dc078e06859c"
                   },
                   {
@@ -1172,9 +1139,6 @@
                     "id": "sha256:6477fb3c3285158f676360e228057e13dc6e983f453c7c74ed4ab140357f9a0d"
                   },
                   {
-                    "id": "sha256:147e281881105acfb8aa184a1d59faff4e3c1249205a86abb900b8d7a02cacbe"
-                  },
-                  {
                     "id": "sha256:2358982717e4c6df5e0dfc4ad906dade4ecf051cb7612b1aa087ab6c03f36da2"
                   },
                   {
@@ -1191,9 +1155,6 @@
                   },
                   {
                     "id": "sha256:bc0f73fb262df04514d6ce8f4d970adefc7385be519e759c9d61bf7f715cc6e1"
-                  },
-                  {
-                    "id": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3"
                   },
                   {
                     "id": "sha256:409beeb1faf626a882e95763ec4892d514077289e6074d3b61bef1b90739ad66"
@@ -1232,13 +1193,7 @@
                     "id": "sha256:6440c783cf8872f6d948164f24eedc54935130a4e095a933ba910cd799419cd4"
                   },
                   {
-                    "id": "sha256:20a46ac392014c17b6c2192a87d419189a2632830554d436f2895d15269c6f98"
-                  },
-                  {
                     "id": "sha256:57b689e668acf407ed7542fbedcd29529fff28b3ace62cbff7659f9a42d8e1dd"
-                  },
-                  {
-                    "id": "sha256:b64133227dca092ba89a703ba539e422299fc04a8663ab862240a433f116e5e9"
                   },
                   {
                     "id": "sha256:cf60adcc7a5f0cb469e6f066a1bdc62ae9af7c06305c76c15884b59df7f93274"
@@ -1505,12 +1460,6 @@
                     "id": "sha256:9624fc9a5d5b4b0229d8d6f2505992142b6ba236fe02610214419e6e3ff9f273"
                   },
                   {
-                    "id": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a"
-                  },
-                  {
-                    "id": "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021"
-                  },
-                  {
                     "id": "sha256:4b7c4822f92e7ba97b78893d273b01161e411151ccc627b076d13719ad404a69"
                   },
                   {
@@ -1628,12 +1577,6 @@
                     "id": "sha256:d763e4d9e98fd3aac3db1828ed0de1f4b5ff46c939a207597db05fe60af52832"
                   },
                   {
-                    "id": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56"
-                  },
-                  {
-                    "id": "sha256:c44be051ee349ab2fb432004b5fef2023b3aecc456997123fa381710bff848a4"
-                  },
-                  {
                     "id": "sha256:34384ca5d51125d92a02a1f20e8a68aa8e17314eb0ecf4dec64594ac61e4fee7"
                   },
                   {
@@ -1658,36 +1601,6 @@
                     "id": "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a"
                   },
                   {
-                    "id": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a"
-                  },
-                  {
-                    "id": "sha256:a7cc761f2e5a06b5858d412e9a03e2d7778158d2f27099c4e5d2050d15103970"
-                  },
-                  {
-                    "id": "sha256:564b8d00d26b50ae57423aa5be39aa525bbd71d50600e2618ea75e2295f6f2e8"
-                  },
-                  {
-                    "id": "sha256:61e3b32b1509c44dcddeedb0b1a8b6b0c6bbd343affa3ef229127d05d32913ab"
-                  },
-                  {
-                    "id": "sha256:8743d4eab6e262efbe770232eb34c3fb5f0c304531b97cc95442ed6c7c8e2909"
-                  },
-                  {
-                    "id": "sha256:887b23796b57b9e476f916c32b27d446a4db40957b92940519162ea7ba1689cc"
-                  },
-                  {
-                    "id": "sha256:68642d32e38d1bb4e847911c8fc41a78a23e74823a7282e94cf9e3abc5c169ab"
-                  },
-                  {
-                    "id": "sha256:9fd5fe7855c4586366cc8f8eef57bd6ff15aff469a817ac77ec8d3be89783c68"
-                  },
-                  {
-                    "id": "sha256:dffac89417d819b7c2a65d116d45c2a2c12c9385553a48fa3336dfe92d30e9de"
-                  },
-                  {
-                    "id": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974"
-                  },
-                  {
                     "id": "sha256:63cf867f399e02846f7b4766d60dc4d2aaba9c7256136e429cb040741d054d2d"
                   },
                   {
@@ -1697,31 +1610,10 @@
                     "id": "sha256:476b59e484e2c1654d26693a74eef5c2e9655089347c9d12609b1474863baff9"
                   },
                   {
-                    "id": "sha256:1a91c11ac1b40db298284bdc320a07f66e5e3db1cb22818c28f72d5227411f2a"
-                  },
-                  {
                     "id": "sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a"
                   },
                   {
                     "id": "sha256:9b003e9aea7c1c6ea17ae1309da24cd3fbfe15b0a75512e0e90dbb1e660fa20e"
-                  },
-                  {
-                    "id": "sha256:6eaa30c581a2ceb81d8a60c30263bf525f73e1f3be5e3185bf5e4d4ceed31ebb"
-                  },
-                  {
-                    "id": "sha256:73f108442e63d22895b169eedacb091c2e9c99bd9c5d6b3dc93d685f3939d7b9"
-                  },
-                  {
-                    "id": "sha256:bdd2d4f06e8d776cd01733cc946e32a492653044efa957c073be384d020de1f4"
-                  },
-                  {
-                    "id": "sha256:80144445a23c730b953deba3cd07e35d9bc7fdc41caa0c2fb80dfef751fb87b8"
-                  },
-                  {
-                    "id": "sha256:a938f2428e2cc5f843f9abdfdf6fced58ba8dea2cea9df6d4be444389d4eeeff"
-                  },
-                  {
-                    "id": "sha256:cf943b1956ec13cc3accbe6165578b8b216e7b53410fd89c86a129fee7e0295a"
                   },
                   {
                     "id": "sha256:4b2fde1186aae6e3d9feb728ad234ef2174286d90cd324caf9d5535978208aea"
@@ -1794,12 +1686,6 @@
                   },
                   {
                     "id": "sha256:fb3d2020dca3f3674da8d25c5acdac1c9eee7acbc933acc720b39e92266265a7"
-                  },
-                  {
-                    "id": "sha256:4361d66a963fe8c62bd1a4e887a06fbe937faa70a7ac704a127021937b2e1b69"
-                  },
-                  {
-                    "id": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c"
                   },
                   {
                     "id": "sha256:161886c799cef7e8647edaba77da3a89633fe58cf1102126e010e89ec6e9de08"
@@ -2028,10 +1914,6 @@
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat",
-                "unified": true
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-55.el9.x86_64",
               "write_cmdline": false,
               "config": {
@@ -2342,9 +2224,6 @@
           "sha256:0c8f8e301f75c77a24821cc9170596a799edb33c1bf58b6490aa97c8ed7d5996": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/gmp-6.2.0-10.el9.x86_64.rpm"
           },
-          "sha256:0e5a1e3e42ff063ac8914f58d1c0e21dcd1ecf36840916c5d4e78838b49b5c2f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efi-filesystem-4-9.el9.noarch.rpm"
-          },
           "sha256:0f1df5e0d48c2ac9914bfffa7ed569cd58e42b17ba96bb3f7cf74d1e80de2597": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libutempter-1.2.1-6.el9.x86_64.rpm"
           },
@@ -2371,9 +2250,6 @@
           },
           "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm"
-          },
-          "sha256:147e281881105acfb8aa184a1d59faff4e3c1249205a86abb900b8d7a02cacbe": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libusbx-1.0.24-4.el9.x86_64.rpm"
           },
           "sha256:14b7ff2f7fdaf8ebec90261f4619ea7f7c3564c4de8483666de7ed4b1f49b66f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libpwquality-1.4.4-8.el9.x86_64.rpm"
@@ -2402,9 +2278,6 @@
           "sha256:1a17cbe0a1a6667c8bb1e1bb954e5b5ed03879164325f0aa585de85816b5da3f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-pyserial-3.4-12.el9.noarch.rpm"
           },
-          "sha256:1a91c11ac1b40db298284bdc320a07f66e5e3db1cb22818c28f72d5227411f2a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libudisks2-2.9.4-2.el9.x86_64.rpm"
-          },
           "sha256:1aa1d059f7696ae397f8746d8d4fe5ead73bac461f53cce01b92db73fbd2fa81": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/findutils-4.8.0-5.el9.x86_64.rpm"
           },
@@ -2428,9 +2301,6 @@
           },
           "sha256:1eccf723e9479d332fb0c2ca94e895822191fe308facac257ffb1ed6f61eb471": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/rpm-4.16.1.3-10.el9.x86_64.rpm"
-          },
-          "sha256:20a46ac392014c17b6c2192a87d419189a2632830554d436f2895d15269c6f98": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/mdadm-4.2-1.el9.x86_64.rpm"
           },
           "sha256:210ce4b006e8d129524123cc2379c01c529e185767f54cc5a6f9dafb21cd9c24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/zlib-1.2.11-31.el9.x86_64.rpm"
@@ -2501,9 +2371,6 @@
           "sha256:2d98292bdf2bda73ac4b78790b54c65f594cc179775c2775f4aad5dc61a5aa24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sssd-common-2.6.2-2.el9.x86_64.rpm"
           },
-          "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgudev-237-1.el9.x86_64.rpm"
-          },
           "sha256:30a3b8b08eafb81232ae7758eaef2ba2eef8e2ada837571fee0aaaa874de1f15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-ethtool-0.15-2.el9.x86_64.rpm"
           },
@@ -2512,9 +2379,6 @@
           },
           "sha256:317a8307ec703093e29e05342493afaa9d85a6b4c1e8dda17eeab2c5e2dd1b50": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/subscription-manager-rhsm-certificates-1.29.23-1.el9.x86_64.rpm"
-          },
-          "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm"
           },
           "sha256:328f907df63fc5869776fef6ee59bf1215bd131bf08453f71e225204e58ea740": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/kernel-modules-5.14.0-55.el9.x86_64.rpm"
@@ -2594,12 +2458,6 @@
           "sha256:435c54623ddcbb6d38d20e22b7964ad6bb627a88a2762120feeb98bbbadba1d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libeconf-0.4.1-2.el9.x86_64.rpm"
           },
-          "sha256:4361d66a963fe8c62bd1a4e887a06fbe937faa70a7ac704a127021937b2e1b69": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/udisks2-2.9.4-2.el9.x86_64.rpm"
-          },
-          "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/shared-mime-info-2.1-4.el9.x86_64.rpm"
-          },
           "sha256:44d73e10c58816ff1a215c6b5cefa4a24237892ec4bcd47e2d7d5bb84fa16619": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nettle-3.7.3-2.el9.x86_64.rpm"
           },
@@ -2654,17 +2512,11 @@
           "sha256:4f6741962c5b9346e5daf41795407976e8f22c42d64066c239e482556abba9cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-dnf-4.10.0-3.el9.noarch.rpm"
           },
-          "sha256:51734fbc7cc766ec9fd8ce87f29edc5db13e2135d6bd38d09b8376daf1f94fc7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/grub2-efi-x64-2.06-16.el9.x86_64.rpm"
-          },
           "sha256:5196f5f7d2387e9dcdf504c8534e3109cc84f7545240b6fbd18866217653b4fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-055-10.git20210824.el9.x86_64.rpm"
           },
           "sha256:51d508ed30f9b74fbef756f2be64cca597de9e797b6f5f00f70e4ec88a7c4d3a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.x86_64.rpm"
-          },
-          "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm"
           },
           "sha256:535399f8bac6023869afd7452f3a1dd1dfca32f2b7ee98b3d330c07559634fca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/cronie-anacron-1.5.7-5.el9.x86_64.rpm"
@@ -2687,9 +2539,6 @@
           "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/langpacks-en-3.0-16.el9.noarch.rpm"
           },
-          "sha256:564b8d00d26b50ae57423aa5be39aa525bbd71d50600e2618ea75e2295f6f2e8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-crypto-2.25-11.el9.x86_64.rpm"
-          },
           "sha256:5787221dc306786025fdd87e8a7bb3eb780e4a0319fc66612ee476c8b3760e20": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/xz-libs-5.2.5-7.el9.x86_64.rpm"
           },
@@ -2699,20 +2548,11 @@
           "sha256:57f832788769a0bab197c09e1c5720f571b06e8952c485ed721b9875ae7ad27d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libnl3-cli-3.5.0-10.el9.x86_64.rpm"
           },
-          "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
-          },
           "sha256:588411c7135c1b78c55f17328e1ff29bbcc9f64dc2dbedac656b0f9ca6788d66": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/rpm-sign-libs-4.16.1.3-10.el9.x86_64.rpm"
           },
           "sha256:588e8736af3376abfb3cdf372c10baef02c40d916a55958f3bee9767f9ad8526": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libcbor-0.7.0-5.el9.x86_64.rpm"
-          },
-          "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libjcat-0.1.6-3.el9.x86_64.rpm"
-          },
-          "sha256:598ab332a213d929861baaec1eb4fdd110a495e6ecee182a0726b6d11f2acc76": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fwupd-1.5.9-3.el9.x86_64.rpm"
           },
           "sha256:5ae707b0785b6a36943aa4abc7fed6b4ffcb57adbea536effbbc981f4588ce2e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/authselect-1.2.3-7.el9.x86_64.rpm"
@@ -2744,9 +2584,6 @@
           "sha256:60f5722840b615527ad31ee363279327ba2415699d0855042e54b05a54f5b6ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libselinux-utils-3.3-2.el9.x86_64.rpm"
           },
-          "sha256:61e3b32b1509c44dcddeedb0b1a8b6b0c6bbd343affa3ef229127d05d32913ab": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-fs-2.25-11.el9.x86_64.rpm"
-          },
           "sha256:62e71529d30a23056ce1c38ca40c517ab425c864b681b135b275204fdd479ae7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iputils-20210202-7.el9.x86_64.rpm"
           },
@@ -2765,9 +2602,6 @@
           "sha256:644ed9b3264a546abac89fdd40c0140911ed8ceef6e05d7594f84e0f570c6347": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libffi-3.4.2-7.el9.x86_64.rpm"
           },
-          "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgusb-0.3.8-1.el9.x86_64.rpm"
-          },
           "sha256:6477fb3c3285158f676360e228057e13dc6e983f453c7c74ed4ab140357f9a0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libunistring-0.9.10-15.el9.x86_64.rpm"
           },
@@ -2783,9 +2617,6 @@
           "sha256:67d24d8ec5984645dfa9ff35a359693b2ed4079030d2f776702912684b6847da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/parted-3.4-6.el9.x86_64.rpm"
           },
-          "sha256:68642d32e38d1bb4e847911c8fc41a78a23e74823a7282e94cf9e3abc5c169ab": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-part-2.25-11.el9.x86_64.rpm"
-          },
           "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm"
           },
@@ -2798,9 +2629,6 @@
           "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm"
           },
-          "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efibootmgr-16-12.el9.x86_64.rpm"
-          },
           "sha256:6e7ff4ef538a85596df359947fa5069052a532dd1ce8c2eeedd1557639c08ec1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sssd-client-2.6.2-2.el9.x86_64.rpm"
           },
@@ -2809,9 +2637,6 @@
           },
           "sha256:6ea4966a7336839fc47ae6308c8a00f69e4126bc1ff0832899c9a0eaa0661d19": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libcap-2.48-8.el9.x86_64.rpm"
-          },
-          "sha256:6eaa30c581a2ceb81d8a60c30263bf525f73e1f3be5e3185bf5e4d4ceed31ebb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/nspr-4.32.0-8.el9.x86_64.rpm"
           },
           "sha256:6eb75ccc16c3e4f41a8e1e07b79fd924c2b68b1b22f0a6ff4e862bd94f00beaf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/systemd-libs-249-9.el9.x86_64.rpm"
@@ -2837,17 +2662,11 @@
           "sha256:722e3c6fb3dff112298025a33c36da22a5283ce05003aee216ba6bfe740df6b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/pciutils-libs-3.7.0-5.el9.x86_64.rpm"
           },
-          "sha256:73f108442e63d22895b169eedacb091c2e9c99bd9c5d6b3dc93d685f3939d7b9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/nss-3.71.0-6.el9.x86_64.rpm"
-          },
           "sha256:746988d3ce76d009c66d2df693641b9085e5971bc1e09d6efeb03c6279b41f1a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/systemd-249-9.el9.x86_64.rpm"
           },
           "sha256:7493224a1482e44507df3a479b7664a8776b9506a288b6f53a3713bf4298f1b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/elfutils-default-yama-scope-0.186-1.el9.noarch.rpm"
-          },
-          "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libatasmart-0.19-22.el9.x86_64.rpm"
           },
           "sha256:76403bb0496ba71bb4c17e714469c9d6e66aad263d2b8ad3775a10d3a792dbfc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dhcp-common-4.4.2-15.b1.el9.noarch.rpm"
@@ -2894,9 +2713,6 @@
           "sha256:7fdae4fbdd8791238524e520fb23cb9bae35abb3e2052808f92adb062f08c903": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/kernel-5.14.0-55.el9.x86_64.rpm"
           },
-          "sha256:80144445a23c730b953deba3cd07e35d9bc7fdc41caa0c2fb80dfef751fb87b8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/nss-softokn-freebl-3.71.0-6.el9.x86_64.rpm"
-          },
           "sha256:803d0eccbf7c03c389d82ff35b392c0442c3d9712bd76d75c6504a374066cfa1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/coreutils-8.32-31.el9.x86_64.rpm"
           },
@@ -2920,12 +2736,6 @@
           },
           "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm"
-          },
-          "sha256:8743d4eab6e262efbe770232eb34c3fb5f0c304531b97cc95442ed6c7c8e2909": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-loop-2.25-11.el9.x86_64.rpm"
-          },
-          "sha256:887b23796b57b9e476f916c32b27d446a4db40957b92940519162ea7ba1689cc": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-mdraid-2.25-11.el9.x86_64.rpm"
           },
           "sha256:88f1d788f4e3324e450831e01e2d319b8336b0f4f9dcc297c9fd17560cbfe74f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/langpacks-core-en-3.0-16.el9.noarch.rpm"
@@ -3047,9 +2857,6 @@
           "sha256:9dc719992c6b385ce2c5d3ef35ecb5a0b5aae29ea99fa164f97aa2acb4346a02": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dbus-common-1.12.20-5.el9.noarch.rpm"
           },
-          "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm"
-          },
           "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-linux-procfs-0.7.0-1.el9.noarch.rpm"
           },
@@ -3064,9 +2871,6 @@
           },
           "sha256:9f640485eb1df3b8d8759b3051bb1651b264fd0ca139b90c85ad919e365b0f22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/json-glib-1.6.6-1.el9.x86_64.rpm"
-          },
-          "sha256:9fd5fe7855c4586366cc8f8eef57bd6ff15aff469a817ac77ec8d3be89783c68": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-swap-2.25-11.el9.x86_64.rpm"
           },
           "sha256:9fd692ccfb841bafb0b1c594c0fb7295796facc6d73b7f44ccca868facb799b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/kernel-tools-libs-5.14.0-55.el9.x86_64.rpm"
@@ -3107,14 +2911,8 @@
           "sha256:a7968c8561828e1c853061980f2b7430d8910d33b350e44525902ded8b663054": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/glibc-langpack-en-2.34-21.el9.x86_64.rpm"
           },
-          "sha256:a7cc761f2e5a06b5858d412e9a03e2d7778158d2f27099c4e5d2050d15103970": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-2.25-11.el9.x86_64.rpm"
-          },
           "sha256:a891d5fb2fcfab640f66d16eb802eebf8ea9dcc5f14048937c52e3fb812032b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libfastjson-0.99.9-3.el9.x86_64.rpm"
-          },
-          "sha256:a938f2428e2cc5f843f9abdfdf6fced58ba8dea2cea9df6d4be444389d4eeeff": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/nss-sysinit-3.71.0-6.el9.x86_64.rpm"
           },
           "sha256:a9f4c2f707dea5753aa09bc3143c305799670fc65b72d11b9b59017d17ee8fb3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/xz-5.2.5-7.el9.x86_64.rpm"
@@ -3161,17 +2959,11 @@
           "sha256:b186969760f3a5eae1c1dea7096bcfb7539605039c9a10780945cd89505b3cd0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/polkit-0.117-8.el9.x86_64.rpm"
           },
-          "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/shim-x64-15-16.el8.x86_64.rpm"
-          },
           "sha256:b261ae0b9f219792473feeccecc515794e3602c8298f81cb8f492944b7aade03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libcurl-7.76.1-14.el9.x86_64.rpm"
           },
           "sha256:b584cded28ef42ffc789a63f71575aa57f4cd69d69adb6f7d1e34e041ce8dca0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libsss_certmap-2.6.2-2.el9.x86_64.rpm"
-          },
-          "sha256:b64133227dca092ba89a703ba539e422299fc04a8663ab862240a433f116e5e9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/mokutil-0.4.0-8.el9.x86_64.rpm"
           },
           "sha256:b7fe377d0cb75a9592f0f2381e8419c645d9158032b71a809b77e0c42d7c7cc8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/openssh-server-8.7p1-6.el9.x86_64.rpm"
@@ -3203,17 +2995,11 @@
           "sha256:bd6a3956f8d84430d1e03ee2a4cf18629a3846ac4341cd49771a6f89271bdf78": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libblkid-2.37.2-1.el9.x86_64.rpm"
           },
-          "sha256:bdd2d4f06e8d776cd01733cc946e32a492653044efa957c073be384d020de1f4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/nss-softokn-3.71.0-6.el9.x86_64.rpm"
-          },
           "sha256:be2638ef29334bc7b00f517b4327a97a14a853d56e5c09a9147e903580089b66": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/crypto-policies-20220203-1.gitf03e75e.el9.noarch.rpm"
           },
           "sha256:beeab77bbdd6adcb6816807f69e908110cd7002b0e3e99e4a47869d2f7727713": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/insights-client-3.1.7-1.el9.noarch.rpm"
-          },
-          "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/flashrom-1.2-10.el9.x86_64.rpm"
           },
           "sha256:bf3baf444e49eba4189e57d562a7522ab714132d2960db87ef9b99f1b46a3cc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sed-4.8-9.el9.x86_64.rpm"
@@ -3226,9 +3012,6 @@
           },
           "sha256:c432790f9b6cf33ef8c6e3618b209e8922b409de79f0519cc9679b1ad6cb20ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libini_config-1.3.1-51.el9.x86_64.rpm"
-          },
-          "sha256:c44be051ee349ab2fb432004b5fef2023b3aecc456997123fa381710bff848a4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/fwupd-plugin-flashrom-1.5.9-3.el9.x86_64.rpm"
           },
           "sha256:c491f49444112b0ceaaeac310a646a85a78e041cbf110c7cb465bd5783274160": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/kbd-2.4.0-8.el9.x86_64.rpm"
@@ -3284,9 +3067,6 @@
           "sha256:cf756251450efcb49efd925527a3843217f9076ea8392f2f22b63bba56eba2d1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/e2fsprogs-1.46.5-2.el9.x86_64.rpm"
           },
-          "sha256:cf943b1956ec13cc3accbe6165578b8b216e7b53410fd89c86a129fee7e0295a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/nss-util-3.71.0-6.el9.x86_64.rpm"
-          },
           "sha256:cf9c271c85d461922948f52a3e89b53448d924d33e94b13daf5d9324f0342dd7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-gpg-1.15.1-5.el9.x86_64.rpm"
           },
@@ -3319,9 +3099,6 @@
           },
           "sha256:d763e4d9e98fd3aac3db1828ed0de1f4b5ff46c939a207597db05fe60af52832": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/cloud-utils-growpart-0.31-10.el9.x86_64.rpm"
-          },
-          "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm"
           },
           "sha256:d9b53fda4b8757fd63b53a415f533ab876c18c28a94fd21d10658de85978f254": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/cpio-2.13-16.el9.x86_64.rpm"
@@ -3358,9 +3135,6 @@
           },
           "sha256:dfbb0c4f2c524b731e2c2ed7d352541183667ad7981fb01de6474c6be5e52951": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libzstd-1.5.0-2.el9.x86_64.rpm"
-          },
-          "sha256:dffac89417d819b7c2a65d116d45c2a2c12c9385553a48fa3336dfe92d30e9de": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-utils-2.25-11.el9.x86_64.rpm"
           },
           "sha256:e0882a2ed0dfd34af53563bb3d578893c5ec630bb3110df4613db3d84b6f0e17": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/grubby-8.40-54.el9.x86_64.rpm"
@@ -3421,9 +3195,6 @@
           },
           "sha256:ec8a0fdd3d75a859347cbe48200fea16ed1642874c48bdeefa3f83b2c0890693": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/rsync-3.2.3-9.el9.x86_64.rpm"
-          },
-          "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libbytesize-2.5-3.el9.x86_64.rpm"
           },
           "sha256:ed36145fea237f5666bffe6547178740a16c592f48432ef86756a15e2d0a5e04": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sssd-kcm-2.6.2-2.el9.x86_64.rpm"
@@ -3505,9 +3276,6 @@
           },
           "sha256:f84294afdeaddb4f44243b80e3b32cf65a5aff76e5b7528f4810657c90559181": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/NetworkManager-team-1.36.0-0.7.el9.x86_64.rpm"
-          },
-          "sha256:f91b3de89d9598092e093d262e35c4d7ac0ec9b2f8d3c5ea0cbdd620c47664d6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efivar-libs-37-17.el9.x86_64.rpm"
           },
           "sha256:fa3abe9c3196c58b2a2943bd759eb30542962d3464970ce4171627e741160f28": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-oauthlib-3.1.1-2.el9.noarch.rpm"
@@ -5096,15 +4864,6 @@
         "checksum": "sha256:f835cc738fa003147087d68427c407e17c08587156ae961d641b2dfcee1fe7af"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.1",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
-        "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
-      },
-      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -5465,33 +5224,6 @@
         "checksum": "sha256:07a6ff3d4ef4f04c7dc7f006a68795e030057745d10ea2a251e724e1d726e49b"
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "4",
-        "release": "9.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efi-filesystem-4-9.el9.noarch.rpm",
-        "checksum": "sha256:0e5a1e3e42ff063ac8914f58d1c0e21dcd1ecf36840916c5d4e78838b49b5c2f"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "12.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efibootmgr-16-12.el9.x86_64.rpm",
-        "checksum": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "17.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efivar-libs-37-17.el9.x86_64.rpm",
-        "checksum": "sha256:f91b3de89d9598092e093d262e35c4d7ac0ec9b2f8d3c5ea0cbdd620c47664d6"
-      },
-      {
         "name": "elfutils-default-yama-scope",
         "epoch": 0,
         "version": "0.186",
@@ -5589,15 +5321,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm",
         "checksum": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.5.9",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fwupd-1.5.9-3.el9.x86_64.rpm",
-        "checksum": "sha256:598ab332a213d929861baaec1eb4fdd110a495e6ecee182a0726b6d11f2acc76"
       },
       {
         "name": "gawk",
@@ -5751,15 +5474,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/grub2-common-2.06-16.el9.noarch.rpm",
         "checksum": "sha256:f2b7c3a5c800e3c670c6943672a9fc323c507ab12ade4dc9b7c956572966fc29"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "16.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/grub2-efi-x64-2.06-16.el9.x86_64.rpm",
-        "checksum": "sha256:51734fbc7cc766ec9fd8ce87f29edc5db13e2135d6bd38d09b8376daf1f94fc7"
       },
       {
         "name": "grub2-pc",
@@ -6302,15 +6016,6 @@
         "checksum": "sha256:8a57200f0c0b94cb84751b35fa70b111c264186937ca9bda93448dac1a5166d6"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgcab1-1.4-6.el9.x86_64.rpm",
-        "checksum": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.2.1",
@@ -6347,24 +6052,6 @@
         "checksum": "sha256:8248e20d7a253aa9c0dc7dc3d56b42e1def4fd5753ce8e8b9e980aa664fc9068"
       },
       {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "237",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgudev-237-1.el9.x86_64.rpm",
-        "checksum": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.8",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgusb-0.3.8-1.el9.x86_64.rpm",
-        "checksum": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39"
-      },
-      {
         "name": "libibverbs",
         "epoch": 0,
         "version": "37.2",
@@ -6390,15 +6077,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libini_config-1.3.1-51.el9.x86_64.rpm",
         "checksum": "sha256:c432790f9b6cf33ef8c6e3618b209e8922b409de79f0519cc9679b1ad6cb20ed"
-      },
-      {
-        "name": "libjcat",
-        "epoch": 0,
-        "version": "0.1.6",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libjcat-0.1.6-3.el9.x86_64.rpm",
-        "checksum": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf"
       },
       {
         "name": "libkcapi",
@@ -6662,15 +6340,6 @@
         "checksum": "sha256:d9f2166d5f2f5ecad7c49fc2f6bf49d6014b0df0a266b3ee6522959eeb13ed3f"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.3",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm",
-        "checksum": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -6815,15 +6484,6 @@
         "checksum": "sha256:6477fb3c3285158f676360e228057e13dc6e983f453c7c74ed4ab140357f9a0d"
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libusbx-1.0.24-4.el9.x86_64.rpm",
-        "checksum": "sha256:147e281881105acfb8aa184a1d59faff4e3c1249205a86abb900b8d7a02cacbe"
-      },
-      {
         "name": "libuser",
         "epoch": 0,
         "version": "0.63",
@@ -6876,15 +6536,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxml2-2.9.12-4.el9.x86_64.rpm",
         "checksum": "sha256:bc0f73fb262df04514d6ce8f4d970adefc7385be519e759c9d61bf7f715cc6e1"
-      },
-      {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.3.3",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm",
-        "checksum": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3"
       },
       {
         "name": "libyaml",
@@ -6995,15 +6646,6 @@
         "checksum": "sha256:6440c783cf8872f6d948164f24eedc54935130a4e095a933ba910cd799419cd4"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/mdadm-4.2-1.el9.x86_64.rpm",
-        "checksum": "sha256:20a46ac392014c17b6c2192a87d419189a2632830554d436f2895d15269c6f98"
-      },
-      {
         "name": "microcode_ctl",
         "epoch": 4,
         "version": "20210608",
@@ -7011,15 +6653,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/microcode_ctl-20210608-2.el9.noarch.rpm",
         "checksum": "sha256:57b689e668acf407ed7542fbedcd29529fff28b3ace62cbff7659f9a42d8e1dd"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 2,
-        "version": "0.4.0",
-        "release": "8.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/mokutil-0.4.0-8.el9.x86_64.rpm",
-        "checksum": "sha256:b64133227dca092ba89a703ba539e422299fc04a8663ab862240a433f116e5e9"
       },
       {
         "name": "mpfr",
@@ -7814,24 +7447,6 @@
         "checksum": "sha256:9624fc9a5d5b4b0229d8d6f2505992142b6ba236fe02610214419e6e3ff9f273"
       },
       {
-        "name": "shared-mime-info",
-        "epoch": 0,
-        "version": "2.1",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/shared-mime-info-2.1-4.el9.x86_64.rpm",
-        "checksum": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a"
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15",
-        "release": "16.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/shim-x64-15-16.el8.x86_64.rpm",
-        "checksum": "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -8183,24 +7798,6 @@
         "checksum": "sha256:d763e4d9e98fd3aac3db1828ed0de1f4b5ff46c939a207597db05fe60af52832"
       },
       {
-        "name": "flashrom",
-        "epoch": 0,
-        "version": "1.2",
-        "release": "10.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/flashrom-1.2-10.el9.x86_64.rpm",
-        "checksum": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56"
-      },
-      {
-        "name": "fwupd-plugin-flashrom",
-        "epoch": 0,
-        "version": "1.5.9",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/fwupd-plugin-flashrom-1.5.9-3.el9.x86_64.rpm",
-        "checksum": "sha256:c44be051ee349ab2fb432004b5fef2023b3aecc456997123fa381710bff848a4"
-      },
-      {
         "name": "gawk-all-langpacks",
         "epoch": 0,
         "version": "5.1.0",
@@ -8273,96 +7870,6 @@
         "checksum": "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "22.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libatasmart-0.19-22.el9.x86_64.rpm",
-        "checksum": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:a7cc761f2e5a06b5858d412e9a03e2d7778158d2f27099c4e5d2050d15103970"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-crypto-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:564b8d00d26b50ae57423aa5be39aa525bbd71d50600e2618ea75e2295f6f2e8"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-fs-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:61e3b32b1509c44dcddeedb0b1a8b6b0c6bbd343affa3ef229127d05d32913ab"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-loop-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:8743d4eab6e262efbe770232eb34c3fb5f0c304531b97cc95442ed6c7c8e2909"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-mdraid-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:887b23796b57b9e476f916c32b27d446a4db40957b92940519162ea7ba1689cc"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-part-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:68642d32e38d1bb4e847911c8fc41a78a23e74823a7282e94cf9e3abc5c169ab"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-swap-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:9fd5fe7855c4586366cc8f8eef57bd6ff15aff469a817ac77ec8d3be89783c68"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-utils-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:dffac89417d819b7c2a65d116d45c2a2c12c9385553a48fa3336dfe92d30e9de"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "2.5",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libbytesize-2.5-3.el9.x86_64.rpm",
-        "checksum": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.11",
@@ -8390,15 +7897,6 @@
         "checksum": "sha256:476b59e484e2c1654d26693a74eef5c2e9655089347c9d12609b1474863baff9"
       },
       {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libudisks2-2.9.4-2.el9.x86_64.rpm",
-        "checksum": "sha256:1a91c11ac1b40db298284bdc320a07f66e5e3db1cb22818c28f72d5227411f2a"
-      },
-      {
         "name": "libxcrypt-compat",
         "epoch": 0,
         "version": "4.4.18",
@@ -8415,60 +7913,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/memstrack-0.2.3-2.el9.x86_64.rpm",
         "checksum": "sha256:9b003e9aea7c1c6ea17ae1309da24cd3fbfe15b0a75512e0e90dbb1e660fa20e"
-      },
-      {
-        "name": "nspr",
-        "epoch": 0,
-        "version": "4.32.0",
-        "release": "8.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/nspr-4.32.0-8.el9.x86_64.rpm",
-        "checksum": "sha256:6eaa30c581a2ceb81d8a60c30263bf525f73e1f3be5e3185bf5e4d4ceed31ebb"
-      },
-      {
-        "name": "nss",
-        "epoch": 0,
-        "version": "3.71.0",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/nss-3.71.0-6.el9.x86_64.rpm",
-        "checksum": "sha256:73f108442e63d22895b169eedacb091c2e9c99bd9c5d6b3dc93d685f3939d7b9"
-      },
-      {
-        "name": "nss-softokn",
-        "epoch": 0,
-        "version": "3.71.0",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/nss-softokn-3.71.0-6.el9.x86_64.rpm",
-        "checksum": "sha256:bdd2d4f06e8d776cd01733cc946e32a492653044efa957c073be384d020de1f4"
-      },
-      {
-        "name": "nss-softokn-freebl",
-        "epoch": 0,
-        "version": "3.71.0",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/nss-softokn-freebl-3.71.0-6.el9.x86_64.rpm",
-        "checksum": "sha256:80144445a23c730b953deba3cd07e35d9bc7fdc41caa0c2fb80dfef751fb87b8"
-      },
-      {
-        "name": "nss-sysinit",
-        "epoch": 0,
-        "version": "3.71.0",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/nss-sysinit-3.71.0-6.el9.x86_64.rpm",
-        "checksum": "sha256:a938f2428e2cc5f843f9abdfdf6fced58ba8dea2cea9df6d4be444389d4eeeff"
-      },
-      {
-        "name": "nss-util",
-        "epoch": 0,
-        "version": "3.71.0",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/nss-util-3.71.0-6.el9.x86_64.rpm",
-        "checksum": "sha256:cf943b1956ec13cc3accbe6165578b8b216e7b53410fd89c86a129fee7e0295a"
       },
       {
         "name": "oddjob",
@@ -8685,24 +8129,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/rsyslog-logrotate-8.2102.0-101.el9.x86_64.rpm",
         "checksum": "sha256:fb3d2020dca3f3674da8d25c5acdac1c9eee7acbc933acc720b39e92266265a7"
-      },
-      {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/udisks2-2.9.4-2.el9.x86_64.rpm",
-        "checksum": "sha256:4361d66a963fe8c62bd1a4e887a06fbe937faa70a7ac704a127021937b2e1b69"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.12",
-        "release": "15.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
-        "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c"
       },
       {
         "name": "rh-amazon-rhui-client",

--- a/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
@@ -612,9 +612,6 @@
                     "id": "sha256:f835cc738fa003147087d68427c407e17c08587156ae961d641b2dfcee1fe7af"
                   },
                   {
-                    "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
-                  },
-                  {
                     "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886"
                   },
                   {
@@ -759,15 +756,6 @@
                     "id": "sha256:07a6ff3d4ef4f04c7dc7f006a68795e030057745d10ea2a251e724e1d726e49b"
                   },
                   {
-                    "id": "sha256:0e5a1e3e42ff063ac8914f58d1c0e21dcd1ecf36840916c5d4e78838b49b5c2f"
-                  },
-                  {
-                    "id": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a"
-                  },
-                  {
-                    "id": "sha256:f91b3de89d9598092e093d262e35c4d7ac0ec9b2f8d3c5ea0cbdd620c47664d6"
-                  },
-                  {
                     "id": "sha256:7493224a1482e44507df3a479b7664a8776b9506a288b6f53a3713bf4298f1b2"
                   },
                   {
@@ -799,9 +787,6 @@
                   },
                   {
                     "id": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee"
-                  },
-                  {
-                    "id": "sha256:598ab332a213d929861baaec1eb4fdd110a495e6ecee182a0726b6d11f2acc76"
                   },
                   {
                     "id": "sha256:ad90074a6bbde7976ef7dff3fac045b74281a8118e7d7714f5b1b9086a12d182"
@@ -853,9 +838,6 @@
                   },
                   {
                     "id": "sha256:f2b7c3a5c800e3c670c6943672a9fc323c507ab12ade4dc9b7c956572966fc29"
-                  },
-                  {
-                    "id": "sha256:51734fbc7cc766ec9fd8ce87f29edc5db13e2135d6bd38d09b8376daf1f94fc7"
                   },
                   {
                     "id": "sha256:82c5216384a8882635744aaf883f2dd36e7f60cae0bb675beaa3728e7aa796d8"
@@ -1053,9 +1035,6 @@
                     "id": "sha256:8a57200f0c0b94cb84751b35fa70b111c264186937ca9bda93448dac1a5166d6"
                   },
                   {
-                    "id": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5"
-                  },
-                  {
                     "id": "sha256:632b52c724d66439336804d332c1d497025889de660ef6c31e77f331ade8d2b8"
                   },
                   {
@@ -1068,12 +1047,6 @@
                     "id": "sha256:8248e20d7a253aa9c0dc7dc3d56b42e1def4fd5753ce8e8b9e980aa664fc9068"
                   },
                   {
-                    "id": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671"
-                  },
-                  {
-                    "id": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39"
-                  },
-                  {
                     "id": "sha256:038fa32c8fbbc1278525a7e91c9645597f09bca2ab83ffd4aeff58bbfc396036"
                   },
                   {
@@ -1084,9 +1057,6 @@
                   },
                   {
                     "id": "sha256:c432790f9b6cf33ef8c6e3618b209e8922b409de79f0519cc9679b1ad6cb20ed"
-                  },
-                  {
-                    "id": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf"
                   },
                   {
                     "id": "sha256:3a4b2718744919d0e09981523d00527051b3eabd8c18bc55cb14181a00e307d6"
@@ -1182,9 +1152,6 @@
                     "id": "sha256:d9f2166d5f2f5ecad7c49fc2f6bf49d6014b0df0a266b3ee6522959eeb13ed3f"
                   },
                   {
-                    "id": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3"
-                  },
-                  {
                     "id": "sha256:f1afff374ac49b11d0d48bfee8e8ec59a329aba00a19630b09e4dc078e06859c"
                   },
                   {
@@ -1236,9 +1203,6 @@
                     "id": "sha256:6477fb3c3285158f676360e228057e13dc6e983f453c7c74ed4ab140357f9a0d"
                   },
                   {
-                    "id": "sha256:147e281881105acfb8aa184a1d59faff4e3c1249205a86abb900b8d7a02cacbe"
-                  },
-                  {
                     "id": "sha256:2358982717e4c6df5e0dfc4ad906dade4ecf051cb7612b1aa087ab6c03f36da2"
                   },
                   {
@@ -1261,9 +1225,6 @@
                   },
                   {
                     "id": "sha256:bc0f73fb262df04514d6ce8f4d970adefc7385be519e759c9d61bf7f715cc6e1"
-                  },
-                  {
-                    "id": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3"
                   },
                   {
                     "id": "sha256:409beeb1faf626a882e95763ec4892d514077289e6074d3b61bef1b90739ad66"
@@ -1308,13 +1269,7 @@
                     "id": "sha256:6440c783cf8872f6d948164f24eedc54935130a4e095a933ba910cd799419cd4"
                   },
                   {
-                    "id": "sha256:20a46ac392014c17b6c2192a87d419189a2632830554d436f2895d15269c6f98"
-                  },
-                  {
                     "id": "sha256:57b689e668acf407ed7542fbedcd29529fff28b3ace62cbff7659f9a42d8e1dd"
-                  },
-                  {
-                    "id": "sha256:b64133227dca092ba89a703ba539e422299fc04a8663ab862240a433f116e5e9"
                   },
                   {
                     "id": "sha256:cf60adcc7a5f0cb469e6f066a1bdc62ae9af7c06305c76c15884b59df7f93274"
@@ -1617,12 +1572,6 @@
                     "id": "sha256:9624fc9a5d5b4b0229d8d6f2505992142b6ba236fe02610214419e6e3ff9f273"
                   },
                   {
-                    "id": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a"
-                  },
-                  {
-                    "id": "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021"
-                  },
-                  {
                     "id": "sha256:4b7c4822f92e7ba97b78893d273b01161e411151ccc627b076d13719ad404a69"
                   },
                   {
@@ -1749,12 +1698,6 @@
                     "id": "sha256:aabddb8a2231c0c296a00c15a9a0b0b7037264004a7e80632fa098f9462b4755"
                   },
                   {
-                    "id": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56"
-                  },
-                  {
-                    "id": "sha256:c44be051ee349ab2fb432004b5fef2023b3aecc456997123fa381710bff848a4"
-                  },
-                  {
                     "id": "sha256:34384ca5d51125d92a02a1f20e8a68aa8e17314eb0ecf4dec64594ac61e4fee7"
                   },
                   {
@@ -1788,36 +1731,6 @@
                     "id": "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a"
                   },
                   {
-                    "id": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a"
-                  },
-                  {
-                    "id": "sha256:a7cc761f2e5a06b5858d412e9a03e2d7778158d2f27099c4e5d2050d15103970"
-                  },
-                  {
-                    "id": "sha256:564b8d00d26b50ae57423aa5be39aa525bbd71d50600e2618ea75e2295f6f2e8"
-                  },
-                  {
-                    "id": "sha256:61e3b32b1509c44dcddeedb0b1a8b6b0c6bbd343affa3ef229127d05d32913ab"
-                  },
-                  {
-                    "id": "sha256:8743d4eab6e262efbe770232eb34c3fb5f0c304531b97cc95442ed6c7c8e2909"
-                  },
-                  {
-                    "id": "sha256:887b23796b57b9e476f916c32b27d446a4db40957b92940519162ea7ba1689cc"
-                  },
-                  {
-                    "id": "sha256:68642d32e38d1bb4e847911c8fc41a78a23e74823a7282e94cf9e3abc5c169ab"
-                  },
-                  {
-                    "id": "sha256:9fd5fe7855c4586366cc8f8eef57bd6ff15aff469a817ac77ec8d3be89783c68"
-                  },
-                  {
-                    "id": "sha256:dffac89417d819b7c2a65d116d45c2a2c12c9385553a48fa3336dfe92d30e9de"
-                  },
-                  {
-                    "id": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974"
-                  },
-                  {
                     "id": "sha256:63cf867f399e02846f7b4766d60dc4d2aaba9c7256136e429cb040741d054d2d"
                   },
                   {
@@ -1828,9 +1741,6 @@
                   },
                   {
                     "id": "sha256:d9a85c17d7d52bba7fd5e09560f4d50727419b4650059c0d8ef68f0d10250eb3"
-                  },
-                  {
-                    "id": "sha256:1a91c11ac1b40db298284bdc320a07f66e5e3db1cb22818c28f72d5227411f2a"
                   },
                   {
                     "id": "sha256:fed835e5c0ee24a232c5db813312569e1a65b2d74c277322d372ef7ccb92691c"
@@ -2172,13 +2082,7 @@
                     "id": "sha256:395eafb58304cec0d88c4e2de4ceaa954eac756c441783e7a46df6d88f049bcd"
                   },
                   {
-                    "id": "sha256:4361d66a963fe8c62bd1a4e887a06fbe937faa70a7ac704a127021937b2e1b69"
-                  },
-                  {
                     "id": "sha256:09f623d0c7e31598fb6e8a91432d644cb32b4c98d519466898633ef356edeb89"
-                  },
-                  {
-                    "id": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c"
                   },
                   {
                     "id": "sha256:deeb29c26fd9ccfa0bbd521bd92fd85f8f691bc8a948604721fa555e3269fc2f"
@@ -2582,10 +2486,6 @@
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat",
-                "unified": true
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-55.el9.x86_64",
               "write_cmdline": false,
               "config": {
@@ -2941,9 +2841,6 @@
           "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-AutoLoader-5.74-479.el9.noarch.rpm"
           },
-          "sha256:0e5a1e3e42ff063ac8914f58d1c0e21dcd1ecf36840916c5d4e78838b49b5c2f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efi-filesystem-4-9.el9.noarch.rpm"
-          },
           "sha256:0f1df5e0d48c2ac9914bfffa7ed569cd58e42b17ba96bb3f7cf74d1e80de2597": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libutempter-1.2.1-6.el9.x86_64.rpm"
           },
@@ -2970,9 +2867,6 @@
           },
           "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm"
-          },
-          "sha256:147e281881105acfb8aa184a1d59faff4e3c1249205a86abb900b8d7a02cacbe": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libusbx-1.0.24-4.el9.x86_64.rpm"
           },
           "sha256:14b7ff2f7fdaf8ebec90261f4619ea7f7c3564c4de8483666de7ed4b1f49b66f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libpwquality-1.4.4-8.el9.x86_64.rpm"
@@ -3013,9 +2907,6 @@
           "sha256:1a17cbe0a1a6667c8bb1e1bb954e5b5ed03879164325f0aa585de85816b5da3f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-pyserial-3.4-12.el9.noarch.rpm"
           },
-          "sha256:1a91c11ac1b40db298284bdc320a07f66e5e3db1cb22818c28f72d5227411f2a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libudisks2-2.9.4-2.el9.x86_64.rpm"
-          },
           "sha256:1aa1d059f7696ae397f8746d8d4fe5ead73bac461f53cce01b92db73fbd2fa81": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/findutils-4.8.0-5.el9.x86_64.rpm"
           },
@@ -3048,9 +2939,6 @@
           },
           "sha256:1fceec46d38218eb98bd45ffa8e917128f3ae2daa198ede53e5755f99d2e759f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-TimeDate-2.33-6.el9.noarch.rpm"
-          },
-          "sha256:20a46ac392014c17b6c2192a87d419189a2632830554d436f2895d15269c6f98": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/mdadm-4.2-1.el9.x86_64.rpm"
           },
           "sha256:20a5a375bd1a12950ba6ca5e4ca9f6af11020214da304317070803be37afd27c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libaio-0.3.111-13.el9.x86_64.rpm"
@@ -3148,9 +3036,6 @@
           "sha256:2d98292bdf2bda73ac4b78790b54c65f594cc179775c2775f4aad5dc61a5aa24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sssd-common-2.6.2-2.el9.x86_64.rpm"
           },
-          "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgudev-237-1.el9.x86_64.rpm"
-          },
           "sha256:306598e27506441423f1c6791336862fe8473e281e8a0d5f8fa6c71f01d3ef87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.0-20220208/Packages/fence-agents-ilo-ssh-4.10.0-16.el9.noarch.rpm"
           },
@@ -3171,9 +3056,6 @@
           },
           "sha256:322f097dfadd422fed3aac722b0b90b95f5116aba3dda913d0630e4914cbb222": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.0-20220208/Packages/libknet1-compress-lz4-plugin-1.22-3.el9.x86_64.rpm"
-          },
-          "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm"
           },
           "sha256:327d4a02d0c817f98ae9a89be474e4a6eaf3182a3635d6b8bfad1c96df8a547f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.0-20220208/Packages/fence-agents-brocade-4.10.0-16.el9.noarch.rpm"
@@ -3301,14 +3183,8 @@
           "sha256:435c54623ddcbb6d38d20e22b7964ad6bb627a88a2762120feeb98bbbadba1d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libeconf-0.4.1-2.el9.x86_64.rpm"
           },
-          "sha256:4361d66a963fe8c62bd1a4e887a06fbe937faa70a7ac704a127021937b2e1b69": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/udisks2-2.9.4-2.el9.x86_64.rpm"
-          },
           "sha256:43d40891623256b30a7d08d8db21a3d94d94756ecade355845e52c64f5af7765": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libevent-2.1.12-6.el9.x86_64.rpm"
-          },
-          "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/shared-mime-info-2.1-4.el9.x86_64.rpm"
           },
           "sha256:44d73e10c58816ff1a215c6b5cefa4a24237892ec4bcd47e2d7d5bb84fa16619": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nettle-3.7.3-2.el9.x86_64.rpm"
@@ -3406,17 +3282,11 @@
           "sha256:4f6741962c5b9346e5daf41795407976e8f22c42d64066c239e482556abba9cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-dnf-4.10.0-3.el9.noarch.rpm"
           },
-          "sha256:51734fbc7cc766ec9fd8ce87f29edc5db13e2135d6bd38d09b8376daf1f94fc7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/grub2-efi-x64-2.06-16.el9.x86_64.rpm"
-          },
           "sha256:5196f5f7d2387e9dcdf504c8534e3109cc84f7545240b6fbd18866217653b4fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-055-10.git20210824.el9.x86_64.rpm"
           },
           "sha256:51d508ed30f9b74fbef756f2be64cca597de9e797b6f5f00f70e4ec88a7c4d3a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.x86_64.rpm"
-          },
-          "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm"
           },
           "sha256:5246e2b08f6c120e3c2fc418c18fcd1db17c9fdc53fe51cd763fabfbe5b6c4fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/pkgconf-pkg-config-1.7.3-9.el9.x86_64.rpm"
@@ -3451,9 +3321,6 @@
           "sha256:55e0798cd68a4f267034621927e949583a38c39c8c28120adc2b14c6e38d4553": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/net-snmp-utils-5.9.1-7.el9.x86_64.rpm"
           },
-          "sha256:564b8d00d26b50ae57423aa5be39aa525bbd71d50600e2618ea75e2295f6f2e8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-crypto-2.25-11.el9.x86_64.rpm"
-          },
           "sha256:56cae8514b05150c9b73c624affbf563a0a923abe07472f2ee19b8007ade875f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/rubygem-bigdecimal-3.0.0-155.el9.x86_64.rpm"
           },
@@ -3466,9 +3333,6 @@
           "sha256:57f832788769a0bab197c09e1c5720f571b06e8952c485ed721b9875ae7ad27d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libnl3-cli-3.5.0-10.el9.x86_64.rpm"
           },
-          "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
-          },
           "sha256:588411c7135c1b78c55f17328e1ff29bbcc9f64dc2dbedac656b0f9ca6788d66": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/rpm-sign-libs-4.16.1.3-10.el9.x86_64.rpm"
           },
@@ -3477,12 +3341,6 @@
           },
           "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm"
-          },
-          "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libjcat-0.1.6-3.el9.x86_64.rpm"
-          },
-          "sha256:598ab332a213d929861baaec1eb4fdd110a495e6ecee182a0726b6d11f2acc76": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fwupd-1.5.9-3.el9.x86_64.rpm"
           },
           "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm"
@@ -3523,9 +3381,6 @@
           "sha256:60f5722840b615527ad31ee363279327ba2415699d0855042e54b05a54f5b6ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libselinux-utils-3.3-2.el9.x86_64.rpm"
           },
-          "sha256:61e3b32b1509c44dcddeedb0b1a8b6b0c6bbd343affa3ef229127d05d32913ab": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-fs-2.25-11.el9.x86_64.rpm"
-          },
           "sha256:62e71529d30a23056ce1c38ca40c517ab425c864b681b135b275204fdd479ae7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iputils-20210202-7.el9.x86_64.rpm"
           },
@@ -3546,9 +3401,6 @@
           },
           "sha256:64503745cf21983eb7633431d432c28102baca09db9584cd221a924c42845ed6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pyparsing-2.4.7-7.1.el9.noarch.rpm"
-          },
-          "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgusb-0.3.8-1.el9.x86_64.rpm"
           },
           "sha256:6477fb3c3285158f676360e228057e13dc6e983f453c7c74ed4ab140357f9a0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libunistring-0.9.10-15.el9.x86_64.rpm"
@@ -3573,9 +3425,6 @@
           },
           "sha256:67d24d8ec5984645dfa9ff35a359693b2ed4079030d2f776702912684b6847da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/parted-3.4-6.el9.x86_64.rpm"
-          },
-          "sha256:68642d32e38d1bb4e847911c8fc41a78a23e74823a7282e94cf9e3abc5c169ab": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-part-2.25-11.el9.x86_64.rpm"
           },
           "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm"
@@ -3609,9 +3458,6 @@
           },
           "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm"
-          },
-          "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efibootmgr-16-12.el9.x86_64.rpm"
           },
           "sha256:6e7ff4ef538a85596df359947fa5069052a532dd1ce8c2eeedd1557639c08ec1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sssd-client-2.6.2-2.el9.x86_64.rpm"
@@ -3678,9 +3524,6 @@
           },
           "sha256:7493224a1482e44507df3a479b7664a8776b9506a288b6f53a3713bf4298f1b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/elfutils-default-yama-scope-0.186-1.el9.noarch.rpm"
-          },
-          "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libatasmart-0.19-22.el9.x86_64.rpm"
           },
           "sha256:762751146305f9aea53b74a21495a610e7bdde956fa3246565d265b1128b56a8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-Socket-2.031-4.el9.x86_64.rpm"
@@ -3795,12 +3638,6 @@
           },
           "sha256:8738d8b17ac67e68128b4c2f47178d717341403f896777e2ae410756077ca6f6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.0-20220208/Packages/fence-agents-amt-ws-4.10.0-16.el9.noarch.rpm"
-          },
-          "sha256:8743d4eab6e262efbe770232eb34c3fb5f0c304531b97cc95442ed6c7c8e2909": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-loop-2.25-11.el9.x86_64.rpm"
-          },
-          "sha256:887b23796b57b9e476f916c32b27d446a4db40957b92940519162ea7ba1689cc": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-mdraid-2.25-11.el9.x86_64.rpm"
           },
           "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-Exporter-5.74-461.el9.noarch.rpm"
@@ -3958,9 +3795,6 @@
           "sha256:9dc719992c6b385ce2c5d3ef35ecb5a0b5aae29ea99fa164f97aa2acb4346a02": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dbus-common-1.12.20-5.el9.noarch.rpm"
           },
-          "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm"
-          },
           "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-linux-procfs-0.7.0-1.el9.noarch.rpm"
           },
@@ -3975,9 +3809,6 @@
           },
           "sha256:9f640485eb1df3b8d8759b3051bb1651b264fd0ca139b90c85ad919e365b0f22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/json-glib-1.6.6-1.el9.x86_64.rpm"
-          },
-          "sha256:9fd5fe7855c4586366cc8f8eef57bd6ff15aff469a817ac77ec8d3be89783c68": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-swap-2.25-11.el9.x86_64.rpm"
           },
           "sha256:9fd692ccfb841bafb0b1c594c0fb7295796facc6d73b7f44ccca868facb799b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/kernel-tools-libs-5.14.0-55.el9.x86_64.rpm"
@@ -4023,9 +3854,6 @@
           },
           "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-overload-1.31-479.el9.noarch.rpm"
-          },
-          "sha256:a7cc761f2e5a06b5858d412e9a03e2d7778158d2f27099c4e5d2050d15103970": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-2.25-11.el9.x86_64.rpm"
           },
           "sha256:a891d5fb2fcfab640f66d16eb802eebf8ea9dcc5f14048937c52e3fb812032b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libfastjson-0.99.9-3.el9.x86_64.rpm"
@@ -4114,17 +3942,11 @@
           "sha256:b186969760f3a5eae1c1dea7096bcfb7539605039c9a10780945cd89505b3cd0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/polkit-0.117-8.el9.x86_64.rpm"
           },
-          "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/shim-x64-15-16.el8.x86_64.rpm"
-          },
           "sha256:b261ae0b9f219792473feeccecc515794e3602c8298f81cb8f492944b7aade03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libcurl-7.76.1-14.el9.x86_64.rpm"
           },
           "sha256:b584cded28ef42ffc789a63f71575aa57f4cd69d69adb6f7d1e34e041ce8dca0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libsss_certmap-2.6.2-2.el9.x86_64.rpm"
-          },
-          "sha256:b64133227dca092ba89a703ba539e422299fc04a8663ab862240a433f116e5e9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/mokutil-0.4.0-8.el9.x86_64.rpm"
           },
           "sha256:b7d9597aa6a247344ffdb19d0805124e718156a87cf0cb259c108ea79d1a43b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/lvm2-libs-2.03.14-3.el9.x86_64.rpm"
@@ -4189,9 +4011,6 @@
           "sha256:bef1d4c3d1ecab3c5c8dd5b81b7584f81533d6286a2d50f1092437148fc0fa4a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-ply-3.11-13.el9.noarch.rpm"
           },
-          "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/flashrom-1.2-10.el9.x86_64.rpm"
-          },
           "sha256:bf3baf444e49eba4189e57d562a7522ab714132d2960db87ef9b99f1b46a3cc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sed-4.8-9.el9.x86_64.rpm"
           },
@@ -4212,9 +4031,6 @@
           },
           "sha256:c432790f9b6cf33ef8c6e3618b209e8922b409de79f0519cc9679b1ad6cb20ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libini_config-1.3.1-51.el9.x86_64.rpm"
-          },
-          "sha256:c44be051ee349ab2fb432004b5fef2023b3aecc456997123fa381710bff848a4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/fwupd-plugin-flashrom-1.5.9-3.el9.x86_64.rpm"
           },
           "sha256:c491f49444112b0ceaaeac310a646a85a78e041cbf110c7cb465bd5783274160": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/kbd-2.4.0-8.el9.x86_64.rpm"
@@ -4345,9 +4161,6 @@
           "sha256:d90cdf48fd47bfd8389529ad08b265ff13bd7289f90eadbadef17e7142b2cfc1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.0-20220208/Packages/libknet1-crypto-openssl-plugin-1.22-3.el9.x86_64.rpm"
           },
-          "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm"
-          },
           "sha256:d9a85c17d7d52bba7fd5e09560f4d50727419b4650059c0d8ef68f0d10250eb3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libqb-2.0.3-7.el9.x86_64.rpm"
           },
@@ -4395,9 +4208,6 @@
           },
           "sha256:dfbb0c4f2c524b731e2c2ed7d352541183667ad7981fb01de6474c6be5e52951": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libzstd-1.5.0-2.el9.x86_64.rpm"
-          },
-          "sha256:dffac89417d819b7c2a65d116d45c2a2c12c9385553a48fa3336dfe92d30e9de": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-utils-2.25-11.el9.x86_64.rpm"
           },
           "sha256:e0882a2ed0dfd34af53563bb3d578893c5ec630bb3110df4613db3d84b6f0e17": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/grubby-8.40-54.el9.x86_64.rpm"
@@ -4491,9 +4301,6 @@
           },
           "sha256:ec8a0fdd3d75a859347cbe48200fea16ed1642874c48bdeefa3f83b2c0890693": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/rsync-3.2.3-9.el9.x86_64.rpm"
-          },
-          "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libbytesize-2.5-3.el9.x86_64.rpm"
           },
           "sha256:ed36145fea237f5666bffe6547178740a16c592f48432ef86756a15e2d0a5e04": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sssd-kcm-2.6.2-2.el9.x86_64.rpm"
@@ -4590,9 +4397,6 @@
           },
           "sha256:f84294afdeaddb4f44243b80e3b32cf65a5aff76e5b7528f4810657c90559181": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/NetworkManager-team-1.36.0-0.7.el9.x86_64.rpm"
-          },
-          "sha256:f91b3de89d9598092e093d262e35c4d7ac0ec9b2f8d3c5ea0cbdd620c47664d6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efivar-libs-37-17.el9.x86_64.rpm"
           },
           "sha256:fa3abe9c3196c58b2a2943bd759eb30542962d3464970ce4171627e741160f28": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-oauthlib-3.1.1-2.el9.noarch.rpm"
@@ -6202,15 +6006,6 @@
         "checksum": "sha256:f835cc738fa003147087d68427c407e17c08587156ae961d641b2dfcee1fe7af"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.1",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
-        "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
-      },
-      {
         "name": "bzip2",
         "epoch": 0,
         "version": "1.0.8",
@@ -6643,33 +6438,6 @@
         "checksum": "sha256:07a6ff3d4ef4f04c7dc7f006a68795e030057745d10ea2a251e724e1d726e49b"
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "4",
-        "release": "9.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efi-filesystem-4-9.el9.noarch.rpm",
-        "checksum": "sha256:0e5a1e3e42ff063ac8914f58d1c0e21dcd1ecf36840916c5d4e78838b49b5c2f"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "12.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efibootmgr-16-12.el9.x86_64.rpm",
-        "checksum": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "17.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efivar-libs-37-17.el9.x86_64.rpm",
-        "checksum": "sha256:f91b3de89d9598092e093d262e35c4d7ac0ec9b2f8d3c5ea0cbdd620c47664d6"
-      },
-      {
         "name": "elfutils-default-yama-scope",
         "epoch": 0,
         "version": "0.186",
@@ -6767,15 +6535,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm",
         "checksum": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.5.9",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fwupd-1.5.9-3.el9.x86_64.rpm",
-        "checksum": "sha256:598ab332a213d929861baaec1eb4fdd110a495e6ecee182a0726b6d11f2acc76"
       },
       {
         "name": "gawk",
@@ -6929,15 +6688,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/grub2-common-2.06-16.el9.noarch.rpm",
         "checksum": "sha256:f2b7c3a5c800e3c670c6943672a9fc323c507ab12ade4dc9b7c956572966fc29"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "16.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/grub2-efi-x64-2.06-16.el9.x86_64.rpm",
-        "checksum": "sha256:51734fbc7cc766ec9fd8ce87f29edc5db13e2135d6bd38d09b8376daf1f94fc7"
       },
       {
         "name": "grub2-pc",
@@ -7525,15 +7275,6 @@
         "checksum": "sha256:8a57200f0c0b94cb84751b35fa70b111c264186937ca9bda93448dac1a5166d6"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgcab1-1.4-6.el9.x86_64.rpm",
-        "checksum": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.2.1",
@@ -7570,24 +7311,6 @@
         "checksum": "sha256:8248e20d7a253aa9c0dc7dc3d56b42e1def4fd5753ce8e8b9e980aa664fc9068"
       },
       {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "237",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgudev-237-1.el9.x86_64.rpm",
-        "checksum": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671"
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.8",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgusb-0.3.8-1.el9.x86_64.rpm",
-        "checksum": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39"
-      },
-      {
         "name": "libibverbs",
         "epoch": 0,
         "version": "37.2",
@@ -7622,15 +7345,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libini_config-1.3.1-51.el9.x86_64.rpm",
         "checksum": "sha256:c432790f9b6cf33ef8c6e3618b209e8922b409de79f0519cc9679b1ad6cb20ed"
-      },
-      {
-        "name": "libjcat",
-        "epoch": 0,
-        "version": "0.1.6",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libjcat-0.1.6-3.el9.x86_64.rpm",
-        "checksum": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf"
       },
       {
         "name": "libkcapi",
@@ -7912,15 +7626,6 @@
         "checksum": "sha256:d9f2166d5f2f5ecad7c49fc2f6bf49d6014b0df0a266b3ee6522959eeb13ed3f"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.3",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm",
-        "checksum": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -8074,15 +7779,6 @@
         "checksum": "sha256:6477fb3c3285158f676360e228057e13dc6e983f453c7c74ed4ab140357f9a0d"
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libusbx-1.0.24-4.el9.x86_64.rpm",
-        "checksum": "sha256:147e281881105acfb8aa184a1d59faff4e3c1249205a86abb900b8d7a02cacbe"
-      },
-      {
         "name": "libuser",
         "epoch": 0,
         "version": "0.63",
@@ -8153,15 +7849,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxml2-2.9.12-4.el9.x86_64.rpm",
         "checksum": "sha256:bc0f73fb262df04514d6ce8f4d970adefc7385be519e759c9d61bf7f715cc6e1"
-      },
-      {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.3.3",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm",
-        "checksum": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3"
       },
       {
         "name": "libyaml",
@@ -8290,15 +7977,6 @@
         "checksum": "sha256:6440c783cf8872f6d948164f24eedc54935130a4e095a933ba910cd799419cd4"
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/mdadm-4.2-1.el9.x86_64.rpm",
-        "checksum": "sha256:20a46ac392014c17b6c2192a87d419189a2632830554d436f2895d15269c6f98"
-      },
-      {
         "name": "microcode_ctl",
         "epoch": 4,
         "version": "20210608",
@@ -8306,15 +7984,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/microcode_ctl-20210608-2.el9.noarch.rpm",
         "checksum": "sha256:57b689e668acf407ed7542fbedcd29529fff28b3ace62cbff7659f9a42d8e1dd"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 2,
-        "version": "0.4.0",
-        "release": "8.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/mokutil-0.4.0-8.el9.x86_64.rpm",
-        "checksum": "sha256:b64133227dca092ba89a703ba539e422299fc04a8663ab862240a433f116e5e9"
       },
       {
         "name": "mpfr",
@@ -9217,24 +8886,6 @@
         "checksum": "sha256:9624fc9a5d5b4b0229d8d6f2505992142b6ba236fe02610214419e6e3ff9f273"
       },
       {
-        "name": "shared-mime-info",
-        "epoch": 0,
-        "version": "2.1",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/shared-mime-info-2.1-4.el9.x86_64.rpm",
-        "checksum": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a"
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15",
-        "release": "16.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/shim-x64-15-16.el8.x86_64.rpm",
-        "checksum": "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -9613,24 +9264,6 @@
         "checksum": "sha256:aabddb8a2231c0c296a00c15a9a0b0b7037264004a7e80632fa098f9462b4755"
       },
       {
-        "name": "flashrom",
-        "epoch": 0,
-        "version": "1.2",
-        "release": "10.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/flashrom-1.2-10.el9.x86_64.rpm",
-        "checksum": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56"
-      },
-      {
-        "name": "fwupd-plugin-flashrom",
-        "epoch": 0,
-        "version": "1.5.9",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/fwupd-plugin-flashrom-1.5.9-3.el9.x86_64.rpm",
-        "checksum": "sha256:c44be051ee349ab2fb432004b5fef2023b3aecc456997123fa381710bff848a4"
-      },
-      {
         "name": "gawk-all-langpacks",
         "epoch": 0,
         "version": "5.1.0",
@@ -9730,96 +9363,6 @@
         "checksum": "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a"
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "22.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libatasmart-0.19-22.el9.x86_64.rpm",
-        "checksum": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a"
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:a7cc761f2e5a06b5858d412e9a03e2d7778158d2f27099c4e5d2050d15103970"
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-crypto-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:564b8d00d26b50ae57423aa5be39aa525bbd71d50600e2618ea75e2295f6f2e8"
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-fs-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:61e3b32b1509c44dcddeedb0b1a8b6b0c6bbd343affa3ef229127d05d32913ab"
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-loop-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:8743d4eab6e262efbe770232eb34c3fb5f0c304531b97cc95442ed6c7c8e2909"
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-mdraid-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:887b23796b57b9e476f916c32b27d446a4db40957b92940519162ea7ba1689cc"
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-part-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:68642d32e38d1bb4e847911c8fc41a78a23e74823a7282e94cf9e3abc5c169ab"
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-swap-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:9fd5fe7855c4586366cc8f8eef57bd6ff15aff469a817ac77ec8d3be89783c68"
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "11.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-utils-2.25-11.el9.x86_64.rpm",
-        "checksum": "sha256:dffac89417d819b7c2a65d116d45c2a2c12c9385553a48fa3336dfe92d30e9de"
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "2.5",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libbytesize-2.5-3.el9.x86_64.rpm",
-        "checksum": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974"
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.11",
@@ -9854,15 +9397,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libqb-2.0.3-7.el9.x86_64.rpm",
         "checksum": "sha256:d9a85c17d7d52bba7fd5e09560f4d50727419b4650059c0d8ef68f0d10250eb3"
-      },
-      {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libudisks2-2.9.4-2.el9.x86_64.rpm",
-        "checksum": "sha256:1a91c11ac1b40db298284bdc320a07f66e5e3db1cb22818c28f72d5227411f2a"
       },
       {
         "name": "libwsman1",
@@ -10882,15 +10416,6 @@
         "checksum": "sha256:395eafb58304cec0d88c4e2de4ceaa954eac756c441783e7a46df6d88f049bcd"
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/udisks2-2.9.4-2.el9.x86_64.rpm",
-        "checksum": "sha256:4361d66a963fe8c62bd1a4e887a06fbe937faa70a7ac704a127021937b2e1b69"
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.13.1",
@@ -10898,15 +10423,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/unbound-libs-1.13.1-9.el9.x86_64.rpm",
         "checksum": "sha256:09f623d0c7e31598fb6e8a91432d644cb32b4c98d519466898633ef356edeb89"
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.12",
-        "release": "15.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
-        "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c"
       },
       {
         "name": "corosync",

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -660,9 +660,6 @@
                     "id": "sha256:0cd5b0bd07a3b6caf9b83ead1e06b4b3ddddda26980785060bfe3064dab86935"
                   },
                   {
-                    "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
-                  },
-                  {
                     "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886"
                   },
                   {
@@ -831,15 +828,6 @@
                     "id": "sha256:5fb3c625fd1ace94f133522bdaf4768abd78f029e20886b8e4aed2d6d1aac664"
                   },
                   {
-                    "id": "sha256:0e5a1e3e42ff063ac8914f58d1c0e21dcd1ecf36840916c5d4e78838b49b5c2f"
-                  },
-                  {
-                    "id": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a"
-                  },
-                  {
-                    "id": "sha256:f91b3de89d9598092e093d262e35c4d7ac0ec9b2f8d3c5ea0cbdd620c47664d6"
-                  },
-                  {
                     "id": "sha256:29c6638c62851cc38b320ff8e75d238e7c102ef53a0ebed6d228d6540f671e52"
                   },
                   {
@@ -880,9 +868,6 @@
                   },
                   {
                     "id": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee"
-                  },
-                  {
-                    "id": "sha256:598ab332a213d929861baaec1eb4fdd110a495e6ecee182a0726b6d11f2acc76"
                   },
                   {
                     "id": "sha256:ad90074a6bbde7976ef7dff3fac045b74281a8118e7d7714f5b1b9086a12d182"
@@ -940,9 +925,6 @@
                   },
                   {
                     "id": "sha256:f2b7c3a5c800e3c670c6943672a9fc323c507ab12ade4dc9b7c956572966fc29"
-                  },
-                  {
-                    "id": "sha256:51734fbc7cc766ec9fd8ce87f29edc5db13e2135d6bd38d09b8376daf1f94fc7"
                   },
                   {
                     "id": "sha256:82c5216384a8882635744aaf883f2dd36e7f60cae0bb675beaa3728e7aa796d8"
@@ -1188,9 +1170,6 @@
                     "id": "sha256:8a57200f0c0b94cb84751b35fa70b111c264186937ca9bda93448dac1a5166d6"
                   },
                   {
-                    "id": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5"
-                  },
-                  {
                     "id": "sha256:632b52c724d66439336804d332c1d497025889de660ef6c31e77f331ade8d2b8"
                   },
                   {
@@ -1222,9 +1201,6 @@
                   },
                   {
                     "id": "sha256:c3430dcc5fca4efb8abdd730e084933e0e0b885296bb30cadb4767043aeee46e"
-                  },
-                  {
-                    "id": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf"
                   },
                   {
                     "id": "sha256:a0d199e7367fa3cd51842b3475b6692d19b40a55f01dec598e5762d5a767c1f9"
@@ -1338,9 +1314,6 @@
                     "id": "sha256:06db3669a27e9a57a528350f283f8885cef7f486da49c9bd999862261d435922"
                   },
                   {
-                    "id": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3"
-                  },
-                  {
                     "id": "sha256:f1afff374ac49b11d0d48bfee8e8ec59a329aba00a19630b09e4dc078e06859c"
                   },
                   {
@@ -1419,9 +1392,6 @@
                     "id": "sha256:bc0f73fb262df04514d6ce8f4d970adefc7385be519e759c9d61bf7f715cc6e1"
                   },
                   {
-                    "id": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3"
-                  },
-                  {
                     "id": "sha256:409beeb1faf626a882e95763ec4892d514077289e6074d3b61bef1b90739ad66"
                   },
                   {
@@ -1483,9 +1453,6 @@
                   },
                   {
                     "id": "sha256:27bc149f91c6740d37eb11b8e8e3c113092b7de231a11bc5552f3e0db78ae07e"
-                  },
-                  {
-                    "id": "sha256:b64133227dca092ba89a703ba539e422299fc04a8663ab862240a433f116e5e9"
                   },
                   {
                     "id": "sha256:cf60adcc7a5f0cb469e6f066a1bdc62ae9af7c06305c76c15884b59df7f93274"
@@ -1830,9 +1797,6 @@
                     "id": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a"
                   },
                   {
-                    "id": "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021"
-                  },
-                  {
                     "id": "sha256:4b7c4822f92e7ba97b78893d273b01161e411151ccc627b076d13719ad404a69"
                   },
                   {
@@ -2160,9 +2124,6 @@
                     "id": "sha256:9744821354186cbb88b27327ec9b152a5e8c45cc05c07089faf986d8279c2bc1"
                   },
                   {
-                    "id": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56"
-                  },
-                  {
                     "id": "sha256:8a15b7e35024c2378a3188048bcb615ac97f208a6e2c13b87f62ef88d23e5044"
                   },
                   {
@@ -2185,9 +2146,6 @@
                   },
                   {
                     "id": "sha256:68cb3103a3d1d211d9b5b846a6ac71be07c2708465b79f0b11ae5512944a4a82"
-                  },
-                  {
-                    "id": "sha256:c44be051ee349ab2fb432004b5fef2023b3aecc456997123fa381710bff848a4"
                   },
                   {
                     "id": "sha256:34384ca5d51125d92a02a1f20e8a68aa8e17314eb0ecf4dec64594ac61e4fee7"
@@ -3448,10 +3406,6 @@
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 processor.max_cstate=1 intel_idle.max_cstate=1",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat",
-                "unified": true
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-55.el9.x86_64",
               "write_cmdline": false,
               "config": {
@@ -3861,9 +3815,6 @@
           "sha256:0de951c218acba78fd0b4a26478036dc9368f2cab560063ff8ef17b59c7664ba": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nano-5.6.1-5.el9.x86_64.rpm"
           },
-          "sha256:0e5a1e3e42ff063ac8914f58d1c0e21dcd1ecf36840916c5d4e78838b49b5c2f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efi-filesystem-4-9.el9.noarch.rpm"
-          },
           "sha256:0f1df5e0d48c2ac9914bfffa7ed569cd58e42b17ba96bb3f7cf74d1e80de2597": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libutempter-1.2.1-6.el9.x86_64.rpm"
           },
@@ -4200,9 +4151,6 @@
           "sha256:32089968a80919bb9a22004719ae7ad87ce34700415a3ca26416608e86650459": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/samba-common-libs-4.15.5-100.el9.x86_64.rpm"
           },
-          "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm"
-          },
           "sha256:328f907df63fc5869776fef6ee59bf1215bd131bf08453f71e225204e58ea740": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/kernel-modules-5.14.0-55.el9.x86_64.rpm"
           },
@@ -4518,17 +4466,11 @@
           "sha256:5069b06010395cd7b8f61eac0509ef494a768590b2078e873fe6b05aeaec692f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libpciaccess-0.16-6.el9.x86_64.rpm"
           },
-          "sha256:51734fbc7cc766ec9fd8ce87f29edc5db13e2135d6bd38d09b8376daf1f94fc7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/grub2-efi-x64-2.06-16.el9.x86_64.rpm"
-          },
           "sha256:5196f5f7d2387e9dcdf504c8534e3109cc84f7545240b6fbd18866217653b4fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-055-10.git20210824.el9.x86_64.rpm"
           },
           "sha256:51d508ed30f9b74fbef756f2be64cca597de9e797b6f5f00f70e4ec88a7c4d3a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-libxml2-2.9.12-4.el9.x86_64.rpm"
-          },
-          "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm"
           },
           "sha256:5246e2b08f6c120e3c2fc418c18fcd1db17c9fdc53fe51cd763fabfbe5b6c4fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/pkgconf-pkg-config-1.7.3-9.el9.x86_64.rpm"
@@ -4581,9 +4523,6 @@
           "sha256:57f832788769a0bab197c09e1c5720f571b06e8952c485ed721b9875ae7ad27d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libnl3-cli-3.5.0-10.el9.x86_64.rpm"
           },
-          "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
-          },
           "sha256:583c5975a04bdcd968cd160468430a3d3bcabbc864071c3c150240c2ff9e43d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libappstream-glib-0.7.18-4.el9.x86_64.rpm"
           },
@@ -4595,12 +4534,6 @@
           },
           "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm"
-          },
-          "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libjcat-0.1.6-3.el9.x86_64.rpm"
-          },
-          "sha256:598ab332a213d929861baaec1eb4fdd110a495e6ecee182a0726b6d11f2acc76": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fwupd-1.5.9-3.el9.x86_64.rpm"
           },
           "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm"
@@ -4793,9 +4726,6 @@
           },
           "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm"
-          },
-          "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efibootmgr-16-12.el9.x86_64.rpm"
           },
           "sha256:6e4fb6dc2ad74949cc1142b2d1f0f8fc7cbf00f32a745c67c1d1eb39271cdbd8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-jmespath-0.9.4-11.el9.noarch.rpm"
@@ -5277,9 +5207,6 @@
           "sha256:9dc719992c6b385ce2c5d3ef35ecb5a0b5aae29ea99fa164f97aa2acb4346a02": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dbus-common-1.12.20-5.el9.noarch.rpm"
           },
-          "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm"
-          },
           "sha256:9ddcf4c8e5463a1b75b22be070ae8c67264ffd8bc035e3942791184b4f4b34d7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/jbig2dec-libs-0.19-6.el9.x86_64.rpm"
           },
@@ -5490,9 +5417,6 @@
           "sha256:b1c4763c29ec2273c33a92139d8a3340f4bad615e82c80c27d4b5a02a24e90cc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/usb_modeswitch-2.6.1-4.el9.x86_64.rpm"
           },
-          "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/shim-x64-15-16.el8.x86_64.rpm"
-          },
           "sha256:b261ae0b9f219792473feeccecc515794e3602c8298f81cb8f492944b7aade03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libcurl-7.76.1-14.el9.x86_64.rpm"
           },
@@ -5525,9 +5449,6 @@
           },
           "sha256:b60e10439f180c9fd95d1fdeb3265ddfc088b50098d3c3b389e81ad0e3c8d7de": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libgs-9.54.0-4.el9.x86_64.rpm"
-          },
-          "sha256:b64133227dca092ba89a703ba539e422299fc04a8663ab862240a433f116e5e9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/mokutil-0.4.0-8.el9.x86_64.rpm"
           },
           "sha256:b7138ec10750c522099bba1fc20878dfe3b710975fe08813958fe1e6184a532b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/PackageKit-glib-1.2.4-2.el9.x86_64.rpm"
@@ -5631,9 +5552,6 @@
           "sha256:bef1d4c3d1ecab3c5c8dd5b81b7584f81533d6286a2d50f1092437148fc0fa4a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-ply-3.11-13.el9.noarch.rpm"
           },
-          "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/flashrom-1.2-10.el9.x86_64.rpm"
-          },
           "sha256:bf3baf444e49eba4189e57d562a7522ab714132d2960db87ef9b99f1b46a3cc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sed-4.8-9.el9.x86_64.rpm"
           },
@@ -5672,9 +5590,6 @@
           },
           "sha256:c43a8a16029127aae1ebe644d6c1d675938ce3e80f1ecf8518da23e9d2bf9a78": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libcanberra-gtk2-0.30-26.el9.x86_64.rpm"
-          },
-          "sha256:c44be051ee349ab2fb432004b5fef2023b3aecc456997123fa381710bff848a4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/fwupd-plugin-flashrom-1.5.9-3.el9.x86_64.rpm"
           },
           "sha256:c45fd1a02ecf70516e6ccbf095e5fa322530bb96eba24b5ca6f8820e701615fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libfontenc-1.1.3-17.el9.x86_64.rpm"
@@ -6167,9 +6082,6 @@
           },
           "sha256:f84294afdeaddb4f44243b80e3b32cf65a5aff76e5b7528f4810657c90559181": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/NetworkManager-team-1.36.0-0.7.el9.x86_64.rpm"
-          },
-          "sha256:f91b3de89d9598092e093d262e35c4d7ac0ec9b2f8d3c5ea0cbdd620c47664d6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efivar-libs-37-17.el9.x86_64.rpm"
           },
           "sha256:fa012f589a99133c62e59110d455154cf2cbf91f9d1e7075f35ff182304d84c9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dos2unix-7.4.2-4.el9.x86_64.rpm"
@@ -7887,15 +7799,6 @@
         "checksum": "sha256:0cd5b0bd07a3b6caf9b83ead1e06b4b3ddddda26980785060bfe3064dab86935"
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.1",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
-        "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7"
-      },
-      {
         "name": "bzip2",
         "epoch": 0,
         "version": "1.0.8",
@@ -8400,33 +8303,6 @@
         "checksum": "sha256:5fb3c625fd1ace94f133522bdaf4768abd78f029e20886b8e4aed2d6d1aac664"
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "4",
-        "release": "9.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efi-filesystem-4-9.el9.noarch.rpm",
-        "checksum": "sha256:0e5a1e3e42ff063ac8914f58d1c0e21dcd1ecf36840916c5d4e78838b49b5c2f"
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "12.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efibootmgr-16-12.el9.x86_64.rpm",
-        "checksum": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a"
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "37",
-        "release": "17.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efivar-libs-37-17.el9.x86_64.rpm",
-        "checksum": "sha256:f91b3de89d9598092e093d262e35c4d7ac0ec9b2f8d3c5ea0cbdd620c47664d6"
-      },
-      {
         "name": "elfutils-debuginfod-client",
         "epoch": 0,
         "version": "0.186",
@@ -8551,15 +8427,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm",
         "checksum": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee"
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.5.9",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fwupd-1.5.9-3.el9.x86_64.rpm",
-        "checksum": "sha256:598ab332a213d929861baaec1eb4fdd110a495e6ecee182a0726b6d11f2acc76"
       },
       {
         "name": "gawk",
@@ -8731,15 +8598,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/grub2-common-2.06-16.el9.noarch.rpm",
         "checksum": "sha256:f2b7c3a5c800e3c670c6943672a9fc323c507ab12ade4dc9b7c956572966fc29"
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "16.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/grub2-efi-x64-2.06-16.el9.x86_64.rpm",
-        "checksum": "sha256:51734fbc7cc766ec9fd8ce87f29edc5db13e2135d6bd38d09b8376daf1f94fc7"
       },
       {
         "name": "grub2-pc",
@@ -9471,15 +9329,6 @@
         "checksum": "sha256:8a57200f0c0b94cb84751b35fa70b111c264186937ca9bda93448dac1a5166d6"
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgcab1-1.4-6.el9.x86_64.rpm",
-        "checksum": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5"
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.2.1",
@@ -9577,15 +9426,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libipa_hbac-2.6.2-2.el9.x86_64.rpm",
         "checksum": "sha256:c3430dcc5fca4efb8abdd730e084933e0e0b885296bb30cadb4767043aeee46e"
-      },
-      {
-        "name": "libjcat",
-        "epoch": 0,
-        "version": "0.1.6",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libjcat-0.1.6-3.el9.x86_64.rpm",
-        "checksum": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf"
       },
       {
         "name": "libkadm5",
@@ -9921,15 +9761,6 @@
         "checksum": "sha256:06db3669a27e9a57a528350f283f8885cef7f486da49c9bd999862261d435922"
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.3",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm",
-        "checksum": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3"
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.20",
@@ -10164,15 +9995,6 @@
         "checksum": "sha256:bc0f73fb262df04514d6ce8f4d970adefc7385be519e759c9d61bf7f715cc6e1"
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.3.3",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm",
-        "checksum": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3"
-      },
-      {
         "name": "libyaml",
         "epoch": 0,
         "version": "0.2.5",
@@ -10360,15 +10182,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/mlocate-0.26-30.el9.x86_64.rpm",
         "checksum": "sha256:27bc149f91c6740d37eb11b8e8e3c113092b7de231a11bc5552f3e0db78ae07e"
-      },
-      {
-        "name": "mokutil",
-        "epoch": 2,
-        "version": "0.4.0",
-        "release": "8.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/mokutil-0.4.0-8.el9.x86_64.rpm",
-        "checksum": "sha256:b64133227dca092ba89a703ba539e422299fc04a8663ab862240a433f116e5e9"
       },
       {
         "name": "mpfr",
@@ -11397,15 +11210,6 @@
         "checksum": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a"
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15",
-        "release": "16.el8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/shim-x64-15-16.el8.x86_64.rpm",
-        "checksum": "sha256:b22f239d3bfbb4da333cca35154dae8ffd5698e752052cd82fe75de90e6d5021"
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -12387,15 +12191,6 @@
         "checksum": "sha256:9744821354186cbb88b27327ec9b152a5e8c45cc05c07089faf986d8279c2bc1"
       },
       {
-        "name": "flashrom",
-        "epoch": 0,
-        "version": "1.2",
-        "release": "10.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/flashrom-1.2-10.el9.x86_64.rpm",
-        "checksum": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56"
-      },
-      {
         "name": "fontconfig",
         "epoch": 0,
         "version": "2.13.94",
@@ -12466,15 +12261,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/fuse3-libs-3.10.2-3.el9.x86_64.rpm",
         "checksum": "sha256:68cb3103a3d1d211d9b5b846a6ac71be07c2708465b79f0b11ae5512944a4a82"
-      },
-      {
-        "name": "fwupd-plugin-flashrom",
-        "epoch": 0,
-        "version": "1.5.9",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/fwupd-plugin-flashrom-1.5.9-3.el9.x86_64.rpm",
-        "checksum": "sha256:c44be051ee349ab2fb432004b5fef2023b3aecc456997123fa381710bff848a4"
       },
       {
         "name": "gawk-all-langpacks",

--- a/test/data/manifests/rhel_91-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2-boot.json
@@ -1430,14 +1430,6 @@
                     }
                   },
                   {
-                    "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -1758,30 +1750,6 @@
                     }
                   },
                   {
-                    "id": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd8f32a588f83b75183a94e40f895ec9640bfba4ba1768f1e86b57c18cec3e47",
                     "options": {
                       "metadata": {
@@ -1863,14 +1831,6 @@
                   },
                   {
                     "id": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2007,14 +1967,6 @@
                   },
                   {
                     "id": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2526,14 +2478,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:056c6e51fa98dae4381725ca9510ced292703ec225adf9637a61eb752d1a3a0a",
                     "options": {
                       "metadata": {
@@ -2566,22 +2510,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8d0b54556cefa3f2e9e0f8d01e0727d31559fd3f0b67cc570dec26ff38d61b84",
                     "options": {
                       "metadata": {
@@ -2599,14 +2527,6 @@
                   },
                   {
                     "id": "sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2846,14 +2766,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f70762594db38ab18ba1db1ce92e9ede5a40ca5d5c3cc93c6bd92686556472c8",
                     "options": {
                       "metadata": {
@@ -2982,14 +2894,6 @@
                     }
                   },
                   {
-                    "id": "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:32c933de69b8fae782d4e7c7a1132eaf256e73b455199a7c617bc315f3e97e7a",
                     "options": {
                       "metadata": {
@@ -3031,14 +2935,6 @@
                   },
                   {
                     "id": "sha256:26bee2c6124e4047f5b6261589bbd7a801603ca12dc90b64b0cd178911e25cbb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3142,23 +3038,7 @@
                     }
                   },
                   {
-                    "id": "sha256:dfdaa5afa228685c56e65edd92d2a7aba162c7e1e16cce2053767e246fef6076",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3878,22 +3758,6 @@
                     }
                   },
                   {
-                    "id": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:4b7c4822f92e7ba97b78893d273b01161e411151ccc627b076d13719ad404a69",
                     "options": {
                       "metadata": {
@@ -4206,22 +4070,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c1fcc71c1cc1160d58ace4b60cc6733b68d6f6d406e5ec5ce24327787f452cd1",
                     "options": {
                       "metadata": {
@@ -4286,86 +4134,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fa3e8480793608d79e85ec366280e031470976e7c25e1c75252cad489369ec4a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce7a47da96b91cb7a50a9876fe2931f472e84ad71b72827001c5631c25e30e10",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:aa805098a888939a75c1f9ed46ff281c2c2fcdd282a8d18d37852bd8b0085151",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:88a824609ad38bee5ea8037eb18a6477f6e6b313af6deda6311286406d1065a7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:25536d6377e24d4cb7d95a76ccfc16de8b81c053ea77ad5a0961087ed52cf4c0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ee53fb84a91d66355c438c47593d677df32222be79a856cd406dd73c1e719b25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2671d507c8f07af10dfc20de9695e62c2c8dc9ed3b8cee7e464d47932ac24e97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:774a7de97ac6cdec24de0f2a9be666492b5830d317ae5f5cfe9223c50e3da0c4",
                     "options": {
                       "metadata": {
@@ -4390,63 +4158,7 @@
                     }
                   },
                   {
-                    "id": "sha256:f03e357435c8b27e81ce6cb440992bd911e11a9fa0b211af1401280013651d01",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2fb3471163091eca166f66fb3f69d17dede5f0a3bb51784ab18959dcdc5f7f71",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:81138535e5e487dcb7620946f4494a3d85e38be7c1395af7241498568acd0321",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0d965a214074a7d349497e9aac3ddfa4080e6ddad3e9affeab307cd2b109aed5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9f559003724cf2c43919dfee9c83cee56adcc686b803a35e5609b9d231b066eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5d8010a420803df4e2947d34e40b068405441f9dd2a991a1f339c4f9c792aa4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6c11ea9d03bb1d375559824617b03aea47a4e17ebdbe29a55235722a358740dd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4647,22 +4359,6 @@
                   },
                   {
                     "id": "sha256:8ec4556ce5b7fe7036928025846be69d5cd6597b0428271427b607d45a8e04e5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0dcd6624357942ada8b2ebf933ee47e11b1cbdc4eaee545519c43420adb6f46b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4888,10 +4584,6 @@
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat",
-                "unified": true
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,
               "config": {
@@ -5193,12 +4885,6 @@
           "sha256:0c8f8e301f75c77a24821cc9170596a799edb33c1bf58b6490aa97c8ed7d5996": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/gmp-6.2.0-10.el9.x86_64.rpm"
           },
-          "sha256:0d965a214074a7d349497e9aac3ddfa4080e6ddad3e9affeab307cd2b109aed5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-softokn-3.79.0-14.el9_0.x86_64.rpm"
-          },
-          "sha256:0dcd6624357942ada8b2ebf933ee47e11b1cbdc4eaee545519c43420adb6f46b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/udisks2-2.9.4-3.el9.x86_64.rpm"
-          },
           "sha256:0e5de5b828060e128ee9c0e57cb38a4f72692a2f1f11ed208439c4c07dcf192d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-tools-minimal-2.06-46.el9.x86_64.rpm"
           },
@@ -5307,12 +4993,6 @@
           "sha256:24983ca0db3271a80dfb9fc7282964eec863f155691333f265cd083654dac2da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/virt-what-1.25-1.el9.x86_64.rpm"
           },
-          "sha256:25536d6377e24d4cb7d95a76ccfc16de8b81c053ea77ad5a0961087ed52cf4c0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-part-2.25-14.el9.x86_64.rpm"
-          },
-          "sha256:2671d507c8f07af10dfc20de9695e62c2c8dc9ed3b8cee7e464d47932ac24e97": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-utils-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:26bee2c6124e4047f5b6261589bbd7a801603ca12dc90b64b0cd178911e25cbb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxml2-2.9.13-2.el9.x86_64.rpm"
           },
@@ -5324,9 +5004,6 @@
           },
           "sha256:28a5f98e7922427c7f69d36773c6cd2079812c93442e8116af14fc8dbb139201": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/krb5-libs-1.19.1-22.el9.x86_64.rpm"
-          },
-          "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fwupd-1.7.9-1.el9.x86_64.rpm"
           },
           "sha256:29826b32a7c4a7849f26290be47b4aa41fe14de69550f30da10ebf7d5782a133": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/which-2.21-28.el9.x86_64.rpm"
@@ -5361,12 +5038,6 @@
           "sha256:2ee58b038ff185adf06194e5211b69800ba1efe502158cec867a41b3901cb420": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/logrotate-3.18.0-7.el9.x86_64.rpm"
           },
-          "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgudev-237-1.el9.x86_64.rpm"
-          },
-          "sha256:2fb3471163091eca166f66fb3f69d17dede5f0a3bb51784ab18959dcdc5f7f71": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nspr-4.34.0-14.el9_0.x86_64.rpm"
-          },
           "sha256:2fbc615bf6c839633f51a802e980af5cd4540a7fe3bb7685ee7ce143af29a782": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-librepo-1.14.2-3.el9.x86_64.rpm"
           },
@@ -5381,9 +5052,6 @@
           },
           "sha256:322dd1e3f213b4a90de07a584259b9fa8f058cdfcd3bc38ecf3b5b79175835a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libfdisk-2.37.4-9.el9.x86_64.rpm"
-          },
-          "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm"
           },
           "sha256:32c933de69b8fae782d4e7c7a1132eaf256e73b455199a7c617bc315f3e97e7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libuser-0.63-11.el9.x86_64.rpm"
@@ -5402,9 +5070,6 @@
           },
           "sha256:37b1d60e8acd198f6fd474326524c6467de01f42400ea57f8622861cc2ba34ef": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/hdparm-9.62-2.el9.x86_64.rpm"
-          },
-          "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libusbx-1.0.26-1.el9.x86_64.rpm"
           },
           "sha256:39ada507d193a14f8ee3d5226966dca1b5a6e9b591a1a4b11a059445596db7e0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/linux-firmware-whence-20220708-127.el9.noarch.rpm"
@@ -5468,9 +5133,6 @@
           },
           "sha256:43d40891623256b30a7d08d8db21a3d94d94756ecade355845e52c64f5af7765": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libevent-2.1.12-6.el9.x86_64.rpm"
-          },
-          "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shared-mime-info-2.1-4.el9.x86_64.rpm"
           },
           "sha256:44b4ebb0b3cc5a733d477b684082c23d8b4230953f192113353a6aa664e83624": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/gpgme-1.15.1-6.el9.x86_64.rpm"
@@ -5541,9 +5203,6 @@
           "sha256:50b10ed9964a5824b705a04d3937bc2e22f29751fba66a97b991c429bbb3664c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/nettle-3.8-3.el9_0.x86_64.rpm"
           },
-          "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm"
-          },
           "sha256:533af82d1a7a83f87ccfb9e6dd894043aa05a467a7888651b8d8097251fea75f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-pc-2.06-46.el9.x86_64.rpm"
           },
@@ -5562,9 +5221,6 @@
           "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/langpacks-en-3.0-16.el9.noarch.rpm"
           },
-          "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efivar-libs-38-2.el9.x86_64.rpm"
-          },
           "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm"
           },
@@ -5577,17 +5233,11 @@
           "sha256:563d301817a83d6959469f6117ec1e8fa21aa7aafe8ae0f99ab71a62dbb05ba0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/tuned-2.19.0-1.el9.noarch.rpm"
           },
-          "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
-          },
           "sha256:587284378eec54fded45c8eb778a7afb9d9c3a74201c5e9068ac3030bdca02e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/redhat-release-eula-9.1-1.9.el9.x86_64.rpm"
           },
           "sha256:588e8736af3376abfb3cdf372c10baef02c40d916a55958f3bee9767f9ad8526": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libcbor-0.7.0-5.el9.x86_64.rpm"
-          },
-          "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libjcat-0.1.6-3.el9.x86_64.rpm"
           },
           "sha256:5b62843c5829eedbf04e26d526aa0dc918afdbe4121c9575c7b1b4c92f77a87f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-setuptools-53.0.0-10.el9.noarch.rpm"
@@ -5637,9 +5287,6 @@
           "sha256:644ed9b3264a546abac89fdd40c0140911ed8ceef6e05d7594f84e0f570c6347": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libffi-3.4.2-7.el9.x86_64.rpm"
           },
-          "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgusb-0.3.8-1.el9.x86_64.rpm"
-          },
           "sha256:6477fb3c3285158f676360e228057e13dc6e983f453c7c74ed4ab140357f9a0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libunistring-0.9.10-15.el9.x86_64.rpm"
           },
@@ -5670,9 +5317,6 @@
           "sha256:6aa68f23ec0848d9fcdb836a95764ffbc2f669841ba7d9defde7ffda7af060bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-dnf-plugins-core-4.1.0-3.el9.noarch.rpm"
           },
-          "sha256:6c11ea9d03bb1d375559824617b03aea47a4e17ebdbe29a55235722a358740dd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-util-3.79.0-14.el9_0.x86_64.rpm"
-          },
           "sha256:6d4b71d340f8719afcf3de062ebc415130ce6c12fdaa70baf2737ab35461e9e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libselinux-3.4-3.el9.x86_64.rpm"
           },
@@ -5681,9 +5325,6 @@
           },
           "sha256:6da6e13deb7badafaa4e10bc8f7a81acd40e4cba3c34b4590826e8eb9a329f3d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libnl3-3.7.0-1.el9.x86_64.rpm"
-          },
-          "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efibootmgr-16-12.el9.x86_64.rpm"
           },
           "sha256:6ea4966a7336839fc47ae6308c8a00f69e4126bc1ff0832899c9a0eaa0661d19": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libcap-2.48-8.el9.x86_64.rpm"
@@ -5715,9 +5356,6 @@
           "sha256:722e3c6fb3dff112298025a33c36da22a5283ce05003aee216ba6bfe740df6b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/pciutils-libs-3.7.0-5.el9.x86_64.rpm"
           },
-          "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efi-filesystem-6-2.el9_0.noarch.rpm"
-          },
           "sha256:737a278cdf7c292337d4b54dff0479c1cb88c74200179d2ae0caf6d766ea5d00": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/chrony-4.2-1.el9.x86_64.rpm"
           },
@@ -5729,9 +5367,6 @@
           },
           "sha256:74e68fba2f9e510dd674766800eb0df8ca0ea546fcc20264d92ed9cd5beaee9a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/oddjob-0.34.7-6.el9.x86_64.rpm"
-          },
-          "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libatasmart-0.19-22.el9.x86_64.rpm"
           },
           "sha256:75da9e9faf295a7cdc1e8aede617c5468860ed03750f5543eb1ed00ca1d6c1e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libcollection-0.7.0-53.el9.x86_64.rpm"
@@ -5811,9 +5446,6 @@
           "sha256:80fadaa3c82e156ae8977136ff16b10a6dee28778c96ae5803c153ad717a265c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/e2fsprogs-libs-1.46.5-3.el9.x86_64.rpm"
           },
-          "sha256:81138535e5e487dcb7620946f4494a3d85e38be7c1395af7241498568acd0321": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-3.79.0-14.el9_0.x86_64.rpm"
-          },
           "sha256:813ac40aec3af348c8b4a457b437f3cfe336eacfb7329af8d2848e0d7d9f281e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/checkpolicy-3.4-1.el9.x86_64.rpm"
           },
@@ -5843,9 +5475,6 @@
           },
           "sha256:877a6bc8658f919581b93af9eb01437cbb35d752b4c3587b9e90aa46a58a7aea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/cyrus-sasl-lib-2.1.27-20.el9.x86_64.rpm"
-          },
-          "sha256:88a824609ad38bee5ea8037eb18a6477f6e6b313af6deda6311286406d1065a7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-mdraid-2.25-14.el9.x86_64.rpm"
           },
           "sha256:88f123ca2fd9a3a5c59f4065500ccc2e94e64502035e65a524e1e55574a7df75": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libdnf-plugin-subscription-manager-1.29.30-1.el9.x86_64.rpm"
@@ -5919,9 +5548,6 @@
           "sha256:9658da838021711f687cf283368664984bfb1c8b9176897d7d477a724a11a731": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/lz4-libs-1.9.3-5.el9.x86_64.rpm"
           },
-          "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mokutil-0.4.0-9.el9.x86_64.rpm"
-          },
           "sha256:995b180dbfa3173ca0792c1c72ba8e4c9d8e41bf92850ca0503f2784a4ffdb4d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsysfs-2.1.1-10.el9.x86_64.rpm"
           },
@@ -5946,9 +5572,6 @@
           "sha256:9c332f10871fa27bcf99d7afcea2220fe50227cd8c943b295f83081d44ad6ebf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/NetworkManager-tui-1.40.0-1.el9.x86_64.rpm"
           },
-          "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm"
-          },
           "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-linux-procfs-0.7.0-1.el9.noarch.rpm"
           },
@@ -5957,9 +5580,6 @@
           },
           "sha256:9efda7f39456e3d6689124af5dd18f28710e851eb68702d849bb071a81f5aa0e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/glibc-gconv-extra-2.34-40.el9.x86_64.rpm"
-          },
-          "sha256:9f559003724cf2c43919dfee9c83cee56adcc686b803a35e5609b9d231b066eb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-softokn-freebl-3.79.0-14.el9_0.x86_64.rpm"
           },
           "sha256:9f640485eb1df3b8d8759b3051bb1651b264fd0ca139b90c85ad919e365b0f22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/json-glib-1.6.6-1.el9.x86_64.rpm"
@@ -5988,9 +5608,6 @@
           "sha256:a50bb26a28ee7e6379c86b5b91285299b71569fa87ea968d800a56090b7a179d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxcrypt-4.4.18-3.el9.x86_64.rpm"
           },
-          "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fwupd-plugin-flashrom-1.7.9-1.el9.x86_64.rpm"
-          },
           "sha256:a62889efb540a272b234cd60c68cb610944a1ebcf148171861e07be0d8245b07": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/dracut-squash-057-13.git20220816.el9.x86_64.rpm"
           },
@@ -6014,9 +5631,6 @@
           },
           "sha256:aa6105f1cefa12a2509fd24d8825bf17328339531144dc192ac7900298be3ab7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/polkit-0.117-10.el9_0.x86_64.rpm"
-          },
-          "sha256:aa805098a888939a75c1f9ed46ff281c2c2fcdd282a8d18d37852bd8b0085151": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-loop-2.25-14.el9.x86_64.rpm"
           },
           "sha256:aaa17904b12fe5e7df830fb9c512d971f29221dec19a3e421307b41526696f5e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/pciutils-3.7.0-5.el9.x86_64.rpm"
@@ -6114,9 +5728,6 @@
           "sha256:beed55d3ab1e8dd1207e1bd67e40e180c53a001198b9a7186f4bf07c042b377e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openldap-compat-2.6.2-3.el9.x86_64.rpm"
           },
-          "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/flashrom-1.2-10.el9.x86_64.rpm"
-          },
           "sha256:bf3baf444e49eba4189e57d562a7522ab714132d2960db87ef9b99f1b46a3cc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sed-4.8-9.el9.x86_64.rpm"
           },
@@ -6156,9 +5767,6 @@
           "sha256:c972030a8fbaa2d981f0e5fdfc42d6d5173dd047c94d86ab7732e3e53fc4e97a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libpipeline-1.5.3-4.el9.x86_64.rpm"
           },
-          "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:cb07b2cabae7305f5e4e5784530a75a8f91c57a79da1ae7ff7808ce23917ebd3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libedit-3.1-37.20210216cvs.el9.x86_64.rpm"
           },
@@ -6179,9 +5787,6 @@
           },
           "sha256:ce6dcb35f56a067393e94e5d49299a9ab256ad4949e6f86ac27e6b58516b18a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/kmod-libs-28-7.el9.x86_64.rpm"
-          },
-          "sha256:ce7a47da96b91cb7a50a9876fe2931f472e84ad71b72827001c5631c25e30e10": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-crypto-2.25-14.el9.x86_64.rpm"
           },
           "sha256:cf0662ef00d4e84727fafc79cee6941f865e0cb657332dd7448759b2f83a4809": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libss-1.46.5-3.el9.x86_64.rpm"
@@ -6222,9 +5827,6 @@
           "sha256:d57aae86bd30b4dc8578f3eb7ef39679ef4917d21a71ebb70831b4c84bace71a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libstdc++-11.3.1-2.1.el9.x86_64.rpm"
           },
-          "sha256:d5d8010a420803df4e2947d34e40b068405441f9dd2a991a1f339c4f9c792aa4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-sysinit-3.79.0-14.el9_0.x86_64.rpm"
-          },
           "sha256:d5ff4d9d43f6c32797e80e0518bb3656ae46643069bdc0ef9b8749d912cd74ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/inih-49-6.el9.x86_64.rpm"
           },
@@ -6233,9 +5835,6 @@
           },
           "sha256:d763e4d9e98fd3aac3db1828ed0de1f4b5ff46c939a207597db05fe60af52832": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/cloud-utils-growpart-0.31-10.el9.x86_64.rpm"
-          },
-          "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm"
           },
           "sha256:d9b53fda4b8757fd63b53a415f533ab876c18c28a94fd21d10658de85978f254": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/cpio-2.13-16.el9.x86_64.rpm"
@@ -6264,14 +5863,8 @@
           "sha256:de9869c08df7f6952787d0335b9bf1a09b328bea920556a59af07c8e085dd3cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/dbus-broker-28-7.el9.x86_64.rpm"
           },
-          "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm"
-          },
           "sha256:df2ab474c2d513ed863d2265efbdbb32ce9c1b1dd00365f041f6539ec36dd80d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmartcols-2.37.4-9.el9.x86_64.rpm"
-          },
-          "sha256:dfdaa5afa228685c56e65edd92d2a7aba162c7e1e16cce2053767e246fef6076": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mdadm-4.2-6.el9.x86_64.rpm"
           },
           "sha256:e069efd411901c3d1be3fa6898d18cc8a787722a6fbeb71f56b59890073ca6e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libdnf-0.67.0-3.el9.x86_64.rpm"
@@ -6290,9 +5883,6 @@
           },
           "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/snappy-1.1.8-8.el9.x86_64.rpm"
-          },
-          "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm"
           },
           "sha256:e5c4efec2d4e9e7bb461b5880efc09ba6b5c42c2fab6cc2b784ed2f79a79ca1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-dnf-4.12.0-4.el9.noarch.rpm"
@@ -6330,9 +5920,6 @@
           "sha256:ebddfc188d1ddbb0d6a238583cbc02dcb9fc0bd063a850b22d48980899976628": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libcap-ng-0.8.2-7.el9.x86_64.rpm"
           },
-          "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libbytesize-2.5-3.el9.x86_64.rpm"
-          },
           "sha256:ed4bfb8d96a13bad9b85dde758d6f481fa62abd56595760134e3ea195e63806e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libpath_utils-0.2.1-53.el9.x86_64.rpm"
           },
@@ -6345,9 +5932,6 @@
           "sha256:ee1368739d142d7c46836f2efd86e91a648bae68e46114f00596f819ad08ea31": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-pc-modules-2.06-46.el9.noarch.rpm"
           },
-          "sha256:ee53fb84a91d66355c438c47593d677df32222be79a856cd406dd73c1e719b25": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-swap-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:ee84863d757bd2084b084aa768b80c47753922ecf0b767796399920ea8057f9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/util-linux-2.37.4-9.el9.x86_64.rpm"
           },
@@ -6356,9 +5940,6 @@
           },
           "sha256:ef6eb3e28612b850c9ae97b260d6a38a7fa77e8b9170516079baaa0f1154c09a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/ca-certificates-2022.2.54-90.2.el9_0.noarch.rpm"
-          },
-          "sha256:f03e357435c8b27e81ce6cb440992bd911e11a9fa0b211af1401280013651d01": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.x86_64.rpm"
           },
           "sha256:f148b83396b3a3cc002058225447b4f6fd799eee2627c95e1b24138cf3a0b224": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libselinux-utils-3.4-3.el9.x86_64.rpm"
@@ -6392,9 +5973,6 @@
           },
           "sha256:fa3abe9c3196c58b2a2943bd759eb30542962d3464970ce4171627e741160f28": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/python3-oauthlib-3.1.1-2.el9.noarch.rpm"
-          },
-          "sha256:fa3e8480793608d79e85ec366280e031470976e7c25e1c75252cad489369ec4a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-2.25-14.el9.x86_64.rpm"
           },
           "sha256:fca369324a356c6a9322689fc8c443d742ca8fb820ab2450ed10311f16882668": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-perf-5.14.0-162.6.1.el9_1.x86_64.rpm"
@@ -8100,16 +7678,6 @@
         "check_gpg": true
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.1",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
-        "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
-        "check_gpg": true
-      },
-      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -8510,36 +8078,6 @@
         "check_gpg": true
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "6",
-        "release": "2.el9_0",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efi-filesystem-6-2.el9_0.noarch.rpm",
-        "checksum": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-        "check_gpg": true
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "12.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efibootmgr-16-12.el9.x86_64.rpm",
-        "checksum": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-        "check_gpg": true
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "38",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efivar-libs-38-2.el9.x86_64.rpm",
-        "checksum": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-        "check_gpg": true
-      },
-      {
         "name": "elfutils-default-yama-scope",
         "epoch": 0,
         "version": "0.187",
@@ -8647,16 +8185,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm",
         "checksum": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.9",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fwupd-1.7.9-1.el9.x86_64.rpm",
-        "checksum": "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3",
         "check_gpg": true
       },
       {
@@ -8827,16 +8355,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-common-2.06-46.el9.noarch.rpm",
         "checksum": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "46.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm",
-        "checksum": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
         "check_gpg": true
       },
       {
@@ -9470,16 +8988,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm",
-        "checksum": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.3.1",
@@ -9520,26 +9028,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "237",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgudev-237-1.el9.x86_64.rpm",
-        "checksum": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671",
-        "check_gpg": true
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.8",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgusb-0.3.8-1.el9.x86_64.rpm",
-        "checksum": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39",
-        "check_gpg": true
-      },
-      {
         "name": "libibverbs",
         "epoch": 0,
         "version": "41.0",
@@ -9567,16 +9055,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libini_config-1.3.1-53.el9.x86_64.rpm",
         "checksum": "sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35",
-        "check_gpg": true
-      },
-      {
-        "name": "libjcat",
-        "epoch": 0,
-        "version": "0.1.6",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libjcat-0.1.6-3.el9.x86_64.rpm",
-        "checksum": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
         "check_gpg": true
       },
       {
@@ -9870,16 +9348,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.3",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm",
-        "checksum": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-        "check_gpg": true
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.22",
@@ -10040,16 +9508,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.26",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libusbx-1.0.26-1.el9.x86_64.rpm",
-        "checksum": "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7",
-        "check_gpg": true
-      },
-      {
         "name": "libuser",
         "epoch": 0,
         "version": "0.63",
@@ -10107,16 +9565,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxml2-2.9.13-2.el9.x86_64.rpm",
         "checksum": "sha256:26bee2c6124e4047f5b6261589bbd7a801603ca12dc90b64b0cd178911e25cbb",
-        "check_gpg": true
-      },
-      {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.3.3",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm",
-        "checksum": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3",
         "check_gpg": true
       },
       {
@@ -10240,16 +9688,6 @@
         "check_gpg": true
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mdadm-4.2-6.el9.x86_64.rpm",
-        "checksum": "sha256:dfdaa5afa228685c56e65edd92d2a7aba162c7e1e16cce2053767e246fef6076",
-        "check_gpg": true
-      },
-      {
         "name": "microcode_ctl",
         "epoch": 4,
         "version": "20220809",
@@ -10257,16 +9695,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/microcode_ctl-20220809-1.el9.noarch.rpm",
         "checksum": "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88",
-        "check_gpg": true
-      },
-      {
-        "name": "mokutil",
-        "epoch": 2,
-        "version": "0.4.0",
-        "release": "9.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mokutil-0.4.0-9.el9.x86_64.rpm",
-        "checksum": "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e",
         "check_gpg": true
       },
       {
@@ -11160,26 +10588,6 @@
         "check_gpg": true
       },
       {
-        "name": "shared-mime-info",
-        "epoch": 0,
-        "version": "2.1",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shared-mime-info-2.1-4.el9.x86_64.rpm",
-        "checksum": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a",
-        "check_gpg": true
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
-        "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-        "check_gpg": true
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -11570,26 +10978,6 @@
         "check_gpg": true
       },
       {
-        "name": "flashrom",
-        "epoch": 0,
-        "version": "1.2",
-        "release": "10.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/flashrom-1.2-10.el9.x86_64.rpm",
-        "checksum": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd-plugin-flashrom",
-        "epoch": 0,
-        "version": "1.7.9",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fwupd-plugin-flashrom-1.7.9-1.el9.x86_64.rpm",
-        "checksum": "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c",
-        "check_gpg": true
-      },
-      {
         "name": "gawk-all-langpacks",
         "epoch": 0,
         "version": "5.1.0",
@@ -11670,106 +11058,6 @@
         "check_gpg": true
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "22.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libatasmart-0.19-22.el9.x86_64.rpm",
-        "checksum": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:fa3e8480793608d79e85ec366280e031470976e7c25e1c75252cad489369ec4a",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-crypto-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:ce7a47da96b91cb7a50a9876fe2931f472e84ad71b72827001c5631c25e30e10",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-loop-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:aa805098a888939a75c1f9ed46ff281c2c2fcdd282a8d18d37852bd8b0085151",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-mdraid-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:88a824609ad38bee5ea8037eb18a6477f6e6b313af6deda6311286406d1065a7",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-part-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:25536d6377e24d4cb7d95a76ccfc16de8b81c053ea77ad5a0961087ed52cf4c0",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-swap-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:ee53fb84a91d66355c438c47593d677df32222be79a856cd406dd73c1e719b25",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-utils-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:2671d507c8f07af10dfc20de9695e62c2c8dc9ed3b8cee7e464d47932ac24e97",
-        "check_gpg": true
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "2.5",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libbytesize-2.5-3.el9.x86_64.rpm",
-        "checksum": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974",
-        "check_gpg": true
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.11",
@@ -11800,16 +11088,6 @@
         "check_gpg": true
       },
       {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.x86_64.rpm",
-        "checksum": "sha256:f03e357435c8b27e81ce6cb440992bd911e11a9fa0b211af1401280013651d01",
-        "check_gpg": true
-      },
-      {
         "name": "libxcrypt-compat",
         "epoch": 0,
         "version": "4.4.18",
@@ -11817,66 +11095,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm",
         "checksum": "sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a",
-        "check_gpg": true
-      },
-      {
-        "name": "nspr",
-        "epoch": 0,
-        "version": "4.34.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nspr-4.34.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:2fb3471163091eca166f66fb3f69d17dede5f0a3bb51784ab18959dcdc5f7f71",
-        "check_gpg": true
-      },
-      {
-        "name": "nss",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:81138535e5e487dcb7620946f4494a3d85e38be7c1395af7241498568acd0321",
-        "check_gpg": true
-      },
-      {
-        "name": "nss-softokn",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-softokn-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:0d965a214074a7d349497e9aac3ddfa4080e6ddad3e9affeab307cd2b109aed5",
-        "check_gpg": true
-      },
-      {
-        "name": "nss-softokn-freebl",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-softokn-freebl-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:9f559003724cf2c43919dfee9c83cee56adcc686b803a35e5609b9d231b066eb",
-        "check_gpg": true
-      },
-      {
-        "name": "nss-sysinit",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-sysinit-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:d5d8010a420803df4e2947d34e40b068405441f9dd2a991a1f339c4f9c792aa4",
-        "check_gpg": true
-      },
-      {
-        "name": "nss-util",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-util-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:6c11ea9d03bb1d375559824617b03aea47a4e17ebdbe29a55235722a358740dd",
         "check_gpg": true
       },
       {
@@ -12127,26 +11345,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/rsyslog-logrotate-8.2102.0-105.el9.x86_64.rpm",
         "checksum": "sha256:8ec4556ce5b7fe7036928025846be69d5cd6597b0428271427b607d45a8e04e5",
-        "check_gpg": true
-      },
-      {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/udisks2-2.9.4-3.el9.x86_64.rpm",
-        "checksum": "sha256:0dcd6624357942ada8b2ebf933ee47e11b1cbdc4eaee545519c43420adb6f46b",
-        "check_gpg": true
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.12",
-        "release": "15.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
-        "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
@@ -1441,14 +1441,6 @@
                     }
                   },
                   {
-                    "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
                     "options": {
                       "metadata": {
@@ -1817,30 +1809,6 @@
                     }
                   },
                   {
-                    "id": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd8f32a588f83b75183a94e40f895ec9640bfba4ba1768f1e86b57c18cec3e47",
                     "options": {
                       "metadata": {
@@ -1922,14 +1890,6 @@
                   },
                   {
                     "id": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2066,14 +2026,6 @@
                   },
                   {
                     "id": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2617,14 +2569,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:056c6e51fa98dae4381725ca9510ced292703ec225adf9637a61eb752d1a3a0a",
                     "options": {
                       "metadata": {
@@ -2657,22 +2601,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8d0b54556cefa3f2e9e0f8d01e0727d31559fd3f0b67cc570dec26ff38d61b84",
                     "options": {
                       "metadata": {
@@ -2690,14 +2618,6 @@
                   },
                   {
                     "id": "sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2953,14 +2873,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f70762594db38ab18ba1db1ce92e9ede5a40ca5d5c3cc93c6bd92686556472c8",
                     "options": {
                       "metadata": {
@@ -3097,14 +3009,6 @@
                     }
                   },
                   {
-                    "id": "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:32c933de69b8fae782d4e7c7a1132eaf256e73b455199a7c617bc315f3e97e7a",
                     "options": {
                       "metadata": {
@@ -3154,14 +3058,6 @@
                   },
                   {
                     "id": "sha256:26bee2c6124e4047f5b6261589bbd7a801603ca12dc90b64b0cd178911e25cbb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3281,23 +3177,7 @@
                     }
                   },
                   {
-                    "id": "sha256:dfdaa5afa228685c56e65edd92d2a7aba162c7e1e16cce2053767e246fef6076",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4097,22 +3977,6 @@
                     }
                   },
                   {
-                    "id": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:4b7c4822f92e7ba97b78893d273b01161e411151ccc627b076d13719ad404a69",
                     "options": {
                       "metadata": {
@@ -4457,22 +4321,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c1fcc71c1cc1160d58ace4b60cc6733b68d6f6d406e5ec5ce24327787f452cd1",
                     "options": {
                       "metadata": {
@@ -4561,86 +4409,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fa3e8480793608d79e85ec366280e031470976e7c25e1c75252cad489369ec4a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce7a47da96b91cb7a50a9876fe2931f472e84ad71b72827001c5631c25e30e10",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:aa805098a888939a75c1f9ed46ff281c2c2fcdd282a8d18d37852bd8b0085151",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:88a824609ad38bee5ea8037eb18a6477f6e6b313af6deda6311286406d1065a7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:25536d6377e24d4cb7d95a76ccfc16de8b81c053ea77ad5a0961087ed52cf4c0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ee53fb84a91d66355c438c47593d677df32222be79a856cd406dd73c1e719b25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2671d507c8f07af10dfc20de9695e62c2c8dc9ed3b8cee7e464d47932ac24e97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:774a7de97ac6cdec24de0f2a9be666492b5830d317ae5f5cfe9223c50e3da0c4",
                     "options": {
                       "metadata": {
@@ -4666,14 +4434,6 @@
                   },
                   {
                     "id": "sha256:38c2923779bae32c37a5138ac06231c8de5bd7499f5148b5065c12faa92c5b3c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f03e357435c8b27e81ce6cb440992bd911e11a9fa0b211af1401280013651d01",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5585,23 +5345,7 @@
                     }
                   },
                   {
-                    "id": "sha256:0dcd6624357942ada8b2ebf933ee47e11b1cbdc4eaee545519c43420adb6f46b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c52563ef6ba99cd8806b2fde878357f1c9ce092a098a85086e9bc39054cb54e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6284,10 +6028,6 @@
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat",
-                "unified": true
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,
               "config": {
@@ -6637,9 +6377,6 @@
           "sha256:0d965a214074a7d349497e9aac3ddfa4080e6ddad3e9affeab307cd2b109aed5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nss-softokn-3.79.0-14.el9_0.x86_64.rpm"
           },
-          "sha256:0dcd6624357942ada8b2ebf933ee47e11b1cbdc4eaee545519c43420adb6f46b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/udisks2-2.9.4-3.el9.x86_64.rpm"
-          },
           "sha256:0e5de5b828060e128ee9c0e57cb38a4f72692a2f1f11ed208439c4c07dcf192d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-tools-minimal-2.06-46.el9.x86_64.rpm"
           },
@@ -6790,14 +6527,8 @@
           "sha256:24983ca0db3271a80dfb9fc7282964eec863f155691333f265cd083654dac2da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/virt-what-1.25-1.el9.x86_64.rpm"
           },
-          "sha256:25536d6377e24d4cb7d95a76ccfc16de8b81c053ea77ad5a0961087ed52cf4c0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-part-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:261fc6bda6cc98f638b572e93b611c850f4b44e4c93d7c07e02bccbf9dca946a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.1-20221015/Packages/fence-agents-rsa-4.10.0-30.el9.noarch.rpm"
-          },
-          "sha256:2671d507c8f07af10dfc20de9695e62c2c8dc9ed3b8cee7e464d47932ac24e97": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-utils-2.25-14.el9.x86_64.rpm"
           },
           "sha256:26bee2c6124e4047f5b6261589bbd7a801603ca12dc90b64b0cd178911e25cbb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxml2-2.9.13-2.el9.x86_64.rpm"
@@ -6813,9 +6544,6 @@
           },
           "sha256:28a5f98e7922427c7f69d36773c6cd2079812c93442e8116af14fc8dbb139201": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/krb5-libs-1.19.1-22.el9.x86_64.rpm"
-          },
-          "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fwupd-1.7.9-1.el9.x86_64.rpm"
           },
           "sha256:29826b32a7c4a7849f26290be47b4aa41fe14de69550f30da10ebf7d5782a133": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/which-2.21-28.el9.x86_64.rpm"
@@ -6871,9 +6599,6 @@
           "sha256:2f3ad8da0aa342fcc7343b0a7963aba93e1253f4109a18f46d5a02ac9e030766": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/python3-lxml-4.6.5-3.el9.x86_64.rpm"
           },
-          "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgudev-237-1.el9.x86_64.rpm"
-          },
           "sha256:2fb3471163091eca166f66fb3f69d17dede5f0a3bb51784ab18959dcdc5f7f71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/nspr-4.34.0-14.el9_0.x86_64.rpm"
           },
@@ -6897,9 +6622,6 @@
           },
           "sha256:322dd1e3f213b4a90de07a584259b9fa8f058cdfcd3bc38ecf3b5b79175835a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libfdisk-2.37.4-9.el9.x86_64.rpm"
-          },
-          "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm"
           },
           "sha256:32c933de69b8fae782d4e7c7a1132eaf256e73b455199a7c617bc315f3e97e7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libuser-0.63-11.el9.x86_64.rpm"
@@ -6927,9 +6649,6 @@
           },
           "sha256:39146b9a69e244c59a9a41cfaab20fedcf890c640e04ed0d993e4473e7443106": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libpkgconf-1.7.3-9.el9.x86_64.rpm"
-          },
-          "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libusbx-1.0.26-1.el9.x86_64.rpm"
           },
           "sha256:395eafb58304cec0d88c4e2de4ceaa954eac756c441783e7a46df6d88f049bcd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/telnet-0.17-85.el9.x86_64.rpm"
@@ -7020,9 +6739,6 @@
           },
           "sha256:43d40891623256b30a7d08d8db21a3d94d94756ecade355845e52c64f5af7765": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libevent-2.1.12-6.el9.x86_64.rpm"
-          },
-          "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shared-mime-info-2.1-4.el9.x86_64.rpm"
           },
           "sha256:44b4ebb0b3cc5a733d477b684082c23d8b4230953f192113353a6aa664e83624": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/gpgme-1.15.1-6.el9.x86_64.rpm"
@@ -7135,9 +6851,6 @@
           "sha256:50b10ed9964a5824b705a04d3937bc2e22f29751fba66a97b991c429bbb3664c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/nettle-3.8-3.el9_0.x86_64.rpm"
           },
-          "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm"
-          },
           "sha256:5246e2b08f6c120e3c2fc418c18fcd1db17c9fdc53fe51cd763fabfbe5b6c4fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/pkgconf-pkg-config-1.7.3-9.el9.x86_64.rpm"
           },
@@ -7165,9 +6878,6 @@
           "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/langpacks-en-3.0-16.el9.noarch.rpm"
           },
-          "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efivar-libs-38-2.el9.x86_64.rpm"
-          },
           "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm"
           },
@@ -7180,9 +6890,6 @@
           "sha256:563d301817a83d6959469f6117ec1e8fa21aa7aafe8ae0f99ab71a62dbb05ba0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/tuned-2.19.0-1.el9.noarch.rpm"
           },
-          "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
-          },
           "sha256:587284378eec54fded45c8eb778a7afb9d9c3a74201c5e9068ac3030bdca02e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/redhat-release-eula-9.1-1.9.el9.x86_64.rpm"
           },
@@ -7191,9 +6898,6 @@
           },
           "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm"
-          },
-          "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libjcat-0.1.6-3.el9.x86_64.rpm"
           },
           "sha256:5a43c616c3f06fbba7d45ea4cdd87ca58cc46102908e089a14604de5d55a0393": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/redhat-logos-90.4-1.el9.x86_64.rpm"
@@ -7264,9 +6968,6 @@
           "sha256:644ed9b3264a546abac89fdd40c0140911ed8ceef6e05d7594f84e0f570c6347": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libffi-3.4.2-7.el9.x86_64.rpm"
           },
-          "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgusb-0.3.8-1.el9.x86_64.rpm"
-          },
           "sha256:6477fb3c3285158f676360e228057e13dc6e983f453c7c74ed4ab140357f9a0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libunistring-0.9.10-15.el9.x86_64.rpm"
           },
@@ -7333,9 +7034,6 @@
           "sha256:6da6e13deb7badafaa4e10bc8f7a81acd40e4cba3c34b4590826e8eb9a329f3d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libnl3-3.7.0-1.el9.x86_64.rpm"
           },
-          "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efibootmgr-16-12.el9.x86_64.rpm"
-          },
           "sha256:6ea4966a7336839fc47ae6308c8a00f69e4126bc1ff0832899c9a0eaa0661d19": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libcap-2.48-8.el9.x86_64.rpm"
           },
@@ -7384,9 +7082,6 @@
           "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-vars-1.05-479.el9.noarch.rpm"
           },
-          "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efi-filesystem-6-2.el9_0.noarch.rpm"
-          },
           "sha256:737a278cdf7c292337d4b54dff0479c1cb88c74200179d2ae0caf6d766ea5d00": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/chrony-4.2-1.el9.x86_64.rpm"
           },
@@ -7398,9 +7093,6 @@
           },
           "sha256:74e68fba2f9e510dd674766800eb0df8ca0ea546fcc20264d92ed9cd5beaee9a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/oddjob-0.34.7-6.el9.x86_64.rpm"
-          },
-          "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libatasmart-0.19-22.el9.x86_64.rpm"
           },
           "sha256:75da9e9faf295a7cdc1e8aede617c5468860ed03750f5543eb1ed00ca1d6c1e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libcollection-0.7.0-53.el9.x86_64.rpm"
@@ -7543,9 +7235,6 @@
           "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-Exporter-5.74-461.el9.noarch.rpm"
           },
-          "sha256:88a824609ad38bee5ea8037eb18a6477f6e6b313af6deda6311286406d1065a7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-mdraid-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:88f123ca2fd9a3a5c59f4065500ccc2e94e64502035e65a524e1e55574a7df75": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libdnf-plugin-subscription-manager-1.29.30-1.el9.x86_64.rpm"
           },
@@ -7645,9 +7334,6 @@
           "sha256:973f31bf9aa9e53671d12df1a65c441f7e719455a7cd64d8af9446aaf6d56407": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.1-20221015/Packages/fence-agents-amt-ws-4.10.0-30.el9.noarch.rpm"
           },
-          "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mokutil-0.4.0-9.el9.x86_64.rpm"
-          },
           "sha256:98feca993ba0ce005b91ee5a2123c6a107c0c0154b893c6edc69beed651529e6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.1-20221015/Packages/fence-agents-emerson-4.10.0-30.el9.noarch.rpm"
           },
@@ -7683,9 +7369,6 @@
           },
           "sha256:9c332f10871fa27bcf99d7afcea2220fe50227cd8c943b295f83081d44ad6ebf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/NetworkManager-tui-1.40.0-1.el9.x86_64.rpm"
-          },
-          "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm"
           },
           "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-linux-procfs-0.7.0-1.el9.noarch.rpm"
@@ -7732,9 +7415,6 @@
           "sha256:a50bb26a28ee7e6379c86b5b91285299b71569fa87ea968d800a56090b7a179d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxcrypt-4.4.18-3.el9.x86_64.rpm"
           },
-          "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fwupd-plugin-flashrom-1.7.9-1.el9.x86_64.rpm"
-          },
           "sha256:a62889efb540a272b234cd60c68cb610944a1ebcf148171861e07be0d8245b07": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/dracut-squash-057-13.git20220816.el9.x86_64.rpm"
           },
@@ -7770,9 +7450,6 @@
           },
           "sha256:aa6105f1cefa12a2509fd24d8825bf17328339531144dc192ac7900298be3ab7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/polkit-0.117-10.el9_0.x86_64.rpm"
-          },
-          "sha256:aa805098a888939a75c1f9ed46ff281c2c2fcdd282a8d18d37852bd8b0085151": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-loop-2.25-14.el9.x86_64.rpm"
           },
           "sha256:aaa17904b12fe5e7df830fb9c512d971f29221dec19a3e421307b41526696f5e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/pciutils-3.7.0-5.el9.x86_64.rpm"
@@ -7912,9 +7589,6 @@
           "sha256:beed55d3ab1e8dd1207e1bd67e40e180c53a001198b9a7186f4bf07c042b377e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openldap-compat-2.6.2-3.el9.x86_64.rpm"
           },
-          "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/flashrom-1.2-10.el9.x86_64.rpm"
-          },
           "sha256:bf3baf444e49eba4189e57d562a7522ab714132d2960db87ef9b99f1b46a3cc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sed-4.8-9.el9.x86_64.rpm"
           },
@@ -7981,9 +7655,6 @@
           "sha256:c972030a8fbaa2d981f0e5fdfc42d6d5173dd047c94d86ab7732e3e53fc4e97a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libpipeline-1.5.3-4.el9.x86_64.rpm"
           },
-          "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:cb07b2cabae7305f5e4e5784530a75a8f91c57a79da1ae7ff7808ce23917ebd3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libedit-3.1-37.20210216cvs.el9.x86_64.rpm"
           },
@@ -8004,9 +7675,6 @@
           },
           "sha256:ce6dcb35f56a067393e94e5d49299a9ab256ad4949e6f86ac27e6b58516b18a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/kmod-libs-28-7.el9.x86_64.rpm"
-          },
-          "sha256:ce7a47da96b91cb7a50a9876fe2931f472e84ad71b72827001c5631c25e30e10": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-crypto-2.25-14.el9.x86_64.rpm"
           },
           "sha256:cf0662ef00d4e84727fafc79cee6941f865e0cb657332dd7448759b2f83a4809": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libss-1.46.5-3.el9.x86_64.rpm"
@@ -8092,9 +7760,6 @@
           "sha256:d89db8105e710c721bf12a6419ee394572fa880eaba11237898eb91e4acd0348": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/python3-pycparser-2.20-6.el9.noarch.rpm"
           },
-          "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm"
-          },
           "sha256:d9b53fda4b8757fd63b53a415f533ab876c18c28a94fd21d10658de85978f254": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/cpio-2.13-16.el9.x86_64.rpm"
           },
@@ -8131,14 +7796,8 @@
           "sha256:decaeac8fa883ddd631a32aaf55eb6175ab6e328150d66dfcf8e322b26da258f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/corosynclib-3.1.5-4.el9.x86_64.rpm"
           },
-          "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm"
-          },
           "sha256:df2ab474c2d513ed863d2265efbdbb32ce9c1b1dd00365f041f6539ec36dd80d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmartcols-2.37.4-9.el9.x86_64.rpm"
-          },
-          "sha256:dfdaa5afa228685c56e65edd92d2a7aba162c7e1e16cce2053767e246fef6076": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mdadm-4.2-6.el9.x86_64.rpm"
           },
           "sha256:e069efd411901c3d1be3fa6898d18cc8a787722a6fbeb71f56b59890073ca6e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libdnf-0.67.0-3.el9.x86_64.rpm"
@@ -8163,9 +7822,6 @@
           },
           "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/snappy-1.1.8-8.el9.x86_64.rpm"
-          },
-          "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm"
           },
           "sha256:e5c4efec2d4e9e7bb461b5880efc09ba6b5c42c2fab6cc2b784ed2f79a79ca1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-dnf-4.12.0-4.el9.noarch.rpm"
@@ -8227,9 +7883,6 @@
           "sha256:ec162bbce74978ac450bfcc60e74fe090cdef2e096214cc223117ddafe983ac7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-NDBM_File-1.15-479.el9.x86_64.rpm"
           },
-          "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libbytesize-2.5-3.el9.x86_64.rpm"
-          },
           "sha256:ed4bfb8d96a13bad9b85dde758d6f481fa62abd56595760134e3ea195e63806e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libpath_utils-0.2.1-53.el9.x86_64.rpm"
           },
@@ -8242,9 +7895,6 @@
           "sha256:ee1368739d142d7c46836f2efd86e91a648bae68e46114f00596f819ad08ea31": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-pc-modules-2.06-46.el9.noarch.rpm"
           },
-          "sha256:ee53fb84a91d66355c438c47593d677df32222be79a856cd406dd73c1e719b25": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-swap-2.25-14.el9.x86_64.rpm"
-          },
           "sha256:ee84863d757bd2084b084aa768b80c47753922ecf0b767796399920ea8057f9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/util-linux-2.37.4-9.el9.x86_64.rpm"
           },
@@ -8256,9 +7906,6 @@
           },
           "sha256:ef6eb3e28612b850c9ae97b260d6a38a7fa77e8b9170516079baaa0f1154c09a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/ca-certificates-2022.2.54-90.2.el9_0.noarch.rpm"
-          },
-          "sha256:f03e357435c8b27e81ce6cb440992bd911e11a9fa0b211af1401280013651d01": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.x86_64.rpm"
           },
           "sha256:f0f60e63cb2bcfcf16d4b4bf6948ab0529da8b61f77c1780dd3587354f19fefe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.1-20221015/Packages/libknet1-crypto-nss-plugin-1.24-2.el9.x86_64.rpm"
@@ -8301,9 +7948,6 @@
           },
           "sha256:fa3abe9c3196c58b2a2943bd759eb30542962d3464970ce4171627e741160f28": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/python3-oauthlib-3.1.1-2.el9.noarch.rpm"
-          },
-          "sha256:fa3e8480793608d79e85ec366280e031470976e7c25e1c75252cad489369ec4a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-2.25-14.el9.x86_64.rpm"
           },
           "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm"
@@ -10015,16 +9659,6 @@
         "check_gpg": true
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.1",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
-        "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
-        "check_gpg": true
-      },
-      {
         "name": "bzip2",
         "epoch": 0,
         "version": "1.0.8",
@@ -10485,36 +10119,6 @@
         "check_gpg": true
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "6",
-        "release": "2.el9_0",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efi-filesystem-6-2.el9_0.noarch.rpm",
-        "checksum": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-        "check_gpg": true
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "12.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efibootmgr-16-12.el9.x86_64.rpm",
-        "checksum": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-        "check_gpg": true
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "38",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efivar-libs-38-2.el9.x86_64.rpm",
-        "checksum": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-        "check_gpg": true
-      },
-      {
         "name": "elfutils-default-yama-scope",
         "epoch": 0,
         "version": "0.187",
@@ -10622,16 +10226,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm",
         "checksum": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.9",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fwupd-1.7.9-1.el9.x86_64.rpm",
-        "checksum": "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3",
         "check_gpg": true
       },
       {
@@ -10802,16 +10396,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-common-2.06-46.el9.noarch.rpm",
         "checksum": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "46.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm",
-        "checksum": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
         "check_gpg": true
       },
       {
@@ -11485,16 +11069,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm",
-        "checksum": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.3.1",
@@ -11535,26 +11109,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "237",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgudev-237-1.el9.x86_64.rpm",
-        "checksum": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671",
-        "check_gpg": true
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.8",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgusb-0.3.8-1.el9.x86_64.rpm",
-        "checksum": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39",
-        "check_gpg": true
-      },
-      {
         "name": "libibverbs",
         "epoch": 0,
         "version": "41.0",
@@ -11582,16 +11136,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libini_config-1.3.1-53.el9.x86_64.rpm",
         "checksum": "sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35",
-        "check_gpg": true
-      },
-      {
-        "name": "libjcat",
-        "epoch": 0,
-        "version": "0.1.6",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libjcat-0.1.6-3.el9.x86_64.rpm",
-        "checksum": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
         "check_gpg": true
       },
       {
@@ -11905,16 +11449,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.3",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm",
-        "checksum": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-        "check_gpg": true
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.22",
@@ -12085,16 +11619,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.26",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libusbx-1.0.26-1.el9.x86_64.rpm",
-        "checksum": "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7",
-        "check_gpg": true
-      },
-      {
         "name": "libuser",
         "epoch": 0,
         "version": "0.63",
@@ -12162,16 +11686,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxml2-2.9.13-2.el9.x86_64.rpm",
         "checksum": "sha256:26bee2c6124e4047f5b6261589bbd7a801603ca12dc90b64b0cd178911e25cbb",
-        "check_gpg": true
-      },
-      {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.3.3",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm",
-        "checksum": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3",
         "check_gpg": true
       },
       {
@@ -12315,16 +11829,6 @@
         "check_gpg": true
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mdadm-4.2-6.el9.x86_64.rpm",
-        "checksum": "sha256:dfdaa5afa228685c56e65edd92d2a7aba162c7e1e16cce2053767e246fef6076",
-        "check_gpg": true
-      },
-      {
         "name": "microcode_ctl",
         "epoch": 4,
         "version": "20220809",
@@ -12332,16 +11836,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/microcode_ctl-20220809-1.el9.noarch.rpm",
         "checksum": "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88",
-        "check_gpg": true
-      },
-      {
-        "name": "mokutil",
-        "epoch": 2,
-        "version": "0.4.0",
-        "release": "9.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mokutil-0.4.0-9.el9.x86_64.rpm",
-        "checksum": "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e",
         "check_gpg": true
       },
       {
@@ -13335,26 +12829,6 @@
         "check_gpg": true
       },
       {
-        "name": "shared-mime-info",
-        "epoch": 0,
-        "version": "2.1",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shared-mime-info-2.1-4.el9.x86_64.rpm",
-        "checksum": "sha256:442b665e87e21775c72e47730b330b9dc9f05a1b5f002ab0cd8e96d748abae0a",
-        "check_gpg": true
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
-        "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-        "check_gpg": true
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -13785,26 +13259,6 @@
         "check_gpg": true
       },
       {
-        "name": "flashrom",
-        "epoch": 0,
-        "version": "1.2",
-        "release": "10.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/flashrom-1.2-10.el9.x86_64.rpm",
-        "checksum": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd-plugin-flashrom",
-        "epoch": 0,
-        "version": "1.7.9",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fwupd-plugin-flashrom-1.7.9-1.el9.x86_64.rpm",
-        "checksum": "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c",
-        "check_gpg": true
-      },
-      {
         "name": "gawk-all-langpacks",
         "epoch": 0,
         "version": "5.1.0",
@@ -13915,106 +13369,6 @@
         "check_gpg": true
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "22.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libatasmart-0.19-22.el9.x86_64.rpm",
-        "checksum": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:fa3e8480793608d79e85ec366280e031470976e7c25e1c75252cad489369ec4a",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-crypto-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:ce7a47da96b91cb7a50a9876fe2931f472e84ad71b72827001c5631c25e30e10",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-fs-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:c9dbd8c07913e24231c2c6690df49f7f6d6039888c02c974ac0fcbc7c6eb6d33",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-loop-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:aa805098a888939a75c1f9ed46ff281c2c2fcdd282a8d18d37852bd8b0085151",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-mdraid-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:88a824609ad38bee5ea8037eb18a6477f6e6b313af6deda6311286406d1065a7",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-part-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:25536d6377e24d4cb7d95a76ccfc16de8b81c053ea77ad5a0961087ed52cf4c0",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-swap-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:ee53fb84a91d66355c438c47593d677df32222be79a856cd406dd73c1e719b25",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.25",
-        "release": "14.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libblockdev-utils-2.25-14.el9.x86_64.rpm",
-        "checksum": "sha256:2671d507c8f07af10dfc20de9695e62c2c8dc9ed3b8cee7e464d47932ac24e97",
-        "check_gpg": true
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "2.5",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libbytesize-2.5-3.el9.x86_64.rpm",
-        "checksum": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974",
-        "check_gpg": true
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.11",
@@ -14052,16 +13406,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libqb-2.0.6-1.el9.x86_64.rpm",
         "checksum": "sha256:38c2923779bae32c37a5138ac06231c8de5bd7499f5148b5065c12faa92c5b3c",
-        "check_gpg": true
-      },
-      {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libudisks2-2.9.4-3.el9.x86_64.rpm",
-        "checksum": "sha256:f03e357435c8b27e81ce6cb440992bd911e11a9fa0b211af1401280013651d01",
         "check_gpg": true
       },
       {
@@ -15195,16 +14539,6 @@
         "check_gpg": true
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/udisks2-2.9.4-3.el9.x86_64.rpm",
-        "checksum": "sha256:0dcd6624357942ada8b2ebf933ee47e11b1cbdc4eaee545519c43420adb6f46b",
-        "check_gpg": true
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.16.2",
@@ -15212,16 +14546,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/unbound-libs-1.16.2-2.el9.x86_64.rpm",
         "checksum": "sha256:3c52563ef6ba99cd8806b2fde878357f1c9ce092a098a85086e9bc39054cb54e",
-        "check_gpg": true
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.12",
-        "release": "15.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
-        "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
@@ -2045,30 +2045,6 @@
                     }
                   },
                   {
-                    "id": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:68a8e7a042e8e2f9574db0b684997c3e3c38b3ba95fc45762a2c04befb4acfcf",
                     "options": {
                       "metadata": {
@@ -2182,14 +2158,6 @@
                   },
                   {
                     "id": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2342,14 +2310,6 @@
                   },
                   {
                     "id": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3021,14 +2981,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:056c6e51fa98dae4381725ca9510ced292703ec225adf9637a61eb752d1a3a0a",
                     "options": {
                       "metadata": {
@@ -3110,14 +3062,6 @@
                   },
                   {
                     "id": "sha256:3f36bb46fddf18961d9851da351aef75be8191ef7a634a79199f5abf9979cd8d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3437,14 +3381,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f70762594db38ab18ba1db1ce92e9ede5a40ca5d5c3cc93c6bd92686556472c8",
                     "options": {
                       "metadata": {
@@ -3653,14 +3589,6 @@
                     }
                   },
                   {
-                    "id": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:409beeb1faf626a882e95763ec4892d514077289e6074d3b61bef1b90739ad66",
                     "options": {
                       "metadata": {
@@ -3822,14 +3750,6 @@
                   },
                   {
                     "id": "sha256:27bc149f91c6740d37eb11b8e8e3c113092b7de231a11bc5552f3e0db78ae07e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4773,14 +4693,6 @@
                     }
                   },
                   {
-                    "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:4b7c4822f92e7ba97b78893d273b01161e411151ccc627b076d13719ad404a69",
                     "options": {
                       "metadata": {
@@ -5685,14 +5597,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:21edb6cf19c08c1d100e329d2b7f99b85692f23a518b1b2a1887ee1682d28880",
                     "options": {
                       "metadata": {
@@ -5774,14 +5678,6 @@
                   },
                   {
                     "id": "sha256:a7ba2bb451678b22e4e58cc7b235554e7dee87e6ec01438d512ce1a9c9d46aa1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -8687,10 +8583,6 @@
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 processor.max_cstate=1 intel_idle.max_cstate=1",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat",
-                "unified": true
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-162.6.1.el9_1.x86_64",
               "write_cmdline": false,
               "config": {
@@ -9322,9 +9214,6 @@
           "sha256:28a5f98e7922427c7f69d36773c6cd2079812c93442e8116af14fc8dbb139201": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/krb5-libs-1.19.1-22.el9.x86_64.rpm"
           },
-          "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fwupd-1.7.9-1.el9.x86_64.rpm"
-          },
           "sha256:29826b32a7c4a7849f26290be47b4aa41fe14de69550f30da10ebf7d5782a133": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/which-2.21-28.el9.x86_64.rpm"
           },
@@ -9775,9 +9664,6 @@
           "sha256:50b10ed9964a5824b705a04d3937bc2e22f29751fba66a97b991c429bbb3664c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/nettle-3.8-3.el9_0.x86_64.rpm"
           },
-          "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm"
-          },
           "sha256:5236df95b2d813cf2218310327e1fb10a4bf36ee645f5373a987780c9fab06bf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/avahi-glib-0.8-12.el9.x86_64.rpm"
           },
@@ -9808,9 +9694,6 @@
           "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/langpacks-en-3.0-16.el9.noarch.rpm"
           },
-          "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efivar-libs-38-2.el9.x86_64.rpm"
-          },
           "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm"
           },
@@ -9832,9 +9715,6 @@
           "sha256:571e34c4445cce70faecd1ac1bee18a36b1559eb83b2d52d3b5a8a3b7d8a5bfa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libtracker-sparql-3.1.2-2.el9.x86_64.rpm"
           },
-          "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
-          },
           "sha256:583c5975a04bdcd968cd160468430a3d3bcabbc864071c3c150240c2ff9e43d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libappstream-glib-0.7.18-4.el9.x86_64.rpm"
           },
@@ -9849,9 +9729,6 @@
           },
           "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm"
-          },
-          "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libjcat-0.1.6-3.el9.x86_64.rpm"
           },
           "sha256:595961072f69a1c947e3fe0b14bb5ce160172edb8481961257bda3a8c00b2fdd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/kpatch-0.9.4-3.el9.noarch.rpm"
@@ -10066,9 +9943,6 @@
           "sha256:6dadd44b2e84b1a99d81c260533f1aa8aef7c3338f31aa720509defe3a5cd7c7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/cockpit-system-276.1-1.el9.noarch.rpm"
           },
-          "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efibootmgr-16-12.el9.x86_64.rpm"
-          },
           "sha256:6e449ce10dec4eed41ec10549c0a0131d3152171b2abe1016266c8e34ecf0566": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/bind-libs-9.16.23-5.el9_1.x86_64.rpm"
           },
@@ -10131,9 +10005,6 @@
           },
           "sha256:7290d5c6c200a2c98be30c3f0d9cf58462d0bc1ddb7940a8c7c35ca4f7e090ce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fstrm-0.6.1-3.el9.x86_64.rpm"
-          },
-          "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efi-filesystem-6-2.el9_0.noarch.rpm"
           },
           "sha256:737a278cdf7c292337d4b54dff0479c1cb88c74200179d2ae0caf6d766ea5d00": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/chrony-4.2-1.el9.x86_64.rpm"
@@ -10528,9 +10399,6 @@
           "sha256:9658da838021711f687cf283368664984bfb1c8b9176897d7d477a724a11a731": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/lz4-libs-1.9.3-5.el9.x86_64.rpm"
           },
-          "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mokutil-0.4.0-9.el9.x86_64.rpm"
-          },
           "sha256:979857c9789008c57b121256bc92ec35d1e3a9aaeaca998373c19f34d8b3c84e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/openjpeg2-2.4.0-7.el9.x86_64.rpm"
           },
@@ -10584,9 +10452,6 @@
           },
           "sha256:9c47a3d7531f2619e7636baaccca1ffd3b7893537d0107a335ae639475c96dab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sssd-proxy-2.7.3-4.el9.x86_64.rpm"
-          },
-          "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm"
           },
           "sha256:9ddcf4c8e5463a1b75b22be070ae8c67264ffd8bc035e3942791184b4f4b34d7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/jbig2dec-libs-0.19-6.el9.x86_64.rpm"
@@ -10674,9 +10539,6 @@
           },
           "sha256:a50bb26a28ee7e6379c86b5b91285299b71569fa87ea968d800a56090b7a179d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxcrypt-4.4.18-3.el9.x86_64.rpm"
-          },
-          "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fwupd-plugin-flashrom-1.7.9-1.el9.x86_64.rpm"
           },
           "sha256:a62889efb540a272b234cd60c68cb610944a1ebcf148171861e07be0d8245b07": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/dracut-squash-057-13.git20220816.el9.x86_64.rpm"
@@ -10977,9 +10839,6 @@
           },
           "sha256:beed55d3ab1e8dd1207e1bd67e40e180c53a001198b9a7186f4bf07c042b377e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/openldap-compat-2.6.2-3.el9.x86_64.rpm"
-          },
-          "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/flashrom-1.2-10.el9.x86_64.rpm"
           },
           "sha256:bf3baf444e49eba4189e57d562a7522ab714132d2960db87ef9b99f1b46a3cc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sed-4.8-9.el9.x86_64.rpm"
@@ -11299,9 +11158,6 @@
           "sha256:de9869c08df7f6952787d0335b9bf1a09b328bea920556a59af07c8e085dd3cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/dbus-broker-28-7.el9.x86_64.rpm"
           },
-          "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm"
-          },
           "sha256:df2ab474c2d513ed863d2265efbdbb32ce9c1b1dd00365f041f6539ec36dd80d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmartcols-2.37.4-9.el9.x86_64.rpm"
           },
@@ -11343,9 +11199,6 @@
           },
           "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/snappy-1.1.8-8.el9.x86_64.rpm"
-          },
-          "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm"
           },
           "sha256:e5c4efec2d4e9e7bb461b5880efc09ba6b5c42c2fab6cc2b784ed2f79a79ca1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-dnf-4.12.0-4.el9.noarch.rpm"
@@ -13991,36 +13844,6 @@
         "check_gpg": true
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "6",
-        "release": "2.el9_0",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efi-filesystem-6-2.el9_0.noarch.rpm",
-        "checksum": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-        "check_gpg": true
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "12.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efibootmgr-16-12.el9.x86_64.rpm",
-        "checksum": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-        "check_gpg": true
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "38",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/efivar-libs-38-2.el9.x86_64.rpm",
-        "checksum": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-        "check_gpg": true
-      },
-      {
         "name": "elfutils-debuginfod-client",
         "epoch": 0,
         "version": "0.187",
@@ -14168,16 +13991,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm",
         "checksum": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.9",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/fwupd-1.7.9-1.el9.x86_64.rpm",
-        "checksum": "sha256:28f5875408494af078bdeb5e8c365ab3f1662697e4d511cf369bafb32d20d2f3",
         "check_gpg": true
       },
       {
@@ -14368,16 +14181,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-common-2.06-46.el9.noarch.rpm",
         "checksum": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "46.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm",
-        "checksum": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
         "check_gpg": true
       },
       {
@@ -15211,16 +15014,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libgcab1-1.4-6.el9.x86_64.rpm",
-        "checksum": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.3.1",
@@ -15328,16 +15121,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libipa_hbac-2.7.3-4.el9.x86_64.rpm",
         "checksum": "sha256:3f36bb46fddf18961d9851da351aef75be8191ef7a634a79199f5abf9979cd8d",
-        "check_gpg": true
-      },
-      {
-        "name": "libjcat",
-        "epoch": 0,
-        "version": "0.1.6",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libjcat-0.1.6-3.el9.x86_64.rpm",
-        "checksum": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
         "check_gpg": true
       },
       {
@@ -15731,16 +15514,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.3",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm",
-        "checksum": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-        "check_gpg": true
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.22",
@@ -16001,16 +15774,6 @@
         "check_gpg": true
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.3.3",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libxmlb-0.3.3-1.el9.x86_64.rpm",
-        "checksum": "sha256:52252897096408d32ddbfa3b0e56f78edcd9c18ba7b4813923d12ae01a0f06b3",
-        "check_gpg": true
-      },
-      {
         "name": "libyaml",
         "epoch": 0,
         "version": "0.2.5",
@@ -16218,16 +15981,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mlocate-0.26-30.el9.x86_64.rpm",
         "checksum": "sha256:27bc149f91c6740d37eb11b8e8e3c113092b7de231a11bc5552f3e0db78ae07e",
-        "check_gpg": true
-      },
-      {
-        "name": "mokutil",
-        "epoch": 2,
-        "version": "0.4.0",
-        "release": "9.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mokutil-0.4.0-9.el9.x86_64.rpm",
-        "checksum": "sha256:9765da04593f1dccc9f3d40227cbcc37ea777c2458a377b1197a68534de3f10e",
         "check_gpg": true
       },
       {
@@ -17401,16 +17154,6 @@
         "check_gpg": true
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
-        "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-        "check_gpg": true
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -18541,16 +18284,6 @@
         "check_gpg": true
       },
       {
-        "name": "flashrom",
-        "epoch": 0,
-        "version": "1.2",
-        "release": "10.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/flashrom-1.2-10.el9.x86_64.rpm",
-        "checksum": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-        "check_gpg": true
-      },
-      {
         "name": "flatpak",
         "epoch": 0,
         "version": "1.12.7",
@@ -18658,16 +18391,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fuse3-libs-3.10.2-5.el9.x86_64.rpm",
         "checksum": "sha256:a7ba2bb451678b22e4e58cc7b235554e7dee87e6ec01438d512ce1a9c9d46aa1",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd-plugin-flashrom",
-        "epoch": 0,
-        "version": "1.7.9",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/fwupd-plugin-flashrom-1.7.9-1.el9.x86_64.rpm",
-        "checksum": "sha256:a575c4e9a949da26490eafe75de70491b201b5ce023f2f6938ceed4ac964330c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ec2-boot.json
@@ -1422,14 +1422,6 @@
                     }
                   },
                   {
-                    "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3ee3aafd5036fd0e12513fdc0d28a4a74bb39f04bed5b7653bcbb275fa23d02b",
                     "options": {
                       "metadata": {
@@ -1750,30 +1742,6 @@
                     }
                   },
                   {
-                    "id": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:082ea65a0ef52bf65fbb4c3863366887e3e8257ad310fd1ca460b58e1688178d",
                     "options": {
                       "metadata": {
@@ -1855,14 +1823,6 @@
                   },
                   {
                     "id": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:97712d38810f5300d27b8ebea578c8f6984f2e3cada37000dd20ecb3434be81b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1999,14 +1959,6 @@
                   },
                   {
                     "id": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2518,14 +2470,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9fab6c7677e812b06012d86b3328a5d2e6262589a7403aeb78ebd117b111c2b3",
                     "options": {
                       "metadata": {
@@ -2558,22 +2502,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8d0b54556cefa3f2e9e0f8d01e0727d31559fd3f0b67cc570dec26ff38d61b84",
                     "options": {
                       "metadata": {
@@ -2591,14 +2519,6 @@
                   },
                   {
                     "id": "sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2838,14 +2758,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f70762594db38ab18ba1db1ce92e9ede5a40ca5d5c3cc93c6bd92686556472c8",
                     "options": {
                       "metadata": {
@@ -2974,14 +2886,6 @@
                     }
                   },
                   {
-                    "id": "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f644c7f76ebf48b83195ca31fc87b505006d447e2c72b24b4cb527acf0110dee",
                     "options": {
                       "metadata": {
@@ -3023,14 +2927,6 @@
                   },
                   {
                     "id": "sha256:d0df37751c0763741b991401554407105183c950a896f3ae212d74210697eebe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f33f19715860b40598d176525497fffece2ee2bc7d24b515ec28e7ade4cb75ce",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3134,23 +3030,7 @@
                     }
                   },
                   {
-                    "id": "sha256:6b2aa798ccab5b3709deb4130337562eda7eeadb29df1ee1be2b63082165e636",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:330249ea69dc22395ad848da514cb17e3275c1c7213acbda27d624daf17fd25b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3878,22 +3758,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1331732f85da72b687fbe4ef2115ddf775fb78adf18c8535979cb252d768f60e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:4b7c4822f92e7ba97b78893d273b01161e411151ccc627b076d13719ad404a69",
                     "options": {
                       "metadata": {
@@ -4198,22 +4062,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ec2c2629f59e9c7d707201f480bb95ccf9eb0821729c2bcc418243bc7b756b5d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c1fcc71c1cc1160d58ace4b60cc6733b68d6f6d406e5ec5ce24327787f452cd1",
                     "options": {
                       "metadata": {
@@ -4278,86 +4126,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fd1da85101ff67b3e2d801230f926c6f6bcb632339cb996080c27b5b87edf4fd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b3f6b58ac6cd309d9bc8afb304ef6a7cdae0c7240ab24f7b0a324bcacc9a3b0d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fc67ab16312b26497fed6fc572f8383e9210cd84758612a59b0e7f88635ee12c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:70f0ccc14a538624e86dab1cf1160a5a3409a4576a7a746b8e4bc4b1c377a2d7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:81210ba232a2f2bcae617dddcd02a1a8ed5f2b7966105b364aba478d41ba77c2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b3aa4b3aa5ed9008a8705ec0f85fb7bcb45e301468aeb3550996a113f3ecf9d1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9a393d269642a6406fd03d24a886b5b38ab446b1d074c80a5e736576f14c6a58",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:debc0c80c4de8074af7ac6cb4c4654cbc70861eeca7ba7158d97981a5aaef76b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:774a7de97ac6cdec24de0f2a9be666492b5830d317ae5f5cfe9223c50e3da0c4",
                     "options": {
                       "metadata": {
@@ -4382,63 +4150,7 @@
                     }
                   },
                   {
-                    "id": "sha256:482e8076dbe459b9b8d77b4b95895ed5091fc26642c03e0ec31ce433ad2c6ad3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2fb3471163091eca166f66fb3f69d17dede5f0a3bb51784ab18959dcdc5f7f71",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:81138535e5e487dcb7620946f4494a3d85e38be7c1395af7241498568acd0321",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0d965a214074a7d349497e9aac3ddfa4080e6ddad3e9affeab307cd2b109aed5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9f559003724cf2c43919dfee9c83cee56adcc686b803a35e5609b9d231b066eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5d8010a420803df4e2947d34e40b068405441f9dd2a991a1f339c4f9c792aa4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6c11ea9d03bb1d375559824617b03aea47a4e17ebdbe29a55235722a358740dd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4639,22 +4351,6 @@
                   },
                   {
                     "id": "sha256:6852337bd09dedeb5057696a423f6c2827f00db05c59f113fe9944a98bdcd8dd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:17aab3ef99a2590ca905c28421572ae2ea378a634a157b312ec9a9e83e405a54",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4880,10 +4576,6 @@
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat",
-                "unified": true
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-226.el9.x86_64",
               "write_cmdline": false,
               "config": {
@@ -5185,9 +4877,6 @@
           "sha256:0d81ea65c92c485dd2bbfc111164a054103c240ee10b425fb236f602c7421a96": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-librepo-1.14.5-1.el9.x86_64.rpm"
           },
-          "sha256:0d965a214074a7d349497e9aac3ddfa4080e6ddad3e9affeab307cd2b109aed5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/nss-softokn-3.79.0-14.el9_0.x86_64.rpm"
-          },
           "sha256:0e5de5b828060e128ee9c0e57cb38a4f72692a2f1f11ed208439c4c07dcf192d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/grub2-tools-minimal-2.06-46.el9.x86_64.rpm"
           },
@@ -5208,9 +4897,6 @@
           },
           "sha256:128e0c250bb2b81fe5e0ca62ae6fcb6d541bfcce839924992747e881244d94a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/glibc-common-2.34-54.el9.x86_64.rpm"
-          },
-          "sha256:1331732f85da72b687fbe4ef2115ddf775fb78adf18c8535979cb252d768f60e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shared-mime-info-2.1-5.el9.x86_64.rpm"
           },
           "sha256:143e828d11b7bc8d5855378a524dfc8c8fa890398ce2a9b5ee0796dec1d6a122": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/tar-1.34-5.el9.x86_64.rpm"
@@ -5235,9 +4921,6 @@
           },
           "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
-          },
-          "sha256:17aab3ef99a2590ca905c28421572ae2ea378a634a157b312ec9a9e83e405a54": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/udisks2-2.9.4-7.el9.x86_64.rpm"
           },
           "sha256:185c9b26e524ad1e026cb223f05b6eaf9fd5769ced16ff9897080aa8735ffe64": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/ipcalc-1.0.0-5.el9.x86_64.rpm"
@@ -5335,12 +5018,6 @@
           "sha256:2ee58b038ff185adf06194e5211b69800ba1efe502158cec867a41b3901cb420": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/logrotate-3.18.0-7.el9.x86_64.rpm"
           },
-          "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgudev-237-1.el9.x86_64.rpm"
-          },
-          "sha256:2fb3471163091eca166f66fb3f69d17dede5f0a3bb51784ab18959dcdc5f7f71": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/nspr-4.34.0-14.el9_0.x86_64.rpm"
-          },
           "sha256:30a3b8b08eafb81232ae7758eaef2ba2eef8e2ada837571fee0aaaa874de1f15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-ethtool-0.15-2.el9.x86_64.rpm"
           },
@@ -5352,12 +5029,6 @@
           },
           "sha256:326d466b616996a7bdac4202f67c8afe4fde534d57c58ba9e647ee25be583216": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/cloud-init-22.1-7.el9.noarch.rpm"
-          },
-          "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm"
-          },
-          "sha256:330249ea69dc22395ad848da514cb17e3275c1c7213acbda27d624daf17fd25b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/mokutil-0.6.0-4.el9.x86_64.rpm"
           },
           "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/microcode_ctl-20220809-1.el9.noarch.rpm"
@@ -5379,9 +5050,6 @@
           },
           "sha256:38a756f2f86bed8a0017bc1a50595ec2b9adf25287c2cd6e3cc105d90adbc09f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/hwdata-0.348-9.6.el9.noarch.rpm"
-          },
-          "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libusbx-1.0.26-1.el9.x86_64.rpm"
           },
           "sha256:39d6fe73373ae5692e510b7c6219ad1ffadad0f1bc59cb7095faf6e095811768": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-libcomps-0.1.18-1.el9.x86_64.rpm"
@@ -5473,9 +5141,6 @@
           "sha256:4792f3dd66b1250a597cc5bc3dfee924f98c89eec2c6b431679928bfbcf4aa40": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/crontabs-1.11-27.20190603git.el9_0.noarch.rpm"
           },
-          "sha256:482e8076dbe459b9b8d77b4b95895ed5091fc26642c03e0ec31ce433ad2c6ad3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libudisks2-2.9.4-7.el9.x86_64.rpm"
-          },
           "sha256:4846ecf18d3670ad6fbdcc1c29d6cdd37faa4ae20786c64d080307daae1a6f97": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-babel-2.9.1-2.el9.noarch.rpm"
           },
@@ -5533,9 +5198,6 @@
           "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/langpacks-en-3.0-16.el9.noarch.rpm"
           },
-          "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efivar-libs-38-2.el9.x86_64.rpm"
-          },
           "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm"
           },
@@ -5557,14 +5219,8 @@
           "sha256:578a0fef939ffcabcd7266cfae4f9f305b9dc52879d4c789e370919f6ad2834e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/systemd-udev-252-2.el9.x86_64.rpm"
           },
-          "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
-          },
           "sha256:588e8736af3376abfb3cdf372c10baef02c40d916a55958f3bee9767f9ad8526": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libcbor-0.7.0-5.el9.x86_64.rpm"
-          },
-          "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libjcat-0.1.6-3.el9.x86_64.rpm"
           },
           "sha256:59ae5f56ad08c41dfa73182de11fe6881bbf0f9a6b6753be65d0364e7a36e724": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/rpm-4.16.1.3-22.el9.x86_64.rpm"
@@ -5623,9 +5279,6 @@
           "sha256:644ed9b3264a546abac89fdd40c0140911ed8ceef6e05d7594f84e0f570c6347": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libffi-3.4.2-7.el9.x86_64.rpm"
           },
-          "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgusb-0.3.8-1.el9.x86_64.rpm"
-          },
           "sha256:6477fb3c3285158f676360e228057e13dc6e983f453c7c74ed4ab140357f9a0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libunistring-0.9.10-15.el9.x86_64.rpm"
           },
@@ -5659,12 +5312,6 @@
           "sha256:6b21484456d0db54736039d16f2363830e17468f84936800761eb791d2a2857d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/procps-ng-3.3.17-9.el9.x86_64.rpm"
           },
-          "sha256:6b2aa798ccab5b3709deb4130337562eda7eeadb29df1ee1be2b63082165e636": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/mdadm-4.2-7.el9.x86_64.rpm"
-          },
-          "sha256:6c11ea9d03bb1d375559824617b03aea47a4e17ebdbe29a55235722a358740dd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/nss-util-3.79.0-14.el9_0.x86_64.rpm"
-          },
           "sha256:6c54ef9e820fa1d330b643e905d62a35e34ed61fbc9b185b9175e5bc3472c89c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/rpm-build-libs-4.16.1.3-22.el9.x86_64.rpm"
           },
@@ -5676,9 +5323,6 @@
           },
           "sha256:6da6e13deb7badafaa4e10bc8f7a81acd40e4cba3c34b4590826e8eb9a329f3d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libnl3-3.7.0-1.el9.x86_64.rpm"
-          },
-          "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efibootmgr-16-12.el9.x86_64.rpm"
           },
           "sha256:6ea4966a7336839fc47ae6308c8a00f69e4126bc1ff0832899c9a0eaa0661d19": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libcap-2.48-8.el9.x86_64.rpm"
@@ -5692,9 +5336,6 @@
           "sha256:70dd2956e1b705b2cef72b93b0ab666644dee6ae2440dbd8d460b921d98a84fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/iptables-libs-1.8.8-6.el9_1.x86_64.rpm"
           },
-          "sha256:70f0ccc14a538624e86dab1cf1160a5a3409a4576a7a746b8e4bc4b1c377a2d7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-loop-2.28-3.el9.x86_64.rpm"
-          },
           "sha256:719a03ecef47b672795e803e68173b2bf94ff6ce0a5a14909e93b58e793c22e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/openssh-clients-8.7p1-24.el9_1.x86_64.rpm"
           },
@@ -5707,17 +5348,11 @@
           "sha256:727975aabe96f9bb1c2d54aad8646ca2c5acf2e34d54c50ee8348ead80aad1b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/dracut-network-057-20.git20221213.el9.x86_64.rpm"
           },
-          "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efi-filesystem-6-2.el9_0.noarch.rpm"
-          },
           "sha256:738d7e86ffd7cf47e8f432756a7b07adbb6f30aab417745b2fbbceb4faf4d954": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-libsemanage-3.4-2.el9.x86_64.rpm"
           },
           "sha256:75111b402b4e49dea70d150a0e1e2dde6cf5da4725e2c047a3eda9303dc4b9fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/zlib-1.2.11-35.el9_1.x86_64.rpm"
-          },
-          "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libatasmart-0.19-22.el9.x86_64.rpm"
           },
           "sha256:75da9e9faf295a7cdc1e8aede617c5468860ed03750f5543eb1ed00ca1d6c1e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libcollection-0.7.0-53.el9.x86_64.rpm"
@@ -5776,14 +5411,8 @@
           "sha256:80fadaa3c82e156ae8977136ff16b10a6dee28778c96ae5803c153ad717a265c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/e2fsprogs-libs-1.46.5-3.el9.x86_64.rpm"
           },
-          "sha256:81138535e5e487dcb7620946f4494a3d85e38be7c1395af7241498568acd0321": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/nss-3.79.0-14.el9_0.x86_64.rpm"
-          },
           "sha256:8115ff32b7f619956e34afba884acb032cd96b9795e10832ef4651babd86ad43": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/systemd-252-2.el9.x86_64.rpm"
-          },
-          "sha256:81210ba232a2f2bcae617dddcd02a1a8ed5f2b7966105b364aba478d41ba77c2": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-mdraid-2.28-3.el9.x86_64.rpm"
           },
           "sha256:8126bb11b3e04abf0889d61878389226b6b8bf268e42c1d6fee7d7156f82a70a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgcrypt-1.10.0-8.el9_0.x86_64.rpm"
@@ -5902,9 +5531,6 @@
           "sha256:96d75824948387a884d206865db534cd3d46f32422efcb020c20060b59edb27c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/keyutils-libs-1.6.3-1.el9.x86_64.rpm"
           },
-          "sha256:97712d38810f5300d27b8ebea578c8f6984f2e3cada37000dd20ecb3434be81b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/fwupd-1.7.10-1.el9.x86_64.rpm"
-          },
           "sha256:995b180dbfa3173ca0792c1c72ba8e4c9d8e41bf92850ca0503f2784a4ffdb4d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libsysfs-2.1.1-10.el9.x86_64.rpm"
           },
@@ -5916,9 +5542,6 @@
           },
           "sha256:99fda6725a2c668bae29fbab74d1b347e074f4e8c8ed18d656cb928fb6fc92b7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/gawk-5.1.0-6.el9.x86_64.rpm"
-          },
-          "sha256:9a393d269642a6406fd03d24a886b5b38ab446b1d074c80a5e736576f14c6a58": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-swap-2.28-3.el9.x86_64.rpm"
           },
           "sha256:9ac30c6a007bd649d242ba9f42b0ff550219344ef15df058cb6dbecfc39795f3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/dnf-4.14.0-3.el9.noarch.rpm"
@@ -5932,17 +5555,11 @@
           "sha256:9d791f2e26655b6d00c397354630c00bbf6582bccb07ec03e583580ed024759e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/glibc-2.34-54.el9.x86_64.rpm"
           },
-          "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm"
-          },
           "sha256:9ef1dc94353b414d37671cbf862b11326ac1b1384ef12d2657d438ffbfdf3e5f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/sudo-1.9.5p2-7.el9.x86_64.rpm"
           },
           "sha256:9f31d1e80342e75dcfa7a4007df1c019f4e1f857e20a56d08303117537cc449e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/elfutils-libelf-0.188-3.el9.x86_64.rpm"
-          },
-          "sha256:9f559003724cf2c43919dfee9c83cee56adcc686b803a35e5609b9d231b066eb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/nss-softokn-freebl-3.79.0-14.el9_0.x86_64.rpm"
           },
           "sha256:9f640485eb1df3b8d8759b3051bb1651b264fd0ca139b90c85ad919e365b0f22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/json-glib-1.6.6-1.el9.x86_64.rpm"
@@ -6028,12 +5645,6 @@
           "sha256:b38b44d1588a6fa85530b66e903a3271b70a77a97aaa107df0dc2d4c167e8f2c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libmount-2.37.4-9.el9.x86_64.rpm"
           },
-          "sha256:b3aa4b3aa5ed9008a8705ec0f85fb7bcb45e301468aeb3550996a113f3ecf9d1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-part-2.28-3.el9.x86_64.rpm"
-          },
-          "sha256:b3f6b58ac6cd309d9bc8afb304ef6a7cdae0c7240ab24f7b0a324bcacc9a3b0d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-crypto-2.28-3.el9.x86_64.rpm"
-          },
           "sha256:b4c9231c4d2a53d531b8993df4ace4359af2a840cc654af4c3b29ba617203159": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/dhcp-common-4.4.2-18.b1.el9.noarch.rpm"
           },
@@ -6072,9 +5683,6 @@
           },
           "sha256:beed55d3ab1e8dd1207e1bd67e40e180c53a001198b9a7186f4bf07c042b377e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/openldap-compat-2.6.2-3.el9.x86_64.rpm"
-          },
-          "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/flashrom-1.2-10.el9.x86_64.rpm"
           },
           "sha256:bf3baf444e49eba4189e57d562a7522ab714132d2960db87ef9b99f1b46a3cc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/sed-4.8-9.el9.x86_64.rpm"
@@ -6181,9 +5789,6 @@
           "sha256:d579161275a7d3d93a6420279331503c8b1a597cc3a9b611d615450bf42fb69f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/ncurses-libs-6.2-8.20210508.el9.x86_64.rpm"
           },
-          "sha256:d5d8010a420803df4e2947d34e40b068405441f9dd2a991a1f339c4f9c792aa4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/nss-sysinit-3.79.0-14.el9_0.x86_64.rpm"
-          },
           "sha256:d5ff4d9d43f6c32797e80e0518bb3656ae46643069bdc0ef9b8749d912cd74ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/inih-49-6.el9.x86_64.rpm"
           },
@@ -6195,9 +5800,6 @@
           },
           "sha256:d92f2383e68062b9ded78afa8814f18d84fee98e09781f541169627272ce85cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/cyrus-sasl-lib-2.1.27-21.el9.x86_64.rpm"
-          },
-          "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm"
           },
           "sha256:d9b53fda4b8757fd63b53a415f533ab876c18c28a94fd21d10658de85978f254": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/cpio-2.13-16.el9.x86_64.rpm"
@@ -6222,12 +5824,6 @@
           },
           "sha256:de98d581f6b97bba6be98c42c11565a1c2863118e13971e85e3b96e1b0d71f2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/oddjob-mkhomedir-0.34.7-7.el9.x86_64.rpm"
-          },
-          "sha256:debc0c80c4de8074af7ac6cb4c4654cbc70861eeca7ba7158d97981a5aaef76b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-utils-2.28-3.el9.x86_64.rpm"
-          },
-          "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shim-x64-15.6-1.el9.x86_64.rpm"
           },
           "sha256:df2ab474c2d513ed863d2265efbdbb32ce9c1b1dd00365f041f6539ec36dd80d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libsmartcols-2.37.4-9.el9.x86_64.rpm"
@@ -6259,9 +5855,6 @@
           "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/snappy-1.1.8-8.el9.x86_64.rpm"
           },
-          "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm"
-          },
           "sha256:e5d8869dbc34672bb6bc94e00045f659b7d2415172cd27ee9f949e1769f71bb8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/passwd-0.80-12.el9.x86_64.rpm"
           },
@@ -6288,12 +5881,6 @@
           },
           "sha256:ebddfc188d1ddbb0d6a238583cbc02dcb9fc0bd063a850b22d48980899976628": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libcap-ng-0.8.2-7.el9.x86_64.rpm"
-          },
-          "sha256:ec2c2629f59e9c7d707201f480bb95ccf9eb0821729c2bcc418243bc7b756b5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/fwupd-plugin-flashrom-1.7.10-1.el9.x86_64.rpm"
-          },
-          "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libbytesize-2.5-3.el9.x86_64.rpm"
           },
           "sha256:ed002f74928923f9b508da50393f8a19845ca631714024867cf01e4300863ab2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/authselect-1.2.6-1.el9.x86_64.rpm"
@@ -6349,9 +5936,6 @@
           "sha256:f2a101cdb73ca4782b3f46e9cce0bb1b17ad17c83514e2e082729732b34efd93": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libmnl-1.0.4-15.el9.x86_64.rpm"
           },
-          "sha256:f33f19715860b40598d176525497fffece2ee2bc7d24b515ec28e7ade4cb75ce": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libxmlb-0.3.10-1.el9.x86_64.rpm"
-          },
           "sha256:f414157f818f64143767726d668146fa060903be08969957d4e4f1d2cac43f64": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libldb-2.6.1-1.el9.x86_64.rpm"
           },
@@ -6385,14 +5969,8 @@
           "sha256:fbfc2ad9eb4ac3f50ce13b11c280c1df1886b4494aa7abff5d6e178293de8b43": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libbpf-0.8.0-1.el9.x86_64.rpm"
           },
-          "sha256:fc67ab16312b26497fed6fc572f8383e9210cd84758612a59b0e7f88635ee12c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-fs-2.28-3.el9.x86_64.rpm"
-          },
           "sha256:fccd311803e002eeb0fdd8fc7d33c4a808c75d7849ee8be7c1f4dad6d0d27c70": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-netifaces-0.10.6-15.el9.x86_64.rpm"
-          },
-          "sha256:fd1da85101ff67b3e2d801230f926c6f6bcb632339cb996080c27b5b87edf4fd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-2.28-3.el9.x86_64.rpm"
           },
           "sha256:fd24ba32272c36acc348330207d1dddc923852a78c8055e25b9dc6378831440a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shadow-utils-4.9-6.el9.x86_64.rpm"
@@ -8082,16 +7660,6 @@
         "check_gpg": true
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.1",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
-        "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
-        "check_gpg": true
-      },
-      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -8492,36 +8060,6 @@
         "check_gpg": true
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "6",
-        "release": "2.el9_0",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efi-filesystem-6-2.el9_0.noarch.rpm",
-        "checksum": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-        "check_gpg": true
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "12.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efibootmgr-16-12.el9.x86_64.rpm",
-        "checksum": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-        "check_gpg": true
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "38",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efivar-libs-38-2.el9.x86_64.rpm",
-        "checksum": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-        "check_gpg": true
-      },
-      {
         "name": "elfutils-default-yama-scope",
         "epoch": 0,
         "version": "0.188",
@@ -8629,16 +8167,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm",
         "checksum": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.10",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/fwupd-1.7.10-1.el9.x86_64.rpm",
-        "checksum": "sha256:97712d38810f5300d27b8ebea578c8f6984f2e3cada37000dd20ecb3434be81b",
         "check_gpg": true
       },
       {
@@ -8809,16 +8337,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/grub2-common-2.06-46.el9.noarch.rpm",
         "checksum": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "46.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm",
-        "checksum": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
         "check_gpg": true
       },
       {
@@ -9452,16 +8970,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgcab1-1.4-6.el9.x86_64.rpm",
-        "checksum": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.3.1",
@@ -9502,26 +9010,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "237",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgudev-237-1.el9.x86_64.rpm",
-        "checksum": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671",
-        "check_gpg": true
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.8",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgusb-0.3.8-1.el9.x86_64.rpm",
-        "checksum": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39",
-        "check_gpg": true
-      },
-      {
         "name": "libibverbs",
         "epoch": 0,
         "version": "41.0",
@@ -9549,16 +9037,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libini_config-1.3.1-53.el9.x86_64.rpm",
         "checksum": "sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35",
-        "check_gpg": true
-      },
-      {
-        "name": "libjcat",
-        "epoch": 0,
-        "version": "0.1.6",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libjcat-0.1.6-3.el9.x86_64.rpm",
-        "checksum": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
         "check_gpg": true
       },
       {
@@ -9852,16 +9330,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.3",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm",
-        "checksum": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-        "check_gpg": true
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.22",
@@ -10022,16 +9490,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.26",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libusbx-1.0.26-1.el9.x86_64.rpm",
-        "checksum": "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7",
-        "check_gpg": true
-      },
-      {
         "name": "libuser",
         "epoch": 0,
         "version": "0.63",
@@ -10089,16 +9547,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libxml2-2.9.13-3.el9_1.x86_64.rpm",
         "checksum": "sha256:d0df37751c0763741b991401554407105183c950a896f3ae212d74210697eebe",
-        "check_gpg": true
-      },
-      {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.3.10",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libxmlb-0.3.10-1.el9.x86_64.rpm",
-        "checksum": "sha256:f33f19715860b40598d176525497fffece2ee2bc7d24b515ec28e7ade4cb75ce",
         "check_gpg": true
       },
       {
@@ -10222,16 +9670,6 @@
         "check_gpg": true
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "7.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/mdadm-4.2-7.el9.x86_64.rpm",
-        "checksum": "sha256:6b2aa798ccab5b3709deb4130337562eda7eeadb29df1ee1be2b63082165e636",
-        "check_gpg": true
-      },
-      {
         "name": "microcode_ctl",
         "epoch": 4,
         "version": "20220809",
@@ -10239,16 +9677,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/microcode_ctl-20220809-1.el9.noarch.rpm",
         "checksum": "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88",
-        "check_gpg": true
-      },
-      {
-        "name": "mokutil",
-        "epoch": 2,
-        "version": "0.6.0",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/mokutil-0.6.0-4.el9.x86_64.rpm",
-        "checksum": "sha256:330249ea69dc22395ad848da514cb17e3275c1c7213acbda27d624daf17fd25b",
         "check_gpg": true
       },
       {
@@ -11152,26 +10580,6 @@
         "check_gpg": true
       },
       {
-        "name": "shared-mime-info",
-        "epoch": 0,
-        "version": "2.1",
-        "release": "5.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shared-mime-info-2.1-5.el9.x86_64.rpm",
-        "checksum": "sha256:1331732f85da72b687fbe4ef2115ddf775fb78adf18c8535979cb252d768f60e",
-        "check_gpg": true
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
-        "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-        "check_gpg": true
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -11552,26 +10960,6 @@
         "check_gpg": true
       },
       {
-        "name": "flashrom",
-        "epoch": 0,
-        "version": "1.2",
-        "release": "10.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/flashrom-1.2-10.el9.x86_64.rpm",
-        "checksum": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd-plugin-flashrom",
-        "epoch": 0,
-        "version": "1.7.10",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/fwupd-plugin-flashrom-1.7.10-1.el9.x86_64.rpm",
-        "checksum": "sha256:ec2c2629f59e9c7d707201f480bb95ccf9eb0821729c2bcc418243bc7b756b5d",
-        "check_gpg": true
-      },
-      {
         "name": "gawk-all-langpacks",
         "epoch": 0,
         "version": "5.1.0",
@@ -11652,106 +11040,6 @@
         "check_gpg": true
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "22.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libatasmart-0.19-22.el9.x86_64.rpm",
-        "checksum": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:fd1da85101ff67b3e2d801230f926c6f6bcb632339cb996080c27b5b87edf4fd",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-crypto-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:b3f6b58ac6cd309d9bc8afb304ef6a7cdae0c7240ab24f7b0a324bcacc9a3b0d",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-fs-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:fc67ab16312b26497fed6fc572f8383e9210cd84758612a59b0e7f88635ee12c",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-loop-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:70f0ccc14a538624e86dab1cf1160a5a3409a4576a7a746b8e4bc4b1c377a2d7",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-mdraid-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:81210ba232a2f2bcae617dddcd02a1a8ed5f2b7966105b364aba478d41ba77c2",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-part-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:b3aa4b3aa5ed9008a8705ec0f85fb7bcb45e301468aeb3550996a113f3ecf9d1",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-swap-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:9a393d269642a6406fd03d24a886b5b38ab446b1d074c80a5e736576f14c6a58",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-utils-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:debc0c80c4de8074af7ac6cb4c4654cbc70861eeca7ba7158d97981a5aaef76b",
-        "check_gpg": true
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "2.5",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libbytesize-2.5-3.el9.x86_64.rpm",
-        "checksum": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974",
-        "check_gpg": true
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.11",
@@ -11782,16 +11070,6 @@
         "check_gpg": true
       },
       {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "7.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libudisks2-2.9.4-7.el9.x86_64.rpm",
-        "checksum": "sha256:482e8076dbe459b9b8d77b4b95895ed5091fc26642c03e0ec31ce433ad2c6ad3",
-        "check_gpg": true
-      },
-      {
         "name": "libxcrypt-compat",
         "epoch": 0,
         "version": "4.4.18",
@@ -11799,66 +11077,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm",
         "checksum": "sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a",
-        "check_gpg": true
-      },
-      {
-        "name": "nspr",
-        "epoch": 0,
-        "version": "4.34.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/nspr-4.34.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:2fb3471163091eca166f66fb3f69d17dede5f0a3bb51784ab18959dcdc5f7f71",
-        "check_gpg": true
-      },
-      {
-        "name": "nss",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/nss-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:81138535e5e487dcb7620946f4494a3d85e38be7c1395af7241498568acd0321",
-        "check_gpg": true
-      },
-      {
-        "name": "nss-softokn",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/nss-softokn-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:0d965a214074a7d349497e9aac3ddfa4080e6ddad3e9affeab307cd2b109aed5",
-        "check_gpg": true
-      },
-      {
-        "name": "nss-softokn-freebl",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/nss-softokn-freebl-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:9f559003724cf2c43919dfee9c83cee56adcc686b803a35e5609b9d231b066eb",
-        "check_gpg": true
-      },
-      {
-        "name": "nss-sysinit",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/nss-sysinit-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:d5d8010a420803df4e2947d34e40b068405441f9dd2a991a1f339c4f9c792aa4",
-        "check_gpg": true
-      },
-      {
-        "name": "nss-util",
-        "epoch": 0,
-        "version": "3.79.0",
-        "release": "14.el9_0",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/nss-util-3.79.0-14.el9_0.x86_64.rpm",
-        "checksum": "sha256:6c11ea9d03bb1d375559824617b03aea47a4e17ebdbe29a55235722a358740dd",
         "check_gpg": true
       },
       {
@@ -12109,26 +11327,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/rsyslog-logrotate-8.2102.0-107.el9.x86_64.rpm",
         "checksum": "sha256:6852337bd09dedeb5057696a423f6c2827f00db05c59f113fe9944a98bdcd8dd",
-        "check_gpg": true
-      },
-      {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "7.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/udisks2-2.9.4-7.el9.x86_64.rpm",
-        "checksum": "sha256:17aab3ef99a2590ca905c28421572ae2ea378a634a157b312ec9a9e83e405a54",
-        "check_gpg": true
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.12",
-        "release": "15.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
-        "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ec2_ha-boot.json
@@ -1433,14 +1433,6 @@
                     }
                   },
                   {
-                    "id": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bcf99808e187b3bab9a18dc37b7aecb470053f2cfee0577d744335e70317c886",
                     "options": {
                       "metadata": {
@@ -1809,30 +1801,6 @@
                     }
                   },
                   {
-                    "id": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:082ea65a0ef52bf65fbb4c3863366887e3e8257ad310fd1ca460b58e1688178d",
                     "options": {
                       "metadata": {
@@ -1914,14 +1882,6 @@
                   },
                   {
                     "id": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:97712d38810f5300d27b8ebea578c8f6984f2e3cada37000dd20ecb3434be81b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2058,14 +2018,6 @@
                   },
                   {
                     "id": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2609,14 +2561,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9fab6c7677e812b06012d86b3328a5d2e6262589a7403aeb78ebd117b111c2b3",
                     "options": {
                       "metadata": {
@@ -2649,22 +2593,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8d0b54556cefa3f2e9e0f8d01e0727d31559fd3f0b67cc570dec26ff38d61b84",
                     "options": {
                       "metadata": {
@@ -2682,14 +2610,6 @@
                   },
                   {
                     "id": "sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2945,14 +2865,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f70762594db38ab18ba1db1ce92e9ede5a40ca5d5c3cc93c6bd92686556472c8",
                     "options": {
                       "metadata": {
@@ -3089,14 +3001,6 @@
                     }
                   },
                   {
-                    "id": "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f644c7f76ebf48b83195ca31fc87b505006d447e2c72b24b4cb527acf0110dee",
                     "options": {
                       "metadata": {
@@ -3146,14 +3050,6 @@
                   },
                   {
                     "id": "sha256:d0df37751c0763741b991401554407105183c950a896f3ae212d74210697eebe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f33f19715860b40598d176525497fffece2ee2bc7d24b515ec28e7ade4cb75ce",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3273,23 +3169,7 @@
                     }
                   },
                   {
-                    "id": "sha256:6b2aa798ccab5b3709deb4130337562eda7eeadb29df1ee1be2b63082165e636",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:330249ea69dc22395ad848da514cb17e3275c1c7213acbda27d624daf17fd25b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4097,22 +3977,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1331732f85da72b687fbe4ef2115ddf775fb78adf18c8535979cb252d768f60e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:4b7c4822f92e7ba97b78893d273b01161e411151ccc627b076d13719ad404a69",
                     "options": {
                       "metadata": {
@@ -4449,22 +4313,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ec2c2629f59e9c7d707201f480bb95ccf9eb0821729c2bcc418243bc7b756b5d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c1fcc71c1cc1160d58ace4b60cc6733b68d6f6d406e5ec5ce24327787f452cd1",
                     "options": {
                       "metadata": {
@@ -4553,86 +4401,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fd1da85101ff67b3e2d801230f926c6f6bcb632339cb996080c27b5b87edf4fd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b3f6b58ac6cd309d9bc8afb304ef6a7cdae0c7240ab24f7b0a324bcacc9a3b0d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fc67ab16312b26497fed6fc572f8383e9210cd84758612a59b0e7f88635ee12c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:70f0ccc14a538624e86dab1cf1160a5a3409a4576a7a746b8e4bc4b1c377a2d7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:81210ba232a2f2bcae617dddcd02a1a8ed5f2b7966105b364aba478d41ba77c2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b3aa4b3aa5ed9008a8705ec0f85fb7bcb45e301468aeb3550996a113f3ecf9d1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9a393d269642a6406fd03d24a886b5b38ab446b1d074c80a5e736576f14c6a58",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:debc0c80c4de8074af7ac6cb4c4654cbc70861eeca7ba7158d97981a5aaef76b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:774a7de97ac6cdec24de0f2a9be666492b5830d317ae5f5cfe9223c50e3da0c4",
                     "options": {
                       "metadata": {
@@ -4658,14 +4426,6 @@
                   },
                   {
                     "id": "sha256:ab767bc9d84896688b02c34ae7e99676c6656e0315d805b1b85e716873d14a76",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:482e8076dbe459b9b8d77b4b95895ed5091fc26642c03e0ec31ce433ad2c6ad3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5577,23 +5337,7 @@
                     }
                   },
                   {
-                    "id": "sha256:17aab3ef99a2590ca905c28421572ae2ea378a634a157b312ec9a9e83e405a54",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c52563ef6ba99cd8806b2fde878357f1c9ce092a098a85086e9bc39054cb54e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6276,10 +6020,6 @@
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat",
-                "unified": true
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-226.el9.x86_64",
               "write_cmdline": false,
               "config": {
@@ -6647,9 +6387,6 @@
           "sha256:128e0c250bb2b81fe5e0ca62ae6fcb6d541bfcce839924992747e881244d94a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/glibc-common-2.34-54.el9.x86_64.rpm"
           },
-          "sha256:1331732f85da72b687fbe4ef2115ddf775fb78adf18c8535979cb252d768f60e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shared-mime-info-2.1-5.el9.x86_64.rpm"
-          },
           "sha256:143e828d11b7bc8d5855378a524dfc8c8fa890398ce2a9b5ee0796dec1d6a122": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/tar-1.34-5.el9.x86_64.rpm"
           },
@@ -6682,9 +6419,6 @@
           },
           "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
-          },
-          "sha256:17aab3ef99a2590ca905c28421572ae2ea378a634a157b312ec9a9e83e405a54": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/udisks2-2.9.4-7.el9.x86_64.rpm"
           },
           "sha256:17e6f494a5ec0b24f0fce0783a31af86f3477dc184ef4ec310cd0b3fc66e20d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.2-20230101/Packages/libknet1-compress-bzip2-plugin-1.24-2.el9.x86_64.rpm"
@@ -6836,9 +6570,6 @@
           "sha256:2f3ad8da0aa342fcc7343b0a7963aba93e1253f4109a18f46d5a02ac9e030766": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-lxml-4.6.5-3.el9.x86_64.rpm"
           },
-          "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgudev-237-1.el9.x86_64.rpm"
-          },
           "sha256:2fb3471163091eca166f66fb3f69d17dede5f0a3bb51784ab18959dcdc5f7f71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/nspr-4.34.0-14.el9_0.x86_64.rpm"
           },
@@ -6856,12 +6587,6 @@
           },
           "sha256:326d466b616996a7bdac4202f67c8afe4fde534d57c58ba9e647ee25be583216": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/cloud-init-22.1-7.el9.noarch.rpm"
-          },
-          "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm"
-          },
-          "sha256:330249ea69dc22395ad848da514cb17e3275c1c7213acbda27d624daf17fd25b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/mokutil-0.6.0-4.el9.x86_64.rpm"
           },
           "sha256:3372d77ee30fec7d17645b8e086ceee09af4cbbdca4edbd098f4cf5615a2f07c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.2-20230101/Packages/fence-agents-brocade-4.10.0-40.el9.noarch.rpm"
@@ -6895,9 +6620,6 @@
           },
           "sha256:38a756f2f86bed8a0017bc1a50595ec2b9adf25287c2cd6e3cc105d90adbc09f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/hwdata-0.348-9.6.el9.noarch.rpm"
-          },
-          "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libusbx-1.0.26-1.el9.x86_64.rpm"
           },
           "sha256:395eafb58304cec0d88c4e2de4ceaa954eac756c441783e7a46df6d88f049bcd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/telnet-0.17-85.el9.x86_64.rpm"
@@ -7019,9 +6741,6 @@
           "sha256:4792f3dd66b1250a597cc5bc3dfee924f98c89eec2c6b431679928bfbcf4aa40": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/crontabs-1.11-27.20190603git.el9_0.noarch.rpm"
           },
-          "sha256:482e8076dbe459b9b8d77b4b95895ed5091fc26642c03e0ec31ce433ad2c6ad3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libudisks2-2.9.4-7.el9.x86_64.rpm"
-          },
           "sha256:4846ecf18d3670ad6fbdcc1c29d6cdd37faa4ae20786c64d080307daae1a6f97": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-babel-2.9.1-2.el9.noarch.rpm"
           },
@@ -7124,9 +6843,6 @@
           "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/langpacks-en-3.0-16.el9.noarch.rpm"
           },
-          "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efivar-libs-38-2.el9.x86_64.rpm"
-          },
           "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm"
           },
@@ -7148,17 +6864,11 @@
           "sha256:578a0fef939ffcabcd7266cfae4f9f305b9dc52879d4c789e370919f6ad2834e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/systemd-udev-252-2.el9.x86_64.rpm"
           },
-          "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
-          },
           "sha256:588e8736af3376abfb3cdf372c10baef02c40d916a55958f3bee9767f9ad8526": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libcbor-0.7.0-5.el9.x86_64.rpm"
           },
           "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm"
-          },
-          "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libjcat-0.1.6-3.el9.x86_64.rpm"
           },
           "sha256:59ae5f56ad08c41dfa73182de11fe6881bbf0f9a6b6753be65d0364e7a36e724": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/rpm-4.16.1.3-22.el9.x86_64.rpm"
@@ -7238,9 +6948,6 @@
           "sha256:644ed9b3264a546abac89fdd40c0140911ed8ceef6e05d7594f84e0f570c6347": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libffi-3.4.2-7.el9.x86_64.rpm"
           },
-          "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgusb-0.3.8-1.el9.x86_64.rpm"
-          },
           "sha256:6477fb3c3285158f676360e228057e13dc6e983f453c7c74ed4ab140357f9a0d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libunistring-0.9.10-15.el9.x86_64.rpm"
           },
@@ -7292,9 +6999,6 @@
           "sha256:6b21484456d0db54736039d16f2363830e17468f84936800761eb791d2a2857d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/procps-ng-3.3.17-9.el9.x86_64.rpm"
           },
-          "sha256:6b2aa798ccab5b3709deb4130337562eda7eeadb29df1ee1be2b63082165e636": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/mdadm-4.2-7.el9.x86_64.rpm"
-          },
           "sha256:6b7a283a8d6c05556b12dbe97aabef62c31d5b5ba811f66c8695f99a7636ec17": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.2-20230101/Packages/libknet1-compress-zstd-plugin-1.24-2.el9.x86_64.rpm"
           },
@@ -7315,9 +7019,6 @@
           },
           "sha256:6da6e13deb7badafaa4e10bc8f7a81acd40e4cba3c34b4590826e8eb9a329f3d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libnl3-3.7.0-1.el9.x86_64.rpm"
-          },
-          "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efibootmgr-16-12.el9.x86_64.rpm"
           },
           "sha256:6ea4966a7336839fc47ae6308c8a00f69e4126bc1ff0832899c9a0eaa0661d19": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libcap-2.48-8.el9.x86_64.rpm"
@@ -7340,9 +7041,6 @@
           "sha256:70dd2956e1b705b2cef72b93b0ab666644dee6ae2440dbd8d460b921d98a84fe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/iptables-libs-1.8.8-6.el9_1.x86_64.rpm"
           },
-          "sha256:70f0ccc14a538624e86dab1cf1160a5a3409a4576a7a746b8e4bc4b1c377a2d7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-loop-2.28-3.el9.x86_64.rpm"
-          },
           "sha256:719a03ecef47b672795e803e68173b2bf94ff6ce0a5a14909e93b58e793c22e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/openssh-clients-8.7p1-24.el9_1.x86_64.rpm"
           },
@@ -7358,17 +7056,11 @@
           "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/perl-vars-1.05-479.el9.noarch.rpm"
           },
-          "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efi-filesystem-6-2.el9_0.noarch.rpm"
-          },
           "sha256:738d7e86ffd7cf47e8f432756a7b07adbb6f30aab417745b2fbbceb4faf4d954": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-libsemanage-3.4-2.el9.x86_64.rpm"
           },
           "sha256:75111b402b4e49dea70d150a0e1e2dde6cf5da4725e2c047a3eda9303dc4b9fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/zlib-1.2.11-35.el9_1.x86_64.rpm"
-          },
-          "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libatasmart-0.19-22.el9.x86_64.rpm"
           },
           "sha256:756fb606dfbf6c6f92fcd3316ba902b5e09232102cb6371d9bccd983b8d4bbdf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/keyutils-1.6.3-1.el9.x86_64.rpm"
@@ -7456,9 +7148,6 @@
           },
           "sha256:8115ff32b7f619956e34afba884acb032cd96b9795e10832ef4651babd86ad43": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/systemd-252-2.el9.x86_64.rpm"
-          },
-          "sha256:81210ba232a2f2bcae617dddcd02a1a8ed5f2b7966105b364aba478d41ba77c2": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-mdraid-2.28-3.el9.x86_64.rpm"
           },
           "sha256:8126bb11b3e04abf0889d61878389226b6b8bf268e42c1d6fee7d7156f82a70a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgcrypt-1.10.0-8.el9_0.x86_64.rpm"
@@ -7622,9 +7311,6 @@
           "sha256:973e23aaf3aed44582a97a80badf05aa431533e4d0f13b28331c013924e71648": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.2-20230101/Packages/resource-agents-4.10.0-28.el9.x86_64.rpm"
           },
-          "sha256:97712d38810f5300d27b8ebea578c8f6984f2e3cada37000dd20ecb3434be81b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/fwupd-1.7.10-1.el9.x86_64.rpm"
-          },
           "sha256:97cfd216791ba291e90d61973deef3a5ef89cdac6093948ecee5c80fe89e8222": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/lvm2-libs-2.03.17-3.el9.x86_64.rpm"
           },
@@ -7646,9 +7332,6 @@
           "sha256:99fda6725a2c668bae29fbab74d1b347e074f4e8c8ed18d656cb928fb6fc92b7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/gawk-5.1.0-6.el9.x86_64.rpm"
           },
-          "sha256:9a393d269642a6406fd03d24a886b5b38ab446b1d074c80a5e736576f14c6a58": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-swap-2.28-3.el9.x86_64.rpm"
-          },
           "sha256:9a502d81d73d3303ceb53a06ad7ce525c97117ea64352174a33708bf3429283d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm"
           },
@@ -7666,9 +7349,6 @@
           },
           "sha256:9d791f2e26655b6d00c397354630c00bbf6582bccb07ec03e583580ed024759e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/glibc-2.34-54.el9.x86_64.rpm"
-          },
-          "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm"
           },
           "sha256:9e7b431c273c8b6d5203f96b2e652acc00702bbba957b535f135d7ab802662bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/ruby-libs-3.0.4-160.el9_0.x86_64.rpm"
@@ -7793,12 +7473,6 @@
           "sha256:b38b44d1588a6fa85530b66e903a3271b70a77a97aaa107df0dc2d4c167e8f2c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libmount-2.37.4-9.el9.x86_64.rpm"
           },
-          "sha256:b3aa4b3aa5ed9008a8705ec0f85fb7bcb45e301468aeb3550996a113f3ecf9d1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-part-2.28-3.el9.x86_64.rpm"
-          },
-          "sha256:b3f6b58ac6cd309d9bc8afb304ef6a7cdae0c7240ab24f7b0a324bcacc9a3b0d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-crypto-2.28-3.el9.x86_64.rpm"
-          },
           "sha256:b4c9231c4d2a53d531b8993df4ace4359af2a840cc654af4c3b29ba617203159": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/dhcp-common-4.4.2-18.b1.el9.noarch.rpm"
           },
@@ -7858,9 +7532,6 @@
           },
           "sha256:beed55d3ab1e8dd1207e1bd67e40e180c53a001198b9a7186f4bf07c042b377e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/openldap-compat-2.6.2-3.el9.x86_64.rpm"
-          },
-          "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/flashrom-1.2-10.el9.x86_64.rpm"
           },
           "sha256:bf3baf444e49eba4189e57d562a7522ab714132d2960db87ef9b99f1b46a3cc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/sed-4.8-9.el9.x86_64.rpm"
@@ -8045,9 +7716,6 @@
           "sha256:d92f2383e68062b9ded78afa8814f18d84fee98e09781f541169627272ce85cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/cyrus-sasl-lib-2.1.27-21.el9.x86_64.rpm"
           },
-          "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm"
-          },
           "sha256:d9b53fda4b8757fd63b53a415f533ab876c18c28a94fd21d10658de85978f254": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/cpio-2.13-16.el9.x86_64.rpm"
           },
@@ -8081,14 +7749,8 @@
           "sha256:de98d581f6b97bba6be98c42c11565a1c2863118e13971e85e3b96e1b0d71f2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/oddjob-mkhomedir-0.34.7-7.el9.x86_64.rpm"
           },
-          "sha256:debc0c80c4de8074af7ac6cb4c4654cbc70861eeca7ba7158d97981a5aaef76b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-utils-2.28-3.el9.x86_64.rpm"
-          },
           "sha256:decaeac8fa883ddd631a32aaf55eb6175ab6e328150d66dfcf8e322b26da258f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/corosynclib-3.1.5-4.el9.x86_64.rpm"
-          },
-          "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shim-x64-15.6-1.el9.x86_64.rpm"
           },
           "sha256:df2ab474c2d513ed863d2265efbdbb32ce9c1b1dd00365f041f6539ec36dd80d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libsmartcols-2.37.4-9.el9.x86_64.rpm"
@@ -8128,9 +7790,6 @@
           },
           "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/snappy-1.1.8-8.el9.x86_64.rpm"
-          },
-          "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm"
           },
           "sha256:e5d8869dbc34672bb6bc94e00045f659b7d2415172cd27ee9f949e1769f71bb8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/passwd-0.80-12.el9.x86_64.rpm"
@@ -8174,14 +7833,8 @@
           "sha256:ec162bbce74978ac450bfcc60e74fe090cdef2e096214cc223117ddafe983ac7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/perl-NDBM_File-1.15-479.el9.x86_64.rpm"
           },
-          "sha256:ec2c2629f59e9c7d707201f480bb95ccf9eb0821729c2bcc418243bc7b756b5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/fwupd-plugin-flashrom-1.7.10-1.el9.x86_64.rpm"
-          },
           "sha256:ec85f7abe3759447ecbd2f7b5cd6ea2c95d01299fa0c8a339dd562d37485c807": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.2-20230101/Packages/fence-agents-apc-4.10.0-40.el9.noarch.rpm"
-          },
-          "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libbytesize-2.5-3.el9.x86_64.rpm"
           },
           "sha256:ed002f74928923f9b508da50393f8a19845ca631714024867cf01e4300863ab2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/authselect-1.2.6-1.el9.x86_64.rpm"
@@ -8246,9 +7899,6 @@
           "sha256:f33e6c4a6614b10e98de52cbf9923f07f54f1a9004c48776b82741fd1e928d53": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.2-20230101/Packages/fence-agents-ifmib-4.10.0-40.el9.noarch.rpm"
           },
-          "sha256:f33f19715860b40598d176525497fffece2ee2bc7d24b515ec28e7ade4cb75ce": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libxmlb-0.3.10-1.el9.x86_64.rpm"
-          },
           "sha256:f3a36c56ef83249b315f91c320a461273dd67ce5c0c03b8e436d0f562d710410": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/device-mapper-multipath-libs-0.8.7-16.el9.x86_64.rpm"
           },
@@ -8297,17 +7947,11 @@
           "sha256:fbfc2ad9eb4ac3f50ce13b11c280c1df1886b4494aa7abff5d6e178293de8b43": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libbpf-0.8.0-1.el9.x86_64.rpm"
           },
-          "sha256:fc67ab16312b26497fed6fc572f8383e9210cd84758612a59b0e7f88635ee12c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-fs-2.28-3.el9.x86_64.rpm"
-          },
           "sha256:fccd311803e002eeb0fdd8fc7d33c4a808c75d7849ee8be7c1f4dad6d0d27c70": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-netifaces-0.10.6-15.el9.x86_64.rpm"
           },
           "sha256:fd1b4cf7223dd36f9d18763ba0b21b9428929783fa8afe3c529edc6fdc9d764d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.2-20230101/Packages/pacemaker-cli-2.1.5-4.el9.x86_64.rpm"
-          },
-          "sha256:fd1da85101ff67b3e2d801230f926c6f6bcb632339cb996080c27b5b87edf4fd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-2.28-3.el9.x86_64.rpm"
           },
           "sha256:fd24ba32272c36acc348330207d1dddc923852a78c8055e25b9dc6378831440a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shadow-utils-4.9-6.el9.x86_64.rpm"
@@ -9997,16 +9641,6 @@
         "check_gpg": true
       },
       {
-        "name": "bubblewrap",
-        "epoch": 0,
-        "version": "0.4.1",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm",
-        "checksum": "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7",
-        "check_gpg": true
-      },
-      {
         "name": "bzip2",
         "epoch": 0,
         "version": "1.0.8",
@@ -10467,36 +10101,6 @@
         "check_gpg": true
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "6",
-        "release": "2.el9_0",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efi-filesystem-6-2.el9_0.noarch.rpm",
-        "checksum": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-        "check_gpg": true
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "12.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efibootmgr-16-12.el9.x86_64.rpm",
-        "checksum": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-        "check_gpg": true
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "38",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efivar-libs-38-2.el9.x86_64.rpm",
-        "checksum": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-        "check_gpg": true
-      },
-      {
         "name": "elfutils-default-yama-scope",
         "epoch": 0,
         "version": "0.188",
@@ -10604,16 +10208,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm",
         "checksum": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.10",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/fwupd-1.7.10-1.el9.x86_64.rpm",
-        "checksum": "sha256:97712d38810f5300d27b8ebea578c8f6984f2e3cada37000dd20ecb3434be81b",
         "check_gpg": true
       },
       {
@@ -10784,16 +10378,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/grub2-common-2.06-46.el9.noarch.rpm",
         "checksum": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "46.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm",
-        "checksum": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
         "check_gpg": true
       },
       {
@@ -11467,16 +11051,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgcab1-1.4-6.el9.x86_64.rpm",
-        "checksum": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.3.1",
@@ -11517,26 +11091,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgudev",
-        "epoch": 0,
-        "version": "237",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgudev-237-1.el9.x86_64.rpm",
-        "checksum": "sha256:2fabb90bb3f87581b44b3805865042ac881a200b055bfdcd48ecba3bb16c5671",
-        "check_gpg": true
-      },
-      {
-        "name": "libgusb",
-        "epoch": 0,
-        "version": "0.3.8",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgusb-0.3.8-1.el9.x86_64.rpm",
-        "checksum": "sha256:6473bf7ff907d9f0755db8ffde2774c03c4259d3902bec2c37ceb0e93fdd3b39",
-        "check_gpg": true
-      },
-      {
         "name": "libibverbs",
         "epoch": 0,
         "version": "41.0",
@@ -11564,16 +11118,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libini_config-1.3.1-53.el9.x86_64.rpm",
         "checksum": "sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35",
-        "check_gpg": true
-      },
-      {
-        "name": "libjcat",
-        "epoch": 0,
-        "version": "0.1.6",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libjcat-0.1.6-3.el9.x86_64.rpm",
-        "checksum": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
         "check_gpg": true
       },
       {
@@ -11887,16 +11431,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.3",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm",
-        "checksum": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-        "check_gpg": true
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.22",
@@ -12067,16 +11601,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.26",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libusbx-1.0.26-1.el9.x86_64.rpm",
-        "checksum": "sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7",
-        "check_gpg": true
-      },
-      {
         "name": "libuser",
         "epoch": 0,
         "version": "0.63",
@@ -12144,16 +11668,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libxml2-2.9.13-3.el9_1.x86_64.rpm",
         "checksum": "sha256:d0df37751c0763741b991401554407105183c950a896f3ae212d74210697eebe",
-        "check_gpg": true
-      },
-      {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.3.10",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libxmlb-0.3.10-1.el9.x86_64.rpm",
-        "checksum": "sha256:f33f19715860b40598d176525497fffece2ee2bc7d24b515ec28e7ade4cb75ce",
         "check_gpg": true
       },
       {
@@ -12297,16 +11811,6 @@
         "check_gpg": true
       },
       {
-        "name": "mdadm",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "7.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/mdadm-4.2-7.el9.x86_64.rpm",
-        "checksum": "sha256:6b2aa798ccab5b3709deb4130337562eda7eeadb29df1ee1be2b63082165e636",
-        "check_gpg": true
-      },
-      {
         "name": "microcode_ctl",
         "epoch": 4,
         "version": "20220809",
@@ -12314,16 +11818,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/microcode_ctl-20220809-1.el9.noarch.rpm",
         "checksum": "sha256:3518cc9eb5f649cf3eec7f77ee4f09801f9a1292481fda6c09d7c5c362002e88",
-        "check_gpg": true
-      },
-      {
-        "name": "mokutil",
-        "epoch": 2,
-        "version": "0.6.0",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/mokutil-0.6.0-4.el9.x86_64.rpm",
-        "checksum": "sha256:330249ea69dc22395ad848da514cb17e3275c1c7213acbda27d624daf17fd25b",
         "check_gpg": true
       },
       {
@@ -13327,26 +12821,6 @@
         "check_gpg": true
       },
       {
-        "name": "shared-mime-info",
-        "epoch": 0,
-        "version": "2.1",
-        "release": "5.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shared-mime-info-2.1-5.el9.x86_64.rpm",
-        "checksum": "sha256:1331732f85da72b687fbe4ef2115ddf775fb78adf18c8535979cb252d768f60e",
-        "check_gpg": true
-      },
-      {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
-        "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-        "check_gpg": true
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -13767,26 +13241,6 @@
         "check_gpg": true
       },
       {
-        "name": "flashrom",
-        "epoch": 0,
-        "version": "1.2",
-        "release": "10.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/flashrom-1.2-10.el9.x86_64.rpm",
-        "checksum": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd-plugin-flashrom",
-        "epoch": 0,
-        "version": "1.7.10",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/fwupd-plugin-flashrom-1.7.10-1.el9.x86_64.rpm",
-        "checksum": "sha256:ec2c2629f59e9c7d707201f480bb95ccf9eb0821729c2bcc418243bc7b756b5d",
-        "check_gpg": true
-      },
-      {
         "name": "gawk-all-langpacks",
         "epoch": 0,
         "version": "5.1.0",
@@ -13897,106 +13351,6 @@
         "check_gpg": true
       },
       {
-        "name": "libatasmart",
-        "epoch": 0,
-        "version": "0.19",
-        "release": "22.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libatasmart-0.19-22.el9.x86_64.rpm",
-        "checksum": "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:fd1da85101ff67b3e2d801230f926c6f6bcb632339cb996080c27b5b87edf4fd",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-crypto",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-crypto-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:b3f6b58ac6cd309d9bc8afb304ef6a7cdae0c7240ab24f7b0a324bcacc9a3b0d",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-fs",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-fs-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:fc67ab16312b26497fed6fc572f8383e9210cd84758612a59b0e7f88635ee12c",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-loop",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-loop-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:70f0ccc14a538624e86dab1cf1160a5a3409a4576a7a746b8e4bc4b1c377a2d7",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-mdraid",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-mdraid-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:81210ba232a2f2bcae617dddcd02a1a8ed5f2b7966105b364aba478d41ba77c2",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-part",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-part-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:b3aa4b3aa5ed9008a8705ec0f85fb7bcb45e301468aeb3550996a113f3ecf9d1",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-swap",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-swap-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:9a393d269642a6406fd03d24a886b5b38ab446b1d074c80a5e736576f14c6a58",
-        "check_gpg": true
-      },
-      {
-        "name": "libblockdev-utils",
-        "epoch": 0,
-        "version": "2.28",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-utils-2.28-3.el9.x86_64.rpm",
-        "checksum": "sha256:debc0c80c4de8074af7ac6cb4c4654cbc70861eeca7ba7158d97981a5aaef76b",
-        "check_gpg": true
-      },
-      {
-        "name": "libbytesize",
-        "epoch": 0,
-        "version": "2.5",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libbytesize-2.5-3.el9.x86_64.rpm",
-        "checksum": "sha256:ecd016bdec2368c741d5762085100846ad8e203ec34ad5f812862de9edc12974",
-        "check_gpg": true
-      },
-      {
         "name": "libestr",
         "epoch": 0,
         "version": "0.1.11",
@@ -14034,16 +13388,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libqb-2.0.6-2.el9_1.x86_64.rpm",
         "checksum": "sha256:ab767bc9d84896688b02c34ae7e99676c6656e0315d805b1b85e716873d14a76",
-        "check_gpg": true
-      },
-      {
-        "name": "libudisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "7.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libudisks2-2.9.4-7.el9.x86_64.rpm",
-        "checksum": "sha256:482e8076dbe459b9b8d77b4b95895ed5091fc26642c03e0ec31ce433ad2c6ad3",
         "check_gpg": true
       },
       {
@@ -15177,16 +14521,6 @@
         "check_gpg": true
       },
       {
-        "name": "udisks2",
-        "epoch": 0,
-        "version": "2.9.4",
-        "release": "7.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/udisks2-2.9.4-7.el9.x86_64.rpm",
-        "checksum": "sha256:17aab3ef99a2590ca905c28421572ae2ea378a634a157b312ec9a9e83e405a54",
-        "check_gpg": true
-      },
-      {
         "name": "unbound-libs",
         "epoch": 0,
         "version": "1.16.2",
@@ -15194,16 +14528,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/unbound-libs-1.16.2-2.el9.x86_64.rpm",
         "checksum": "sha256:3c52563ef6ba99cd8806b2fde878357f1c9ce092a098a85086e9bc39054cb54e",
-        "check_gpg": true
-      },
-      {
-        "name": "volume_key-libs",
-        "epoch": 0,
-        "version": "0.3.12",
-        "release": "15.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
-        "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ec2_sap-boot.json
@@ -2045,30 +2045,6 @@
                     }
                   },
                   {
-                    "id": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:df6e3b52da814d27566382c3feed7e20c5fe7c8d9c58522630034f94160c86ff",
                     "options": {
                       "metadata": {
@@ -2182,14 +2158,6 @@
                   },
                   {
                     "id": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:97712d38810f5300d27b8ebea578c8f6984f2e3cada37000dd20ecb3434be81b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2342,14 +2310,6 @@
                   },
                   {
                     "id": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3021,14 +2981,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9fab6c7677e812b06012d86b3328a5d2e6262589a7403aeb78ebd117b111c2b3",
                     "options": {
                       "metadata": {
@@ -3110,14 +3062,6 @@
                   },
                   {
                     "id": "sha256:c83af834d9175ccd158c3a742222f6693617e0c9c65f1b0b4c032521e9e1e88e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3437,14 +3381,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f70762594db38ab18ba1db1ce92e9ede5a40ca5d5c3cc93c6bd92686556472c8",
                     "options": {
                       "metadata": {
@@ -3653,14 +3589,6 @@
                     }
                   },
                   {
-                    "id": "sha256:f33f19715860b40598d176525497fffece2ee2bc7d24b515ec28e7ade4cb75ce",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:409beeb1faf626a882e95763ec4892d514077289e6074d3b61bef1b90739ad66",
                     "options": {
                       "metadata": {
@@ -3822,14 +3750,6 @@
                   },
                   {
                     "id": "sha256:27bc149f91c6740d37eb11b8e8e3c113092b7de231a11bc5552f3e0db78ae07e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:330249ea69dc22395ad848da514cb17e3275c1c7213acbda27d624daf17fd25b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4773,14 +4693,6 @@
                     }
                   },
                   {
-                    "id": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:4b7c4822f92e7ba97b78893d273b01161e411151ccc627b076d13719ad404a69",
                     "options": {
                       "metadata": {
@@ -5653,14 +5565,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:21edb6cf19c08c1d100e329d2b7f99b85692f23a518b1b2a1887ee1682d28880",
                     "options": {
                       "metadata": {
@@ -5742,14 +5646,6 @@
                   },
                   {
                     "id": "sha256:a7ba2bb451678b22e4e58cc7b235554e7dee87e6ec01438d512ce1a9c9d46aa1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ec2c2629f59e9c7d707201f480bb95ccf9eb0821729c2bcc418243bc7b756b5d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -8631,10 +8527,6 @@
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
               "kernel_opts": "console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 processor.max_cstate=1 intel_idle.max_cstate=1",
               "legacy": "i386-pc",
-              "uefi": {
-                "vendor": "redhat",
-                "unified": true
-              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.14.0-226.el9.x86_64",
               "write_cmdline": false,
               "config": {
@@ -9350,9 +9242,6 @@
           "sha256:327920d59130c2a3a318774b2300babfd2e5ac2994ca4123dfa10f08f5e1d9e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/bubblewrap-0.4.1-6.el9.x86_64.rpm"
           },
-          "sha256:330249ea69dc22395ad848da514cb17e3275c1c7213acbda27d624daf17fd25b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/mokutil-0.6.0-4.el9.x86_64.rpm"
-          },
           "sha256:3515d58921e8182b7ad86e78b0ec3546461efd9370b6a6d0eaa7c219d6869b20": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-rhui-4-20230101/Packages/rh-amazon-rhui-client-sap-bundle-e4s-4.0.4-1.el9.noarch.rpm"
           },
@@ -9710,9 +9599,6 @@
           "sha256:559086733d1710325bf8ab631266d101214bafbc15e5d39f230609a616b1c04a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/langpacks-en-3.0-16.el9.noarch.rpm"
           },
-          "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efivar-libs-38-2.el9.x86_64.rpm"
-          },
           "sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/python3-pyyaml-5.4.1-6.el9.x86_64.rpm"
           },
@@ -9740,9 +9626,6 @@
           "sha256:578a0fef939ffcabcd7266cfae4f9f305b9dc52879d4c789e370919f6ad2834e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/systemd-udev-252-2.el9.x86_64.rpm"
           },
-          "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgcab1-1.4-6.el9.x86_64.rpm"
-          },
           "sha256:583c5975a04bdcd968cd160468430a3d3bcabbc864071c3c150240c2ff9e43d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libappstream-glib-0.7.18-4.el9.x86_64.rpm"
           },
@@ -9751,9 +9634,6 @@
           },
           "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm"
-          },
-          "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libjcat-0.1.6-3.el9.x86_64.rpm"
           },
           "sha256:5964dcf5d0ec41d9caf8ad3b4ef03c058018613bd7ee65337b24f57c744434b1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/p11-kit-server-0.24.1-2.el9.x86_64.rpm"
@@ -9989,9 +9869,6 @@
           "sha256:6da6e13deb7badafaa4e10bc8f7a81acd40e4cba3c34b4590826e8eb9a329f3d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libnl3-3.7.0-1.el9.x86_64.rpm"
           },
-          "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efibootmgr-16-12.el9.x86_64.rpm"
-          },
           "sha256:6e4fb6dc2ad74949cc1142b2d1f0f8fc7cbf00f32a745c67c1d1eb39271cdbd8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-jmespath-0.9.4-11.el9.noarch.rpm"
           },
@@ -10051,9 +9928,6 @@
           },
           "sha256:7290d5c6c200a2c98be30c3f0d9cf58462d0bc1ddb7940a8c7c35ca4f7e090ce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/fstrm-0.6.1-3.el9.x86_64.rpm"
-          },
-          "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efi-filesystem-6-2.el9_0.noarch.rpm"
           },
           "sha256:738d7e86ffd7cf47e8f432756a7b07adbb6f30aab417745b2fbbceb4faf4d954": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/python3-libsemanage-3.4-2.el9.x86_64.rpm"
@@ -10445,9 +10319,6 @@
           "sha256:96d75824948387a884d206865db534cd3d46f32422efcb020c20060b59edb27c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/keyutils-libs-1.6.3-1.el9.x86_64.rpm"
           },
-          "sha256:97712d38810f5300d27b8ebea578c8f6984f2e3cada37000dd20ecb3434be81b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/fwupd-1.7.10-1.el9.x86_64.rpm"
-          },
           "sha256:979857c9789008c57b121256bc92ec35d1e3a9aaeaca998373c19f34d8b3c84e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/openjpeg2-2.4.0-7.el9.x86_64.rpm"
           },
@@ -10510,9 +10381,6 @@
           },
           "sha256:9d791f2e26655b6d00c397354630c00bbf6582bccb07ec03e583580ed024759e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/glibc-2.34-54.el9.x86_64.rpm"
-          },
-          "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm"
           },
           "sha256:9ddcf4c8e5463a1b75b22be070ae8c67264ffd8bc035e3942791184b4f4b34d7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/jbig2dec-libs-0.19-6.el9.x86_64.rpm"
@@ -10850,9 +10718,6 @@
           "sha256:befbe1a5dc7b843b993d7db6f08c9f29c504d549ad7b51fda5485380f47ded3c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/gsettings-desktop-schemas-40.0-6.el9.x86_64.rpm"
           },
-          "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/flashrom-1.2-10.el9.x86_64.rpm"
-          },
           "sha256:bf3baf444e49eba4189e57d562a7522ab714132d2960db87ef9b99f1b46a3cc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/sed-4.8-9.el9.x86_64.rpm"
           },
@@ -11156,9 +11021,6 @@
           "sha256:debc0c80c4de8074af7ac6cb4c4654cbc70861eeca7ba7158d97981a5aaef76b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/libblockdev-utils-2.28-3.el9.x86_64.rpm"
           },
-          "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shim-x64-15.6-1.el9.x86_64.rpm"
-          },
           "sha256:df2ab474c2d513ed863d2265efbdbb32ce9c1b1dd00365f041f6539ec36dd80d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libsmartcols-2.37.4-9.el9.x86_64.rpm"
           },
@@ -11209,9 +11071,6 @@
           },
           "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/snappy-1.1.8-8.el9.x86_64.rpm"
-          },
-          "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm"
           },
           "sha256:e5d8869dbc34672bb6bc94e00045f659b7d2415172cd27ee9f949e1769f71bb8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/passwd-0.80-12.el9.x86_64.rpm"
@@ -11281,9 +11140,6 @@
           },
           "sha256:ec162bbce74978ac450bfcc60e74fe090cdef2e096214cc223117ddafe983ac7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/perl-NDBM_File-1.15-479.el9.x86_64.rpm"
-          },
-          "sha256:ec2c2629f59e9c7d707201f480bb95ccf9eb0821729c2bcc418243bc7b756b5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/fwupd-plugin-flashrom-1.7.10-1.el9.x86_64.rpm"
           },
           "sha256:ec701b1727e7fe832f48c0410804c9279341a5b10751ad9a8e9691a9c3269d66": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/xdg-desktop-portal-gtk-1.12.0-3.el9.x86_64.rpm"
@@ -11374,9 +11230,6 @@
           },
           "sha256:f2a101cdb73ca4782b3f46e9cce0bb1b17ad17c83514e2e082729732b34efd93": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libmnl-1.0.4-15.el9.x86_64.rpm"
-          },
-          "sha256:f33f19715860b40598d176525497fffece2ee2bc7d24b515ec28e7ade4cb75ce": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libxmlb-0.3.10-1.el9.x86_64.rpm"
           },
           "sha256:f3a36c56ef83249b315f91c320a461273dd67ce5c0c03b8e436d0f562d710410": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/device-mapper-multipath-libs-0.8.7-16.el9.x86_64.rpm"
@@ -13917,36 +13770,6 @@
         "check_gpg": true
       },
       {
-        "name": "efi-filesystem",
-        "epoch": 0,
-        "version": "6",
-        "release": "2.el9_0",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efi-filesystem-6-2.el9_0.noarch.rpm",
-        "checksum": "sha256:732a42476bae76eb7877892465adcfd1d78d27321b3e2e9355a52fbf3062ceef",
-        "check_gpg": true
-      },
-      {
-        "name": "efibootmgr",
-        "epoch": 0,
-        "version": "16",
-        "release": "12.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efibootmgr-16-12.el9.x86_64.rpm",
-        "checksum": "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a",
-        "check_gpg": true
-      },
-      {
-        "name": "efivar-libs",
-        "epoch": 0,
-        "version": "38",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/efivar-libs-38-2.el9.x86_64.rpm",
-        "checksum": "sha256:55ad92b603caff4c601440ae6a308894190fdaeadf9cec7fc6de6f7eee35fba6",
-        "check_gpg": true
-      },
-      {
         "name": "elfutils-debuginfod-client",
         "epoch": 0,
         "version": "0.188",
@@ -14094,16 +13917,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm",
         "checksum": "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd",
-        "epoch": 0,
-        "version": "1.7.10",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/fwupd-1.7.10-1.el9.x86_64.rpm",
-        "checksum": "sha256:97712d38810f5300d27b8ebea578c8f6984f2e3cada37000dd20ecb3434be81b",
         "check_gpg": true
       },
       {
@@ -14294,16 +14107,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/grub2-common-2.06-46.el9.noarch.rpm",
         "checksum": "sha256:e472737d6e9cc726c54aa0b94530f24ffa69314cdf412a6c6f719445a061f772",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-efi-x64",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "46.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/grub2-efi-x64-2.06-46.el9.x86_64.rpm",
-        "checksum": "sha256:e5a66a4dc1f65cd957a8fa8da6859e0375143617caf72a89116e257e47a8395e",
         "check_gpg": true
       },
       {
@@ -15137,16 +14940,6 @@
         "check_gpg": true
       },
       {
-        "name": "libgcab1",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libgcab1-1.4-6.el9.x86_64.rpm",
-        "checksum": "sha256:5832b9e077fecec48cbd1febe5ea1c10649d753835e797eaf67a8bea3a40f8b5",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.3.1",
@@ -15254,16 +15047,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libipa_hbac-2.8.2-1.el9.x86_64.rpm",
         "checksum": "sha256:c83af834d9175ccd158c3a742222f6693617e0c9c65f1b0b4c032521e9e1e88e",
-        "check_gpg": true
-      },
-      {
-        "name": "libjcat",
-        "epoch": 0,
-        "version": "0.1.6",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libjcat-0.1.6-3.el9.x86_64.rpm",
-        "checksum": "sha256:58fc22ba8ff2c75390d677883bc12ce09e1edad99bb04cda017188d8c6f5f0cf",
         "check_gpg": true
       },
       {
@@ -15657,16 +15440,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsmbios",
-        "epoch": 0,
-        "version": "2.4.3",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm",
-        "checksum": "sha256:9dd7f1ac080f5b300e42bbb8667abeb6167f57e85ea55bd3d41f7faac509dbf3",
-        "check_gpg": true
-      },
-      {
         "name": "libsolv",
         "epoch": 0,
         "version": "0.7.22",
@@ -15927,16 +15700,6 @@
         "check_gpg": true
       },
       {
-        "name": "libxmlb",
-        "epoch": 0,
-        "version": "0.3.10",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/libxmlb-0.3.10-1.el9.x86_64.rpm",
-        "checksum": "sha256:f33f19715860b40598d176525497fffece2ee2bc7d24b515ec28e7ade4cb75ce",
-        "check_gpg": true
-      },
-      {
         "name": "libyaml",
         "epoch": 0,
         "version": "0.2.5",
@@ -16144,16 +15907,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/mlocate-0.26-30.el9.x86_64.rpm",
         "checksum": "sha256:27bc149f91c6740d37eb11b8e8e3c113092b7de231a11bc5552f3e0db78ae07e",
-        "check_gpg": true
-      },
-      {
-        "name": "mokutil",
-        "epoch": 2,
-        "version": "0.6.0",
-        "release": "4.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/mokutil-0.6.0-4.el9.x86_64.rpm",
-        "checksum": "sha256:330249ea69dc22395ad848da514cb17e3275c1c7213acbda27d624daf17fd25b",
         "check_gpg": true
       },
       {
@@ -17327,16 +17080,6 @@
         "check_gpg": true
       },
       {
-        "name": "shim-x64",
-        "epoch": 0,
-        "version": "15.6",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20230101/Packages/shim-x64-15.6-1.el9.x86_64.rpm",
-        "checksum": "sha256:df0896bc9cb5c6136f791408e5e5d5063fe65b94dabd45310dfc69816811cd0f",
-        "check_gpg": true
-      },
-      {
         "name": "slang",
         "epoch": 0,
         "version": "2.3.2",
@@ -18427,16 +18170,6 @@
         "check_gpg": true
       },
       {
-        "name": "flashrom",
-        "epoch": 0,
-        "version": "1.2",
-        "release": "10.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/flashrom-1.2-10.el9.x86_64.rpm",
-        "checksum": "sha256:bf082e093af4071810a0bf473b2ceb1451bd90f5349026d4305262fc6bf84d56",
-        "check_gpg": true
-      },
-      {
         "name": "flatpak",
         "epoch": 0,
         "version": "1.12.7",
@@ -18544,16 +18277,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/fuse3-libs-3.10.2-5.el9.x86_64.rpm",
         "checksum": "sha256:a7ba2bb451678b22e4e58cc7b235554e7dee87e6ec01438d512ce1a9c9d46aa1",
-        "check_gpg": true
-      },
-      {
-        "name": "fwupd-plugin-flashrom",
-        "epoch": 0,
-        "version": "1.7.10",
-        "release": "1.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/fwupd-plugin-flashrom-1.7.10-1.el9.x86_64.rpm",
-        "checksum": "sha256:ec2c2629f59e9c7d707201f480bb95ccf9eb0821729c2bcc418243bc7b756b5d",
         "check_gpg": true
       },
       {


### PR DESCRIPTION
RHEL EC2 (RHUI) images are rebuilt as part of batch updates even for GA releases. To not introduce a boot mode and partitioning change to those images as part of a batch update, revert back the changes for RHEL EC2 (RHUI) images prior to 8.9 and 9.3 releases.

This change affects only RHEL EC2 RHUI images (built in Brew).
This change does not affect CentOS Stream AMIs or RHEL AMI (not using RHUI) built in the service.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
